### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to SMB3-RS are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The project has not had a tagged release yet — it is pre-1.0 and the
+`Cargo.toml` version is bumped internally as work lands (currently `0.8.x`).
+Until the first release, everything below lives under **[Unreleased]**; cut a
+versioned section here when a release is tagged.
+
+## [Unreleased]
+
+This is a baseline backfill of notable changes since the project began. It
+summarizes feature areas rather than every commit — see `git log` for the
+full history.
+
+### Added
+
+- **Overworld builder pipeline** — the core randomization system. A
+  four-phase pipeline (catalog → pickup → build → write) that re-lays each
+  world: assigns levels to map slots via BFS-ordered placement, places
+  fortresses with locks, distributes pipes, and tags hammer-bro slots while
+  enforcing connectivity.
+- **Start ↔ airship swap (SAS)** — per-world option that swaps the start tile
+  with the airship, including engine scaffolding, death-respawn handling, and
+  game-over finalize.
+- **Troll-pipe level slots** — disguise level slots as pipe tiles (`0xBC`),
+  one candidate per world W2–W8.
+- **Hand-trap level slots** — visible grabbing-hand tiles (`0xE6`) with a 100%
+  grab.
+- **Cross-world shuffles** — Toad Houses and spade games shuffled across
+  worlds; world progression order shuffle.
+- **Segment composers** — `segment_writer` foundation plus the Bowser-castle
+  and 5-F2 podoboo-gauntlet composers for safe, X-sorted enemy-segment edits.
+- **Enemy randomization** — within-class enemy swapping, a Wild piranha pool
+  (self-contained, with Rocky Wrench and directional fire jets), and an
+  expanded hazard taxonomy.
+- **Quality-of-life flags** — Faster Frog, Limit Bro Movement, MaCobra
+  tail-attack patches, W1 hammer rock, and lives/drawbridge tweaks.
+- **Tri-state (off/on/maybe) flags** — seed-hidden options that resolve via a
+  dedicated RNG substream.
+- **Cosmetic options** — palette randomization, "Oops all Anchors" anchor
+  visuals, title-screen seed-hash icons with seeded menu music, randomized
+  king rescue quotes, and bundled visual patches (Super Princess Peach,
+  Super Toad, Dr. Mario Bros 3, and others).
+- **Web app** — browser frontend with grouped options
+  (Map/Enemies/Bosses/Items/Player/Cosmetic), Off/On pills, presets, and
+  sprite-sheet icons.
+- **Tooling** — `tools/rom_map.py` ROM map generator with diagnostic modes,
+  plus `/level`, `/tile`, and other lookup helpers; ROM Rev 1 CRC
+  fingerprint and upload-time validation.
+
+### Changed
+
+- Fortress FX visibility checks use Mario's position and the real per-world
+  FX slot (derived from `FortressFX_W1_W8[...]`) rather than `$0745`
+  directly.
+- Bullet-bill class points at cannon IDs (`0xBC`/`0xBD`) with asymmetric Wild
+  counts that never exceed vanilla.
+- Pipes are forbidden adjacent to start/target tiles to eliminate
+  trivial-bypass worlds.
+
+### Fixed
+
+- Level-data walk no longer overruns the PRG bank into the desert metatile
+  table.
+- Canoe edges are scoped to their own world in the overworld walker, with a
+  stateful required-progression analyzer.
+- SAS game-over continue softlock when the start is on a non-zero overworld
+  page; W3 fixed-pipe partner biased so the SAS start can reach the airship.
+- Wild piranhas keep their hitbox/visibility correct when shuffled into other
+  slots; piranhas are never replaced by upward-firing hazards.
+- Numerous per-level enemy protections (4-F1 narrow hallway, 7-F2 boss room,
+  7-5 walkways, 8-1 Boo, 8F Roto-Discs) so randomized hazards can't block
+  required paths.
+
+[Unreleased]: https://github.com/hamstringquestionable/smb3-rs/commits/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ When clippy flags new code:
 
 Never silence a lint by deleting the warning text or globally disabling — the goal is "every warning was considered," not "no warnings emitted."
 
+## Changelog
+
+`CHANGELOG.md` (repo root, [Keep a Changelog](https://keepachangelog.com/) format) tracks notable changes. When a change is user-visible or notable (a new flag/option, a behavior change, a fixed bug players would notice), add a one-line entry under the `[Unreleased]` section in the right group (`Added` / `Changed` / `Fixed` / `Removed`) as part of the same change. Skip purely internal refactors, test-only changes, and tooling tweaks. At version-bump time, move the accumulated `[Unreleased]` entries into a new versioned section.
+
 ## Architecture: Separate Randomization from ROM Writes
 
 Randomization modules follow a **decide then write** pattern. Each feature area has two layers:


### PR DESCRIPTION
## What

Resolves #36. Adds a `CHANGELOG.md` at the repo root following [Keep a Changelog](https://keepachangelog.com/) conventions, grouped `Added` / `Changed` / `Fixed`.

## Decision note

The repo has **no git tags / no tagged release** — it's pre-1.0 and the `Cargo.toml` version is bumped internally (currently `0.8.x`). Rather than invent version boundaries that don't exist, everything is placed under a single **[Unreleased]** section with a header explaining the pre-release status and how to cut a versioned section later. The backfill summarizes major feature areas (overworld builder, SAS, segment composers, enemy/QoL/cosmetic options, web app, tooling) rather than transcribing every commit — `git log` remains the full record.

Going forward, new notable changes go under `[Unreleased]` and get moved into a versioned section at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)