### PR TITLE
fix: stop level-data walk overrunning PRG bank into desert metatile table (#34)

### DIFF
--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1381,6 +1381,22 @@ stride (every 8th sprite slot) to avoid the 8-sprites-per-scanline hardware limi
 | 0x17 | Airship | 0x34 | 0x6A |
 | 0x1A | HUD | 0x5C | 0x5E |
 
+### Bank Layout Pitfall: Level Data vs. Metatile Tables
+
+Each $A000 level-data bank is 8KB (file offset = 0x10 + bank × 0x2000) and the
+level-data walk must never cross a bank boundary. Concretely: the
+Cloudy/Giant/Plant (TS5/11/13) bank (PRG 19, file 0x26010–0x28010) ends with an
+empty stub level at 0x28000–0x28009, so its level data ends at **0x2800A**. The
+next bank (PRG 20, the Desert/TS9 bank) opens with the **desert metatile
+quadrant table at 0x28010–0x28410** (UL/LL/UR/LR × 256, same layout as the
+world-map table at 0x18010), followed by further tileset tables/code until the
+first desert level header at 0x28F36. A region scan that overruns 0x28010
+misparses these tables as level headers/commands and "finds" phantom powerup
+blocks inside metatile definitions — writing to them corrupts desert metatile
+quadrants (e.g. metatile 0x8F LL → stray palm-leaf-tip CHR tile 0x0B next to
+every battle-scene palm crown, and junk tiles near 2-1's pipes). This was the
+root cause of issue #34.
+
 ### Tileset-to-PRG Page Mapping
 
 Maps 19 tilesets (0–18) to their ROM page banks:

--- a/src/randomize/powerups.rs
+++ b/src/randomize/powerups.rs
@@ -226,6 +226,28 @@ mod tests {
     }
 
     #[test]
+    fn test_regions_stay_within_one_prg_bank() {
+        // Level data is addressed CPU $A000-$BFFF within a single switched
+        // PRG bank, so no region may cross a 8KB bank boundary. A region
+        // whose `end` overruns its bank walks into the next bank's metatile
+        // quadrant table and the randomizer corrupts metatile definitions
+        // (stray tiles in desert levels and HB battle scenes — issue #34).
+        const INES_HEADER: usize = 0x10;
+        const BANK_SIZE: usize = 0x2000;
+        for region in LEVEL_DATA_REGIONS {
+            let start_bank = (region.start - INES_HEADER) / BANK_SIZE;
+            let end_bank = (region.end - 1 - INES_HEADER) / BANK_SIZE;
+            assert_eq!(
+                start_bank, end_bank,
+                "region 0x{:05X}-0x{:05X} crosses PRG bank boundary 0x{:05X}",
+                region.start,
+                region.end,
+                (start_bank + 1) * BANK_SIZE + INES_HEADER
+            );
+        }
+    }
+
+    #[test]
     fn test_protected_offset_not_changed() {
         let mut data = vec![0u8; 393232];
         data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -314,7 +314,14 @@ pub(super) const LEVEL_DATA_REGIONS: &[LevelDataRegion] = &[
         randomize_note_wood: true,
     },
     LevelDataRegion { // Cloudy / Giant / Plant (TS5/11/13)
-        start: 0x26A6F, end: 0x28C05,
+        // End 0x2800A, NOT 0x28C05: this region's PRG bank ($A000 = file
+        // 0x26010) ends at 0x28010, and the next bank opens with the desert
+        // metatile quadrant table. Walking past the bank boundary misparses
+        // that table as level data and the powerup pass then writes item IDs
+        // into desert metatile quadrants (stray palm-leaf tiles in desert
+        // levels and HB battle scenes). Real data ends with an empty stub
+        // level at 0x28000-0x28009; 0x2800A is one past its terminator.
+        start: 0x26A6F, end: 0x2800A,
         extra_byte_dispatches: &[
             13,                                // DoubleCloud
             35, 36, 37, 38, 39, 40, 41, 42,   // TopDecoBlocks

--- a/tools/rom_map.py
+++ b/tools/rom_map.py
@@ -195,7 +195,9 @@ LEVEL_DATA_REGIONS = [
         "name": "Cloudy/Giant/Plant (TS5/11/13)",
         "tileset_ids": [5, 11, 13],
         "start": 0x26A6F,
-        "end": 0x28C05,
+        # 0x2800A, NOT 0x28C05: bank ends at 0x28010 and the next bank opens
+        # with the desert metatile quadrant table (see rom_data.rs).
+        "end": 0x2800A,
         "extra_byte_dispatches": {13, 35, 36, 37, 38, 39, 40, 41, 42, 45, 46, 48, 51},
         "randomize_note_wood": True,
     },


### PR DESCRIPTION
## Summary

Fixes the long-standing "sprite corruption" in desert HammerBro battle scenes (palm trees) and near 2-1's pipes — issue #34. It was never CHR/sprite corruption: a level-data region's `end` overran its PRG bank, so the powerup randomizer wrote item IDs into the **desert metatile definition table**.

## Root cause

`LEVEL_DATA_REGIONS` declared the Cloudy/Giant/Plant (TS5/11/13) region as `0x26A6F–0x28C05`, but that `$A000` PRG bank physically ends at `0x28010`. Real level data ends at `0x2800A` (an empty stub level); the next bank opens with the **desert metatile quadrant table** (`0x28010–0x28410`).

The powerup scan walked past the bank boundary, misparsed the metatile table as level headers/commands, and fabricated ~36 phantom levels containing 14 phantom "powerup blocks." Each seed, the randomizer rolled new item IDs for those phantom blocks and wrote them into metatile quadrants — e.g. metatile `0x8F` LL changed from blank (`0x06`) to `0x0B` (palm-leaf-tip CHR tile), producing a stray green tile beside palm crowns.

This explains every symptom:
- **"Byte-perfect" compares** — the CHR graphics were untouched; only the tilemap entries pointing at them changed.
- **Seed-dependent** — corruption only appears when a roll lands on a byte different from the original.
- **Desert-only** — both repro sites use the desert (TS9) tileset whose metatiles got clobbered.

The phantom levels were also feeding bogus `enemy_ptr`s into the wild-injection entry-point collection in `enemies.rs`, so this likely prevents other latent corruption as well.

## Diagnosis method

Full-ROM diff of the affected seed vs vanilla → classified the diff chunks → 4 stray writes landed in the bank-20 metatile table → traced them through `rom_map.json` to "powerup byte2 offsets" in phantom levels. Confirmed the visual tile by extracting the green wedge from a pause-screenshot (sprites removed) and pattern-matching it against all 8192 CHR tiles across palette permutations: exact match to vanilla tile `0x0B`.

## Changes

- **`rom_data.rs`**: region end `0x28C05` → `0x2800A`, with explanatory comment.
- **`tools/rom_map.py`**: same fix (`rom_map.json` regenerated — phantom levels gone).
- **`powerups.rs`**: regression test `test_regions_stay_within_one_prg_bank` asserting no region crosses an 8KB PRG bank boundary.
- **`docs/smb3_rom_reference.md`**: documented the bank-boundary / metatile-table pitfall.

## Verification

- All 220 tests pass; `cargo clippy --all-targets` clean.
- Generated ROMs for 3 seeds including the exact repro seed `5397597992758900`: **zero** writes in the metatile table region (`0x28010–0x28F36`), down from 4–5 before.

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)