### PR TITLE
Expand hazard taxonomy + curated narrow-hall protections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.15"
+version = "0.8.16"
 edition = "2024"
 
 [lib]

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -3005,6 +3005,40 @@ of wild mode settings. Current protected levels:
 - **2-3** (0xD1F0): 2 GreenTroopas at end — shells needed to break bricks
 - **6-5** sub-area (0xC5EB): 1 GreenTroopa — shell needed for progression
 
+### Hazard-Excluded Levels
+
+Some enemies are unfair to *introduce* at a forced or narrow spot — unstompable
+or continuous threats that block a path or can't be avoided. The randomizer
+groups them into a hazard taxonomy (6 categories, 18 IDs) and filters them out of
+the swap pool at curated `ExcludeHazards` offsets:
+
+| Category | IDs |
+|----------|-----|
+| Thwomp | 0x8A–0x8F |
+| Lava Lotus | 0x67 |
+| Patooie (spike-ball plants) | 0x2A, 0x46 |
+| Nipper | 0x33, 0x39, 0x3D |
+| Hot Foot | 0x30, 0x45 |
+| Hammer Bro | 0x81, 0x82, 0x86, 0x87 |
+
+**Additive-only (vanilla exception):** at an `ExcludeHazards` offset a hazard is
+excluded *unless the vanilla enemy there was the same category*, so within-category
+shuffle (e.g. Thwomp variants) still works and a designed-in hazard is never
+stripped — only *introducing* a new hazard category is blocked. See
+`hazard_excluded` / `HAZARD_CATEGORIES` in `enemies.rs`.
+
+Current `ExcludeHazards` levels (`enemy_protections.rs`):
+- **7F2** Boom-Boom sub-area (0xD45C): tight boss arena
+- **7-5** sub-area (0xC171): open field — floor hazards unfair
+- **β4** sub-area (0xC7A7): narrow corridor on the Buzzy Beetle path
+- **4F1** (0xD528) + sub-area 1 (0xC968): narrow-hallway fort — any hazard blocks the only path
+- **8-1** (0xC424): single Boo slot — a hazard there blocks a narrow pathway
+
+Piranha-pipe slots are *not* listed: the piranha pools (`PIRANHAS_WILD` /
+`PIRANHASC_WILD`) are self-contained and hold no hazards, so a pipe lip can't
+become one through the pool. The `enemy_invariant_baseline` test verifies both
+this and the `ExcludeHazards` filter over many seeds.
+
 ### Player Physics
 
 | File Offset | Description |

--- a/src/randomize/enemies.rs
+++ b/src/randomize/enemies.rs
@@ -188,6 +188,60 @@ const THWOMPS: &[u8] = &[
     0x8F, // OBJ_THWOMPDIAGONALDL
 ];
 
+// --- Hazard taxonomy ---
+//
+// Enemies that are unfair to *introduce* at a curated `ExcludeHazards` spot:
+// unstompable/continuous threats (drops, fire, spike balls, projectile bros)
+// that a player can't avoid in a tight or forced-transit position. Grouped by
+// category so the placement filter can honor the "vanilla exception" — a hazard
+// is allowed when the slot's vanilla enemy was the *same category*, so the level
+// keeps the threat it was designed with (and within-category shuffle, e.g.
+// thwomp variants, still works). The filter is additive-only: it blocks
+// introducing a new hazard category, never strips an existing one.
+
+const HAZARD_LAVA_LOTUS: &[u8] = &[0x67]; // OBJ_LAVALOTUS (fire arcs)
+const HAZARD_PATOOIE: &[u8] = &[
+    0x2A, // OBJ_PATOOIE (spits a spike ball up)
+    0x46, // OBJ_PIRANHASPIKEBALL (Ptooie-style spike-ball launcher)
+];
+const HAZARD_NIPPER: &[u8] = &[
+    0x33, // OBJ_NIPPER
+    0x39, // OBJ_NIPPERHOPPING
+    0x3D, // OBJ_NIPPERFIREBREATHER
+];
+const HAZARD_HOTFOOT: &[u8] = &[
+    0x30, // OBJ_HOTFOOT_SHY
+    0x45, // OBJ_HOTFOOT
+];
+
+/// All hazard categories. THWOMPS and BRO_ENEMIES are reused as-is (the bros
+/// throw continuous projectiles, unavoidable in a forced spot).
+const HAZARD_CATEGORIES: &[&[u8]] = &[
+    THWOMPS,
+    HAZARD_LAVA_LOTUS,
+    HAZARD_PATOOIE,
+    HAZARD_NIPPER,
+    HAZARD_HOTFOOT,
+    BRO_ENEMIES,
+];
+
+/// The hazard category `id` belongs to (its index in [`HAZARD_CATEGORIES`]), or
+/// `None` if `id` isn't a hazard.
+fn hazard_category(id: u8) -> Option<usize> {
+    HAZARD_CATEGORIES.iter().position(|cat| cat.contains(&id))
+}
+
+/// Whether `candidate` must be excluded at a protected spot whose vanilla enemy
+/// was `vanilla`. A hazard is excluded unless it shares the vanilla enemy's
+/// category (the additive-only vanilla exception); a non-hazard is never
+/// excluded.
+fn hazard_excluded(candidate: u8, vanilla: u8) -> bool {
+    match hazard_category(candidate) {
+        None => false,
+        Some(c) => hazard_category(vanilla) != Some(c),
+    }
+}
+
 /// Enemies whose sprites are taller than a standard 1-tile enemy.
 /// When one of these is the replacement in a swap, Y is decremented by 1
 /// to prevent the taller sprite from clipping into the floor.
