### PR TITLE
β4 sub-area hazard protection + beta sub-area trace in rom_map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.11"
+version = "0.8.12"
 edition = "2024"
 
 [lib]

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -184,6 +184,20 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
         ],
     },
 
+    LevelProtection {
+        label: "β4 sub-area (narrow corridor — hazards on Buzzy Beetle path unfair)",
+        enemy_ptr: 0xC7A7,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0C7B8, rule: EntryProtection::ExcludeHazards }, // BuzzyBeatle scr=1 col=2
+            EntryRule { offset: 0x0C7BB, rule: EntryProtection::ExcludeHazards }, // BuzzyBeatle scr=1 col=5
+            EntryRule { offset: 0x0C7BE, rule: EntryProtection::ExcludeHazards }, // BuzzyBeatle scr=1 col=9
+            EntryRule { offset: 0x0C7CA, rule: EntryProtection::ExcludeHazards }, // BuzzyBeatle scr=2 col=11
+            EntryRule { offset: 0x0C7CD, rule: EntryProtection::ExcludeHazards }, // BuzzyBeatle scr=3 col=2
+            EntryRule { offset: 0x0C7D0, rule: EntryProtection::ExcludeHazards }, // BuzzyBeatle scr=3 col=4
+        ],
+    },
+
     // --- Hammer Bro encounters (walker uses HB modes; injection skips) ---
     LevelProtection {
         label: "W1 Hammer Bro",

--- a/tools/rom_map.py
+++ b/tools/rom_map.py
@@ -2633,12 +2633,73 @@ def parse_enemy_entries(rom, obj_cpu_ptr):
     return entries
 
 
+def _render_enemy_lines(enemies):
+    """Format parsed enemies into indented display lines (offset, name, tags)."""
+    out = []
+    for e in enemies:
+        name = e.get("name", f"0x{e['obj_id']:02X}")
+        cls = e.get("class", "")
+        boss = e.get("boss", "")
+        tags = []
+        if cls:
+            tags.append(f"class:{cls}")
+        if boss:
+            tags.append(f"{RED}BOSS:{boss}{RESET}")
+        tag_str = f"  ({', '.join(tags)})" if tags else ""
+        out.append(f"    0x{e['offset']:05X}: {name} "
+                   f"scr={e['screen']} col={e['x_col']} row={e['y_row']}"
+                   f"{tag_str}")
+    return out
+
+
+def trace_beta_sub_areas(rom, main_lay_off):
+    """Follow a beta level's alt-area chain from its main header.
+
+    Each area's 9-byte header points (alt_layout/alt_objects/alt_tileset) at the
+    NEXT area, exactly as the engine loads a sub-area when Mario takes a pipe or
+    door. Area N's enemies come from area N-1's header `alt_objects`. We walk the
+    chain, seeding the visited set with the main layout offset so an alt pointer
+    that loops back to the main area (the common "no sub-area" encoding) stops
+    the trace. Returns a list of dicts for each sub-area (index >= 1):
+        {idx, lay_off, enemy_ptr, screens, tileset, enemies}
+    """
+    subs = []
+    if main_lay_off is None or main_lay_off + 9 > len(rom):
+        return subs
+    visited = {main_lay_off}
+    hdr = parse_level_header(rom, main_lay_off)
+    next_lay, next_obj, next_ts = hdr["alt_layout"], hdr["alt_objects"], hdr["alt_tileset"]
+    idx = 1
+    while idx <= 8:  # depth guard; real chains are 1-2 deep
+        if next_lay < 0xA000:
+            break
+        lay_off = layout_file_offset(next_lay, next_ts)
+        if lay_off is None or lay_off + 9 > len(rom) or lay_off in visited:
+            break
+        visited.add(lay_off)
+        sub_hdr = parse_level_header(rom, lay_off)
+        enemies = parse_enemy_entries(rom, next_obj) if next_obj >= 0xC000 else []
+        subs.append({
+            "idx": idx,
+            "lay_off": lay_off,
+            "enemy_ptr": next_obj,
+            "screens": sub_hdr["screens"],
+            "tileset": next_ts,
+            "enemies": enemies,
+        })
+        next_lay, next_obj, next_ts = (
+            sub_hdr["alt_layout"], sub_hdr["alt_objects"], sub_hdr["alt_tileset"])
+        idx += 1
+    return subs
+
+
 def _render_beta_entry(rom, cname, entry):
     """Render the lookup output for a beta (unreferenced) level.
 
-    Beta levels lack a pointer-table slot, world position, sub-area trace,
-    and powerup index. We show identity, header, enemies (from the borrowed
-    obj_ptr), and any BETA_PATCHES that target this layout.
+    Beta levels lack a pointer-table slot, world position, and powerup index.
+    We show identity, header, main-area enemies (from the borrowed obj_ptr),
+    sub-area enemies (traced through the header's alt_layout/alt_objects chain),
+    and any BETA_PATCHES that target this layout.
     """
     obj = entry["obj_ptr"]
     lay = entry["lay_ptr"]
@@ -2676,26 +2737,26 @@ def _render_beta_entry(rom, cname, entry):
         except Exception:
             pass
 
-    # Enemies
+    # Main-area enemies (from the borrowed pointer-table obj_ptr)
     enemies = parse_enemy_entries(rom, obj)
     lines.append("")
     lines.append(f"  {WHITE}Enemies (obj 0x{obj:04X}, {len(enemies)} entries):{RESET}")
     if enemies:
-        for e in enemies:
-            name = e.get("name", f"0x{e['obj_id']:02X}")
-            cls = e.get("class", "")
-            boss = e.get("boss", "")
-            tags = []
-            if cls:
-                tags.append(f"class:{cls}")
-            if boss:
-                tags.append(f"{RED}BOSS:{boss}{RESET}")
-            tag_str = f"  ({', '.join(tags)})" if tags else ""
-            lines.append(f"    0x{e['offset']:05X}: {name} "
-                         f"scr={e['screen']} col={e['x_col']} row={e['y_row']}"
-                         f"{tag_str}")
+        lines.extend(_render_enemy_lines(enemies))
     else:
         lines.append("    (none)")
+
+    # Sub-areas (trace the header's alt_layout/alt_objects chain, like the engine)
+    if lay_off is not None:
+        for sa in trace_beta_sub_areas(rom, lay_off):
+            lines.append("")
+            lines.append(f"  {WHITE}Sub-area {sa['idx']} "
+                         f"(enemy_ptr 0x{sa['enemy_ptr']:04X}, ts{sa['tileset']}, "
+                         f"{sa['screens']} screens, {len(sa['enemies'])} enemies):{RESET}")
+            if sa["enemies"]:
+                lines.extend(_render_enemy_lines(sa["enemies"]))
+            else:
+                lines.append("    (none)")
 
     # BETA_PATCHES for this entry's layout range
     patches = beta_patches_for_entry(entry)


### PR DESCRIPTION
## Summary
- Add an `ExcludeHazards` protection for the first 6 Buzzy Beetles in β4's sub-area (`enemy_ptr 0xC7A7`) — a narrow corridor where a stationary hazard swap (Ptooie / Lava Lotus / Thwomp) would be unfair. Same rule already used for 7-5 and the 7F2 arena.
- Fix the `/level` diagnostic (`tools/rom_map.py`) so it follows a beta level's `alt_layout`/`alt_objects` header chain — the way the engine loads sub-areas. Beta content living in a sub-area (e.g. β4's 22 enemies, including all its piranhas) was previously hidden because the renderer only read the borrowed main `obj_ptr`.
- Bump version to 0.8.12.

## Testing
- `cargo test` — 209 + 1 + 2 pass, 0 fail
- `cargo clippy --all-targets` — clean
- Verified `/level beta-1..9` trace cleanly (no cycles/crashes; β5 correctly shows no sub-area)

🤖 Generated with [Claude Code](https://claude.com/claude-code)