### PR TITLE
chore: move ROM/IPS assets into roms/ and patches/

### DIFF
--- a/.claude/commands/test-level.md
+++ b/.claude/commands/test-level.md
@@ -16,7 +16,7 @@ Examples:
 2. **Generate** the ROM using `target/release/smb3-rs` with the provided flags/seed (or defaults: `--no-enemies --no-palettes --no-chest-items --no-levels`, seed random). Always use `--patched-rom -o test_level.nes`.
 
 3. **Apply open-movement patches** from the practice ROM so the player can walk over level/lock/fortress tiles without entering or clearing them:
-   `nix-shell -p python3 --run 'python3 tools/apply_ips_subset.py smb3practice_SE.ips test_level.nes 0x14010 0x18010'`
+   `nix-shell -p python3 --run 'python3 tools/apply_ips_subset.py patches/smb3practice_SE.ips test_level.nes 0x14010 0x18010'`
    This applies only the PRG010–011 records (~19 records, ~85 bytes). Do NOT apply the full IPS — its PRG006/PRG012 records would clobber the randomized enemy data and overworld map.
 
 4. **Identify levels** by name. Use these mappings to find vanilla obj_ptr/lay_ptr/tileset:
@@ -42,5 +42,5 @@ Examples:
 ## Key ROM offsets
 - Map object ID master pointer: 0x16050 (per-world, 9 slots each)
 - Starting world byte: 0x30CC3
-- Vanilla ROM: `Super Mario Bros. 3 (USA) (Rev 1).nes`
+- Vanilla ROM: `roms/Super Mario Bros. 3 (USA) (Rev 1).nes`
 - Pointer table starts: W1=0x19438, W2=0x194BA, W3=0x195D8, W4=0x19714, W5=0x197E4, W6=0x198E4, W7=0x19A3E, W8=0x19B56

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1302,7 +1302,7 @@ by Recolored, proving these are the master per-tileset/area palette tables.
 
 > **Empirical confirmations** are from `tools/gen_palette_probes.py` runs in an emulator
 > (paint each table to NES `0x24` hot magenta, observe which graphics turn pink).
-> Probes apply `smb3practice_SE.ips` for warp whistles + level select + open movement
+> Probes apply `patches/smb3practice_SE.ips` for warp whistles + level select + open movement
 > so all worlds are reachable. Filenames: `test_roms/palette_probe_<name>_wN.nes`.
 
 > **Quartet alignment varies** across these tables — outline `0F` is at byte 2 in
@@ -3249,7 +3249,7 @@ The track is chosen deterministically from the seed via a curated 16-entry table
 
 ## Autoscroll Disable
 
-Disabling autoscrollers requires far more than removing the D3 autoscroll objects. The reference patch `Super_Mario_Bros_3_NoAutoscrolls(Except 5-9).ips` (65 records, 662 bytes) makes changes across five ROM regions:
+Disabling autoscrollers requires far more than removing the D3 autoscroll objects. The reference patch `patches/Super_Mario_Bros_3_NoAutoscrolls(Except 5-9).ips` (65 records, 662 bytes) makes changes across five ROM regions:
 
 ### 1. Enemy/Object Data (0x0BFD8–0x0E00D)
 

