### PR TITLE
feature: W8 Dark World canoe docks + water-bridge final page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.17"
+version = "0.8.18"
 edition = "2024"
 
 [lib]

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1768,6 +1768,19 @@ Pointer tables indexed by World_Num (8 entries each):
 
 9 objects max per world (Hammer Bros, bonus objects, HELP bubble, Airship, etc.)
 
+Master pointer table file offsets: `Map_List_Object_Ys` 0x16020, `_XHis` 0x16030,
+`_XLos` 0x16040, `_IDs` 0x16050 (8 LE CPU words each; entries point into PRG011,
+CPU $A000–$BFFF → file `0x16010 + (cpu - 0xA000)`). A slot's grid position encodes
+as `Y = (row+2)*16`, `XHi = col/16`, `XLo = (col%16)*16`.
+
+**Canoe object (ID 0x10) is not W3-specific.** Writing a canoe into an otherwise
+empty map-object slot makes it function in any world — the engine processes all
+populated slots, not just W3's. The randomizer uses this to add a W8 canoe at
+slot 6 (vanilla W8 uses slots 0–5: `01 00 0E 0D 0F 0E …`), floating beside a
+dock tile (`0x4B`) so the player can board it. See the randomizer's
+`write_map_sprite` and W8 `CANOE_EDGES` (mainland `(5,6)` → islands
+`(3,8)/(5,10)/(5,12)`).
+
 ### Map_Unused7EEA — Dead Code LUT (PRG011: 0x16018)
 
 An 8-byte LUT at PRG011 CPU `$A008` (file `0x16018`), labeled `Map_Unused7EEA_Vals` in

--- a/src/randomize/overworld_pickup.rs
+++ b/src/randomize/overworld_pickup.rs
@@ -208,6 +208,9 @@ fn pick_up_world(
 const BLANK_TILE_OVERRIDES: &[(usize, usize, usize, u8)] = &[
     (2, 8, 6, 0x47), // W3 spade near start — heuristic picks 0x44 (no neighbors), needs 0x47 for BFS
     (4, 6, 20, 0xD9), // W5 spade in sky region — neighbors are non-path sky bg, heuristic falls to land
+    (7, 5, 8, 0x8D), // W8 battleship entry — its cell is navy water (canoe area), not a land blank.
+                     // The entry is still picked up into the pool (placed elsewhere); only this
+                     // leftover tile changes, so the heuristic's 0x44 land tile is overridden to water.
 ];
 
 /// Positions that should use island-themed blank tiles (0xAE/0xAF/0xB5/0xB6).

--- a/src/randomize/qol.rs
+++ b/src/randomize/qol.rs
@@ -187,6 +187,60 @@ pub fn remove_rocks(rom: &mut Rom) {
     }
 }
 