@@ -496,7 +550,7 @@ const BIG_Q_BLOCKS: &[u8] = &[
 const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
 use super::enemy_protections::{entry_protection_at, is_injection_blocked, walker_segment_rule_at, EntryProtection, WalkerSegmentRule};
-use super::rom_data::{HAZARD_PROJECTILE_IDS, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS, STOMPABLE_ENEMIES, TANK_BRO_POOL};
+use super::rom_data::{HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS, STOMPABLE_ENEMIES, TANK_BRO_POOL};
 
 /// Injection candidates for wild_injections mode: special enemies injected after
 /// normal swaps. CHR compatibility checked via `sprite_bank()` at filter time.
@@ -1312,8 +1366,11 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                     }
                     Some(EntryProtection::ExcludeHazards) => {
                         find_class_pool(entry.obj_id, modes, wild_pool).map(|pool| {
+                            // Drop hazards, but keep any of the same category as the
+                            // vanilla enemy here (additive-only: don't strip a
+                            // designed-in hazard, only block introducing a new one).
                             let fp: Vec<u8> = pool.iter().copied()
-                                .filter(|id| !HAZARD_PROJECTILE_IDS.contains(id)).collect();
+                                .filter(|&id| !hazard_excluded(id, entry.obj_id)).collect();
                             let pick = pick_compatible(&fp, committed_slot4, committed_slot5, rng);
                             (pick, Cow::Owned(fp))
                         })
@@ -1350,18 +1407,16 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                 let was_bertha = BERTHA_IDS.contains(&data[entry.data_index]);
                 let cap_full = bertha_count.saturating_sub(was_bertha as u8)
                     >= MAX_BERTHA_PER_SEGMENT;
-                let old_was_piranha = PIRANHAS.contains(&entry.obj_id)
-                    || PIRANHASC.contains(&entry.obj_id);
                 let keep = |id: u8| -> bool {
                     // Big Bertha cap: no new bertha once the segment is full.
                     let over_cap = cap_full && BERTHA_IDS.contains(&id);
                     // Giant red piranha (off-center hitbox) only where one was.
                     let bad_giant = id == GIANT_RED_PIRANHA && entry.obj_id != GIANT_RED_PIRANHA;
-                    // A piranha slot is often the only way through a level
-                    // (forced pipe transit): never a stationary hazard there.
-                    let bad_hazard = old_was_piranha && HAZARD_PROJECTILE_IDS.contains(&id);
-                    !(over_cap || bad_giant || bad_hazard)
+                    !(over_cap || bad_giant)
                 };
+                // (A piranha slot can't become a hazard: the piranha pools are
+                // self-contained and contain none — verified by the harness's
+                // piranha-hazard invariant, so no explicit guard is needed.)
 
                 // Accept the primary pick if it satisfies every constraint;
                 // otherwise re-pick once from the base pool filtered by all of
@@ -2776,9 +2831,9 @@ mod tests {
                         bad("ForceTankBro but result not a tank bro".into());
                     }
                     Some(EntryProtection::ExcludeHazards)
-                        if HAZARD_PROJECTILE_IDS.contains(&new) =>
+                        if hazard_excluded(new, orig) =>
                     {
-                        bad("ExcludeHazards but result is a hazard projectile".into());
+                        bad("ExcludeHazards but introduced a new hazard category".into());
                     }
                     _ => {}
                 }
