### PR TITLE
fix(qol): reland bros-no-hands with corrected JSR target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.12"
+version = "0.8.13"
 edition = "2024"
 
 [lib]

--- a/src/randomize/qol.rs
+++ b/src/randomize/qol.rs
@@ -10,6 +10,7 @@ use super::rom_data::{
     FS_FASTER_FROG,
     FS_HAMMER_LOCKS,
     FS_STARTING_ITEMS,
+    jsr_into_bank,
 };
 
 /// Starting lives value byte (LDA #imm operand).
@@ -629,10 +630,10 @@ const HOTFOOT_TAIL_C: usize = 0x0814D;
 //
 // MaCobra's standalone IPS placed the helper at CPU $BC80 (file 0x17C90),
 // which collides with our FS_SAS_GAMEOVER_FINALIZE allocation (0x17C87); it
-// is relocated here to FS_BROS_NO_HANDS. Only the JSR operand changes with
-// the relocation; the helper bytes are position-independent.
+// is relocated here to FS_BROS_NO_HANDS. The JSR operand is derived from the
+// helper's file offset via `jsr_into_bank` (never hand-written) so it can't
+// drift from where the helper bytes actually land — see issue #14.
 const BROS_NO_HANDS_HOOK: usize = 0x17435; // CPU $B425, vanilla `CMP $7E98,Y`
-const BROS_NO_HANDS_JSR: [u8; 3] = [0x20, 0x32, 0xBD]; // JSR $BD32 (file 0x17D42)
 const BROS_NO_HANDS_SUB: [u8; 8] = [0xC9, 0xE6, 0xF0, 0x03, 0xD9, 0x98, 0x7E, 0x60];
 
 // ---------------------------------------------------------------------------
@@ -862,7 +863,9 @@ pub fn apply_macobra_patches(rom: &mut Rom) {
     rom.write_byte(HOTFOOT_TAIL_C, 0x25);
 
     // Roaming bros don't rest on hand-trap tiles (0xE6). Fixes issue #14.
-    rom.write_range(BROS_NO_HANDS_HOOK, &BROS_NO_HANDS_JSR);
+    // FS_BROS_NO_HANDS lives in PRG011 (bank 11); derive the JSR operand from
+    // its file offset so the hook can never point past the helper.
+    rom.write_range(BROS_NO_HANDS_HOOK, &jsr_into_bank(11, FS_BROS_NO_HANDS));
     rom.write_range(FS_BROS_NO_HANDS, &BROS_NO_HANDS_SUB);
 }
 