+/// W8 (Dark World) map layout edits: canoe docks on screen 0, extra paths on
+/// screen 2, and a water + bridge approach on screen 3 (the final page).
+///
+/// Each entry is `(row, global_col, tile)`. These are stamped into the W8 tile
+/// grid before the overworld builder picks it up, so the builder's BFS sees the
+/// new path connectivity and the bridge tiles (`0xB3`) on the final page get
+/// gated as water gaps (`gap_tile_for`: `0xB3 -> 0x9D`) instead of locks.
+///
+/// `0x4B` is the canoe dock tile. `0x51` is the horizontal hammer-breakable
+/// rock (breaks into `0x45`).
+///
+/// (5,6) is the mainland dock; the canoe sprite floats at (5,7) beside it, and
+/// (3,8)/(5,10)/(5,12) are island docks reachable by canoe (see `CANOE_EDGES`).
+/// The vanilla lock at (2,8) is intentionally NOT removed here — the builder
+/// opens that FX slot during pickup.
+const W8_MAP_EDITS: &[(usize, usize, u8)] = &[
+    // --- Screen 0: canoe docks + navy approach ---
+    (3, 8, 0x4B), (3, 10, 0x44), (3, 12, 0x44),
+    (4, 8, 0x85), (4, 10, 0x46), (4, 12, 0x46),
+    (5, 6, 0x4B), (5, 7, 0x8C), (5, 8, 0x8D), (5, 10, 0x4B), (5, 12, 0x4B),
+    // --- Screen 2: extra paths ---
+    (1, 36, 0x44), (1, 37, 0x45), (1, 38, 0x45), (1, 39, 0x45), (1, 40, 0x47),
+    (1, 41, 0x45), (1, 42, 0x47), (1, 43, 0x45), (1, 44, 0x47), (1, 45, 0x45),
+    (1, 46, 0x47),
+    (2, 36, 0x46), (2, 46, 0x46),
+    (3, 36, 0x4A), (3, 37, 0x51), (3, 46, 0x48),
+    (4, 46, 0x46),
+    (5, 45, 0x45), (5, 46, 0x4A),
+    // --- Screen 3: water (row 4) + bridges (row 5) on the final page ---
+    (4, 51, 0x99), (4, 52, 0xA2), (4, 53, 0x83), (4, 54, 0xA2), (4, 55, 0x83),
+    (4, 56, 0xA2), (4, 57, 0x83), (4, 58, 0xA2), (4, 59, 0x9A),
+    (5, 51, 0xB3), (5, 53, 0xB3), (5, 55, 0xB3), (5, 57, 0xB3), (5, 59, 0xB3),
+];
+
+/// Apply the W8 Dark World map layout edits (see [`W8_MAP_EDITS`]).
+pub fn apply_w8_map_edits(rom: &mut Rom) {
+    for &(row, col, tile) in W8_MAP_EDITS {
+        rom.write_byte(super::rom_data::map_tile_offset(7, row, col), tile);
+    }
+    // Vanilla FX slot 16 sits at W8 (row 5, col 53) — right on our new bridge
+    // row — and its replace_tile is 0x45 (plain path). The builder's pickup
+    // `open_fx_gaps()` stamps that replace_tile over the grid, clobbering our
+    // 0xB3 bridge. Point it at the bridge tile so the slot opens to a bridge,
+    // matching the other bridge columns (and gating as a water gap if a
+    // fortress lands there).
+    rom.write_byte(super::rom_data::FX_MAP_TILE_REPLACE + 16, 0xB3);
+
+    // Place the W8 canoe (object ID 0x10) in map-object slot 6, floating at
+    // (5,7) beside the mainland dock (5,6). Slot 6 is past the builder's army
+    // sprites (slots 2-5), so the overworld writer leaves it intact. This is
+    // the boat that makes the screen-0 island docks reachable in-game.
+    super::rom_data::write_map_sprite(rom, 7, 6, 5, 7, 0x10);
+}
+
 /// Turn the W1 (6,5) blocking decoration into a hammer-breakable rock.
 ///
 /// Vanilla puts 0x53 (visually a rock, blocks all directions, not removable)

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -237,8 +237,15 @@ pub(super) const TILE_START: u8 = 0xE5;
 /// filter by `world_idx`, or they will fabricate canoe connectivity in any
 /// other world that happens to reach a mainland dock's raw coordinate.
 pub(super) const CANOE_EDGES: &[(usize, TeleportEdge)] = &[
+    // W3: mainland dock (6,20) → two island docks.
     (2, ((6, 20), (5, 24))),  // mainland dock → island 1
     (2, ((6, 20), (0, 32))),  // mainland dock → island 2
+    // W8: mainland dock (5,6) → three island docks on screen 0.
+    // The canoe sprite floats at (5,7), immediately right of (5,6) — same
+    // "sprite one tile beside the mainland dock" convention as W3.
+    (7, ((5, 6), (3, 8))),
+    (7, ((5, 6), (5, 10))),
+    (7, ((5, 6), (5, 12))),
 ];
 
 // ---------------------------------------------------------------------------
@@ -688,6 +695,8 @@ const MAP_OBJ_YS_MASTER: usize = 0x16020;
 const MAP_OBJ_XHIS_MASTER: usize = 0x16030;
 /// Master pointer table for Map_List_Object_XLos.
 const MAP_OBJ_XLOS_MASTER: usize = 0x16040;
+/// Master pointer table for Map_List_Object_IDs.
+const MAP_OBJ_IDS_MASTER: usize = 0x16050;
 
 /// Map object → pointer table entry linkage.
 /// (world_idx, object_slot, pointer_table_entry_idx)
@@ -1142,6 +1151,21 @@ pub(super) fn write_map_sprite_position(
     rom.write_byte(xlo_off, xlo);
 }
 
+/// Place a map-object sprite: write its position (Y/XHi/XLo) and its type ID.
+/// Used to add new sprites (e.g. the W8 canoe at an otherwise-empty slot).
+pub(super) fn write_map_sprite(
+    rom: &mut Rom,
+    world_idx: usize,
+    slot: usize,
+    grid_row: usize,
+    grid_col: usize,
+    id: u8,
+) {
+    write_map_sprite_position(rom, world_idx, slot, grid_row, grid_col);
+    let id_off = map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot);
+    rom.write_byte(id_off, id);
+}
+
 /// Read the grid positions of all active floating sprites for a world.
 ///
 /// Each world has up to 9 map object slots. A slot with ID $FF is unused.
