### PR TITLE
fix(qol): roaming bros don't rest on hand-trap tiles (#14)

### DIFF
--- a/src/randomize/qol.rs
+++ b/src/randomize/qol.rs
@@ -3,6 +3,7 @@ use super::rom_data::{
     BETA_PATCHES,
     FS_BIG_Q_LOOKUP as BIG_Q_ROUTINE_OFFSET,
     FS_BIG_Q_SAVE as BIG_Q_PRG030_OFFSET,
+    FS_BROS_NO_HANDS,
     FS_CANOE_BACKUP,
     FS_CANOE_RESPAWN,
     FS_CARD_CLEAR as CARD_TRAMPOLINE,
@@ -602,6 +603,38 @@ const HOTFOOT_TAIL_A: usize = 0x0413C;
 const HOTFOOT_TAIL_B: usize = 0x04151;
 const HOTFOOT_TAIL_C: usize = 0x0814D;
 
+// Bros don't stop on hands (by MaCobra52) — fixes issue #14. Roaming
+// overworld bros decide where they may rest via the object-movement level
+// gate at PRG011 $B425 (`CMP $7E98,Y`), the sprite-side twin of the player
+// level gate. It reuses the shared per-palette-page threshold table
+// ($7E98,Y); a tile at-or-above its page threshold is a level slot the bro
+// won't rest on, below-threshold tiles are plain path it can settle on.
+// HANDTRAP tile 0xE6 sits just *below* the page-3 threshold (0xE9), so a
+// wandering bro treats it as plain path and can come to rest on a hand-trap
+// slot — colliding the two encounters (one clears the other).
+//
+// The fix replaces the inline `CMP $7E98,Y` at the gate with a JSR to an
+// 8-byte helper in PRG011 free space (FS_BROS_NO_HANDS, CPU $BD42) that
+// forces 0xE6 to read as gated and otherwise performs the identical compare:
+//
+//   CMP #$E6     ; hand-trap tile?
+//   BEQ +3       ; yes -> return with carry SET (gated), skipping the compare
+//   CMP $7E98,Y  ; no  -> vanilla threshold compare (flags identical)
+//   RTS          ; RTS preserves flags; A/X/Y untouched
+//
+// So 0xE6 now behaves like a normal uncompleted level tile to roaming bros:
+// they may walk *over* it but never rest on it. Completed hand-traps are
+// rewritten to a checkmark tile (already above-threshold), so they act as a
+// barrier with no extra work — matching issue #14's desired behavior.
+//
+// MaCobra's standalone IPS placed the helper at CPU $BC80 (file 0x17C90),
+// which collides with our FS_SAS_GAMEOVER_FINALIZE allocation (0x17C87); it
+// is relocated here to FS_BROS_NO_HANDS. Only the JSR operand changes with
+// the relocation; the helper bytes are position-independent.
+const BROS_NO_HANDS_HOOK: usize = 0x17435; // CPU $B425, vanilla `CMP $7E98,Y`
+const BROS_NO_HANDS_JSR: [u8; 3] = [0x20, 0x42, 0xBD]; // JSR $BD42
+const BROS_NO_HANDS_SUB: [u8; 8] = [0xC9, 0xE6, 0xF0, 0x03, 0xD9, 0x98, 0x7E, 0x60];
+
 // ---------------------------------------------------------------------------
 // MaCobra patches — opt-in features
 // Each apply_* below is gated by an individual option in randomizer.rs;
@@ -827,6 +860,10 @@ pub fn apply_macobra_patches(rom: &mut Rom) {
     rom.write_byte(HOTFOOT_TAIL_A, 0x00);
     rom.write_byte(HOTFOOT_TAIL_B, 0x00);
     rom.write_byte(HOTFOOT_TAIL_C, 0x25);
+
+    // Roaming bros don't rest on hand-trap tiles (0xE6). Fixes issue #14.
+    rom.write_range(BROS_NO_HANDS_HOOK, &BROS_NO_HANDS_JSR);
+    rom.write_range(FS_BROS_NO_HANDS, &BROS_NO_HANDS_SUB);
 }
 
 #[cfg(test)]
@@ -1013,6 +1050,30 @@ mod tests {
         assert_eq!(rom.read_byte(HOTFOOT_TAIL_A), 0x00);
         assert_eq!(rom.read_byte(HOTFOOT_TAIL_B), 0x00);
         assert_eq!(rom.read_byte(HOTFOOT_TAIL_C), 0x25);
+    }
+
+    #[test]
+    fn test_macobra_bros_no_hands_writes() {
+        let mut rom = make_test_rom();
+        apply_macobra_patches(&mut rom);
+
+        // Hook rewritten to JSR the relocated helper.
+        assert_eq!(
+            rom.read_range(BROS_NO_HANDS_HOOK, BROS_NO_HANDS_JSR.len()),
+            &BROS_NO_HANDS_JSR
+        );
+        // Helper landed in PRG011 free space.
+        assert_eq!(
+            rom.read_range(FS_BROS_NO_HANDS, BROS_NO_HANDS_SUB.len()),
+            &BROS_NO_HANDS_SUB
+        );
+        // JSR operand must point at FS_BROS_NO_HANDS (CPU $BD42, bank-local).
+        let cpu = 0xA000 + (FS_BROS_NO_HANDS - 0x16000);
+        assert_eq!(BROS_NO_HANDS_JSR[1], (cpu & 0xFF) as u8);
+        assert_eq!(BROS_NO_HANDS_JSR[2], (cpu >> 8) as u8);
+        // Helper preserves vanilla behavior for non-hand tiles: its tail is the
+        // original `CMP $7E98,Y` (D9 98 7E) the hook replaced.
+        assert_eq!(&BROS_NO_HANDS_SUB[4..7], &[0xD9, 0x98, 0x7E]);
     }
 
     #[test]

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -47,6 +47,7 @@ const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
     (0x17C87, 29, "start_airship_swap: game-over twirl finalize helper"),
     (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
+    (0x17D42, 8, "bros_no_hands: hand-trap tile bypass for overworld bro movement gate"),
     // PRG001 (file 0x02010, CPU $A000–$BFFF)
     (0x0382A, 23, "koopa_hits: subroutine + defeat JMP + threshold table"),
     (0x03841, 13, "koopa_collision_guard: skip collision bitmap during invuln"),
@@ -131,6 +132,10 @@ pub(super) const FS_CANOE_RESPAWN: usize     = 0x15DF0; // 35 bytes
 
 // PRG011
 pub(super) const FS_CANOE_BACKUP: usize      = 0x17D00; // 59 bytes
+// 8-byte hand-trap bypass subroutine for the overworld bro movement gate
+// (MaCobra52's "Bros don't stop on hands"). CPU $BD42. Sits just past the
+// 66-byte FS_CANOE_BACKUP reservation; the gate hook at $B425 JSRs here.
+pub(super) const FS_BROS_NO_HANDS: usize     = 0x17D42; // 8 bytes (CPU $BD42)
 
 // PRG026 (cont.)
 pub(super) const FS_MYSTERY_ANCHOR: usize    = 0x35572; // 13 bytes


### PR DESCRIPTION
## Summary

Fixes #14 — roaming overworld bros could come to rest on hand-trap (`0xE6`) tiles, colliding the bro and hand-trap encounters so completing one silently cleared the other.

Roaming bros decide where they may rest via the **object-movement level gate** at PRG011 `$B425` (`CMP $7E98,Y`) — the sprite-side twin of the player level gate, keyed on the shared per-palette-page threshold table (`$7E98,Y`). A tile at-or-above its page threshold is a level slot the bro won't rest on; below-threshold tiles are plain path it can settle on. HANDTRAP `0xE6` sits just *below* the page-3 threshold (`0xE9`), so a wandering bro treats it as plain path.

This ports MaCobra52's **"Bros don't stop on hands"**: the inline compare at the gate is replaced with a `JSR` to an 8-byte helper that forces `0xE6` to read as **gated** and otherwise runs the identical `CMP $7E98,Y` (flags preserved for every other tile):

```
CMP #$E6     ; hand-trap tile?
BEQ +3       ; yes -> return with carry SET (gated), skip the compare
CMP $7E98,Y  ; no  -> vanilla threshold compare
RTS          ; preserves flags; A/X/Y untouched
```

Now `0xE6` behaves like a normal uncompleted level tile to roaming bros: they may walk **over** it but never **rest** on it (desired-behavior #1). Completed hand-traps are rewritten to a checkmark tile that is already above-threshold, so they act as a barrier with no extra work (desired-behavior #2).

It's a **true no-op** when no hand tile is reachable (only `0xE6` diverges from vanilla), so it ships **always-on** in the MaCobra bundle rather than gated on `hands_levels`.

## Relocation

MaCobra's standalone IPS placed the helper at CPU `$BC80` (file `0x17C90`), which **collides** with our `FS_SAS_GAMEOVER_FINALIZE` allocation (`0x17C87`, 29 B). Relocated to a freshly registered `FS_BROS_NO_HANDS` (`0x17D42` / CPU `$BD42`), just past the `FS_CANOE_BACKUP` reservation. Only the `JSR` operand changes with the relocation; the helper bytes are position-independent.

## Testing

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 213 passed (incl. the free-space overlap test, which now covers the new allocation); new `test_macobra_bros_no_hands_writes` asserts the hook JSR, the helper bytes, the bank-local JSR operand, and that the helper's tail is the original `CMP $7E98,Y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)