### PR TITLE
fix: correct nipper/bertha enemy labels and reclassify Big Bertha

### DIFF
--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -759,7 +759,7 @@ lifted these from observed laser placements):
 
 Vanilla uses `(0x40, 0x15)` and `(0xA3, 0x16)`. The other 7 are
 "shootable but vanilla-decorative" — the level art has a statue head
-there but no `CFIRE_LASER` entry points at it. SMB3R's `bowser_castle`
+there but no `CFIRE_LASER` entry points at it. SMB3-RS's `bowser_castle`
 composer picks any 2 of the 9 and writes them at the two laser entry
 slots, coordinating fireball placement so the segment stays X-sorted.
 
@@ -781,7 +781,7 @@ Tight vanilla X gaps where naive ±2 jitter could break sort order:
 
 Enemy data segments are the level loader's input — entries within a
 segment must stay in ascending X order or activation timing breaks.
-SMB3R routes all segment edits through `src/randomize/segment_writer.rs`
+SMB3-RS routes all segment edits through `src/randomize/segment_writer.rs`
 which sorts by X, validates count and X-collision invariants, and
 writes back. Per-level "composer" modules (`bowser_castle.rs`,
 `podoboo_gauntlet.rs`, etc.) build a full proposed entry list and pass
@@ -2624,7 +2624,7 @@ partial tables in the sections above are subsets of this data.
 | 0x2A | $0A | $0A | +4 | Patooie |
 | 0x2B | $0B | $0B | +4 | Goomba in Shoe |
 | 0x2C | $0E | $0E | +4 | ChainChomp |
-| 0x2D | $1A | $1A | +4 | ChainChomp Strained |
+| 0x2D | $1A | $1A | +4 | BigBertha |
 | 0x2E | $93 | $13 | +5 | WoodBlock |
 | 0x2F | $12 | $12 | +4 | Boo |
 | 0x30 | $12 | $12 | +4 | HotFoot (shy) |
@@ -2640,7 +2640,7 @@ partial tables in the sections above are subsets of this data.
 | 0x3A | $93 | $13 | +5 | RocketSled |
 | 0x3B | $CF | $4F | +5 | FireJet Left |
 | 0x3C | $0E | $0E | +4 | PlatformCircle |
-| 0x3D | $0A | $0A | +4 | Airship Anchor |
+| 0x3D | $0A | $0A | +4 | NipperFireBreather |
 | 0x3E | $1A | $1A | +4 | PlatformULDR |
 | 0x3F | $93 | $13 | +5 | Dry Bones |
 | 0x40 | $0A | $0A | +4 | Buster Beetle |
@@ -2649,7 +2649,7 @@ partial tables in the sections above are subsets of this data.
 | 0x43 | $CF | $4F | +5 | ObjectEntry43 |
 | 0x44 | $0E | $0E | +4 | PlatformURLL |
 | 0x45 | $12 | $12 | +4 | HotFoot |
-| 0x46 | $0A | $0A | +4 | WonderWing |
+| 0x46 | $0A | $0A | +4 | PiranhaSpikeBall |
 | 0x47 | $00 | — | NOCHANGE | WaterCurrent Down |
 
 **Group 3 — PRG003 (0x06154): IDs 0x48–0x6B**

