### PR TITLE
fix(start_airship_swap): stamp start position at game-over twirl finalize

### DIFF
--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -33,7 +33,7 @@ const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x35572, 13, "mystery_anchor: item redirect trampoline"),
     (0x3557F, 50, "hammer_locks: tile check subroutine + tables"),
     (0x3E260, 33, "starting_items: lives + intro skip + menu music + inventory init trampoline"),
-    (0x3E281, 69, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + X helper + XHi helper + game-over X helper"),
+    (0x3E281, 64, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + X helper + XHi helper"),
     (0x3E965, 13, "title_screen: intro skip + menu music routine"),
     (0x3FFF0, 26, "card_speed_clear: XOR trampoline"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
@@ -45,7 +45,8 @@ const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x15554, 80, "fx_screen_check: cross-screen lock patch (Fred's algorithm verbatim)"),
     (0x15DF0, 35, "canoe_fix: death respawn position save"),
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
-    (0x17D00, 59, "canoe_fix: backup/restore subroutines"),
+    (0x17C87, 29, "start_airship_swap: game-over twirl finalize helper"),
+    (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
     // PRG001 (file 0x02010, CPU $A000–$BFFF)
     (0x0382A, 23, "koopa_hits: subroutine + defeat JMP + threshold table"),
     (0x03841, 13, "koopa_collision_guard: skip collision bitmap during invuln"),
@@ -73,18 +74,24 @@ pub(super) const FS_SEED_HASH_DATA: usize    = 0x3E93D; // 40 bytes
 pub(super) const FS_INTRO_SKIP: usize        = 0x3E965; // 13 bytes
 pub(super) const FS_CARD_CLEAR: usize        = 0x3FFF0; // 26 bytes
 
-// PRG031 — start_airship_swap engine scaffolding. One 69-byte block split into
-// 4 × 8-byte per-world tables followed by three assembled subroutines. PRG031
-// is always-mapped at $E000-$FFFF so Map_Init / GameOver_TwirlToStart (PRG011)
-// can JSR into it directly.
-pub(super) const FS_SAS_BLOCK: usize             = 0x3E281;       // 69 bytes total
+// PRG031 — start_airship_swap engine scaffolding. One 64-byte block: 4 × 8-byte
+// per-world tables followed by two assembled subroutines. PRG031 is always-mapped
+// at $E000-$FFFF so Map_Init / GameOver_TwirlToStart (PRG011) can read the tables
+// regardless of which bank is at $A000. NOTE: the PRG031 free run at 0x3E281 ends
+// at 0x3E2D0 (real code follows) — only ~79 bytes; do not grow this block past 64.
+pub(super) const FS_SAS_BLOCK: usize             = 0x3E281;       // 64 bytes total
 pub(super) const FS_SAS_X_TABLE: usize           = FS_SAS_BLOCK;       // 8 bytes — Mario X-low pixel per world
 pub(super) const FS_SAS_XHI_TABLE: usize         = FS_SAS_BLOCK + 8;   // 8 bytes — Mario screen index per world
 pub(super) const FS_SAS_SCRL_TABLE: usize        = FS_SAS_BLOCK + 16;  // 8 bytes — camera scroll low per world ($0722)
 pub(super) const FS_SAS_SCRH_TABLE: usize        = FS_SAS_BLOCK + 24;  // 8 bytes — camera scroll high per world ($0724)
 pub(super) const FS_SAS_X_HELPER: usize          = FS_SAS_BLOCK + 32;  // 10 bytes — writes Map_Entered_X / $7982
 pub(super) const FS_SAS_XHI_HELPER: usize        = FS_SAS_BLOCK + 42;  // 22 bytes — writes Map_Entered_XHi + death-respawn XHi + scroll seeds
-pub(super) const FS_SAS_GAMEOVER_X_HELPER: usize = FS_SAS_BLOCK + 64;  // 5 bytes — A := A - FS_SAS_X_TABLE[Y]; RTS
+
+// The game-over twirl finalize helper lives in PRG011 free space (not FS_SAS_BLOCK
+// — that PRG031 run has no room for 29 more bytes). PRG011 is the hook's own bank,
+// so the JSR is bank-local; the helper still reads the FS_SAS_* tables in
+// always-resident PRG031.
+pub(super) const FS_SAS_GAMEOVER_FINALIZE: usize = 0x17C87;  // PRG011, 29 bytes — stamps World_Map_X/XHi + scroll at twirl finalize (clean gap before FS_CANOE_BACKUP)
 
 // Vanilla 8-byte Map_Y_Starts table (per-world Mario spawn Y-pixel). Lives in
 // PRG030's world-enter routine. The start_airship_swap module rewrites this
@@ -98,13 +105,18 @@ pub(super) const MAP_Y_STARTS_OFF: usize  = 0x3C39A;
 pub(super) const MAP_INIT_X_LOW_SITE: usize  = 0x16257;   // 8 bytes — `LDA #$20 / STA $797A,X / STA $7982,X`
 pub(super) const MAP_INIT_SCROLL_SITE: usize = 0x1627E;   // 3 bytes — `STA $0724,X`
 
-// GameOver_TwirlToStart inline patch site in PRG011 (CPU $A5F1). Vanilla
-// hardcodes the spiral-back-to-start X target as column 2 (`SEC / SBC #$20`).
-// SAS replaces these 3 bytes with `JSR FS_SAS_GAMEOVER_X_HELPER` so the
-// delta is computed against the per-world X start instead. Y is preloaded
-// with World_Num two instructions earlier (`LDY $0727`) and isn't modified
-// before this site, so the helper can use `SBC FS_SAS_X_TABLE,Y` directly.
-pub(super) const GAMEOVER_TWIRL_X_SUB_SITE: usize = 0x16601;  // 3 bytes — `SEC / SBC #$20`
+// GameOver_TwirlToStart finalize hook in PRG011 (CPU $A6AA). The twirl is a
+// delta-animation: it spirals Mario back to the start by a per-frame X/Y delta,
+// then at finalize copies World_Map_X/XHi/Y into Map_Previous_*. The delta is
+// low-byte/within-screen only and has a second hardcoded column-2 ($20) for the
+// skid direction, so a swapped start on a different column/screen is unreachable
+// by patching the delta. Instead we let the vanilla animation play and STAMP the
+// correct start position at finalize: replace `STA Map_Prev_XHi2,X` (the last
+// store before the World_Map → Map_Previous copies) with `JSR finalize helper`,
+// which overwrites World_Map_X ($79,X) / World_Map_XHi ($77,X) and the camera
+// scroll ($0722/$0724,X) from the FS_SAS_* tables. The subsequent vanilla copies
+// then propagate the corrected position into Map_Previous_X/XHi.
+pub(super) const GAMEOVER_FINALIZE_SITE: usize = 0x166BA;  // 3 bytes — `STA $7988,X` (Map_Prev_XHi2,X)
 
 // Map_Object slot 1 == the airship sprite per southbird's disassembly:
 // "NOTE: Assumes Index 1 is the Airship!"

--- a/src/randomize/start_airship_swap.rs
+++ b/src/randomize/start_airship_swap.rs
@@ -27,9 +27,9 @@ use crate::rom::Rom;
 use super::node_catalog::{NodeCatalog, NodeKind};
 use super::pipe_helpers::grid_pos_to_dest_nibbles;
 use super::rom_data::{
-    self, AIRSHIP_OBJ_SLOT, FS_SAS_GAMEOVER_X_HELPER, FS_SAS_SCRH_TABLE, FS_SAS_SCRL_TABLE,
+    self, AIRSHIP_OBJ_SLOT, FS_SAS_GAMEOVER_FINALIZE, FS_SAS_SCRH_TABLE, FS_SAS_SCRL_TABLE,
     FS_SAS_X_HELPER, FS_SAS_X_TABLE, FS_SAS_XHI_HELPER, FS_SAS_XHI_TABLE,
-    GAMEOVER_TWIRL_X_SUB_SITE, Grid, MAP_INIT_SCROLL_SITE, MAP_INIT_X_LOW_SITE,
+    GAMEOVER_FINALIZE_SITE, Grid, MAP_INIT_SCROLL_SITE, MAP_INIT_X_LOW_SITE,
     MAP_Y_STARTS_OFF, WORLDS,
 };
 
@@ -178,11 +178,11 @@ pub(super) fn write_swapped_world_entries(rom: &mut Rom, world_idx: usize, catal
 /// Writes:
 ///   * `Map_Y_Starts` (vanilla 8-byte table at `MAP_Y_STARTS_OFF`)
 ///   * Four per-world tables in PRG031 free space (X, XHi, ScrL, ScrH)
-///   * Three helper subroutines (X-low setter, XHi + camera-scroll setter,
-///     game-over-spiral X delta computer)
+///   * Two PRG031 helper subroutines (X-low setter, XHi + camera-scroll setter)
+///     plus a PRG011 game-over finalize helper (stamps World_Map_X/XHi + scroll)
 ///   * `Map_Init` inline patches replaced with `JSR helper`
-///   * `GameOver_TwirlToStart` `SEC / SBC #$20` replaced with `JSR helper` so
-///     the spiral-back targets the per-world X instead of vanilla column 2
+///   * `GameOver_TwirlToStart` finalize store replaced with `JSR finalize` so
+///     the spiral lands on the per-world start instead of vanilla column 2
 ///   * Per-swapped-world `Map_Object` slot-1 sprite position move
 pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     let mut y_tbl = [0u8; 8];
@@ -263,23 +263,39 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
         &[0x20, (xhi_helper_cpu & 0xFF) as u8, (xhi_helper_cpu >> 8) as u8],
     );
 
-    // GameOver_TwirlToStart computes the spiral-back X delta as
-    // `current_X - $20` (hardcoded column 2). In a swapped world the new
-    // start sits elsewhere, so the spiral lands Mario at column 2 of the
-    // right screen instead of the new start. Replace `SEC / SBC #$20`
-    // (3 bytes) with `JSR FS_SAS_GAMEOVER_X_HELPER`; the helper does
-    // `SEC / SBC FS_SAS_X_TABLE,Y / RTS` (Y is already World_Num here).
-    rom.set_tag("start_airship_swap/gameover_x");
-    let gameover_x_helper = [
-        0x38,                                                 // SEC
-        0xF9, (x_tbl_cpu & 0xFF) as u8, (x_tbl_cpu >> 8) as u8, // SBC FS_SAS_X_TABLE,Y
-        0x60,                                                 // RTS
+    // GameOver_TwirlToStart spirals Mario back to the start via a per-frame X/Y
+    // delta, then at finalize copies World_Map_X/XHi/Y into Map_Previous_*. The
+    // delta is low-byte/within-screen only (and uses a second hardcoded column-2
+    // for the skid *direction*), so it can't be retargeted to a swapped start on
+    // a different column/screen by patching the delta. Instead we let the vanilla
+    // animation play and STAMP the correct position at finalize.
+    //
+    // Hook: replace `STA Map_Prev_XHi2,X` (the last store before the World_Map →
+    // Map_Previous copies; A = 0 there) with `JSR finalize`. The helper re-does
+    // the displaced store, then overwrites World_Map_X ($79,X) / World_Map_XHi
+    // ($77,X) and camera scroll ($0722/$0724,X) from the FS_SAS_* tables. The
+    // vanilla copies that follow then propagate the corrected X/XHi into
+    // Map_Previous_X/XHi, so the continue lands on the real start tile. Y is
+    // World_Num (re-loaded in the helper); X is Player_Current (live at the site).
+    rom.set_tag("start_airship_swap/gameover_finalize");
+    let finalize_helper = [
+        0x9D, 0x88, 0x79,                                            // STA $7988,X (displaced Map_Prev_XHi2,X, A=0)
+        0xAC, 0x27, 0x07,                                            // LDY World_Num ($0727)
+        0xB9, (x_tbl_cpu & 0xFF) as u8, (x_tbl_cpu >> 8) as u8,      // LDA FS_SAS_X_TABLE,Y
+        0x95, 0x79,                                                  // STA World_Map_X,X   ($79,X)
+        0xB9, (xhi_tbl_cpu & 0xFF) as u8, (xhi_tbl_cpu >> 8) as u8,  // LDA FS_SAS_XHI_TABLE,Y
+        0x95, 0x77,                                                  // STA World_Map_XHi,X ($77,X)
+        0xB9, (scrl_tbl_cpu & 0xFF) as u8, (scrl_tbl_cpu >> 8) as u8,// LDA FS_SAS_SCRL_TABLE,Y
+        0x9D, 0x22, 0x07,                                            // STA Map_Prev_XOff,X ($0722)
+        0xB9, (scrh_tbl_cpu & 0xFF) as u8, (scrh_tbl_cpu >> 8) as u8,// LDA FS_SAS_SCRH_TABLE,Y
+        0x9D, 0x24, 0x07,                                            // STA Map_Prev_XHi,X  ($0724)
+        0x60,                                                        // RTS
     ];
-    rom.write_range(FS_SAS_GAMEOVER_X_HELPER, &gameover_x_helper);
-    let gameover_helper_cpu = file_to_prg031_cpu(FS_SAS_GAMEOVER_X_HELPER);
+    rom.write_range(FS_SAS_GAMEOVER_FINALIZE, &finalize_helper);
+    let finalize_cpu = file_to_prg011_cpu(FS_SAS_GAMEOVER_FINALIZE);
     rom.write_range(
-        GAMEOVER_TWIRL_X_SUB_SITE,
-        &[0x20, (gameover_helper_cpu & 0xFF) as u8, (gameover_helper_cpu >> 8) as u8],
+        GAMEOVER_FINALIZE_SITE,
+        &[0x20, (finalize_cpu & 0xFF) as u8, (finalize_cpu >> 8) as u8],
     );
 
     rom.set_tag("start_airship_swap/slot1");
@@ -300,4 +316,11 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
 /// PRG031 file offset → CPU address. PRG031 is always mapped at $E000.
 fn file_to_prg031_cpu(file_off: usize) -> u16 {
     (0xE000 + (file_off - 0x3E010)) as u16
+}
+
+/// PRG011 file offset → CPU address. PRG011 is mapped at $A000 during the map
+/// (it owns Map_Init / GameOver_TwirlToStart), so a JSR from the game-over hook
+/// to a helper in the same bank is bank-local.
+fn file_to_prg011_cpu(file_off: usize) -> u16 {
+    (0xA000 + (file_off - 0x16010)) as u16
 }


### PR DESCRIPTION
## Summary

Fixes the start↔airship swap (SAS) game-over bug where, after a full game over in a swapped world, Mario always spiraled back to vanilla column 2 instead of the new start tile.

**Root cause:** `GameOver_TwirlToStart` is a *delta animation* — it moves Mario back to the start by a per-frame X/Y step. The X delta is low-byte/within-screen only and the skid *direction* uses a second hardcoded column-2 (`CMP #$20`), so retargeting the delta (the previous `SBC #$20` → table patch) can't reach a swapped start on a different column/screen.

**Fix:** revert the `SBC` instruction patch (back to vanilla `38 E9 20`) and instead **stamp the correct start at the twirl's finalize step**. The vanilla `STA Map_Prev_XHi2,X` at `0x166BA` (CPU `$A6AA`) is replaced with `JSR` to a 29-byte helper that:
- re-does the displaced store (A=0 there),
- writes `World_Map_X` (`$79,X`) and `World_Map_XHi` (`$77,X`) from the per-world tables,
- writes camera scroll `$0722`/`$0724,X` from the scroll tables.

The vanilla copies that follow propagate the corrected X/XHi into `Map_Previous_X/XHi`, so the continue lands on the real start tile on any screen. The spiral plays its graceful vanilla path and snaps to the start on the final frame. The helper stamps from the tables for every world, so unswapped worlds get their true vanilla start too.

**Placement:** the helper lives in PRG011 free space (`0x17C87`, bank-local to the hook) — *not* `FS_SAS_BLOCK`, whose PRG031 run ends at `0x3E2D0` (real code follows). An earlier attempt that grew the block into that code crashed.

**Also fixes a latent registry bug:** `CANOE_BACKUP_ROUTINE` is 66 bytes but was registered as 59 in `FREE_SPACE_ALLOCATIONS`; it overruns to `0x17D42`. Corrected to 66 so the overlap test guards that region (it silently clobbered an intermediate placement attempt).

## Test plan
- `cargo build` / `cargo clippy --all-targets`: clean
- `cargo test free_space`: overlap + registry tests pass
- Byte-verified in a generated ROM: hook = `JSR $BC77`, helper intact at `0x17C87`, PRG031 code and canoe routine both untouched, twirl site back to vanilla
- ⚠️ Still wants an in-emulator pass: game-over in a swapped world should land on the airship-start tile + correct screen/camera

🤖 Generated with [Claude Code](https://claude.com/claude-code)