### PR TITLE
refactor(enemies): unify protection lists into LEVEL_PROTECTIONS registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.9"
+version = "0.8.10"
 edition = "2024"
 
 [lib]

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -2955,10 +2955,11 @@ small sub-area with **two BoomerangBros** as the fight reward.
 | Enemy contents | 2× `0x82` (BoomerangBro) + `0xBA` terminator (3 entries) |
 
 The sub-area has no world pointer table entry — it's reached only via the
-in-layout junction — so the randomizer protects it via
-`HAMMER_BRO_SEGMENT_OFFSETS` (file offset `0x0DA1F`) rather than via
-`HAMMER_BRO_OBJ_PTRS`. This routes its enemy randomization through the HB-wild
-path (stompable-only pool, optionally one shell-killable + one shell partner).
+in-layout junction — so the randomizer protects it via a `LevelProtection`
+row in `LEVEL_PROTECTIONS` (enemy_ptr `0xDA0F`, `walker_segment:
+WalkerSegmentRule::HammerBro`). This routes its enemy randomization through
+the HB-wild path (stompable-only pool, optionally one shell-killable + one
+shell partner).
 
 ### Enemy Stompability Classification
 

--- a/src/randomize/enemies.rs
+++ b/src/randomize/enemies.rs
@@ -421,7 +421,8 @@ const BIG_Q_BLOCKS: &[u8] = &[
 /// The W7 room is at enemy_ptr 0xC9A3; the Tanooki is the second entry.
 const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
-use super::rom_data::{HAMMER_BRO_ENEMY_PTRS, HAMMER_BRO_SEGMENT_OFFSETS, HAZARD_PROJECTILE_IDS, HAZARD_RESTRICTED_OFFSETS, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS, PROTECTED_ENEMY_OFFSETS, PROTECTED_ENEMY_PTRS, PROTECTED_ENEMY_SEGMENTS, SHELL_PROTECTED_OFFSETS, STOMPABLE_ENEMIES, STOMPABLE_PROTECTED_OFFSETS, TANK_BRO_POOL, TANK_BRO_PROTECTED_OFFSETS};
+use super::enemy_protections::{entry_protection_at, is_injection_blocked, walker_segment_rule_at, EntryProtection, WalkerSegmentRule};
+use super::rom_data::{HAZARD_PROJECTILE_IDS, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS, STOMPABLE_ENEMIES, TANK_BRO_POOL};
 
 /// Injection candidates for wild_injections mode: special enemies injected after
 /// normal swaps. CHR compatibility checked via `sprite_bank()` at filter time.
@@ -908,10 +909,7 @@ fn inject_at_entry_points<R: Rng>(
         if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&ep) {
             continue;
         }
-        if PROTECTED_ENEMY_PTRS.contains(&ep_u16) {
-            continue;
-        }
-        if HAMMER_BRO_ENEMY_PTRS.contains(&ep_u16) {
+        if is_injection_blocked(ep_u16) {
             continue;
         }
 
@@ -956,18 +954,19 @@ fn inject_at_entry_points<R: Rng>(
 
         let entry = &entries[0];
         let fo = ENEMY_DATA_START + entry.data_index;
-        // Skip if this position is touched by any class-specific "protected"
-        // handler in the walker pass. Those handlers run after this pass and
-        // force a class-pool pick regardless of what's there (e.g. 6-5's
-        // entry at 0xC5EB *must* stay a shell enemy so the player can break
-        // bricks for progression). Without this guard we'd happily write
-        // Lakitu only to have it stomped back to a shell by the class-swap
-        // walker — visible as a 34-event silent revert in the head-to-head
-        // diff before this guard was added.
-        let class_protected = PROTECTED_ENEMY_OFFSETS.contains(&fo)
-            || SHELL_PROTECTED_OFFSETS.contains(&fo)
-            || STOMPABLE_PROTECTED_OFFSETS.contains(&fo)
-            || TANK_BRO_PROTECTED_OFFSETS.contains(&fo);
+        // Skip if the walker pass would override or filter our pick: the four
+        // force-* rules silently replace the injected enemy with a class pool
+        // member (e.g. 6-5's shell at 0xC5EB must stay shell for brick-break
+        // progression), and ExcludeHazards would filter a Lakitu/Boss Bass
+        // back out (e.g. 7F2's Boom-Boom arena).
+        let class_protected = matches!(
+            entry_protection_at(fo),
+            Some(EntryProtection::SkipSwap
+                | EntryProtection::ForceShell
+                | EntryProtection::ForceStompable
+                | EntryProtection::ForceTankBro
+                | EntryProtection::ExcludeHazards)
+        );
         let swappable = !class_protected
             && find_class_pool(entry.obj_id, &normal_modes, &normal_wild_pool).is_some();
         if !swappable {
@@ -1058,17 +1057,17 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         let seg_file_offset = ENEMY_DATA_START + seg_start;
         i += 1;
 
-        // Skip entire segment if it's in the protected list
-        let skip_segment = PROTECTED_ENEMY_SEGMENTS.contains(&seg_file_offset);
-        if skip_segment {
+        let segment_rule = walker_segment_rule_at(seg_file_offset);
+
+        // Skip entire segment if it's protected
+        if segment_rule == WalkerSegmentRule::Skip {
             while i + 2 < data.len() && data[i] != 0xFF {
                 i += 3;
             }
             continue;
         }
 
-        // Determine if this is an HB encounter segment
-        let is_hb_segment = HAMMER_BRO_SEGMENT_OFFSETS.contains(&seg_file_offset);
+        let is_hb_segment = segment_rule == WalkerSegmentRule::HammerBro;
         let (modes, wild_pool, page_buckets) = if is_hb_segment {
             (&hb_modes, hb_wild_pool.as_slice(), &normal_page_buckets) // HB uses own wild path
         } else {
@@ -1132,6 +1131,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                 let entry = &entries[idx];
                 let file_offset = ENEMY_DATA_START + entry.data_index;
 
+                let protection = entry_protection_at(file_offset);
                 if big_q_only {
                     if BIG_Q_BLOCKS.contains(&entry.obj_id)
                         && file_offset != W7F1_TANOOKI_OFFSET
@@ -1140,19 +1140,19 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                     }
                 } else if BOOMBOOM_SWAP.contains(&data[entry.data_index]) {
                     data[entry.data_index] = *BOOMBOOM_SWAP.choose(rng).unwrap();
-                } else if PROTECTED_ENEMY_OFFSETS.contains(&file_offset) {
+                } else if protection == Some(EntryProtection::SkipSwap) {
                     commit_chr_page(entry.obj_id, &mut committed_slot4, &mut committed_slot5);
-                } else if SHELL_PROTECTED_OFFSETS.contains(&file_offset) && modes.shell != EnemyMode::Off {
+                } else if protection == Some(EntryProtection::ForceShell) && modes.shell != EnemyMode::Off {
                     if let Some(chosen) = pick_compatible(SHELL_ENEMIES, committed_slot4, committed_slot5, rng) {
                         swap_enemy(&mut data, entry.data_index, chosen);
                         commit_chr_page(chosen, &mut committed_slot4, &mut committed_slot5);
                     }
-                } else if TANK_BRO_PROTECTED_OFFSETS.contains(&file_offset) && modes.bros != EnemyMode::Off {
+                } else if protection == Some(EntryProtection::ForceTankBro) && modes.bros != EnemyMode::Off {
                     if let Some(chosen) = pick_compatible(TANK_BRO_POOL, committed_slot4, committed_slot5, rng) {
                         swap_enemy(&mut data, entry.data_index, chosen);
                         commit_chr_page(chosen, &mut committed_slot4, &mut committed_slot5);
                     }
-                } else if STOMPABLE_PROTECTED_OFFSETS.contains(&file_offset) {
+                } else if protection == Some(EntryProtection::ForceStompable) {
                     if let Some(pool) = find_class_pool(entry.obj_id, modes, wild_pool) {
                         let stompable_pool: Vec<u8> = pool.iter()
                             .copied()
@@ -1163,7 +1163,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                             commit_chr_page(chosen, &mut committed_slot4, &mut committed_slot5);
                         }
                     }
-                } else if HAZARD_RESTRICTED_OFFSETS.contains(&file_offset) {
+                } else if protection == Some(EntryProtection::ExcludeHazards) {
                     if let Some(pool) = find_class_pool(entry.obj_id, modes, wild_pool) {
                         let filtered_pool: Vec<u8> = pool.iter()
                             .copied()
@@ -1196,9 +1196,11 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                         chosen
                     };
                     // A piranha slot is often a pipe that's the only way
-                    // through the level. Never replace one with an upward-
-                    // firing hazard (Ptooie / Lava Lotus) — they cover the
-                    // pipe lip with continuous fire and can't be stomped.
+                    // through the level. Never replace one with a stationary
+                    // hazard (Ptooie / Lava Lotus / Thwomp) — Ptooie/Lotus
+                    // cover the pipe lip with continuous fire; a Thwomp drops
+                    // on the pipe entry/exit. Neither is fair at a forced
+                    // transit point, and none can be stomped.
                     let old_was_piranha = PIRANHAS.contains(&entry.obj_id)
                         || PIRANHASC.contains(&entry.obj_id);
                     let chosen = if old_was_piranha

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -1,0 +1,315 @@
+//! Per-level enemy protection registry.
+//!
+//! One labeled table (`LEVEL_PROTECTIONS`) per protected level or sub-area
+//! that the enemy randomization passes must treat specially. Each row
+//! identifies the level by `enemy_ptr` and declares:
+//!   - `walker_segment`: how the walker pass treats the containing $FF segment
+//!     (`Default`, `Skip`, or `HammerBro`). Non-`Default` rows also block
+//!     wild injection at this entry_ptr.
+//!   - `entries`: per-entry rules keyed by absolute file offset.
+//!
+//! Adding a new protection is one block here with a label and a reason.
+//! Both passes (the walker in `enemies::randomize_object_data` and
+//! `enemies::inject_at_entry_points`) consume the registry through the
+//! derived helpers (`entry_protection_at`, `is_injection_blocked`,
+//! `walker_segment_rule_at`) — never the table directly.
+
+use super::rom_data::enemy_ptr_to_file_offset;
+
+/// One logical level or sub-area with protections that affect enemy
+/// randomization.
+pub(super) struct LevelProtection {
+    // Reason: `label` is documentation embedded in the table — its value is
+    // grep-ability when investigating a protected offset.
+    #[allow(dead_code)]
+    pub label: &'static str,
+    pub enemy_ptr: u16,
+    pub walker_segment: WalkerSegmentRule,
+    pub entries: &'static [EntryRule],
+}
+
+/// How the walker treats the $FF-bounded segment containing this level's
+/// enemy_ptr.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum WalkerSegmentRule {
+    /// Default class-based swaps.
+    Default,
+    /// Skip the entire segment (no swaps at all). Only valid for top-level
+    /// entries whose enemy_ptr lands at the segment's page byte — NOT for
+    /// sub-area entries that share a segment with a parent level (skipping
+    /// would also block the parent's swaps).
+    Skip,
+    /// Hammer Bro encounter — walker uses HB-specific modes and pool.
+    HammerBro,
+}
+
+/// Per-entry rule attached to a specific 3-byte enemy entry by its absolute
+/// file offset.
+pub(super) struct EntryRule {
+    pub offset: usize,
+    pub rule: EntryProtection,
+}
+
+/// Per-entry behavior. The walker applies these inline during its swap pass;
+/// `inject_at_entry_points` also skips injection at any position carrying one
+/// of these (so wild injection can't bypass a per-entry safeguard).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum EntryProtection {
+    /// Walker skips this entry (pre-commits CHR page only).
+    SkipSwap,
+    /// Walker forces a pick from SHELL_ENEMIES when shell mode is on.
+    ForceShell,
+    /// Walker forces a pick from the entry's natural pool ∩ STOMPABLE_ENEMIES.
+    ForceStompable,
+    /// Walker forces a pick from TANK_BRO_POOL when bros mode is on.
+    ForceTankBro,
+    /// Walker excludes HAZARD_PROJECTILE_IDS from the chosen pool.
+    ExcludeHazards,
+}
+
+pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
+    // --- Whole-level skips ---
+    LevelProtection {
+        label: "3-2 (enemies-as-platforms, sprite-overload risk)",
+        enemy_ptr: 0xCA23,
+        walker_segment: WalkerSegmentRule::Skip,
+        entries: &[],
+    },
+
+    // --- Individual gameplay-critical entries (walker skips, no whole-level block) ---
+    LevelProtection {
+        label: "8-1 (Boo + FlyingRedParatroopa required for progression)",
+        enemy_ptr: 0xC424,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0C456, rule: EntryProtection::SkipSwap }, // Boo scr=5 col=1
+            EntryRule { offset: 0x0C465, rule: EntryProtection::SkipSwap }, // FlyingRedParatroopa scr=6 col=14
+        ],
+    },
+    LevelProtection {
+        label: "6-3 (FlyingRedParatroopas required as platforms)",
+        enemy_ptr: 0xCA8E,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0CAB1, rule: EntryProtection::SkipSwap }, // scr=6 col=13
+            EntryRule { offset: 0x0CAB4, rule: EntryProtection::SkipSwap }, // scr=7 col=1
+        ],
+    },
+
+    // --- Shell-locked entries (shells needed to break bricks for progression) ---
+    LevelProtection {
+        label: "2-Pyr sub-area (Buzzy Beetles needed to break bricks)",
+        enemy_ptr: 0xC5BC,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0C5CD, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5D0, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5D3, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5D6, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5DC, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5DF, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5E2, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5E5, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5E8, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5EB, rule: EntryProtection::ForceShell },
+            EntryRule { offset: 0x0C5F1, rule: EntryProtection::ForceShell },
+        ],
+    },
+    LevelProtection {
+        label: "2-3 (shells needed to break end-of-level bricks)",
+        enemy_ptr: 0xD1F0,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0D22B, rule: EntryProtection::ForceShell }, // GreenTroopa scr=8 col=11
+            EntryRule { offset: 0x0D22E, rule: EntryProtection::ForceShell }, // GreenTroopa scr=8 col=13
+        ],
+    },
+    LevelProtection {
+        label: "6-5 sub-area (shell needed for progression)",
+        enemy_ptr: 0xC5EB,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0C60E, rule: EntryProtection::ForceShell }, // GreenTroopa scr=4 col=10
+        ],
+    },
+
+    // --- Stompable-locked entries ---
+    LevelProtection {
+        label: "6-6 sub-area (floor spikes — non-stompable swap would corner player)",
+        enemy_ptr: 0xC64B,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0C6A7, rule: EntryProtection::ForceStompable }, // Spike scr=10 col=0
+            EntryRule { offset: 0x0C6AA, rule: EntryProtection::ForceStompable }, // Spike scr=10 col=6
+            EntryRule { offset: 0x0C6AD, rule: EntryProtection::ForceStompable }, // Spike scr=10 col=4
+        ],
+    },
+
+    // --- Bros-pool restriction (HammerBro fails to spawn in tileset 10) ---
+    LevelProtection {
+        label: "8-Tank sub-area (HammerBro fails to spawn in ts=10)",
+        enemy_ptr: 0xDA29,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0DA3A, rule: EntryProtection::ForceTankBro }, // BoomerangBro scr=0 col=12
+        ],
+    },
+
+    // --- Hazard-excluded entries (no Patooie/Lavalotus on player walking path) ---
+    LevelProtection {
+        label: "7F2 Boom-Boom sub-area (tight boss arena)",
+        enemy_ptr: 0xD45C,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0D46D, rule: EntryProtection::ExcludeHazards }, // Rotodisc CW scr=1 col=0
+            EntryRule { offset: 0x0D470, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=1 col=1
+            EntryRule { offset: 0x0D473, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=1 col=3
+            EntryRule { offset: 0x0D476, rule: EntryProtection::ExcludeHazards }, // Rotodisc CW scr=1 col=9
+            EntryRule { offset: 0x0D479, rule: EntryProtection::ExcludeHazards }, // Thwomp      scr=1 col=10
+        ],
+    },
+    LevelProtection {
+        label: "7-5 sub-area (open horizontal field — hazards at floor level unfair)",
+        enemy_ptr: 0xC171,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0C182, rule: EntryProtection::ExcludeHazards }, // ParatroopaGreenHop scr=0 col=12
+            EntryRule { offset: 0x0C185, rule: EntryProtection::ExcludeHazards }, // ParatroopaGreenHop scr=1 col=2
+            EntryRule { offset: 0x0C18E, rule: EntryProtection::ExcludeHazards }, // BobOmb             scr=2 col=5
+            EntryRule { offset: 0x0C191, rule: EntryProtection::ExcludeHazards }, // BobOmb             scr=2 col=7
+            EntryRule { offset: 0x0C194, rule: EntryProtection::ExcludeHazards }, // BobOmb             scr=2 col=9
+            EntryRule { offset: 0x0C1A0, rule: EntryProtection::ExcludeHazards }, // ParatroopaGreenHop scr=4 col=14
+            EntryRule { offset: 0x0C1A3, rule: EntryProtection::ExcludeHazards }, // ParatroopaGreenHop scr=5 col=1
+            EntryRule { offset: 0x0C1A6, rule: EntryProtection::ExcludeHazards }, // ParatroopaGreenHop scr=5 col=4
+        ],
+    },
+
+    // --- Hammer Bro encounters (walker uses HB modes; injection skips) ---
+    LevelProtection {
+        label: "W1 Hammer Bro",
+        enemy_ptr: 0xC72B,
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
+    },
+    LevelProtection {
+        label: "W2 Hammer Bro",
+        enemy_ptr: 0xD14D,
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
+    },
+    LevelProtection {
+        label: "W2 Hammer Bro (variant)",
+        enemy_ptr: 0xD142,
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
+    },
+    LevelProtection {
+        label: "W3/W5/W6/W7 Hammer Bro",
+        enemy_ptr: 0xC640,
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
+    },
+    LevelProtection {
+        label: "W4 Hammer Bro",
+        enemy_ptr: 0xD0EA,
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
+    },
+    LevelProtection {
+        label: "W8 Hammer Bro (uses 7-7 layout)",
+        enemy_ptr: 0xC03D,
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
+    },
+    LevelProtection {
+        label: "Coin Ship end-pipe (2-BoomerangBro fight)",
+        enemy_ptr: 0xDA0F,
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
+    },
+];
+
+/// Per-entry rule for the entry at this absolute file offset, if any.
+pub(super) fn entry_protection_at(file_offset: usize) -> Option<EntryProtection> {
+    LEVEL_PROTECTIONS
+        .iter()
+        .flat_map(|l| l.entries)
+        .find_map(|e| (e.offset == file_offset).then_some(e.rule))
+}
+
+/// True if `wild_injection` should not fire at this entry_ptr. Any row with a
+/// non-`Default` walker rule blocks injection too — `Skip` and `HammerBro`
+/// segments both override or replace the player-visible enemy choice.
+pub(super) fn is_injection_blocked(enemy_ptr: u16) -> bool {
+    LEVEL_PROTECTIONS
+        .iter()
+        .any(|l| l.enemy_ptr == enemy_ptr && l.walker_segment != WalkerSegmentRule::Default)
+}
+
+/// Walker rule for the segment whose page byte sits at this absolute file
+/// offset. Returns `Default` for unprotected segments.
+pub(super) fn walker_segment_rule_at(segment_file_offset: usize) -> WalkerSegmentRule {
+    LEVEL_PROTECTIONS
+        .iter()
+        .find(|l| l.walker_segment != WalkerSegmentRule::Default
+            && enemy_ptr_to_file_offset(l.enemy_ptr) == segment_file_offset)
+        .map_or(WalkerSegmentRule::Default, |l| l.walker_segment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn registry_entries_have_unique_offsets() {
+        // An offset must not carry two conflicting rules — the walker would
+        // take whichever rule entry_protection_at returns first, so duplicates
+        // silently change behavior.
+        let mut seen: HashSet<usize> = HashSet::new();
+        for level in LEVEL_PROTECTIONS {
+            for entry in level.entries {
+                assert!(
+                    seen.insert(entry.offset),
+                    "offset 0x{:05X} appears in multiple entries", entry.offset
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn registry_enemy_ptrs_are_unique() {
+        let mut seen: HashSet<u16> = HashSet::new();
+        for level in LEVEL_PROTECTIONS {
+            assert!(
+                seen.insert(level.enemy_ptr),
+                "enemy_ptr 0x{:04X} appears in multiple LevelProtection rows", level.enemy_ptr
+            );
+        }
+    }
+
+    #[test]
+    fn skip_segments_use_top_level_eps() {
+        // WalkerSegmentRule::Skip only makes sense at top-level enemy_ptrs
+        // (where the ep's file offset = a segment's page byte). Sub-area
+        // entry_ptrs land mid-segment, so "skip the segment" would also block
+        // the parent level's swaps. There's no cheap way to detect this without
+        // walking the ROM, but we can at least sanity-check that a Skip row's
+        // ep doesn't collide with any other row's per-entry offsets — if it
+        // did, that's a strong hint the Skip target is mid-segment.
+        let skip_eps: Vec<usize> = LEVEL_PROTECTIONS
+            .iter()
+            .filter(|l| l.walker_segment == WalkerSegmentRule::Skip)
+            .map(|l| enemy_ptr_to_file_offset(l.enemy_ptr))
+            .collect();
+        for level in LEVEL_PROTECTIONS {
+            for entry in level.entries {
+                assert!(
+                    !skip_eps.contains(&entry.offset),
+                    "per-entry offset 0x{:05X} collides with a Skip segment's ep — likely a sub-area mislabeled as top-level skip",
+                    entry.offset,
+                );
+            }
+        }
+    }
+}

--- a/src/randomize/mod.rs
+++ b/src/randomize/mod.rs
@@ -2,6 +2,7 @@ pub mod anchor_visuals;
 pub mod autoscroll;
 pub mod bowser_castle;
 pub mod enemies;
+pub mod enemy_protections;
 pub mod hand_rooms;
 pub mod hands_levels;
 pub mod items;

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -613,38 +613,6 @@ pub(super) const HB_EXCLUDE_OBJ_PTRS: &[u16] = &[
     0xC03D, // W8 — 7-7 layout
 ];
 
-/// File offsets of the enemy data segments for each Hammer Bro encounter obj_ptr.
-/// Computed as: 0x0C010 + (obj_ptr - 0xC000).
-/// Used by the enemy randomizer to detect HB encounter segments.
-///
-/// Includes the Coin Ship sub-area at 0xDA0F: when a wandering Hammer Bro
-/// transforms into a Coin Ship sprite, entering it loads an autoscroll ship
-/// level whose end-pipe junction targets this 2-BoomerangBro fight room.
-/// The room has no world pointer table entry — it's reached only via the
-/// junction in PRG023 — so it must be protected here, not via OBJ_PTRS.
-pub(super) const HAMMER_BRO_SEGMENT_OFFSETS: &[usize] = &[
-    0x0C73B, // 0xC72B — W1
-    0x0D15D, // 0xD14D — W2
-    0x0D152, // 0xD142 — W2 (variant)
-    0x0C650, // 0xC640 — W3, W5, W6, W7
-    0x0D0FA, // 0xD0EA — W4
-    0x0C04D, // 0xC03D — W8 (uses 7-7 layout)
-    0x0DA1F, // 0xDA0F — Coin Ship end-pipe 2-BoomerangBro fight
-];
-
-/// HB encounter enemy_ptr values — what level headers store, *not* the
-/// walker-segment offset. These mirror HAMMER_BRO_SEGMENT_OFFSETS but in
-/// the coordinate frame an entry-point-driven pass needs.
-pub(super) const HAMMER_BRO_ENEMY_PTRS: &[u16] = &[
-    0xC72B, // W1
-    0xD14D, // W2
-    0xD142, // W2 (variant)
-    0xC640, // W3, W5, W6, W7
-    0xD0EA, // W4
-    0xC03D, // W8 (uses 7-7 layout)
-    0xDA0F, // Coin Ship end-pipe 2-BoomerangBro fight
-];
-
 /// Stompable enemies — safe for single-enemy HB Wild segments and the default
 /// pool for 2-enemy segments. The player can always defeat these by jumping.
 pub(super) const STOMPABLE_ENEMIES: &[u8] = &[
@@ -899,7 +867,13 @@ pub(super) fn layout_file_offset(cpu_addr: u16, tileset: u8) -> Option<usize> {
 }
 
 /// ROM file offset of PRG006 enemy/object data base (CPU $C000).
-const ENEMY_DATA_FILE_BASE: usize = 0x0C010;
+pub(super) const ENEMY_DATA_FILE_BASE: usize = 0x0C010;
+
+/// Translate a CPU enemy-data pointer (`$C000..=$E00D`) to its absolute file
+/// offset.
+pub(super) fn enemy_ptr_to_file_offset(ep: u16) -> usize {
+    ENEMY_DATA_FILE_BASE + (ep as usize - 0xC000)
+}
 
 /// Enemy/object data block: 0x0BFD8..0x0E00D (exclusive end).
 /// Each level's enemy set is a sequence of segments separated by 0xFF.
@@ -908,88 +882,22 @@ const ENEMY_DATA_FILE_BASE: usize = 0x0C010;
 pub const ENEMY_DATA_START: usize = 0x0BFD8;
 pub const ENEMY_DATA_END: usize = 0x0E00D;
 
-/// Individual enemy offsets excluded from randomization.
-/// These specific enemies are required for gameplay (e.g., needed as platforms
-/// to make jumps, or positioned to enable required routes).
-pub(super) const PROTECTED_ENEMY_OFFSETS: &[usize] = &[
-    0x0C456, // 8-1 Boo (scr=5, col=1) — spawns on player; any non-passable swap forces a hit
-    0x0C465, // 8-1 FlyingRedParatroopa (scr=6, col=14) — needed to reach upper platform
-    0x0CAB1, // 6-3 FlyingRedParatroopa (scr=6, col=13) — needed for jump
-    0x0CAB4, // 6-3 FlyingRedParatroopa (scr=7, col=1) — needed for jump
-];
-
-/// Shell-class enemies at these offsets are forced to shuffle within SHELL_ENEMIES
-/// regardless of the shell mode (Shuffle or Wild). When shell is Off, these are
-/// untouched. Levels where shells are required to break bricks for progression.
-pub(super) const SHELL_PROTECTED_OFFSETS: &[usize] = &[
-    // 2-Pyr sub-area (enemy_ptr 0xC5BC): 10 Buzzy Beetles + 1 extra
-    0x0C5CD, // BuzzyBeetle scr=1 col=0 row=15
-    0x0C5D0, // BuzzyBeetle scr=1 col=3 row=2
-    0x0C5D3, // BuzzyBeetle scr=2 col=3 row=15
-    0x0C5D6, // BuzzyBeetle scr=2 col=5 row=9
-    0x0C5DC, // BuzzyBeetle scr=3 col=2 row=10
-    0x0C5DF, // BuzzyBeetle scr=3 col=4 row=9
-    0x0C5E2, // BuzzyBeetle scr=3 col=11 row=4
-    0x0C5E5, // BuzzyBeetle scr=4 col=0 row=15
-    0x0C5E8, // BuzzyBeetle scr=4 col=11 row=3
-    0x0C5EB, // BuzzyBeetle scr=4 col=14 row=6
-    0x0C5F1, // BuzzyBeetle scr=6 col=7 row=15
-    // 2-3 (obj 0xD1F0): shells needed to break bricks at end
-    0x0D22B, // GreenTroopa scr=8 col=11 row=3
-    0x0D22E, // GreenTroopa scr=8 col=13 row=3
-    // 6-5 sub-area (enemy_ptr 0xC5EB): shell needed for progression
-    0x0C60E, // GreenTroopa scr=4 col=10 row=8
-];
-
-/// 8-Tank sub-area bro: HammerBro (0x81) doesn't spawn in tileset 10.
-/// Must always shuffle within the non-HammerBro bro pool (0x82/0x86/0x87).
-pub(super) const TANK_BRO_PROTECTED_OFFSETS: &[usize] = &[
-    0x0DA3A, // BoomerangBro scr=0 col=12 row=7 (8-Tank sub-area, enemy_ptr 0xDA29)
-];
-
-/// Enemies at these offsets must remain stompable: the chosen replacement
-/// is the intersection of the enemy's normal pool (per current mode) with
-/// STOMPABLE_ENEMIES. Used at floor positions where a non-stompable swap
-/// would corner the player with no way to defeat the enemy.
-pub(super) const STOMPABLE_PROTECTED_OFFSETS: &[usize] = &[
-    // 6-6 sub-area (enemy_ptr 0xC64B): 3 spikes on the floor of screen 10
-    0x0C6A7, // Spike scr=10 col=0 row=15
-    0x0C6AA, // Spike scr=10 col=6 row=15
-    0x0C6AD, // Spike scr=10 col=4 row=15
-];
-
-/// Stationary upward-projectile hazards. In tight sub-areas (especially
-/// boss arenas) these create unfair encounters because they fire continuously
-/// with no telegraph and can't be stomped. The randomizer filters them out
-/// of the swap pool at `HAZARD_RESTRICTED_OFFSETS`, regardless of mode.
+/// Unstompable hazards that are unfair to introduce into tight sub-areas
+/// (especially boss arenas) or onto a player's walking path. Patooie/Lavalotus
+/// fire continuously with no telegraph; Thwomps drop or slide unpredictably
+/// when added on top of a designed encounter. The registry filters these
+/// out of the chosen swap pool at `EntryProtection::ExcludeHazards`
+/// positions, and they're also excluded from piranha-slot replacements
+/// (a pipe-lip swap to one of these covers or blocks the only way through).
 pub(super) const HAZARD_PROJECTILE_IDS: &[u8] = &[
     0x2A, // OBJ_PATOOIE (spits spikes upward)
     0x67, // OBJ_LAVALOTUS (spits fire in arcs)
-];
-
-/// Offsets where `HAZARD_PROJECTILE_IDS` must never land. The filter excludes
-/// those IDs from the chosen swap pool but otherwise leaves randomization
-/// alone — vanilla non-stompables (Thwomp, Rotodisc) stay put in Shuffle
-/// modes and only get swapped if their own class is Wild.
-pub(super) const HAZARD_RESTRICTED_OFFSETS: &[usize] = &[
-    // 7-F2 Boom-Boom sub-area (enemy_ptr 0xD45C): tight boss arena.
-    // Boom-Boom itself (0x4B) is never randomized, so not listed.
-    0x0D46D, // Rotodisc CW   scr=1 col=0  row=5
-    0x0D470, // DryBones      scr=1 col=1  row=8
-    0x0D473, // DryBones      scr=1 col=3  row=8
-    0x0D476, // Rotodisc CW   scr=1 col=9  row=5
-    0x0D479, // Thwomp        scr=1 col=10 row=15
-    // 7-5 sub-area (enemy_ptr 0xC171): horizontal open field; a Patooie/
-    // Lotus at floor level on the player's path covers walking ground
-    // with continuous upward fire and is unfair.
-    0x0C182, // ParatroopaGreenHop scr=0 col=12 row=9
-    0x0C185, // ParatroopaGreenHop scr=1 col=2  row=9
-    0x0C18E, // BobOmb             scr=2 col=5  row=9
-    0x0C191, // BobOmb             scr=2 col=7  row=9
-    0x0C194, // BobOmb             scr=2 col=9  row=9
-    0x0C1A0, // ParatroopaGreenHop scr=4 col=14 row=9
-    0x0C1A3, // ParatroopaGreenHop scr=5 col=1  row=9
-    0x0C1A6, // ParatroopaGreenHop scr=5 col=4  row=9
+    0x8A, // OBJ_THWOMP (standard drop)
+    0x8B, // OBJ_THWOMPLEFTSLIDE
+    0x8C, // OBJ_THWOMPRIGHTSLIDE
+    0x8D, // OBJ_THWOMPUPDOWN
+    0x8E, // OBJ_THWOMPDIAGONALUL
+    0x8F, // OBJ_THWOMPDIAGONALDL
 ];
 
 /// Bro enemies that work in tileset 10 (8-Tank sub-area).
@@ -1000,19 +908,6 @@ pub(super) const TANK_BRO_POOL: &[u8] = &[
     0x87, // OBJ_FIREBRO
 ];
 
-/// Enemy segments (by file offset of page flag byte) excluded from randomization.
-/// These levels rely on specific enemy types/counts for gameplay (e.g., enemies
-/// used as platforms in speedtech, where wrong types cause sprite overload).
-pub(super) const PROTECTED_ENEMY_SEGMENTS: &[usize] = &[
-    0x0CA33, // 3-2 (obj 0xCA23): enemies used as platforms, sprite overload risk
-];
-
-/// Protected enemy_ptr values — entry-point coordinate frame mirror of
-/// PROTECTED_ENEMY_SEGMENTS.
-pub(super) const PROTECTED_ENEMY_PTRS: &[u16] = &[
-    0xCA23, // 3-2
-];
-
 /// Check whether the first enemy data segment at `obj_ptr` contains `target_id`.
 ///
 /// Enemy data format: 1-byte page flag, then 3-byte entries `[id, x, y]`,
@@ -1021,7 +916,7 @@ pub(super) fn has_enemy_id(rom: &Rom, obj_ptr: u16, target_id: u8) -> bool {
     if obj_ptr < 0xC000 {
         return false;
     }
-    let file_off = ENEMY_DATA_FILE_BASE + (obj_ptr as usize - 0xC000);
+    let file_off = enemy_ptr_to_file_offset(obj_ptr);
     if file_off + 1 >= rom.data.len() {
         return false;
     }


### PR DESCRIPTION
## Summary

- Replaces nine parallel protection constants in `rom_data.rs` (`PROTECTED_ENEMY_OFFSETS`, `SHELL_PROTECTED_OFFSETS`, `STOMPABLE_PROTECTED_OFFSETS`, `TANK_BRO_PROTECTED_OFFSETS`, `HAZARD_RESTRICTED_OFFSETS`, `PROTECTED_ENEMY_SEGMENTS`, `PROTECTED_ENEMY_PTRS`, `HAMMER_BRO_SEGMENT_OFFSETS`, `HAMMER_BRO_ENEMY_PTRS`) with one labeled `LEVEL_PROTECTIONS` table in a new module `src/randomize/enemy_protections.rs`.
- Each row identifies a level by `enemy_ptr` and declares its walker rule + per-entry rules; both passes consume the registry through three helpers (`is_injection_blocked`, `walker_segment_rule_at`, `entry_protection_at`).
- Closes #4.

## Behavior changes

- **Wild injection now also skips `ExcludeHazards` positions.** Previously the walker filtered hazards out of swap pools but injection didn't, so a Lakitu/Angry Sun/Boss Bass could still land in 7F2's Boom-Boom arena or 7-5's open field. The registry collapses both passes onto the same per-entry rule list, closing the gap.
- **Thwomp variants (`0x8A`–`0x8F`) added to `HAZARD_PROJECTILE_IDS`** so they can't land at hazard-restricted positions or replace pipe-slot piranhas.

## Out of scope

- `W7F1_TANOOKI_OFFSET` (one-off in `big_q_only` mode) stays inline — it protects a level command in a separate randomizer mode, not an enemy class.
- `powerups.rs::PROTECTED_OFFSETS` (7-7 Q-star blocks) — different randomizer.

## Test plan

- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (all 207 tests pass)
- [x] Registry invariant tests cover unique-offset, unique-ep, and the "Skip segments use top-level eps" footgun
- [ ] In-game spot check of 7F2 with wild_injections on — confirm no Lakitu lands in Boom-Boom arena

🤖 Generated with [Claude Code](https://claude.com/claude-code)