### PR TITLE
feature: troll pipes appear 75% per world (preserve the Maybe secret longer)

### DIFF
--- a/src/randomize/troll_pipes.rs
+++ b/src/randomize/troll_pipes.rs
@@ -3,9 +3,24 @@ use rand::seq::IndexedRandom;
 
 use super::overworld_build::{BuildResult, SlotKind};
 
-/// Mark exactly one regular-level slot per world W2-W8 as a troll pipe.
+/// Probability (in percent) that an eligible world actually gets its troll
+/// pipe stamped. Each world W2-W8 rolls independently, so on average about
+/// `7 * 0.75 ≈ 5.25` pipes appear instead of a guaranteed 7. A pipe-free
+/// early world is then ambiguous ("maybe-off, or just an unlucky roll"),
+/// which keeps the Maybe secret hidden for longer. Applies in both On and
+/// Maybe modes — by the time this runs the mode is already resolved to "on",
+/// so there is one rule and no special case.
+const TROLL_PIPE_PERCENT: u32 = 75;
+
+/// Mark at most one regular-level slot per world W2-W8 as a troll pipe.
 /// W1 is excluded so the player has at least one safe world to learn the
 /// game's vanilla appearance before encountering disguised level slots.
+///
+/// Each eligible world independently has a [`TROLL_PIPE_PERCENT`]% chance of
+/// actually receiving a pipe; on the miss the world keeps a normal level
+/// tile. The roll is always drawn (even when there is no candidate slot) so
+/// downstream RNG stays aligned across worlds and the output is reproducible
+/// per seed.
 ///
 /// The writer reads `slot.is_troll_pipe` and stamps `0xBC` (PIPE tile)
 /// instead of a level-number tile. The slot's level pointer entry is
@@ -30,7 +45,12 @@ pub(crate) fn mark_troll_pipes<R: Rng>(build: &mut BuildResult, rng: &mut R) {
             .filter(|(_, s)| s.kind == SlotKind::Level && !s.is_hand_trap)
             .map(|(i, _)| i)
             .collect();
-        if let Some(&pick) = candidates.choose(rng) {
+        // Draw the appearance roll unconditionally so RNG advances by the
+        // same amount per world regardless of whether a candidate exists.
+        let appears = rng.random_range(..100u32) < TROLL_PIPE_PERCENT;
+        if let Some(&pick) = candidates.choose(rng)
+            && appears
+        {
             built.slots[pick].is_troll_pipe = true;
         }
     }
@@ -45,13 +65,15 @@ mod tests {
     use crate::rom::Rom;
 
     #[test]
-    fn marks_one_pipe_per_world_w2_w8() {
+    fn marks_at_most_one_pipe_per_world_w2_w8() {
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
             return; // Base ROM not present (e.g. CI) — skip.
         };
         let rom = Rom::from_bytes(&bytes).unwrap();
-        let mut counts = [0usize; 8];
-        for seed in 0u64..16 {
+        const SEEDS: u64 = 256;
+        let mut marked = 0usize; // W2-W8 worlds that got a pipe
+        let mut eligible = 0usize; // W2-W8 worlds total
+        for seed in 0u64..SEEDS {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let catalog = node_catalog::NodeCatalog::build(&rom, false);
             let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true });
@@ -63,14 +85,40 @@ mod tests {
                 if w.world_idx == 0 {
                     assert_eq!(n, 0, "W1 should never have a troll pipe (seed {seed})");
                 } else {
-                    assert_eq!(n, 1, "W{} should have exactly 1 troll pipe (seed {seed})", w.world_idx + 1);
-                    counts[w.world_idx] += 1;
+                    assert!(n <= 1, "W{} should have at most 1 troll pipe (seed {seed})", w.world_idx + 1);
+                    eligible += 1;
+                    marked += n;
                 }
             }
         }
-        assert_eq!(counts[0], 0);
-        for (w, &count) in counts.iter().enumerate().skip(1) {
-            assert_eq!(count, 16, "W{} should be marked 16 times across 16 seeds", w + 1);
-        }
+        // Each eligible world rolls an independent 75% appearance chance, so
+        // the observed marked fraction should sit near 0.75. Use a wide band
+        // so the assertion is robust across RNG noise but still catches a
+        // regression to 100% (always) or 0% (never).
+        let frac = marked as f64 / eligible as f64;
+        assert!(
+            (0.68..0.82).contains(&frac),
+            "marked fraction {frac:.3} not near the 0.75 target (marked {marked}/{eligible})"
+        );
+    }
+
+    #[test]
+    fn deterministic_per_seed() {
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            return; // Base ROM not present (e.g. CI) — skip.
+        };
+        let rom = Rom::from_bytes(&bytes).unwrap();
+        let run = || {
+            let mut rng = ChaCha8Rng::seed_from_u64(42);
+            let catalog = node_catalog::NodeCatalog::build(&rom, false);
+            let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true });
+            let data = overworld_build::OverworldData { pickup: &pickup, catalog: &catalog };
+            let mut build = overworld_build::build(&rom, &data, &mut rng, true);
+            troll_pipes::mark_troll_pipes(&mut build, &mut rng);
+            build.worlds.iter()
+                .map(|w| w.slots.iter().filter(|s| s.is_troll_pipe).count())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(run(), run(), "same seed must produce identical troll-pipe marking");
     }
 }


### PR DESCRIPTION
## What

Resolves #47. When Troll Pipes is active, each eligible world W2-W8 now has an independent **75% chance** to actually receive its disguised pipe, instead of every eligible world getting one (100%).

## Why

With 100%, a player who reaches W2 and sees a pipe-disguised level immediately knows the feature is on — which in **Maybe** mode instantly resolves the seed-hidden secret. At 75%, a pipe-free early world is ambiguous ("maybe resolved off, or just an unlucky roll"), so the secret holds for several worlds. Expected pipe count drops from ~7 to ~5.25 across W2-W8 — a modest reduction that keeps the feature's flavor.

## How

- `mark_troll_pipes()` draws a `TROLL_PIPE_PERCENT` (75%) roll per eligible world and only marks the slot on a hit.
- The roll is drawn **unconditionally** (even when a world has no candidate slot) so per-world RNG advances by a fixed amount → output stays deterministic per seed.
- One rule covers both **On** and **Maybe**: by the time this runs the mode is already resolved to a bool, so there is no special case (grug-brain). On still averages ~5 pipes, which is plenty.
- No flag-key change — internal behavior of the existing flag.

## Decision notes

The issue raised an open question — apply 75% to On too, or Maybe-only? I went with **both**, matching the issue's leaning, because the marking code can't distinguish the modes at that point and a single uniform rule is simpler than threading the mode through. Easy to revisit if On should stay deterministic-per-world.

## Tests

- `marks_at_most_one_pipe_per_world_w2_w8` — W1 never marked; each world ≤1; observed marked fraction sits in a 0.68–0.82 band across 256 seeds (catches regression to 100% or 0%).
- `deterministic_per_seed` — same seed → identical marking.
- `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)