### PR TITLE
fix: SAS game-over continue softlock on non-zero start page

### DIFF
--- a/docs/start_airship_swap_findings.md
+++ b/docs/start_airship_swap_findings.md
@@ -69,6 +69,45 @@ The builder used `walk_map` for its connectivity checks (lock safety, pipe place
 
 After this change the SAS 1000-seed sweep drops from 63 unreachable W3 cases to 0. The W5 carve-out and other SAS mechanics are unaffected — they don't interact with canoes.
 
+### Game Over → Continue (twirl-to-start) — the live-scroll trap
+
+Dying with lives left is self-correcting and page-agnostic: the per-frame map
+loop `PRG030_8775` continuously syncs the live scroll `Horz_Scroll`/`Horz_Scroll_Hi`
+(`$FD`/`$12`) into `Map_Prev_XOff`/`XHi` (`$0722`/`$0724`) and `World_Map_*` into
+`Map_Entered_*`, and every level entry snapshots those into the skid-back
+backups. `MO_SkidToPrev` restores from the backups, so the respawn always tracks
+live state. SAS needs to do nothing extra here.
+
+**Game Over is different.** The vanilla continue animation assumes the start is at
+page-0 hard-left:
+
+- `GameOver_Timeout` (PRG010, state 3) picks `GameOver_TwirlFromAfar` (state 5)
+  vs `GameOver_TwirlToStart` (state 4) by testing `Horz_Scroll`/`Horz_Scroll_Hi`.
+  Any nonzero (i.e. the camera is scrolled off page-0-left) → TwirlFromAfar.
+- `GameOver_TwirlFromAfar` flies Mario left, **scrolling `Horz_Scroll` down to 0**,
+  then zeroes `Map_Prev_XOff`/`XHi`/`Map_Entered_XHi`.
+- `AlignToStartY` (6) / `ReturnToStartX` (7) then operate entirely within page 0
+  (`World_Map_X` 240 → `$20`) before landing at `PRG011_A698` (state 8).
+
+So at the twirl landing the live scroll is **page 0**, no matter where the swapped
+start actually is. The SAS finalize helper is hooked into that landing
+(`STA Map_Prev_XHi2,X` at `$A6AA`) and stamps the per-player position
+(`World_Map_X/XHi`) and scroll backup (`$0722`/`$0724`) to the real start. But on
+continue, `PRG030_92B6` copies the **live** `Horz_Scroll`/`Horz_Scroll_Hi` into
+`Map_Prev_XOff`/`XHi`, and the world re-enter at `PRG030_8634` reloads
+`Horz_Scroll` *from* `Map_Prev` and does a full nametable redraw. A stale page-0
+live scroll therefore wins: the map redraws on page 0 while Mario is placed on the
+real (≥1) start page → **off-map softlock whenever the Game Over happened on a
+different overworld page than the start tile.** (If the Game Over happened on the
+start's own page, live scroll already matched, which is why it went unnoticed at
+first.)
+
+**Fix:** the finalize helper also stamps the live scroll ZP `Horz_Scroll` (`$FD`)
+= 0 and `Horz_Scroll_Hi` (`$12`) = start screen index (global, not per-player).
+The subsequent `92B6`/`8634` re-enter then carries the start page through and
+redraws the nametable there. Values are identical to the Map_Init seeds, so
+unswapped / page-0 worlds get no-op stores.
+
 ## Verification tooling
 
 The W3 reachability bug was caught by `test_required_progression` in `src/randomize/overworld_build.rs`, a Dijkstra-based must-clear analyzer. Useful flow when changing anything SAS-related:

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -45,7 +45,7 @@ const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x15554, 80, "fx_screen_check: cross-screen lock patch (Fred's algorithm verbatim)"),
     (0x15DF0, 35, "canoe_fix: death respawn position save"),
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
-    (0x17C87, 29, "start_airship_swap: game-over twirl finalize helper"),
+    (0x17C87, 33, "start_airship_swap: game-over twirl finalize helper"),
     (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
     (0x17D42, 8, "bros_no_hands: hand-trap tile bypass for overworld bro movement gate"),
     // PRG001 (file 0x02010, CPU $A000–$BFFF)
@@ -89,7 +89,7 @@ pub(super) const FS_SAS_XHI_HELPER: usize        = FS_SAS_BLOCK + 42;  // 22 byt
 // — that PRG031 run has no room for 29 more bytes). PRG011 is the hook's own bank,
 // so the JSR is bank-local; the helper still reads the FS_SAS_* tables in
 // always-resident PRG031.
-pub(super) const FS_SAS_GAMEOVER_FINALIZE: usize = 0x17C87;  // PRG011, 29 bytes — stamps World_Map_X/XHi + scroll at twirl finalize (clean gap before FS_CANOE_BACKUP)
+pub(super) const FS_SAS_GAMEOVER_FINALIZE: usize = 0x17C87;  // PRG011, 33 bytes — stamps World_Map_X/XHi + scroll backup + live Horz_Scroll/Hi at twirl finalize (clean gap before FS_CANOE_BACKUP)
 
 // Vanilla 8-byte Map_Y_Starts table (per-world Mario spawn Y-pixel). Lives in
 // PRG030's world-enter routine. The start_airship_swap module rewrites this

--- a/src/randomize/start_airship_swap.rs
+++ b/src/randomize/start_airship_swap.rs
@@ -277,6 +277,23 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     // vanilla copies that follow then propagate the corrected X/XHi into
     // Map_Previous_X/XHi, so the continue lands on the real start tile. Y is
     // World_Num (re-loaded in the helper); X is Player_Current (live at the site).
+    //
+    // It is NOT enough to fix only the per-player scroll backup ($0722/$0724,X).
+    // The vanilla twirl-to-start assumes the start is at page-0 hard-left and
+    // flies the camera there (GameOver_TwirlFromAfar scrolls Horz_Scroll down to
+    // 0). So at the twirl landing the live scroll ZP `Horz_Scroll`/`Horz_Scroll_Hi`
+    // ($FD/$12) still point at page 0, regardless of where the swapped start
+    // actually is. The game-over continue path then copies the live scroll into
+    // Map_Prev_XOff/XHi (PRG030_92B6) and re-enters the world (PRG030_8634),
+    // which reloads Horz_Scroll FROM Map_Prev and does a full nametable redraw —
+    // so a stale page-0 live scroll wins, drawing the map on page 0 while Mario
+    // is placed on the real (≥1) start page → off-map softlock whenever the
+    // Game Over happened on a different overworld page than the start tile.
+    // Fix: also stamp the live scroll ZP `Horz_Scroll` ($FD) / `Horz_Scroll_Hi`
+    // ($12) here (global, not per-player) so the subsequent re-enter redraws the
+    // nametable on the start page. The SCRL value is 0 and the SCRH value is the
+    // start screen index, identical to the Map_Init seeds; for unswapped /
+    // page-0 worlds these stores are no-ops.
     rom.set_tag("start_airship_swap/gameover_finalize");
     let finalize_helper = [
         0x9D, 0x88, 0x79,                                            // STA $7988,X (displaced Map_Prev_XHi2,X, A=0)
@@ -287,8 +304,10 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
         0x95, 0x77,                                                  // STA World_Map_XHi,X ($77,X)
         0xB9, (scrl_tbl_cpu & 0xFF) as u8, (scrl_tbl_cpu >> 8) as u8,// LDA FS_SAS_SCRL_TABLE,Y
         0x9D, 0x22, 0x07,                                            // STA Map_Prev_XOff,X ($0722)
+        0x85, 0xFD,                                                  // STA Horz_Scroll     ($FD, live scroll low)
         0xB9, (scrh_tbl_cpu & 0xFF) as u8, (scrh_tbl_cpu >> 8) as u8,// LDA FS_SAS_SCRH_TABLE,Y
         0x9D, 0x24, 0x07,                                            // STA Map_Prev_XHi,X  ($0724)
+        0x85, 0x12,                                                  // STA Horz_Scroll_Hi  ($12, live scroll page)
         0x60,                                                        // RTS
     ];
     rom.write_range(FS_SAS_GAMEOVER_FINALIZE, &finalize_helper);


### PR DESCRIPTION
## Problem

When Start↔Airship swap (SAS) places a world's start tile on an overworld page other than page 0, getting a **Game Over and continuing** could drop Mario onto a spot that isn't part of the visible map → softlock. Reported symptom: "I was on a different page of the overworld from where the start tile was… it placed the player in a spot that is not part of the overworld map."

## Root cause

Death *with lives* is robust — the per-frame map loop (`PRG030_8775`) continuously syncs the live scroll and position into the backups, so the skid-back always tracks live state regardless of page.

Game Over is different. The vanilla twirl-to-start continue animation assumes the start is at **page-0 hard-left**:

- `GameOver_TwirlFromAfar` flies the camera left, scrolling `Horz_Scroll` down to `0`.
- By the twirl landing (`PRG011_A698`, where the SAS finalize is hooked), the live scroll ZP `Horz_Scroll`/`Horz_Scroll_Hi` (`$FD`/`$12`) always points at page 0.

The SAS finalize helper stamped the per-player position (`World_Map_X/XHi`) and the scroll *backup* (`$0722`/`$0724`) to the real start, but **not** the live scroll. On continue, `PRG030_92B6` copies the live scroll into `Map_Prev_XOff/XHi`, and the world re-enter `PRG030_8634` reloads `Horz_Scroll` *from* `Map_Prev` and does a full nametable redraw. So the stale page-0 live scroll won: the map redrew on page 0 while Mario was placed on the real (≥1) start page → off-map softlock. It only manifested when the Game Over happened on a different page than the start (same page hid it — which is why it slipped past the original fix in #8).

## Fix

The finalize helper now also stamps the live scroll `Horz_Scroll` (`$FD`) = 0 and `Horz_Scroll_Hi` (`$12`) = start screen index (global, not per-player). The subsequent `92B6`/`8634` re-enter then carries the start page through and redraws the nametable there. Values mirror the existing Map_Init seeds, so unswapped / page-0 worlds get no-op stores.

- Helper grows 29 → 33 bytes (121-byte gap before `FS_CANOE_BACKUP`; free-space registration updated).
- Full game-over choreography documented in `docs/start_airship_swap_findings.md`.

## Verification

- `cargo build`, `cargo clippy --all-targets`, `cargo test` all clean (217 + integration tests pass).
- Traced end-to-end against the southbird disassembly; `$FD`/`$12` addresses cross-checked against the existing committed canoe respawn routine (`qol.rs`), which reads exactly those.
- ⚠️ **Not yet confirmed in an emulator** — no ROM available in this environment. Beta branch for in-game verification: trigger a Game Over while scrolled to a different page than a swapped world's start and confirm Continue lands on the start tile with the map drawn on the correct page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)