### PR TITLE
fix(start_airship_swap): patch GameOver_TwirlToStart X target

### DIFF
--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -33,7 +33,7 @@ const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x35572, 13, "mystery_anchor: item redirect trampoline"),
     (0x3557F, 50, "hammer_locks: tile check subroutine + tables"),
     (0x3E260, 33, "starting_items: lives + intro skip + menu music + inventory init trampoline"),
-    (0x3E281, 64, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + X helper + XHi helper"),
+    (0x3E281, 69, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + X helper + XHi helper + game-over X helper"),
     (0x3E965, 13, "title_screen: intro skip + menu music routine"),
     (0x3FFF0, 26, "card_speed_clear: XOR trampoline"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
@@ -73,16 +73,18 @@ pub(super) const FS_SEED_HASH_DATA: usize    = 0x3E93D; // 40 bytes
 pub(super) const FS_INTRO_SKIP: usize        = 0x3E965; // 13 bytes
 pub(super) const FS_CARD_CLEAR: usize        = 0x3FFF0; // 26 bytes
 
-// PRG031 — start_airship_swap engine scaffolding. One 64-byte block split into
-// 4 × 8-byte per-world tables followed by two assembled subroutines. PRG031 is
-// always-mapped at $E000-$FFFF so Map_Init (PRG011) can JSR into it directly.
-pub(super) const FS_SAS_BLOCK: usize       = 0x3E281;       // 64 bytes total
-pub(super) const FS_SAS_X_TABLE: usize     = FS_SAS_BLOCK;       // 8 bytes — Mario X-low pixel per world
-pub(super) const FS_SAS_XHI_TABLE: usize   = FS_SAS_BLOCK + 8;   // 8 bytes — Mario screen index per world
-pub(super) const FS_SAS_SCRL_TABLE: usize  = FS_SAS_BLOCK + 16;  // 8 bytes — camera scroll low per world ($0722)
-pub(super) const FS_SAS_SCRH_TABLE: usize  = FS_SAS_BLOCK + 24;  // 8 bytes — camera scroll high per world ($0724)
-pub(super) const FS_SAS_X_HELPER: usize    = FS_SAS_BLOCK + 32;  // 10 bytes — writes Map_Entered_X / $7982
-pub(super) const FS_SAS_XHI_HELPER: usize  = FS_SAS_BLOCK + 42;  // 22 bytes — writes Map_Entered_XHi + death-respawn XHi + scroll seeds
+// PRG031 — start_airship_swap engine scaffolding. One 69-byte block split into
+// 4 × 8-byte per-world tables followed by three assembled subroutines. PRG031
+// is always-mapped at $E000-$FFFF so Map_Init / GameOver_TwirlToStart (PRG011)
+// can JSR into it directly.
+pub(super) const FS_SAS_BLOCK: usize             = 0x3E281;       // 69 bytes total
+pub(super) const FS_SAS_X_TABLE: usize           = FS_SAS_BLOCK;       // 8 bytes — Mario X-low pixel per world
+pub(super) const FS_SAS_XHI_TABLE: usize         = FS_SAS_BLOCK + 8;   // 8 bytes — Mario screen index per world
+pub(super) const FS_SAS_SCRL_TABLE: usize        = FS_SAS_BLOCK + 16;  // 8 bytes — camera scroll low per world ($0722)
+pub(super) const FS_SAS_SCRH_TABLE: usize        = FS_SAS_BLOCK + 24;  // 8 bytes — camera scroll high per world ($0724)
+pub(super) const FS_SAS_X_HELPER: usize          = FS_SAS_BLOCK + 32;  // 10 bytes — writes Map_Entered_X / $7982
+pub(super) const FS_SAS_XHI_HELPER: usize        = FS_SAS_BLOCK + 42;  // 22 bytes — writes Map_Entered_XHi + death-respawn XHi + scroll seeds
+pub(super) const FS_SAS_GAMEOVER_X_HELPER: usize = FS_SAS_BLOCK + 64;  // 5 bytes — A := A - FS_SAS_X_TABLE[Y]; RTS
 
 // Vanilla 8-byte Map_Y_Starts table (per-world Mario spawn Y-pixel). Lives in
 // PRG030's world-enter routine. The start_airship_swap module rewrites this
@@ -95,6 +97,14 @@ pub(super) const MAP_Y_STARTS_OFF: usize  = 0x3C39A;
 // loads from the FS_SAS_* tables instead of the vanilla inline immediates.
 pub(super) const MAP_INIT_X_LOW_SITE: usize  = 0x16257;   // 8 bytes — `LDA #$20 / STA $797A,X / STA $7982,X`
 pub(super) const MAP_INIT_SCROLL_SITE: usize = 0x1627E;   // 3 bytes — `STA $0724,X`
+
+// GameOver_TwirlToStart inline patch site in PRG011 (CPU $A5F1). Vanilla
+// hardcodes the spiral-back-to-start X target as column 2 (`SEC / SBC #$20`).
+// SAS replaces these 3 bytes with `JSR FS_SAS_GAMEOVER_X_HELPER` so the
+// delta is computed against the per-world X start instead. Y is preloaded
+// with World_Num two instructions earlier (`LDY $0727`) and isn't modified
+// before this site, so the helper can use `SBC FS_SAS_X_TABLE,Y` directly.
+pub(super) const GAMEOVER_TWIRL_X_SUB_SITE: usize = 0x16601;  // 3 bytes — `SEC / SBC #$20`
 
 // Map_Object slot 1 == the airship sprite per southbird's disassembly:
 // "NOTE: Assumes Index 1 is the Airship!"

--- a/src/randomize/start_airship_swap.rs
+++ b/src/randomize/start_airship_swap.rs
@@ -13,10 +13,10 @@
 //! and leaves the path tile intact — the relocated airship loses its
 //! decorative top half, but the world stays playable.
 //!
-//! The engine-side scaffolding (per-world camera + Mario-position tables, the
-//! two helper routines, Map_Init JSR patches, and Map_Object slot-1 sprite
-//! moves) is committed once at the tail of the writer via
-//! `write_engine_scaffolding`.
+//! The engine-side scaffolding (per-world camera + Mario-position tables,
+//! three helper routines, Map_Init + GameOver_TwirlToStart JSR patches, and
+//! Map_Object slot-1 sprite moves) is committed once at the tail of the
+//! writer via `write_engine_scaffolding`.
 //!
 //! Background and POC derivation: see `docs/start_airship_swap_findings.md`.
 
@@ -27,9 +27,10 @@ use crate::rom::Rom;
 use super::node_catalog::{NodeCatalog, NodeKind};
 use super::pipe_helpers::grid_pos_to_dest_nibbles;
 use super::rom_data::{
-    self, AIRSHIP_OBJ_SLOT, FS_SAS_SCRH_TABLE, FS_SAS_SCRL_TABLE, FS_SAS_X_HELPER,
-    FS_SAS_X_TABLE, FS_SAS_XHI_HELPER, FS_SAS_XHI_TABLE, Grid, MAP_INIT_SCROLL_SITE,
-    MAP_INIT_X_LOW_SITE, MAP_Y_STARTS_OFF, WORLDS,
+    self, AIRSHIP_OBJ_SLOT, FS_SAS_GAMEOVER_X_HELPER, FS_SAS_SCRH_TABLE, FS_SAS_SCRL_TABLE,
+    FS_SAS_X_HELPER, FS_SAS_X_TABLE, FS_SAS_XHI_HELPER, FS_SAS_XHI_TABLE,
+    GAMEOVER_TWIRL_X_SUB_SITE, Grid, MAP_INIT_SCROLL_SITE, MAP_INIT_X_LOW_SITE,
+    MAP_Y_STARTS_OFF, WORLDS,
 };
 
 // ---------------------------------------------------------------------------
@@ -177,8 +178,11 @@ pub(super) fn write_swapped_world_entries(rom: &mut Rom, world_idx: usize, catal
 /// Writes:
 ///   * `Map_Y_Starts` (vanilla 8-byte table at `MAP_Y_STARTS_OFF`)
 ///   * Four per-world tables in PRG031 free space (X, XHi, ScrL, ScrH)
-///   * Two helper subroutines (X-low setter, XHi + camera-scroll setter)
+///   * Three helper subroutines (X-low setter, XHi + camera-scroll setter,
+///     game-over-spiral X delta computer)
 ///   * `Map_Init` inline patches replaced with `JSR helper`
+///   * `GameOver_TwirlToStart` `SEC / SBC #$20` replaced with `JSR helper` so
+///     the spiral-back targets the per-world X instead of vanilla column 2
 ///   * Per-swapped-world `Map_Object` slot-1 sprite position move
 pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     let mut y_tbl = [0u8; 8];
@@ -257,6 +261,25 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     rom.write_range(
         MAP_INIT_SCROLL_SITE,
         &[0x20, (xhi_helper_cpu & 0xFF) as u8, (xhi_helper_cpu >> 8) as u8],
+    );
+
+    // GameOver_TwirlToStart computes the spiral-back X delta as
+    // `current_X - $20` (hardcoded column 2). In a swapped world the new
+    // start sits elsewhere, so the spiral lands Mario at column 2 of the
+    // right screen instead of the new start. Replace `SEC / SBC #$20`
+    // (3 bytes) with `JSR FS_SAS_GAMEOVER_X_HELPER`; the helper does
+    // `SEC / SBC FS_SAS_X_TABLE,Y / RTS` (Y is already World_Num here).
+    rom.set_tag("start_airship_swap/gameover_x");
+    let gameover_x_helper = [
+        0x38,                                                 // SEC
+        0xF9, (x_tbl_cpu & 0xFF) as u8, (x_tbl_cpu >> 8) as u8, // SBC FS_SAS_X_TABLE,Y
+        0x60,                                                 // RTS
+    ];
+    rom.write_range(FS_SAS_GAMEOVER_X_HELPER, &gameover_x_helper);
+    let gameover_helper_cpu = file_to_prg031_cpu(FS_SAS_GAMEOVER_X_HELPER);
+    rom.write_range(
+        GAMEOVER_TWIRL_X_SUB_SITE,
+        &[0x20, (gameover_helper_cpu & 0xFF) as u8, (gameover_helper_cpu >> 8) as u8],
     );
 
     rom.set_tag("start_airship_swap/slot1");


### PR DESCRIPTION
## Summary

- Pre-game-over death respawn was fixed in `fefe68a` (Map_Init re-stamps `\$7980`/`\$7982`).
- But full game over goes through `GameOver_TwirlToStart`, which computes the spiral-back X delta as `current_X - \$20` from a hardcoded immediate. Vanilla SMB3 always starts Mario at column 2, so the immediate matched the start in vanilla. In a swapped world the new start sits elsewhere, so the spiral landed Mario at column 2 of the right screen.
- Replace `SEC / SBC #\$20` (3 bytes at PRG011 file `0x16601`, CPU `\$A5F1`) with `JSR FS_SAS_GAMEOVER_X_HELPER`. New 5-byte helper in PRG031 does `SEC / SBC FS_SAS_X_TABLE,Y / RTS`; Y is already preloaded with World_Num two instructions earlier (`LDY \$0727`) and isn't modified before the patch site.
- `FS_SAS_BLOCK` grows 64 → 69 bytes.

For unswapped worlds (or W5/W8 excluded from SAS), `FS_SAS_X_TABLE[wi]` holds vanilla `\$20`, so the patched code subtracts `\$20` — byte-equivalent runtime behavior.

## Test plan

- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (all 204 tests pass)
- [ ] In-game verification: in a swapped world, game-over and confirm Mario spirals back to the new start (not column 2 of the start screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)