@@ -1057,11 +1060,6 @@ mod tests {
         let mut rom = make_test_rom();
         apply_macobra_patches(&mut rom);
 
-        // Hook rewritten to JSR the relocated helper.
-        assert_eq!(
-            rom.read_range(BROS_NO_HANDS_HOOK, BROS_NO_HANDS_JSR.len()),
-            &BROS_NO_HANDS_JSR
-        );
         // Helper landed in PRG011 free space.
         assert_eq!(
             rom.read_range(FS_BROS_NO_HANDS, BROS_NO_HANDS_SUB.len()),

--- a/src/randomize/qol.rs
+++ b/src/randomize/qol.rs
@@ -3,6 +3,7 @@ use super::rom_data::{
     BETA_PATCHES,
     FS_BIG_Q_LOOKUP as BIG_Q_ROUTINE_OFFSET,
     FS_BIG_Q_SAVE as BIG_Q_PRG030_OFFSET,
+    FS_BROS_NO_HANDS,
     FS_CANOE_BACKUP,
     FS_CANOE_RESPAWN,
     FS_CARD_CLEAR as CARD_TRAMPOLINE,
@@ -602,6 +603,38 @@ const HOTFOOT_TAIL_A: usize = 0x0413C;
 const HOTFOOT_TAIL_B: usize = 0x04151;
 const HOTFOOT_TAIL_C: usize = 0x0814D;
 
+// Bros don't stop on hands (by MaCobra52) — fixes issue #14. Roaming
+// overworld bros decide where they may rest via the object-movement level
+// gate at PRG011 $B425 (`CMP $7E98,Y`), the sprite-side twin of the player
+// level gate. It reuses the shared per-palette-page threshold table
+// ($7E98,Y); a tile at-or-above its page threshold is a level slot the bro
+// won't rest on, below-threshold tiles are plain path it can settle on.
+// HANDTRAP tile 0xE6 sits just *below* the page-3 threshold (0xE9), so a
+// wandering bro treats it as plain path and can come to rest on a hand-trap
+// slot — colliding the two encounters (one clears the other).
+//
+// The fix replaces the inline `CMP $7E98,Y` at the gate with a JSR to an
+// 8-byte helper in PRG011 free space (FS_BROS_NO_HANDS, CPU $BD32) that
+// forces 0xE6 to read as gated and otherwise performs the identical compare:
+//
+//   CMP #$E6     ; hand-trap tile?
+//   BEQ +3       ; yes -> return with carry SET (gated), skipping the compare
+//   CMP $7E98,Y  ; no  -> vanilla threshold compare (flags identical)
+//   RTS          ; RTS preserves flags; A/X/Y untouched
+//
+// So 0xE6 now behaves like a normal uncompleted level tile to roaming bros:
+// they may walk *over* it but never rest on it. Completed hand-traps are
+// rewritten to a checkmark tile (already above-threshold), so they act as a
+// barrier with no extra work — matching issue #14's desired behavior.
+//
+// MaCobra's standalone IPS placed the helper at CPU $BC80 (file 0x17C90),
+// which collides with our FS_SAS_GAMEOVER_FINALIZE allocation (0x17C87); it
+// is relocated here to FS_BROS_NO_HANDS. Only the JSR operand changes with
+// the relocation; the helper bytes are position-independent.
+const BROS_NO_HANDS_HOOK: usize = 0x17435; // CPU $B425, vanilla `CMP $7E98,Y`
+const BROS_NO_HANDS_JSR: [u8; 3] = [0x20, 0x32, 0xBD]; // JSR $BD32 (file 0x17D42)
+const BROS_NO_HANDS_SUB: [u8; 8] = [0xC9, 0xE6, 0xF0, 0x03, 0xD9, 0x98, 0x7E, 0x60];
+
 // ---------------------------------------------------------------------------
 // MaCobra patches — opt-in features
 // Each apply_* below is gated by an individual option in randomizer.rs;
@@ -827,6 +860,10 @@ pub fn apply_macobra_patches(rom: &mut Rom) {
     rom.write_byte(HOTFOOT_TAIL_A, 0x00);
     rom.write_byte(HOTFOOT_TAIL_B, 0x00);
     rom.write_byte(HOTFOOT_TAIL_C, 0x25);
+
+    // Roaming bros don't rest on hand-trap tiles (0xE6). Fixes issue #14.
+    rom.write_range(BROS_NO_HANDS_HOOK, &BROS_NO_HANDS_JSR);
+    rom.write_range(FS_BROS_NO_HANDS, &BROS_NO_HANDS_SUB);
 }
 
 #[cfg(test)]
@@ -1013,6 +1050,51 @@ mod tests {
         assert_eq!(rom.read_byte(HOTFOOT_TAIL_A), 0x00);
         assert_eq!(rom.read_byte(HOTFOOT_TAIL_B), 0x00);
         assert_eq!(rom.read_byte(HOTFOOT_TAIL_C), 0x25);
+    }
+
+    #[test]
+    fn test_macobra_bros_no_hands_writes() {
+        let mut rom = make_test_rom();
+        apply_macobra_patches(&mut rom);
+
+        // Hook rewritten to JSR the relocated helper.
+        assert_eq!(
+            rom.read_range(BROS_NO_HANDS_HOOK, BROS_NO_HANDS_JSR.len()),
+            &BROS_NO_HANDS_JSR
+        );
+        // Helper landed in PRG011 free space.
+        assert_eq!(
+            rom.read_range(FS_BROS_NO_HANDS, BROS_NO_HANDS_SUB.len()),
+            &BROS_NO_HANDS_SUB
+        );
+        // Follow the JSR operand actually written into the ROM and prove it
+        // resolves to the helper bytes. This is deliberately *semantic*: it
+        // does not recompute the expected operand (the previous version did,
+        // with the same off-by-header arithmetic the production const used, so
+        // it confirmed the bug instead of catching it — see issue #14). A
+        // mis-aimed JSR lands somewhere other than FS_BROS_NO_HANDS, and the
+        // bytes there won't match, regardless of *how* the operand was wrong.
+        let hook = rom.read_range(BROS_NO_HANDS_HOOK, 3);
+        assert_eq!(hook[0], 0x20, "hook must be a JSR");
+        let target_cpu = u16::from_le_bytes([hook[1], hook[2]]) as usize;
+        assert!(
+            (0xA000..0xC000).contains(&target_cpu),
+            "JSR target must stay in the PRG011 $A000-$BFFF window, got {target_cpu:#06X}"
+        );
+        // PRG011 is bank 11: file = 11 * 0x2000 + 0x10 (iNES header) + (cpu - $A000).
+        let target_file = 11 * 0x2000 + 0x10 + (target_cpu - 0xA000);
+        assert_eq!(
+            target_file, FS_BROS_NO_HANDS,
+            "JSR must point at the registered helper allocation, not arbitrary free space"
+        );
+        assert_eq!(
+            rom.read_range(target_file, BROS_NO_HANDS_SUB.len()),
+            &BROS_NO_HANDS_SUB,
+            "JSR operand must land on the helper bytes, not past them"
+        );
+        // Helper preserves vanilla behavior for non-hand tiles: its tail is the
+        // original `CMP $7E98,Y` (D9 98 7E) the hook replaced.
+        assert_eq!(&BROS_NO_HANDS_SUB[4..7], &[0xD9, 0x98, 0x7E]);
     }
 
     #[test]

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -47,6 +47,7 @@ const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
     (0x17C87, 29, "start_airship_swap: game-over twirl finalize helper"),
     (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
+    (0x17D42, 8, "bros_no_hands: hand-trap tile bypass for overworld bro movement gate"),
     // PRG001 (file 0x02010, CPU $A000–$BFFF)
     (0x0382A, 23, "koopa_hits: subroutine + defeat JMP + threshold table"),
     (0x03841, 13, "koopa_collision_guard: skip collision bitmap during invuln"),
@@ -131,6 +132,10 @@ pub(super) const FS_CANOE_RESPAWN: usize     = 0x15DF0; // 35 bytes
 
 // PRG011
 pub(super) const FS_CANOE_BACKUP: usize      = 0x17D00; // 59 bytes
+// 8-byte hand-trap bypass subroutine for the overworld bro movement gate
+// (MaCobra52's "Bros don't stop on hands"). CPU $BD42. Sits just past the
+// 66-byte FS_CANOE_BACKUP reservation; the gate hook at $B425 JSRs here.
+pub(super) const FS_BROS_NO_HANDS: usize     = 0x17D42; // 8 bytes (CPU $BD42)
 
 // PRG026 (cont.)
 pub(super) const FS_MYSTERY_ANCHOR: usize    = 0x35572; // 13 bytes

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -853,13 +853,40 @@ pub(super) fn is_level_pointer(obj_ptr: u16, lay_ptr: u16) -> bool {
     obj_ptr >= 0xC000 && lay_ptr != 0x0000
 }
 
+/// Convert a CPU address in a fixed PRG bank mapped to the $A000-$BFFF window
+/// into its ROM file offset: `bank * 0x2000 + 0x10 + (cpu - 0xA000)`.
+///
+/// The `+ 0x10` is the iNES header. Forgetting it shifts the result by 16
+/// bytes, which silently mis-aims any JSR/JMP operand derived from it — the
+/// root cause of issue #14. Use this (and [`jsr_into_bank`]) instead of
+/// open-coding the formula so the header offset lives in exactly one place.
+pub(super) fn prg_bank_cpu_to_file(bank: usize, cpu_addr: u16) -> usize {
+    bank * 0x2000 + 0x10 + (cpu_addr as usize - 0xA000)
+}
+
+/// Inverse of [`prg_bank_cpu_to_file`]: file offset within an $A000-window
+/// bank back to its CPU address.
+pub(super) fn prg_bank_file_to_cpu(bank: usize, file_offset: usize) -> u16 {
+    (0xA000 + (file_offset - bank * 0x2000 - 0x10)) as u16
+}
+
+/// Build a 3-byte `JSR <target>` where `target` is given as a *file offset*
+/// inside `bank` (the $A000-window bank live when the hook runs). The operand
+/// is computed from [`prg_bank_file_to_cpu`], so it can never drift from where
+/// the target bytes are actually written. Prefer this over hand-writing the
+/// `[0x20, lo, hi]` literal for any same-bank hook → free-space-helper call.
+pub(super) fn jsr_into_bank(bank: usize, target_file: usize) -> [u8; 3] {
+    let cpu = prg_bank_file_to_cpu(bank, target_file);
+    [0x20, (cpu & 0xFF) as u8, (cpu >> 8) as u8]
+}
+
 /// Convert a layout CPU address ($A000-$BFFF) + tileset to a ROM file offset.
 pub(super) fn layout_file_offset(cpu_addr: u16, tileset: u8) -> Option<usize> {
     if tileset as usize >= PAGE_A000_BY_TILESET.len() || cpu_addr < 0xA000 {
         return None;
     }
     let bank = PAGE_A000_BY_TILESET[tileset as usize];
-    Some(bank * 0x2000 + 0x10 + (cpu_addr as usize - 0xA000))
+    Some(prg_bank_cpu_to_file(bank, cpu_addr))
 }
 
 /// ROM file offset of PRG006 enemy/object data base (CPU $C000).
@@ -1091,9 +1118,9 @@ pub(super) fn read_world_fx_assignments(rom: &Rom) -> [Vec<u8>; 8] {
 /// The master table holds 8 CPU-address words ($A010 bank); each points to a
 /// 9-byte per-world sub-table.
 fn map_obj_slot_offset(rom: &Rom, master_table: usize, world_idx: usize, slot: usize) -> usize {
-    let cpu = read_word(rom, master_table + world_idx * 2) as usize;
-    // PRG011 is bank 11 → file offset = 11 * 0x2000 + 0x10 + (cpu - 0xA000)
-    0x16010 + (cpu - 0xA000) + slot
+    let cpu = read_word(rom, master_table + world_idx * 2);
+    // PRG011 is bank 11; the sub-table base is `cpu`, the entry is `slot` past it.
+    prg_bank_cpu_to_file(11, cpu) + slot
 }
 
 
@@ -1235,5 +1262,38 @@ mod free_space_tests {
         assert!(offsets.contains(&FS_STARTING_ITEMS));
         assert!(offsets.contains(&FS_MYSTERY_ANCHOR));
         assert!(offsets.contains(&FS_HAMMER_LOCKS));
+    }
+
+    // Ground-truth pins for the PRG bank ↔ file-offset mapping. Each pair is a
+    // *known-correct* (bank, cpu, file) triple taken from a shipped patch, so
+    // these tests catch drift in the mapping itself — including dropping the
+    // 0x10 iNES header, the issue #14 root cause. Patch code derives operands
+    // from these helpers (e.g. `jsr_into_bank`) rather than transcribing
+    // address bytes, so getting the helpers right protects every hook.
+    #[test]
+    fn test_prg_bank_mapping_known_pairs() {
+        // PRG011 canoe backup routine: file 0x17D00 ↔ CPU $BCF0 (JSR $BCF0).
+        assert_eq!(prg_bank_cpu_to_file(11, 0xBCF0), 0x17D00);
+        assert_eq!(prg_bank_file_to_cpu(11, 0x17D00), 0xBCF0);
+        // Bank start maps to the window base, header included.
+        assert_eq!(prg_bank_cpu_to_file(11, 0xA000), 0x16010);
+        assert_eq!(prg_bank_file_to_cpu(11, 0x16010), 0xA000);
+        // Round-trips across banks and the whole window.
+        for bank in [9usize, 11, 13, 26] {
+            for cpu in [0xA000u16, 0xA001, 0xB425, 0xBD32, 0xBFFF] {
+                assert_eq!(prg_bank_file_to_cpu(bank, prg_bank_cpu_to_file(bank, cpu)), cpu);
+            }
+        }
+    }
+
+    #[test]
+    fn test_jsr_into_bank_builds_correct_operand() {
+        // `JSR <file 0x17D00 in bank 11>` must encode as 20 F0 BC (JSR $BCF0).
+        assert_eq!(jsr_into_bank(11, 0x17D00), [0x20, 0xF0, 0xBC]);
+        // Opcode is always JSR; operand is little-endian CPU address.
+        let j = jsr_into_bank(11, FS_BROS_NO_HANDS);
+        assert_eq!(j[0], 0x20);
+        let cpu = u16::from_le_bytes([j[1], j[2]]);
+        assert_eq!(prg_bank_cpu_to_file(11, cpu), FS_BROS_NO_HANDS);
     }
 }


### PR DESCRIPTION
## Summary

Relands #14 (reverted in `36b4a3d`) with the crash fixed, plus a structural guard so the bug class can't recur in future patches.

### The crash
The gate hook's `JSR` operand was computed against base `0x16000` instead of `0x16010`, dropping the 16-byte iNES header from the PRG011 file→CPU mapping. The helper bytes were written correctly to file `0x17D42` (CPU `$BD32`), but the JSR pointed at `$BD42` — 16 bytes too high, landing 8 bytes past the end of the 8-byte helper in unallocated free space. The CPU executed garbage there and crashed (seen after a level is beaten, when a roaming bro re-evaluates the `$B425` rest gate).

The old test shared the same off-by-16 arithmetic, so it confirmed the bug instead of catching it.

### Fix (`c68aa91`)
- JSR operand `$BD42` → `$BD32`.
- Test is now **semantic**: it follows the operand actually written into the ROM, resolves it to a file offset via the canonical bank-11 mapping, and asserts the helper bytes live there. Verified red on `$BD42`, green on `$BD32`.

### Forward-going guard (`4f06f0f`)
Prevention is structural — derive operands, don't transcribe address bytes:
- One home for the `bank*0x2000 + 0x10 + (cpu - 0xA000)` formula: `prg_bank_cpu_to_file` / `prg_bank_file_to_cpu` / `jsr_into_bank`. De-dupes two open-coded copies.
- bros-no-hands builds its operand with `jsr_into_bank(11, FS_BROS_NO_HANDS)` instead of a `[0x20, lo, hi]` literal — it can't point anywhere but the helper.
- Ground-truth tests pin the mapping to known-correct address pairs, so the helper itself can't drift.

### Version
Bumped to `0.8.13`.

## Test plan
- `cargo test` — 215 pass, clippy clean.
- New: `test_prg_bank_mapping_known_pairs`, `test_jsr_into_bank_builds_correct_operand`, semantic `test_macobra_bros_no_hands_writes`.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)