@@ -2804,11 +2859,13 @@ mod tests {
                     bad("giant-red piranha placed where original wasn't giant-red".into());
                 }
 
-                // --- A piranha slot must never become a stationary hazard ---
+                // --- A piranha slot must never become a hazard (the runtime
+                // guard was removed; this verifies the piranha pools' self-
+                // containment achieves it). ---
                 if (PIRANHAS.contains(&orig) || PIRANHASC.contains(&orig))
-                    && HAZARD_PROJECTILE_IDS.contains(&new)
+                    && hazard_category(new).is_some()
                 {
-                    bad("piranha slot replaced by a stationary hazard".into());
+                    bad("piranha slot replaced by a hazard".into());
                 }
             }
 

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -63,7 +63,9 @@ pub(super) enum EntryProtection {
     ForceStompable,
     /// Walker forces a pick from TANK_BRO_POOL when bros mode is on.
     ForceTankBro,
-    /// Walker excludes HAZARD_PROJECTILE_IDS from the chosen pool.
+    /// Walker excludes hazard-category enemies from the chosen pool (additive-only:
+    /// a hazard of the same category as the vanilla enemy here is kept). See
+    /// `hazard_excluded` in enemies.rs.
     ExcludeHazards,
 }
 

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -203,6 +203,37 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
         ],
     },
 