--- a/src/randomize/enemies.rs
+++ b/src/randomize/enemies.rs
@@ -27,13 +27,12 @@ const GROUND_ENEMIES: &[u8] = &[
     0x2B, // OBJ_GOOMBA_SHOE (Kuribo's Shoe)
     0x29, // OBJ_SPIKE
     0x2A, // OBJ_PATOOIE
-    0x2D, // OBJ_CHAINCHOMP (strained on post)
-    0x3D, // OBJ_CHAINCHOMPSTAKE (chained to stake, lunges)
+    0x3D, // OBJ_NIPPERFIREBREATHER (stationary fire-spitting nipper)
     0x4F, // OBJ_CHAINCHOMPFREE (roams freely without post tile)
     0x33, // OBJ_NIPPER (stationary)
     0x39, // OBJ_NIPPERHOPPING
     0x40, // OBJ_BUSTERBEATLE
-    0x46, // OBJ_LAKITU (level-placed variant, CHR $0A/+4)
+    0x46, // OBJ_PIRANHASPIKEBALL (tall plant with spike ball)
     0x55, // OBJ_BOBOMB
     0x58, // OBJ_FIRECHOMP (floats and chases)
     0x59, // OBJ_FIRESNAKE
@@ -65,10 +64,11 @@ const FLYING_ENEMIES: &[u8] = &[
 
 /// Water enemies that can be swapped with each other.
 const WATER_ENEMIES: &[u8] = &[
+    0x2D, // OBJ_BIGBERTHA (leaping eater — the "Boss Bass")
     0x48, // OBJ_BABYBLOOPER
     0x61, // OBJ_BLOOPERWITHKIDS
     0x62, // OBJ_BLOOPER
-    0x63, // OBJ_BIGBERTHABIRTHER
+    0x63, // OBJ_BIGBERTHABIRTHER (swims, spits a baby Cheep Cheep)
     0x64, // OBJ_CHEEPCHEEPHOPPER
     0x67, // OBJ_LAVALOTUS (southbird: "underwater lava plant")
     0x6A, // OBJ_BLOOPERCHILDSHOOT
@@ -321,7 +321,7 @@ pub fn sprite_bank(id: u8) -> Option<SpriteBank> {
         // Platforms (various)
         0x24 | 0x26 | 0x27 | 0x28 | 0x36 | 0x37 | 0x38 | 0x3C | 0x44 =>
             Some(SpriteBank { chr_page: 0x0E, slot: 4 }),
-        // Spike, Patooie, Nipper, NipperHopping, ChainChompStake, BusterBeetle, Lakitu
+        // Spike, Patooie, Nipper, NipperHopping, NipperFireBreather, BusterBeetle, PiranhaSpikeBall
         0x29 | 0x2A | 0x33 | 0x39 | 0x3D | 0x40 | 0x46 =>
             Some(SpriteBank { chr_page: 0x0A, slot: 4 }),
         // Goomba in Shoe
@@ -501,17 +501,22 @@ use super::rom_data::{HAZARD_PROJECTILE_IDS, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_
 const WILD_INJECTION_IDS: &[u8] = &[
     0x83, // Lakitu (enemy-spawning variant, CHR $0B/+4)
     0xAF, // Angry Sun
-    0x63, // Boss Bass (Big Bertha)
+    0x2D, // Boss Bass (Big Bertha — the leaping eater)
 ];
 
 /// Probability (out of 256) that a segment will receive an injection when wild_injections is on.
 /// ~15% chance per segment.
 const WILD_INJECTION_CHANCE: u8 = 38;
 
-/// Maximum number of Boss Bass (0x63) allowed in a single enemy segment
-/// (= one obj_ptr / sub-area). More than this causes sprite slot exhaustion
-/// that can prevent other objects (e.g. white blocks) from spawning — this
-/// was observed in 3-9 where the white block became unreachable.
+/// Large "Big Bertha" fish that exhaust sprite slots when stacked: the leaping
+/// eater (0x2D, the injected "Boss Bass") and the cheep-spitting birther (0x63).
+/// Both are sprite-heavy, so the per-segment cap counts them together.
+const BERTHA_IDS: &[u8] = &[0x2D, 0x63];
+
+/// Maximum number of Big Bertha fish (see [`BERTHA_IDS`]) allowed in a single
+/// enemy segment (= one obj_ptr / sub-area). More than this causes sprite slot
+/// exhaustion that can prevent other objects (e.g. white blocks) from spawning —
+/// this was observed in 3-9 where the white block became unreachable.
 const MAX_BERTHA_PER_SEGMENT: u8 = 2;
 
 /// Maximum X-tile gap between consecutive enemies (sorted by X) before they
@@ -1114,13 +1119,14 @@ fn inject_at_entry_points<R: Rng>(
 
         if let Some(chosen) = pick_compatible(WILD_INJECTION_IDS, s4, s5, rng) {
             let bertha_count: u8 = entries.iter()
-                .filter(|e| e.obj_id == 0x63)
+                .filter(|e| BERTHA_IDS.contains(&e.obj_id))
                 .count() as u8;
-            let was_bertha = entries[0].obj_id == 0x63;
+            let was_bertha = BERTHA_IDS.contains(&entries[0].obj_id);
+            let chosen_is_bertha = BERTHA_IDS.contains(&chosen);
             let post_count = bertha_count
                 .saturating_sub(was_bertha as u8)
-                .saturating_add((chosen == 0x63) as u8);
-            if !(chosen == 0x63 && post_count > MAX_BERTHA_PER_SEGMENT) {
+                .saturating_add(chosen_is_bertha as u8);
+            if !(chosen_is_bertha && post_count > MAX_BERTHA_PER_SEGMENT) {
                 let di = entry.data_index;
                 swap_enemy(data, di, chosen);
             }
@@ -1220,7 +1226,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         // its own pass) added a Bertha to this segment, that's already
         // reflected here because we re-read obj_ids from `data`.
         let mut bertha_count: u8 = entries.iter()
-            .filter(|e| e.obj_id == 0x63)
+            .filter(|e| BERTHA_IDS.contains(&e.obj_id))
             .count() as u8;
 
         // Split entries into proximity groups by X-position. Each group gets
@@ -1323,16 +1329,16 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                     } else {
                         pick_compatible(pool, committed_slot4, committed_slot5, rng)
                     };
-                    // Enforce Boss Bass cap: if picked 0x63 would push the
-                    // segment over MAX_BERTHA_PER_SEGMENT, re-pick from the
-                    // same pool with 0x63 filtered out.
-                    let was_bertha = data[entry.data_index] == 0x63;
+                    // Enforce Big Bertha cap: if the pick would push the segment
+                    // over MAX_BERTHA_PER_SEGMENT bertha-class fish, re-pick from
+                    // the same pool with the bertha IDs filtered out.
+                    let was_bertha = BERTHA_IDS.contains(&data[entry.data_index]);
                     let cap_full = bertha_count.saturating_sub(was_bertha as u8)
                         >= MAX_BERTHA_PER_SEGMENT;
-                    let chosen = if matches!(chosen, Some(0x63)) && cap_full {
+                    let chosen = if matches!(chosen, Some(id) if BERTHA_IDS.contains(&id)) && cap_full {
                         let filtered: Vec<u8> = pool.iter()
                             .copied()
-                            .filter(|&id| id != 0x63)
+                            .filter(|id| !BERTHA_IDS.contains(id))
                             .collect();
                         pick_compatible(&filtered, committed_slot4, committed_slot5, rng)
                     } else {
@@ -1374,9 +1380,10 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                         chosen
                     };
                     if let Some(chosen) = chosen {
-                        if was_bertha && chosen != 0x63 {
+                        let chosen_is_bertha = BERTHA_IDS.contains(&chosen);
+                        if was_bertha && !chosen_is_bertha {
                             bertha_count = bertha_count.saturating_sub(1);
-                        } else if !was_bertha && chosen == 0x63 {
+                        } else if !was_bertha && chosen_is_bertha {
                             bertha_count = bertha_count.saturating_add(1);
                         }
                         swap_enemy(&mut data, entry.data_index, chosen);
@@ -2277,7 +2284,7 @@ mod tests {
         install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
         let rom = Rom::from_bytes_lax(&data, true).unwrap();
 
-        let injection_ids: &[u8] = &[0x83, 0xAF, 0x63];
+        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
         let mut saw_injection = false;
         for seed in 0..2000u64 {
             let mut rom_copy = rom.clone();
@@ -2317,7 +2324,7 @@ mod tests {
         install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
         let rom = Rom::from_bytes_lax(&data, true).unwrap();
 
-        let injection_ids: &[u8] = &[0x83, 0xAF, 0x63];
+        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
         for seed in 0..500u64 {
             let mut rom_copy = rom.clone();
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -2479,11 +2486,11 @@ mod tests {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             randomize(&mut rom_copy, &mut rng, &flags);
             let bertha_count = entry_offsets.iter()
-                .filter(|&&off| rom_copy.read_byte(ENEMY_DATA_START + off) == 0x63)
+                .filter(|&&off| BERTHA_IDS.contains(&rom_copy.read_byte(ENEMY_DATA_START + off)))
                 .count();
             assert!(
                 bertha_count <= MAX_BERTHA_PER_SEGMENT as usize,
-                "seed {seed}: {bertha_count} Boss Bass in segment, cap is {}",
+                "seed {seed}: {bertha_count} Big Bertha in segment, cap is {}",
                 MAX_BERTHA_PER_SEGMENT
             );
         }


### PR DESCRIPTION
## Summary

Three enemy IDs in `enemies.rs` were mislabeled from a bad naming source. Verified against the [captainsouthbird SMB3 disassembly](https://github.com/captainsouthbird/smb3):

| ID | Was labeled | Actually is |
|----|-------------|-------------|
| 0x3D | ChainChompStake | **OBJ_NIPPERFIREBREATHER** (stationary fire-spitting nipper) |
| 0x2D | ChainChomp | **OBJ_BIGBERTHA** (leaping, player-eating "Boss Bass") |
| 0x46 | Lakitu | **OBJ_PIRANHASPIKEBALL** (Ptooie-style launcher) |

The projectiles these launchers spawn (`SOBJ_NIPPERFIREBALL`, `SOBJ_SPIKEBALL`) are separate special-objects, not these enemy IDs.

## Behavior changes

- **Move 0x2D (Big Bertha) from `GROUND_ENEMIES` → `WATER_ENEMIES`**, alongside its sibling 0x63 (`OBJ_BIGBERTHABIRTHER`). It's a swimming water fish, not a ground enemy.
- **Wild injection now injects the real Boss Bass (0x2D)** instead of the cheep-spitting birther (0x63).
- **The per-segment sprite cap now counts both bertha-class fish** via a new `BERTHA_IDS = [0x2D, 0x63]` constant — so the injected Boss Bass is capped without un-capping the birther that caused the original 3-9 sprite-exhaustion bug.

Also corrects the matching labels in `docs/smb3_rom_reference.md`.

## Testing

`cargo clippy --all-targets` clean; full `cargo test` suite passes (including `test_boss_bass_capped_per_segment` and the wild-injection tests, updated for the new IDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)