@@ -1149,7 +1173,6 @@ pub(super) fn write_map_sprite_position(
 /// These are the positions where floating sprites sit (hammer bros, piranhas,
 /// W8 hand traps, etc.) and should not have level/fort tiles placed under them.
 pub(super) fn read_map_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usize, usize)> {
-    const MAP_OBJ_IDS_MASTER: usize = 0x16050;
     let mut positions = Vec::new();
 
     for slot in 0..9 {
@@ -1185,7 +1208,6 @@ pub(super) fn read_map_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usi
 /// These positions need HB level pointer entries even though they are excluded
 /// from level/fort/pipe placement by `fixed_positions`.
 pub(super) fn read_hb_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usize, usize)> {
-    const MAP_OBJ_IDS_MASTER: usize = 0x16050;
     let mut positions = Vec::new();
 
     for slot in 0..9 {

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -794,6 +794,11 @@ fn randomize_inner(
         randomize::qol::make_w1_hammer_rock(rom);
     }
 
+    // W8 Dark World map edits (beta): extra paths + water/bridge final page.
+    // Must run before the overworld builder so it sees the new connectivity.
+    rom.set_tag("qol/w8_map_edits");
+    randomize::qol::apply_w8_map_edits(rom);
+
     // Fix Big ? Block bonus rooms so they follow the level, not the world slot.
     // Always applied — needed whenever world_order or cross-world shuffle is active,
     // and harmless (identity mapping) when worlds aren't shuffled.
@@ -986,12 +991,12 @@ fn randomize_inner(
         randomize::qol::remove_n_cards(rom);
     }
 
-    // Fix W3 canoe softlocks (needed when spade games are shuffled, since their
-    // original W3 island tiles can then host levels that the canoe interacts with).
-    if options.shuffle_spade_games {
-        rom.set_tag("qol/fix_canoe_softlock");
-        randomize::qol::fix_canoe_softlock(rom);
-    }
+    // Fix canoe softlocks. Always applied: the W8 canoe/docks are unconditional
+    // (see `apply_w8_map_edits`), and the canoe is also reachable via spade and
+    // toad-house shuffle. The fix is world-agnostic (keys on the dock tile 0x4B
+    // and canoe object 0x10), so running it unconditionally is correct and safe.
+    rom.set_tag("qol/fix_canoe_softlock");
+    randomize::qol::fix_canoe_softlock(rom);
 
     // Adjust Bowser and Koopaling hitboxes.
     if options.adjust_boss_hitboxes {


### PR DESCRIPTION
Hand-authored W8 (Dark World) overworld layout, applied as a pre-pickup grid patch (`apply_w8_map_edits`) so the overworld builder builds on top of it.

## What it adds

**Screen 0 — canoe system**
- Mainland dock `(5,6)` with the canoe sprite (object `0x10`, map-object **slot 6**) floating beside it at `(5,7)`.
- Three island docks `(3,8)/(5,10)/(5,12)` reachable by boat — the islands become real placement slots for the builder's pool.

**Screen 2** — extra paths, including a horizontal hammer-breakable rock (`0x51`).

**Screen 3** — a water + bridge approach to Bowser, so fortress gates on the final page resolve to water bridges (`gap_tile_for`: `0xB3 → 0x9D`) instead of locks.

## Wiring

- **`CANOE_EDGES`** gains world-scoped W8 entries `(5,6) → (3,8)/(5,10)/(5,12)`, relying on the world-filter fix from #39.
- **`rom_data::write_map_sprite`** (new helper: position + ID) places the canoe. Slot 6 is past the builder's army-sprite slots (2–5), so the writer leaves it intact.
- **`fix_canoe_softlock` is now always applied** (ungated from `shuffle_spade_games`): the W8 canoe is unconditional, it's also reachable via spade/toad shuffle, and the fix is world-agnostic (keys on dock tile `0x4B` + canoe ID `0x10`).

## Builder-interaction fixes

Two tiles were being clobbered by later builder phases (same class as the bridge-FX issue):
- **FX slot 16** `replace_tile → 0xB3` so pickup's `open_fx_gaps` opens `(5,53)` as a bridge, not plain path.
- **`BLANK_TILE_OVERRIDES (7,5,8,0x8D)`** — the battleship's vanilla pointer-entry cell is navy water, not a land blank. The entry is still picked up into the pool (placed elsewhere); only the leftover tile changes — **no level is lost** (`test_build_all_worlds`: 63 levels + 17 fortresses still place).

## Docs
- `docs/smb3_rom_reference.md`: documented the map-object master-table offsets and that the canoe object (`0x10`) works in any world via an empty map-object slot.

## Verification
- Docks, canoe (slot 6 @ `(5,7)`), and the `(5,8)` navy-water fix verified across 6 randomized seeds.
- `cargo clippy --all-targets` clean; `cargo test` 218 pass.
- Playtest ROM in-game (canoe sails to all three islands) confirmed manually.

## Note
Branch name predates the canoe work (started as just the water-bridge page); the feature now also includes the canoe docks. Version bumped 0.8.17 → 0.8.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)