+    LevelProtection {
+        label: "4F1 (narrow-hallway fort — a hazard anywhere blocks the only path)",
+        enemy_ptr: 0xD528,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0D539, rule: EntryProtection::ExcludeHazards }, // HotFootShy      scr=1 col=0
+            EntryRule { offset: 0x0D53C, rule: EntryProtection::ExcludeHazards }, // HotFootShy      scr=1 col=8
+            EntryRule { offset: 0x0D53F, rule: EntryProtection::ExcludeHazards }, // HotFootShy      scr=2 col=7
+            EntryRule { offset: 0x0D542, rule: EntryProtection::ExcludeHazards }, // ThwompLeftSlide scr=2 col=2
+            EntryRule { offset: 0x0D545, rule: EntryProtection::ExcludeHazards }, // ThwompLeftSlide scr=3 col=0
+            EntryRule { offset: 0x0D548, rule: EntryProtection::ExcludeHazards }, // HotFootShy      scr=3 col=2
+            EntryRule { offset: 0x0D54B, rule: EntryProtection::ExcludeHazards }, // HotFootShy      scr=3 col=10
+            EntryRule { offset: 0x0D54E, rule: EntryProtection::ExcludeHazards }, // ThwompRightSlide scr=4 col=1
+            EntryRule { offset: 0x0D551, rule: EntryProtection::ExcludeHazards }, // HotFootShy      scr=4 col=12
+            EntryRule { offset: 0x0D554, rule: EntryProtection::ExcludeHazards }, // Thwomp          scr=5 col=2
+            EntryRule { offset: 0x0D557, rule: EntryProtection::ExcludeHazards }, // HotFootShy      scr=5 col=3
+            EntryRule { offset: 0x0D55A, rule: EntryProtection::ExcludeHazards }, // ThwompRightSlide scr=5 col=12
+        ],
+    },
+    LevelProtection {
+        label: "4F1 sub-area 1 (narrow-hallway fort)",
+        enemy_ptr: 0xC968,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0C979, rule: EntryProtection::ExcludeHazards }, // DryBones scr=0 col=8
+            EntryRule { offset: 0x0C97C, rule: EntryProtection::ExcludeHazards }, // DryBones scr=1 col=4
+            EntryRule { offset: 0x0C97F, rule: EntryProtection::ExcludeHazards }, // Boo      scr=1 col=13
+            EntryRule { offset: 0x0C982, rule: EntryProtection::ExcludeHazards }, // DryBones scr=2 col=3
+        ],
+    },
+
     // --- Hammer Bro encounters (walker uses HB modes; injection skips) ---
     LevelProtection {
         label: "W1 Hammer Bro",

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -80,11 +80,14 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
 
     // --- Individual gameplay-critical entries (walker skips, no whole-level block) ---
     LevelProtection {
-        label: "8-1 (Boo + FlyingRedParatroopa required for progression)",
+        label: "8-1 (FlyingRedParatroopa required for progression; Boo restricted from path-blocking hazards)",
         enemy_ptr: 0xC424,
         walker_segment: WalkerSegmentRule::Default,
         entries: &[
-            EntryRule { offset: 0x0C456, rule: EntryProtection::SkipSwap }, // Boo scr=5 col=1
+            // Boo is swap-safe, but a hazard here (Ptooie/nipper/lotus/etc.) would
+            // block a narrow pathway the player must pass through — so swap it to
+            // anything except a hazard rather than skipping it outright.
+            EntryRule { offset: 0x0C456, rule: EntryProtection::ExcludeHazards }, // Boo scr=5 col=1
             EntryRule { offset: 0x0C465, rule: EntryProtection::SkipSwap }, // FlyingRedParatroopa scr=6 col=14
         ],
     },

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -905,24 +905,6 @@ pub(super) fn enemy_ptr_to_file_offset(ep: u16) -> usize {
 pub const ENEMY_DATA_START: usize = 0x0BFD8;
 pub const ENEMY_DATA_END: usize = 0x0E00D;
 
-/// Unstompable hazards that are unfair to introduce into tight sub-areas
-/// (especially boss arenas) or onto a player's walking path. Patooie/Lavalotus
-/// fire continuously with no telegraph; Thwomps drop or slide unpredictably
-/// when added on top of a designed encounter. The registry filters these
-/// out of the chosen swap pool at `EntryProtection::ExcludeHazards`
-/// positions, and they're also excluded from piranha-slot replacements
-/// (a pipe-lip swap to one of these covers or blocks the only way through).
-pub(super) const HAZARD_PROJECTILE_IDS: &[u8] = &[
-    0x2A, // OBJ_PATOOIE (spits spikes upward)
-    0x67, // OBJ_LAVALOTUS (spits fire in arcs)
-    0x8A, // OBJ_THWOMP (standard drop)
-    0x8B, // OBJ_THWOMPLEFTSLIDE
-    0x8C, // OBJ_THWOMPRIGHTSLIDE
-    0x8D, // OBJ_THWOMPUPDOWN
-    0x8E, // OBJ_THWOMPDIAGONALUL
-    0x8F, // OBJ_THWOMPDIAGONALDL
-];
-
 /// Bro enemies that work in tileset 10 (8-Tank sub-area).
 /// Excludes HammerBro (0x81) which fails to spawn in ts=10.
 pub(super) const TANK_BRO_POOL: &[u8] = &[


### PR DESCRIPTION
## Summary

Reshapes the enemy hazard handling and uses it to protect narrow/forced spots, building on the predicate pipeline from #30.

### 1. Hazard taxonomy + vanilla exception
Replaces the flat `HAZARD_PROJECTILE_IDS` (Patooie + Lotus + Thwomps) with a 6-category, 18-ID taxonomy:

| Category | IDs |
|---|---|
| Thwomp | 0x8A–0x8F |
| Lava Lotus | 0x67 |
| Patooie (both spike-ball plants) | 0x2A, 0x46 |
| Nipper (all) | 0x33, 0x39, 0x3D |
| Hot Foot (both) | 0x30, 0x45 |
| Hammer Bro | 0x81, 0x82, 0x86, 0x87 |

At an `ExcludeHazards` offset, a hazard is excluded **unless the vanilla enemy there was the same category** — additive-only, so within-category shuffle (e.g. Thwomp variants) still works and a designed-in hazard is never stripped; only *introducing* a new hazard category is blocked.

### 2. Removed the redundant piranha-pipe guard
The piranha pools (`PIRANHAS_WILD` / `PIRANHASC_WILD`) are self-contained and hold none of the 18 hazards, so a pipe lip can't become one through the pool. The runtime guard is dropped; the harness's piranha-hazard invariant is **kept** to verify the pool self-containment achieves that fairness property (green over 500 seeds).

### 3. Curated protections (first real uses)
- **8-1 Boo** (`0x0C456`): `SkipSwap` → `ExcludeHazards` (the "required for progression" label was wrong — the Boo is swap-safe, it was skipped only because a hazard there blocks a narrow pathway).
- **4F1** (narrow-hallway fort): all 16 non-boss enemy slots across the main segment + sub-area 1 tagged `ExcludeHazards`.

### 4. Docs
New "Hazard-Excluded Levels" reference section in `smb3_rom_reference.md`.

## Validation
`enemy_invariant_baseline` over 250 Recommended + 250 Max Chaos seeds: all invariants green, including the updated `ExcludeHazards` check (no new hazard category introduced) and the piranha-hazard check. Full `cargo test` passes; `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)