--- a/src/randomize/autoscroll.rs
+++ b/src/randomize/autoscroll.rs
@@ -33,7 +33,7 @@ pub const SPOILED_SEGMENT_RANGES: &[Range<usize>] = &[
 /// Disable all autoscrollers except 5-9 (parabeetle ride).
 ///
 /// This applies the full set of patches derived from the reference
-/// "Super_Mario_Bros_3_NoAutoscrolls(Except 5-9).ips" patch. The reference
+/// "patches/Super_Mario_Bros_3_NoAutoscrolls(Except 5-9).ips" patch. The reference
 /// patch does far more than simply removing D3 autoscroll objects — it:
 ///
 /// 1. Removes D3 autoscroll controller objects from enemy data

--- a/src/randomize/enemies.rs
+++ b/src/randomize/enemies.rs
@@ -2602,7 +2602,7 @@ mod tests {
     // Run with: cargo test enemy_invariant_baseline -- --nocapture
     // ===================================================================
 
-    const REFERENCE_ROM_PATH: &str = "Super Mario Bros. 3 (USA) (Rev 1).nes";
+    const REFERENCE_ROM_PATH: &str = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes";
 
     fn load_reference_rom() -> Option<Rom> {
         let data = std::fs::read(REFERENCE_ROM_PATH).ok()?;

--- a/src/randomize/map_walker.rs
+++ b/src/randomize/map_walker.rs
@@ -517,7 +517,7 @@ mod tests {
 
     #[test]
     fn test_find_start_all_worlds() {
-        let rom_data_bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes");
+        let rom_data_bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes");
         if rom_data_bytes.is_err() {
             return;
         }
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn test_walk_w1_reachable() {
-        let rom_data_bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes");
+        let rom_data_bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes");
         if rom_data_bytes.is_err() {
             return;
         }
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_walk_w7_needs_pipes() {
-        let rom_data_bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes");
+        let rom_data_bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes");
         if rom_data_bytes.is_err() {
             return;
         }
@@ -592,7 +592,7 @@ mod tests {
 
     #[test]
     fn test_chokepoints_w1() {
-        let rom_data_bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes");
+        let rom_data_bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes");
         if rom_data_bytes.is_err() {
             return;
         }
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_render_debug_visual() {
-        let rom_data_bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes");
+        let rom_data_bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes");
         if rom_data_bytes.is_err() {
             return;
         }
@@ -638,7 +638,7 @@ mod tests {
 
     #[test]
     fn test_render_progression_w6() {
-        let rom_data_bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes");
+        let rom_data_bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes");
         if rom_data_bytes.is_err() {
             return;
         }
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn test_render_randomized_seed() {
-        let rom_data_bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes");
+        let rom_data_bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes");
         if rom_data_bytes.is_err() {
             return;
         }

--- a/src/randomize/node_catalog.rs
+++ b/src/randomize/node_catalog.rs
@@ -595,7 +595,7 @@ mod tests {
     use crate::randomize::rom_data::MAP_TILE_GRIDS;
 
     fn load_rom() -> Option<Rom> {
-        let data = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+        let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
         Rom::from_bytes(&data).ok()
     }
 

--- a/src/randomize/overworld_build.rs
+++ b/src/randomize/overworld_build.rs
@@ -2331,7 +2331,7 @@ mod tests {
     use rand_chacha::ChaCha8Rng;
 
     fn load_rom() -> Option<Rom> {
-        let data = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+        let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
         Rom::from_bytes(&data).ok()
     }
 
@@ -3981,7 +3981,7 @@ mod tests {
     fn test_dump_required_progression() {
         use crate::Options;
 
-        let rom_bytes = match std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
             Ok(b) => b,
             Err(_) => {
                 eprintln!("ROM not found, skipping");

--- a/src/randomize/overworld_pickup.rs
+++ b/src/randomize/overworld_pickup.rs
@@ -303,7 +303,7 @@ mod tests {
     use super::*;
 
     fn load_rom() -> Option<Rom> {
-        let data = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+        let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
         Rom::from_bytes(&data).ok()
     }
 

--- a/src/randomize/overworld_writer.rs
+++ b/src/randomize/overworld_writer.rs
@@ -1310,7 +1310,7 @@ mod tests {
     use rand_chacha::ChaCha8Rng;
 
     fn load_rom() -> Option<Rom> {
-        let data = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+        let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
         Rom::from_bytes(&data).ok()
     }
 

--- a/src/randomize/troll_pipes.rs
+++ b/src/randomize/troll_pipes.rs
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn marks_one_pipe_per_world_w2_w8() {
-        let Ok(bytes) = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
             return; // Base ROM not present (e.g. CI) — skip.
         };
         let rom = Rom::from_bytes(&bytes).unwrap();

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -1135,7 +1135,7 @@ mod tests {
     /// silently skips) when the ROM isn't in the project root, mirroring
     /// `map_walker::tests::test_render_randomized_seed`.
     fn make_test_rom() -> Option<Rom> {
-        let bytes = std::fs::read("Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+        let bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
         Rom::from_bytes(&bytes).ok()
     }
 

--- a/tests/chr_stats.rs
+++ b/tests/chr_stats.rs
@@ -214,7 +214,7 @@ fn print_slot(label: &str, counts: &PageCounts) {
 }
 
 fn load_rom() -> Option<Rom> {
-    let path = "Super Mario Bros. 3 (USA) (Rev 1).nes";
+    let path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes";
     let data = std::fs::read(path).ok()?;
     Rom::from_bytes(&data).ok()
 }

--- a/tests/toad_swap.rs
+++ b/tests/toad_swap.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 const TOAD_IPS_PATH: &str = "web/visual-patches/super-toad-josuecr4ft.ips";
-const USA_ROM_PATH: &str = "Super Mario Bros. 3 (USA) (Rev 1).nes";
+const USA_ROM_PATH: &str = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes";
 
 fn read_optional(path: &str) -> Option<Vec<u8>> {
     if Path::new(path).exists() { Some(fs::read(path).unwrap()) } else { None }

--- a/tools/apply_ips_subset.py
+++ b/tools/apply_ips_subset.py
@@ -9,7 +9,7 @@ Records are kept if their starting offset falls in [start, end) of the ROM file
 
 Example — apply only PRG010-011 records (file offsets 0x14010..0x18010) of the
 practice patch to a freshly-generated test ROM:
-    python3 tools/apply_ips_subset.py smb3practice_SE.ips test_level.nes 0x14010 0x18010
+    python3 tools/apply_ips_subset.py patches/smb3practice_SE.ips test_level.nes 0x14010 0x18010
 """
 
 import sys

--- a/tools/attribute_diffs.py
+++ b/tools/attribute_diffs.py
@@ -14,7 +14,7 @@ import re
 import json
 import sys
 
-VANILLA = "/home/michio/git/SMB3R/Super Mario Bros. 3 (USA) (Rev 1).nes"
+VANILLA = "/home/michio/git/SMB3R/roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 RANDO = "/tmp/smb3rs_repro.nes"
 
 

--- a/tools/canary_chr.py
+++ b/tools/canary_chr.py
@@ -14,14 +14,14 @@ safe.
 
 For convenience the tool also:
 - Applies the practice ROM's open-movement patches (PRG010-011 records of
-  smb3practice_SE.ips) so Mario can walk over level/lock/fortress tiles.
+  patches/smb3practice_SE.ips) so Mario can walk over level/lock/fortress tiles.
 - Injects 3 warp whistles + 5 lives into the starting inventory via the same
   PRG031 trampoline used by src/randomize/qol.rs::write_starting_items.
 
 Usage:
     python3 tools/canary_chr.py [source.nes [output.nes]]
 
-Defaults: source = "Super Mario Bros. 3 (USA) (Rev 1).nes", output = canary.nes
+Defaults: source = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes", output = canary.nes
 """
 
 import sys
@@ -151,7 +151,7 @@ def inject_starting_items(rom: bytearray, lives: int = 5, items=(0x0C, 0x0C, 0x0
 
 def main():
     args = sys.argv[1:]
-    src = Path(args[0]) if len(args) >= 1 else PROJECT_ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
+    src = Path(args[0]) if len(args) >= 1 else PROJECT_ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
     dst = Path(args[1]) if len(args) >= 2 else PROJECT_ROOT / "canary.nes"
     if len(args) > 2:
         sys.exit("Usage: canary_chr.py [source.nes [output.nes]]")
@@ -161,8 +161,8 @@ def main():
     if len(rom) != 393232:
         print(f"WARNING: source size {len(rom)} != expected 393232 bytes")
 
-    print("Applying open-movement patches (PRG010-011 of smb3practice_SE.ips)...")
-    n = apply_ips_subset(rom, PROJECT_ROOT / "smb3practice_SE.ips", 0x14010, 0x18010)
+    print("Applying open-movement patches (PRG010-011 of patches/smb3practice_SE.ips)...")
+    n = apply_ips_subset(rom, PROJECT_ROOT / "patches/smb3practice_SE.ips", 0x14010, 0x18010)
     print(f"  {n} records applied")
 
     print("Injecting 5 lives + 3 warp whistles into starting inventory...")

--- a/tools/check_hb_writes.py
+++ b/tools/check_hb_writes.py
@@ -6,7 +6,7 @@
 import re
 import json
 
-VANILLA = "/home/michio/git/SMB3R/Super Mario Bros. 3 (USA) (Rev 1).nes"
+VANILLA = "/home/michio/git/SMB3R/roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 RANDO = "/tmp/smb3rs_repro.nes"
 
 

--- a/tools/check_powerups_walker.py
+++ b/tools/check_powerups_walker.py
@@ -9,7 +9,7 @@ Any byte modified that DOESN'T match these criteria = walker desync (bug).
 
 import json
 
-VANILLA = "/home/michio/git/SMB3R/Super Mario Bros. 3 (USA) (Rev 1).nes"
+VANILLA = "/home/michio/git/SMB3R/roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 RANDO = "/home/michio/git/SMB3R/smb3-rs_2889718939757641.nes"
 
 QBLOCK = {0x00, 0x01, 0x02}

--- a/tools/check_scroll.py
+++ b/tools/check_scroll.py
@@ -1,4 +1,4 @@
-with open('Super Mario Bros. 3 (USA) (Rev 1).nes', 'rb') as f:
+with open('roms/Super Mario Bros. 3 (USA) (Rev 1).nes', 'rb') as f:
     rom = f.read()
 
 PAGE_A000 = [11, 15, 21, 16, 17, 19, 18, 18, 18, 20, 23, 19, 17, 19, 13, 26, 26, 26, 9]

--- a/tools/diff_hb_layouts.py
+++ b/tools/diff_hb_layouts.py
@@ -10,7 +10,7 @@ end and report all differences.
 
 import json
 
-VANILLA = "/home/michio/git/SMB3R/Super Mario Bros. 3 (USA) (Rev 1).nes"
+VANILLA = "/home/michio/git/SMB3R/roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 RANDO = "/home/michio/git/SMB3R/smb3-rs_2889718939757641.nes"
 
 

--- a/tools/extract_palette_variants.py
+++ b/tools/extract_palette_variants.py
@@ -20,8 +20,8 @@ Regions excluded from the output:
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-ROM = ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
-IPS = ROOT / "Super Mario Bros. 3 Recolored v1.0.ips"
+ROM = ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
+IPS = ROOT / "patches/Super Mario Bros. 3 Recolored v1.0.ips"
 
 REGIONS = [
     ("slot2_overworld_text",       0x36C54, 0x36C8C),

--- a/tools/extract_recolored_pools.py
+++ b/tools/extract_recolored_pools.py
@@ -16,8 +16,8 @@ from pathlib import Path
 from collections import defaultdict
 
 ROOT = Path(__file__).resolve().parent.parent
-ROM_PATH = ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
-IPS_PATH = ROOT / "Super Mario Bros. 3 Recolored v1.0.ips"
+ROM_PATH = ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
+IPS_PATH = ROOT / "patches/Super Mario Bros. 3 Recolored v1.0.ips"
 
 # Regions with confirmed purpose from emulator probes.
 # (label, start, end, notes)

--- a/tools/find_1_3.py
+++ b/tools/find_1_3.py
@@ -3,7 +3,7 @@
 
 import sys
 
-rom_path = "Super Mario Bros. 3 (USA) (Rev 1).nes"
+rom_path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 rom = open(rom_path, "rb").read()
 
 def hexdump(data):

--- a/tools/fx_check.py
+++ b/tools/fx_check.py
@@ -7,7 +7,7 @@ lock shuffle, and related overworld mutations leave the FX system consistent.
 
 Usage:
     python3 tools/fx_check.py <rom_file>
-    python3 tools/fx_check.py "Super Mario Bros. 3 (USA) (Rev 1).nes"
+    python3 tools/fx_check.py "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 
 Output per world:
   - Fortress entries (tileset 2 from pointer table) with grid positions and map tiles

--- a/tools/gen_palette_probes.py
+++ b/tools/gen_palette_probes.py
@@ -3,7 +3,7 @@
 vivid canary color (NES 0x24 hot magenta). Run each in an emulator to identify
 which level/area/sprite uses that table.
 
-Each probe also has the smb3practice_SE.ips open-movement subset (PRG010-011 only)
+Each probe also has the patches/smb3practice_SE.ips open-movement subset (PRG010-011 only)
 applied so Mario can walk freely over locks/forts/levels without entering them —
 this lets us scan the entire overworld map for color changes.
 
@@ -16,8 +16,8 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-ROM_PATH = ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
-PRACTICE_IPS = ROOT / "smb3practice_SE.ips"
+ROM_PATH = ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
+PRACTICE_IPS = ROOT / "patches/smb3practice_SE.ips"
 OPEN_MOVE_RANGE = (0x14010, 0x18010)  # PRG010-011 only; safe vs PRG012-013 palette tables
 START_WORLD_OFFSET = 0x30CC3            # operand of LDA #$00 — sets starting world index 0..7
 OUT_DIR = ROOT / "test_roms"
@@ -176,7 +176,7 @@ def main():
     ap.add_argument(
         "--practice", choices=("open-move", "full"), default="full",
         help=(
-            "what subset of smb3practice_SE.ips to apply. "
+            "what subset of patches/smb3practice_SE.ips to apply. "
             "'open-move' = PRG010-011 only (~85 B, walk freely over locks/forts). "
             "'full' (default) = everything except records that would overwrite a "
             "painted palette table (gives warp whistles, level select, infinite lives, etc.)."

--- a/tools/gen_palette_rainbow.py
+++ b/tools/gen_palette_rainbow.py
@@ -27,8 +27,8 @@ import argparse
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-ROM_PATH = ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
-PRACTICE_IPS = ROOT / "smb3practice_SE.ips"
+ROM_PATH = ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
+PRACTICE_IPS = ROOT / "patches/smb3practice_SE.ips"
 START_WORLD_OFFSET = 0x30CC3
 OUT_DIR = ROOT / "test_roms"
 OUT_DIR.mkdir(exist_ok=True)

--- a/tools/gen_palette_variants.py
+++ b/tools/gen_palette_variants.py
@@ -20,8 +20,8 @@ Usage:
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-ROM = ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
-IPS = ROOT / "Super Mario Bros. 3 Recolored v1.0.ips"
+ROM = ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
+IPS = ROOT / "patches/Super Mario Bros. 3 Recolored v1.0.ips"
 OUT = ROOT / "src/randomize/palette_variants.rs"
 
 # (rust_const_name, label, start, end, description)

--- a/tools/gen_test_roms.py
+++ b/tools/gen_test_roms.py
@@ -2,7 +2,7 @@
 """Generate 8 test ROMs with every level replaced by 7-F1, one per starting world."""
 import os
 
-rom_path = "Super Mario Bros. 3 (USA) (Rev 1).nes"
+rom_path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 rom = bytearray(open(rom_path, "rb").read())
 
 F1_TILESET = 2

--- a/tools/gen_tileset_sampler.py
+++ b/tools/gen_tileset_sampler.py
@@ -6,7 +6,7 @@ across W1's first ~9 tiles, see every tileset under the same probe.
 Combines:
   - tools/gen_palette_rainbow.py (rainbow paint of a region)
   - the per-tileset rep map (one early level per tileset, taken from rom_map.json)
-  - smb3practice_SE.ips (open movement + warp whistles + level select)
+  - patches/smb3practice_SE.ips (open movement + warp whistles + level select)
 
 Usage:
   python3 tools/gen_tileset_sampler.py --start 0x37400 --end 0x37600 --bands 8
@@ -19,8 +19,8 @@ import argparse
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-ROM_PATH = ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
-PRACTICE_IPS = ROOT / "smb3practice_SE.ips"
+ROM_PATH = ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
+PRACTICE_IPS = ROOT / "patches/smb3practice_SE.ips"
 OUT_DIR = ROOT / "test_roms"
 OUT_DIR.mkdir(exist_ok=True)
 

--- a/tools/level_sim.py
+++ b/tools/level_sim.py
@@ -7,7 +7,7 @@ Simulates the SMB3 level generator system to produce a tile grid
 showing exactly which tile IDs end up at each position in a level.
 
 Usage: python3 tools/level_sim.py [rom_path] [level_offset_hex]
-  Default: "Super Mario Bros. 3 (USA) (Rev 1).nes" at 0x1FB92 (World 1-1)
+  Default: "roms/Super Mario Bros. 3 (USA) (Rev 1).nes" at 0x1FB92 (World 1-1)
 """
 
 import os
@@ -545,7 +545,7 @@ class LevelSimulator:
 
 
 def main():
-    rom_path = "Super Mario Bros. 3 (USA) (Rev 1).nes"
+    rom_path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
     level_offset = 0x1FB92  # World 1-1
 
     if len(sys.argv) >= 2:

--- a/tools/map_viz.py
+++ b/tools/map_viz.py
@@ -13,7 +13,7 @@ Usage:
     python3 tools/map_viz.py [rom_path] --raw          # show raw hex tile IDs
     python3 tools/map_viz.py [rom_path] --summary       # just show slot counts
 
-Default ROM: "Super Mario Bros. 3 (USA) (Rev 1).nes"
+Default ROM: "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 """
 
 import os
@@ -685,7 +685,7 @@ def print_mapping_validation(rom):
 
 def main():
     # Parse args
-    rom_path = "Super Mario Bros. 3 (USA) (Rev 1).nes"
+    rom_path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
     world_filter = None
     raw_hex = False
     summary_only = False

--- a/tools/map_walker.py
+++ b/tools/map_walker.py
@@ -552,7 +552,7 @@ def render_walk(grid, nodes, edges, path_tiles, chokepoints, pipe_pairs,
 # ---------------------------------------------------------------------------
 
 def main():
-    rom_path = "Super Mario Bros. 3 (USA) (Rev 1).nes"
+    rom_path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
     world_filter = None
     show_progression = False
 

--- a/tools/palette_inspect.py
+++ b/tools/palette_inspect.py
@@ -27,8 +27,8 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
-ROM_PATH = ROOT / "Super Mario Bros. 3 (USA) (Rev 1).nes"
-IPS_PATH = ROOT / "Super Mario Bros. 3 Recolored v1.0.ips"
+ROM_PATH = ROOT / "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
+IPS_PATH = ROOT / "patches/Super Mario Bros. 3 Recolored v1.0.ips"
 ROM_MAP_PATH = ROOT / "tools" / "rom_map.json"
 
 INES_HEADER = 0x10

--- a/tools/parse_ips.py
+++ b/tools/parse_ips.py
@@ -85,7 +85,7 @@ def main():
         # Default to the reference IPS in the project
         script_dir = os.path.dirname(os.path.abspath(__file__))
         project_dir = os.path.dirname(script_dir)
-        filepath = os.path.join(project_dir, "Super_Mario_Bros_3_NoAutoscrolls(Except 5-9).ips")
+        filepath = os.path.join(project_dir, "patches/Super_Mario_Bros_3_NoAutoscrolls(Except 5-9).ips")
         if not os.path.exists(filepath):
             print(f"Usage: {sys.argv[0]} <ips_file>", file=sys.stderr)
             print(f"Default file not found: {filepath}", file=sys.stderr)

--- a/tools/pipe_shuffle.py
+++ b/tools/pipe_shuffle.py
@@ -776,7 +776,7 @@ def resort_pointer_table(rom, world_idx):
 # ---------------------------------------------------------------------------
 
 def main():
-    rom_path = "Super Mario Bros. 3 (USA) (Rev 1).nes"
+    rom_path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
     output_path = None
     world_filter = None
     seed = 42

--- a/tools/rom_map.py
+++ b/tools/rom_map.py
@@ -22,7 +22,7 @@ Modes:
   python3 tools/rom_map.py [rom] --tile 45          # CHR pattern, behavior, palette
   python3 tools/rom_map.py [rom] --check-dispatches # validate 4-byte dispatch tables
 
-Default ROM: "Super Mario Bros. 3 (USA) (Rev 1).nes"
+Default ROM: "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
 """
 
 import json
@@ -2157,7 +2157,7 @@ def _render_walk_grid(grid, nodes, path_tiles, chokepoints,
 # --------------------------------------------------------------------------
 
 def main():
-    rom_path = "Super Mario Bros. 3 (USA) (Rev 1).nes"
+    rom_path = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes"
     output_path = "tools/rom_map.json"
     mode = "json"  # default: generate JSON
     world_filter = None

--- a/tools/validate_shuffleable.py
+++ b/tools/validate_shuffleable.py
@@ -219,7 +219,7 @@ def collect_shuffleable(rom: bytes, world_idx: int, rowtype_offset: int, entry_c
 def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))
     project_dir = os.path.dirname(script_dir)
-    rom_path = os.path.join(project_dir, "Super Mario Bros. 3 (USA) (Rev 1).nes")
+    rom_path = os.path.join(project_dir, "roms/Super Mario Bros. 3 (USA) (Rev 1).nes")
     map_path = os.path.join(script_dir, "rom_map.json")
 
     if not os.path.exists(rom_path):


### PR DESCRIPTION
Moves the local ROM dumps and IPS patches into `roms/` and `patches/` subdirectories (both gitignored) and updates all hardcoded path references to match.

- `"Super Mario Bros. 3 (USA) (Rev 1).nes"` → `"roms/..."`
- `"<patch>.ips"` → `"patches/<patch>.ips"`

Across source, tests, tools, and docs. Purely mechanical path updates — no logic changes.

ROM-dependent tests (`chr_stats`, `toad_swap`) pass against the new `roms/` location; full suite green (217 unit + integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)