### PR TITLE
fix: scope canoe edges to their world in the overworld walker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.16"
+version = "0.8.17"
 edition = "2024"
 
 [lib]

--- a/src/randomize/map_walker.rs
+++ b/src/randomize/map_walker.rs
@@ -68,10 +68,16 @@ fn canoes_reachable(
     grid: &Grid,
     pipe_pairs: &[TeleportEdge],
     start: (usize, usize),
+    world_idx: usize,
 ) -> bool {
-    // Mainland docks per `CANOE_EDGES` are the `a` side of each tuple.
+    // Mainland docks per `CANOE_EDGES` are the `a` side of each tuple, scoped to
+    // this world. Filtering by `world_idx` is essential: the edge coordinates
+    // are not world-unique, so an unfiltered scan would fabricate canoe
+    // connectivity in any world that happens to reach a mainland dock's
+    // coordinate (e.g. W3's (6,20) also exists in W2/W4–W8).
     let docks: Vec<(usize, usize)> = rom_data::CANOE_EDGES
         .iter()
+        .filter(|&&(w, _)| w == world_idx)
         .map(|&(_, (a, _))| a)
         .collect();
     if docks.is_empty() {
@@ -139,6 +145,7 @@ pub(super) fn walk_map(
     grid: &Grid,
     pipe_pairs: &[TeleportEdge],
     start_pos: Option<(usize, usize)>,
+    world_idx: usize,
 ) -> WalkResult {
     let start = match start_pos.or_else(|| rom_data::find_start(grid)) {
         Some(s) => s,
@@ -172,8 +179,11 @@ pub(super) fn walk_map(
     // structural fix for the SAS-W3 deadlock where the swap moves the start
     // into a region with no walking path to the dock.
     let mut canoe_lookup: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
-    if canoes_reachable(grid, pipe_pairs, start) {
-        for &(_, (a, b)) in rom_data::CANOE_EDGES {
+    if canoes_reachable(grid, pipe_pairs, start, world_idx) {
+        for &(w, (a, b)) in rom_data::CANOE_EDGES {
+            if w != world_idx {
+                continue;
+            }
             canoe_lookup.entry(a).or_default().push(b);
             canoe_lookup.entry(b).or_default().push(a);
         }
@@ -457,7 +467,7 @@ pub(super) fn render_progression(
     }
 
     // Initial walk
-    let result = walk_map(&grid, pipe_pairs, None);
+    let result = walk_map(&grid, pipe_pairs, None, world_idx);
     let chokes = find_chokepoints(&result);
     out.push_str(&render_debug(
         &grid, Some(&result), Some(&chokes), Some(&pipe_pos),
@@ -466,7 +476,7 @@ pub(super) fn render_progression(
 
     loop {
         // Re-walk with current grid state to get fresh reachable set
-        let result = walk_map(&grid, pipe_pairs, None);
+        let result = walk_map(&grid, pipe_pairs, None, world_idx);
 
         let reachable_forts: Vec<usize> = world_forts
             .iter()
@@ -500,7 +510,7 @@ pub(super) fn render_progression(
             }
         }
 
-        let result = walk_map(&grid, pipe_pairs, None);
+        let result = walk_map(&grid, pipe_pairs, None, world_idx);
         let chokes = find_chokepoints(&result);
         out.push_str(&render_debug(
             &grid, Some(&result), Some(&chokes), Some(&pipe_pos), &label,
@@ -545,7 +555,7 @@ mod tests {
         let grid = rom_data::read_tile_grid(&rom, 0);
         let pipes = rom_data::read_pipe_pairs(&rom);
         let w1_pipes = pipes.get(&0).cloned().unwrap_or_default();
-        let result = walk_map(&grid, &w1_pipes, None);
+        let result = walk_map(&grid, &w1_pipes, None, 0);
 
         // W1 has 21 entries, most are reachable from start (no pipes needed)
         assert!(
@@ -566,12 +576,12 @@ mod tests {
         let grid = rom_data::read_tile_grid(&rom, 6);
 
         // Walk without pipes — should be very limited
-        let result_no_pipes = walk_map(&grid, &[], None);
+        let result_no_pipes = walk_map(&grid, &[], None, 6);
 
         // Walk with pipes — should reach many more
         let pipes = rom_data::read_pipe_pairs(&rom);
         let w7_pipes = pipes.get(&6).cloned().unwrap_or_default();
-        let result_with_pipes = walk_map(&grid, &w7_pipes, None);
+        let result_with_pipes = walk_map(&grid, &w7_pipes, None, 6);
 
         assert!(
             result_with_pipes.nodes.len() > result_no_pipes.nodes.len(),
@@ -599,7 +609,7 @@ mod tests {
         let rom = Rom::from_bytes(&rom_data_bytes.unwrap()).unwrap();
 
         let grid = rom_data::read_tile_grid(&rom, 0);
-        let result = walk_map(&grid, &[], None);
+        let result = walk_map(&grid, &[], None, 0);
         let chokepoints = find_chokepoints(&result);
 
         // W1 has a linear path structure with many chokepoints
@@ -621,7 +631,7 @@ mod tests {
         for wi in 0..8 {
             let grid = rom_data::read_tile_grid(&rom, wi);
             let pipes = all_pipes.get(&wi).cloned().unwrap_or_default();
-            let result = walk_map(&grid, &pipes, None);
+            let result = walk_map(&grid, &pipes, None, wi);
             let chokes = find_chokepoints(&result);
 
             let mut pipe_pos = HashSet::new();
@@ -674,7 +684,7 @@ mod tests {
         for wi in 0..8 {
             let grid = rom_data::read_tile_grid(&rom, wi);
             let pipes = all_pipes.get(&wi).cloned().unwrap_or_default();
-            let result = walk_map(&grid, &pipes, None);
+            let result = walk_map(&grid, &pipes, None, wi);
             let chokes = find_chokepoints(&result);
 
             let mut pipe_pos = HashSet::new();

--- a/src/randomize/overworld_build.rs
+++ b/src/randomize/overworld_build.rs
@@ -326,6 +326,7 @@ pub(crate) fn build<R: Rng>(
                 &built.slots,
                 fort_counts[wi],
                 true, // force_safe
+                wi,
                 rng,
             );
             if new_locks.iter().any(|l| l.secret_exit_safe) {
@@ -628,6 +629,7 @@ fn build_world<R: Rng>(
         target_pos,
         pipe_pair_count,
         &fixed_pipe_eps,
+        world_idx,
         rng,
     );
 
@@ -646,18 +648,19 @@ fn build_world<R: Rng>(
         &pipe_positions,
         fixed_positions,
         fort_count,
+        world_idx,
     );
 
     // Build BFS distance map for scoring — reflects actual walkable distance.
     let bfs_distances: HashMap<(usize, usize), usize> =
-        bfs_ordered(&grid, &pipe_pairs, start_pos)
+        bfs_ordered(&grid, &pipe_pairs, start_pos, world_idx)
             .into_iter()
             .collect();
 
     // Reverse BFS from target (airship/Bowser) — used to compute path relevance
     // for level scoring. Positions on the main start→target trunk have low detour.
     let reverse_bfs: HashMap<(usize, usize), usize> = target_pos
-        .map(|tp| walk_map(&grid, &pipe_pairs, Some(tp)).distances)
+        .map(|tp| walk_map(&grid, &pipe_pairs, Some(tp), world_idx).distances)
         .unwrap_or_default();
     let target_bfs_dist = target_pos.and_then(|tp| bfs_distances.get(&tp).copied());
 
@@ -715,6 +718,7 @@ fn build_world<R: Rng>(
         &slots,
         fort_count,
         force_safe,
+        world_idx,
         rng,
     );
 
@@ -813,8 +817,9 @@ pub(super) fn bfs_ordered(
     grid: &Grid,
     pipe_pairs: &[TeleportEdge],
     start_pos: Option<(usize, usize)>,
+    world_idx: usize,
 ) -> Vec<((usize, usize), usize)> {
-    let result = walk_map(grid, pipe_pairs, start_pos);
+    let result = walk_map(grid, pipe_pairs, start_pos, world_idx);
     let mut ordered: Vec<((usize, usize), usize)> = result
         .distances
         .into_iter()
@@ -850,6 +855,11 @@ fn split_blanks_by_reachability(
     (reach, unreach)
 }
 
+// Reason: each argument is a distinct pipe-placement input (grid, candidate
+// blanks, start/target anchors, pair budget, fixed endpoints, world, RNG).
+// They don't form a cohesive concept, so bundling would add indirection
+// without clarity.
+#[allow(clippy::too_many_arguments)]
 fn place_pipes<R: Rng>(
     grid: &mut Grid,
     blank_positions: &[(usize, usize)],
@@ -857,6 +867,7 @@ fn place_pipes<R: Rng>(
     target_pos: Option<(usize, usize)>,
     pair_count: usize,
     fixed_endpoints: &[(usize, usize)],
+    world_idx: usize,
     rng: &mut R,
 ) -> Vec<TeleportEdge> {
     if pair_count == 0 {
@@ -873,7 +884,7 @@ fn place_pipes<R: Rng>(
     let no_pipe_zone: HashSet<(usize, usize)> = {
         let mut zone: HashSet<(usize, usize)> = HashSet::new();
         for anchor in [start_pos, target_pos].into_iter().flatten() {
-            let walk = walk_map(grid, &[], Some(anchor));
+            let walk = walk_map(grid, &[], Some(anchor), world_idx);
             for (&pos, &d) in &walk.distances {
                 if d <= 1 {
                     zone.insert(pos);
@@ -912,7 +923,7 @@ fn place_pipes<R: Rng>(
         used_positions.insert(fixed_pos);
 
         // BFS to find which blanks are reachable from start.
-        let walk = walk_map(grid, &placed_pairs, start_pos);
+        let walk = walk_map(grid, &placed_pairs, start_pos, world_idx);
         let fixed_is_reachable = walk.nodes.contains(&fixed_pos);
 
         // Pick partner from opposite side: if fixed is on an island,
@@ -947,7 +958,7 @@ fn place_pipes<R: Rng>(
     // best-effort in B), then fill remaining pairs in reachable area.
     let target_reachable = |g: &Grid, pairs: &[TeleportEdge]| -> bool {
         if let Some(tp) = target_pos {
-            let walk = walk_map(g, pairs, start_pos);
+            let walk = walk_map(g, pairs, start_pos, world_idx);
             walk.nodes.contains(&tp)
         } else {
             true // no target = nothing to connect
@@ -961,7 +972,7 @@ fn place_pipes<R: Rng>(
             must_connect_target = false;
         }
 
-        let walk = walk_map(grid, &placed_pairs, start_pos);
+        let walk = walk_map(grid, &placed_pairs, start_pos, world_idx);
         let (reachable_blanks, unreachable_blanks) =
             split_blanks_by_reachability(blank_positions, &walk.nodes, &used_positions);
 
@@ -1045,6 +1056,11 @@ fn place_pipes<R: Rng>(
 // ---------------------------------------------------------------------------
 
 /// Divide reachable blank slots into N sections by BFS distance from start.
+// Reason: arguments are distinct traversal inputs (grid, pipes, start, blanks,
+// pipe/fixed position sets, section count, world); they don't cluster into a
+// meaningful concept, so a bundling struct would be a lint bandage, not a real
+// abstraction.
+#[allow(clippy::too_many_arguments)]
 fn bfs_section(
     grid: &Grid,
     pipe_pairs: &[TeleportEdge],
@@ -1053,6 +1069,7 @@ fn bfs_section(
     pipe_positions: &HashSet<(usize, usize)>,
     fixed_positions: &HashSet<(usize, usize)>,
     section_count: usize,
+    world_idx: usize,
 ) -> Vec<Vec<(usize, usize)>> {
     if section_count == 0 {
         return vec![blank_positions
@@ -1063,7 +1080,7 @@ fn bfs_section(
     }
 
     // BFS-order all reachable positions
-    let ordered = bfs_ordered(grid, pipe_pairs, start_pos);
+    let ordered = bfs_ordered(grid, pipe_pairs, start_pos, world_idx);
 
     // Filter to only blank slots that aren't used by pipes or fixed entries
     let assignable: Vec<(usize, usize)> = ordered
@@ -1503,6 +1520,7 @@ fn place_locks<R: Rng>(
     slots: &[SlotAssignment],
     fort_count: usize,
     force_safe: bool,
+    world_idx: usize,
     rng: &mut R,
 ) -> Vec<LockAssignment> {
     let mut locks: Vec<LockAssignment> = Vec::new();
@@ -1602,7 +1620,7 @@ fn place_locks<R: Rng>(
         // Open grid (no candidate lock) is constant for all candidates in this
         // section — hoist the BFS to avoid redundant walks per candidate.
         let open_grid = build_test_grid(None);
-        let open_node_count = walk_map(&open_grid, pipe_pairs, start_pos).nodes.len() as i32;
+        let open_node_count = walk_map(&open_grid, pipe_pairs, start_pos, world_idx).nodes.len() as i32;
 
         // If a previous lock in this world already blocks the target, suppress
         // the target-blocking bonus to avoid stacking multiple locks against
@@ -1616,7 +1634,7 @@ fn place_locks<R: Rng>(
             // Hard rule 1: with this lock placed (and earlier locks opened),
             // the current fortress must still be reachable from start.
             let test_grid = build_test_grid(Some((cand_pos, gap)));
-            let walk = walk_map(&test_grid, pipe_pairs, start_pos);
+            let walk = walk_map(&test_grid, pipe_pairs, start_pos, world_idx);
 
             if !walk.nodes.contains(&fort_pos) {
                 continue;
@@ -1640,7 +1658,7 @@ fn place_locks<R: Rng>(
                     }
                     // Also place the candidate lock
                     g.set(cand_pos.0, cand_pos.1, gap);
-                    let w = walk_map(&g, pipe_pairs, start_pos);
+                    let w = walk_map(&g, pipe_pairs, start_pos, world_idx);
                     !w.nodes.contains(&pf.pos)
                 } else {
                     false
@@ -1941,7 +1959,7 @@ fn analyze_with_pre_opened_mask(
         None => return RequiredProgression::default(),
     };
 
-    let walk = walk_map(&grid, &built.pipe_pairs, Some(start));
+    let walk = walk_map(&grid, &built.pipe_pairs, Some(start), built.world_idx);
 
     // 2. Per-position slot info (skip the target; it's accounted for separately).
     let mut kind_at: HashMap<(usize, usize), &SlotKind> = HashMap::new();
@@ -2470,7 +2488,7 @@ mod tests {
                         .map(|s| s.pos);
 
                     if let Some(fp) = fort_pos {
-                        let walk = walk_map(&locked_grid, &built.pipe_pairs, start_pos);
+                        let walk = walk_map(&locked_grid, &built.pipe_pairs, start_pos, built.world_idx);
                         assert!(walk.nodes.contains(&fp),
                             "Seed {seed} W{}: lock at {:?} blocks its own fort at {:?}",
                             built.world_idx + 1, lock.pos, fp);
@@ -2796,7 +2814,7 @@ mod tests {
                 for (r, c) in &uncovered {
                     eprintln!("    UNCOVERED: ({},{}) tile=${:02X}", r, c, cw.grid.get(*r, *c));
                     // Check if BFS can reach it with the placed pipes
-                    let bfs_all = bfs_ordered(&built.grid, &built.pipe_pairs, rom_data::find_start(&built.grid));
+                    let bfs_all = bfs_ordered(&built.grid, &built.pipe_pairs, rom_data::find_start(&built.grid), built.world_idx);
                     let bfs_set: HashSet<(usize, usize)> = bfs_all.iter().map(|&(p, _)| p).collect();
                     eprintln!("      BFS reachable: {}", bfs_set.contains(&(*r, *c)));
                 }
@@ -2867,12 +2885,12 @@ mod tests {
 
                 for lock in &built.locks {
                     // Open grid: no locks
-                    let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos);
+                    let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos, built.world_idx);
 
                     // Locked grid: this lock closed
                     let mut locked_grid = base_grid.clone();
                     locked_grid.set(lock.pos.0, lock.pos.1, lock.gap_tile);
-                    let walk_locked = walk_map(&locked_grid, &built.pipe_pairs, start_pos);
+                    let walk_locked = walk_map(&locked_grid, &built.pipe_pairs, start_pos, built.world_idx);
 
                     let gated_count = walk_open.nodes.len() as i32 - walk_locked.nodes.len() as i32;
 
@@ -2889,7 +2907,7 @@ mod tests {
 
                     // BFS distance from lock to target (via adjacent nodes)
                     let target_dist = if let Some(tp) = target_pos {
-                        let walk_from_target = walk_map(&base_grid, &built.pipe_pairs, Some(tp));
+                        let walk_from_target = walk_map(&base_grid, &built.pipe_pairs, Some(tp), built.world_idx);
                         let (lr, lc) = lock.pos;
                         [(-1i16, 0i16), (1, 0), (0, -1), (0, 1)].iter()
                             .filter_map(|&(dr, dc)| {
@@ -2970,7 +2988,7 @@ mod tests {
             eprintln!("\n  Section {section_idx} (fort at {:?}):", fort_pos);
 
             // Open grid for this section: earlier locks open, no current lock
-            let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos);
+            let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos, built.world_idx);
             let open_node_count = walk_open.nodes.len();
 
             // Find all lockable path tiles
@@ -2986,7 +3004,7 @@ mod tests {
                     let gap = gap_tile_for(tile);
                     let mut test_grid = base_grid.clone();
                     test_grid.set(r, c, gap);
-                    let walk = walk_map(&test_grid, &built.pipe_pairs, start_pos);
+                    let walk = walk_map(&test_grid, &built.pipe_pairs, start_pos, built.world_idx);
 
                     // Hard rule: fort must be reachable
                     if !walk.nodes.contains(&fort_pos) { continue; }
@@ -3111,7 +3129,7 @@ mod tests {
                 }
 
                 // BFS from target — distances to every reachable node
-                let walk_from_target = walk_map(&stamped, &built.pipe_pairs, Some(tp));
+                let walk_from_target = walk_map(&stamped, &built.pipe_pairs, Some(tp), built.world_idx);
 
                 for lock in &built.locks {
                     total_locks += 1;
@@ -3616,7 +3634,7 @@ mod tests {
                     .collect();
 
                 // BFS from start (matches what scoring used).
-                let walk = walk_map(&built.grid, &built.pipe_pairs, start_pos);
+                let walk = walk_map(&built.grid, &built.pipe_pairs, start_pos, built.world_idx);
                 let bfs_distances = &walk.distances;
 
                 // === Spread: avg pairwise distance between placed levels ===
@@ -3655,7 +3673,7 @@ mod tests {
                 // positions can't have a meaningful detour relative to a route
                 // they're not on.
                 if let Some(tp) = target_pos {
-                    let reverse_walk = walk_map(&built.grid, &built.pipe_pairs, Some(tp));
+                    let reverse_walk = walk_map(&built.grid, &built.pipe_pairs, Some(tp), built.world_idx);
                     if let Some(&td) = bfs_distances.get(&tp) {
                         for &pos in &levels {
                             if let (Some(&fwd), Some(&rev)) = (
@@ -4087,7 +4105,7 @@ mod tests {
                         probe(&built.grid, "target", target);
 
                         // What does walk_map see as reachable from start?
-                        let walk = walk_map(&built.grid, &built.pipe_pairs, Some(start));
+                        let walk = walk_map(&built.grid, &built.pipe_pairs, Some(start), built.world_idx);
                         let mut reachable: Vec<(usize, usize)> = walk.nodes.iter().copied().collect();
                         reachable.sort();
                         eprintln!("\n  walk_map reachable from start ({} nodes):", reachable.len());

--- a/src/randomize/overworld_writer.rs
+++ b/src/randomize/overworld_writer.rs
@@ -655,7 +655,7 @@ fn write_tile_grid<R: Rng>(
         .collect();
 
     let start_pos = rom_data::find_start(&grid);
-    let bfs = bfs_ordered(&grid, &built.pipe_pairs, start_pos);
+    let bfs = bfs_ordered(&grid, &built.pipe_pairs, start_pos, built.world_idx);
 
     // Level tile sequence: $03-$0B = levels 1-9 (vanilla numbered tiles),
     // $0C-$15 = levels 10-19 (double-digit tiles with custom "1" tens digit
@@ -1570,7 +1570,7 @@ mod tests {
                 let pipe_pairs = pipes_by_world.get(&wi)
                     .cloned()
                     .unwrap_or_default();
-                let walk = super::super::map_walker::walk_map(&grid, &pipe_pairs, None);
+                let walk = super::super::map_walker::walk_map(&grid, &pipe_pairs, None, wi);
 
                 // Collect positions that have pointer table entries.
                 let mut covered: HashSet<(usize, usize)> = HashSet::new();

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -227,10 +227,15 @@ pub(super) const VALID_BLANK_TILES: &[u8] = &[
 /// Start tile ID.
 pub(super) const TILE_START: u8 = 0xE5;
 
-/// W3 canoe teleport edges: (world_idx, (origin, destination)).
-/// The canoe transports the player from the mainland dock at (6,20) to two
-/// island docks. These are bidirectional teleport edges in BFS, like pipes.
-/// The mainland dock is only reachable when rocks are cleared.
+/// Canoe teleport edges: (world_idx, (origin, destination)).
+/// The canoe transports the player from a mainland dock to an island dock.
+/// These are bidirectional teleport edges in BFS, like pipes. (W3's mainland
+/// dock at (6,20) is only reachable when rocks are cleared.)
+///
+/// IMPORTANT: the coordinates are NOT world-unique — e.g. (6,20) exists in the
+/// grids of W2/W4–W8 too. Consumers (`canoes_reachable`, `walk_map`) MUST
+/// filter by `world_idx`, or they will fabricate canoe connectivity in any
+/// other world that happens to reach a mainland dock's raw coordinate.
 pub(super) const CANOE_EDGES: &[(usize, TeleportEdge)] = &[
     (2, ((6, 20), (5, 24))),  // mainland dock → island 1
     (2, ((6, 20), (0, 32))),  // mainland dock → island 2


### PR DESCRIPTION
## Problem

`CANOE_EDGES` entries are tagged with a `world_idx`, but the two walker consumers — `canoes_reachable` and `walk_map` — discarded that field and applied **every** canoe edge to **every** world.

The edge coordinates are not world-unique: W3's mainland dock `(6,20)` also exists in the grids of W2 and W4–W8. So any world whose BFS happened to reach that coordinate would get phantom canoe teleports injected into its connectivity graph — fabricating reachability and skewing level placement and lock-safety scoring. Canoe destinations are added as reachable nodes **unconditionally** (unlike walking, there's no `BACKGROUND_TILES` check), so a phantom edge could even mark a water/border tile reachable.

It went unnoticed only because the only edges are W3's, whose high column indices (20/24/32) fall out of bounds in the smaller worlds. Adding W8 docks (low columns on screen 0) would have triggered it for real — which is how it surfaced.

## Fix

Thread `world_idx` through `walk_map`, `canoes_reachable`, `bfs_ordered`, `bfs_section`, `place_pipes`, and `place_locks`, and filter `CANOE_EDGES` by world at both consumers.

- **W3 behaviour is unchanged** (its edges still apply to W3).
- Other worlds simply stop receiving phantom W3 edges.
- `rom_data::CANOE_EDGES` doc updated to spell out the world-scoping contract.

## Verification

- `cargo clippy --all-targets` — clean
- `cargo test` — 217 + 1 + 2 pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)