### PR TITLE
feature: Random Fire Flower (issue #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ full history.
 
 ### Added
 
+- **Random Fire Flower** (`--fire-flower off|on|wild`, issue #22) — an in-level
+  Fire Flower still looks the same but grants a power state derived
+  deterministically from a seed salt (the shuffled starting world), the current
+  world, and the flower's level position, instead of always Fire. `on`
+  substitutes among Fire/Frog/Tanooki/Hammer; `wild` also allows the Small/Big
+  downgrades. Same seed and spot always give the same suit; the mapping rotates
+  per seed when world-order shuffle is enabled.
 - **Overworld builder pipeline** — the core randomization system. A
   four-phase pipeline (catalog → pickup → build → write) that re-lays each
   world: assigns levels to map slots via BFS-ordered placement, places

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.21"
+version = "0.8.22"
 edition = "2024"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use rom::Rom;
 
 pub use ips::apply_ips_patch;
 pub use randomizer::{
-    EnemyMode, Options, Tri, STARTING_LIVES_VALUES,
+    EnemyMode, FireFlowerMode, Options, Tri, STARTING_LIVES_VALUES,
     ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process;
 
-use smb3_rs::{EnemyMode, Options, Tri, STARTING_LIVES_VALUES};
+use smb3_rs::{EnemyMode, FireFlowerMode, Options, Tri, STARTING_LIVES_VALUES};
 
 /// Human-readable label for a tri-state flag in the run summary.
 fn tri_str(t: Tri) -> &'static str {
@@ -183,6 +183,12 @@ struct Cli {
     #[arg(long)]
     faster_frog: bool,
 
+    /// Random Fire Flower: in-level Fire Flowers grant a position-derived power
+    /// state instead of always Fire — off, on, or wild (default: off).
+    /// `on` = Fire/Frog/Tanooki/Hammer; `wild` also allows Small/Big.
+    #[arg(long, default_value = "off")]
+    fire_flower: String,
+
     /// Disable spade-game shuffle (on by default; off keeps vanilla spade positions)
     #[arg(long)]
     no_shuffle_spade_games: bool,
@@ -327,6 +333,19 @@ fn main() {
         }
     }
 
+    fn parse_fire_flower(s: &str) -> FireFlowerMode {
+        match s {
+            "off" => FireFlowerMode::Off,
+            "on" => FireFlowerMode::On,
+            "wild" => FireFlowerMode::Wild,
+            other => {
+                eprintln!("Invalid --fire-flower value: {other}");
+                eprintln!("Valid values: off, on, wild");
+                process::exit(1);
+            }
+        }
+    }
+
     fn parse_tri(s: &str, name: &str) -> Tri {
         match s {
             "off" => Tri::Off,
@@ -421,6 +440,7 @@ fn main() {
             faster_tail_speed: cli.faster_tail_speed,
             no_game_over_penalty: cli.no_game_over_penalty,
             faster_frog: cli.faster_frog,
+            fire_flower: parse_fire_flower(&cli.fire_flower),
             shuffle_spade_games: !cli.no_shuffle_spade_games,
             shuffle_toad_houses: !cli.no_shuffle_toad_houses,
             hands_levels: !cli.no_hands_levels,
@@ -475,6 +495,11 @@ fn main() {
     eprintln!("  Warp whistles: {}", if options.remove_whistles { "removed" } else { "kept" });
     eprintln!("  Remove rocks: {}", if options.remove_rocks { "on" } else { "off" });
     eprintln!("  W1 hammer rock: {}", tri_str(options.w1_hammer_rock));
+    eprintln!("  Random fire flower: {}", match options.fire_flower {
+        FireFlowerMode::Off => "off",
+        FireFlowerMode::On => "on",
+        FireFlowerMode::Wild => "wild",
+    });
     eprintln!("  Airship lock: {}", if options.airship_lock { "on" } else { "off" });
     if !options.starting_items.is_empty() {
         let item_names: Vec<&str> = options.starting_items.iter().map(|&id| match id {

--- a/src/randomize/fire_flower.rs
+++ b/src/randomize/fire_flower.rs
@@ -1,0 +1,253 @@
+//! Random Fire Flower (issue #22).
+//!
+//! When the player collects an **in-level Fire Flower** the sprite still looks
+//! like a Fire Flower, but the power state granted is substituted for one drawn
+//! from a small pool. The substitution is a pure deterministic function of game
+//! state — `World_Num` plus the flower's absolute level position — so it takes
+//! no RNG and bakes no per-seed table: the same flower in the same spot always
+//! yields the same suit, on every ROM and for every player. Two flowers in one
+//! level can still differ because their positions differ.
+//!
+//! ## How it works
+//!
+//! The vanilla in-level Fire Flower grant lives in `ObjHit_FireFlower`
+//! (PRG001). For a non-small Mario it runs `LDA #$03 / STA Player_QueueSuit`
+//! (`$0578`), i.e. it queues suit 2 (Fire); `Player_QueueSuit` holds
+//! `Player_Suit + 1`. We replace that hardcoded store with a `JSR` to an
+//! injected routine that computes:
+//!
+//! ```text
+//! index = (salt + World_Num + Objects_XHi,X + Objects_X,X + Objects_Y,X) mod pool_len
+//! Player_QueueSuit = POOL[index]
+//! ```
+//!
+//! ## Where the variation comes from
+//!
+//! - **`salt`** is a single byte baked in at patch-generation time: the
+//!   *starting world* of the shuffled progression (the first world in
+//!   `world_order`). It is seed-derived, so the whole suit mapping rotates from
+//!   seed to seed — which is the only way a level that **never moves worlds**
+//!   (e.g. Bowser's castle) can give a different suit across seeds, since every
+//!   pure-game-state input is identical for it on every seed. When world order
+//!   shuffling is off, the starting world is always 0, so the salt is constant
+//!   and fixed levels resolve to the same suit across seeds.
+//! - **`World_Num`** (`$0727`) spreads different worlds apart within a single
+//!   playthrough.
+//! - The three object arrays (all indexed by the colliding object's slot in
+//!   `X`) are the flower's *absolute* level coordinates — stable regardless of
+//!   camera scroll — so each flower tile resolves to one fixed suit, and two
+//!   flowers in the same level differ.
+//!
+//! Because the salt is baked into the ROM, the result is fully deterministic
+//! for a given seed (every player gets the same suit from a given flower) with
+//! no live/in-game RNG.
+//!
+//! The hook mirrors the community "Random Fire Flower" patch's site but diverts
+//! to our own routine and uses the starting-world salt + `World_Num` (the
+//! original used `Level_LayPtr_AddrL`, which ties the suit to level *content*).
+//!
+//! ## Scope / caveats
+//!
+//! - **In-level Fire Flower object only** (this also covers a Fire Flower popped
+//!   from a `?` block, since it becomes the same object). Inventory item use is
+//!   untouched.
+//! - **Small Mario is unchanged:** vanilla sends a small Mario down the mushroom
+//!   path (grants Super, not a suit), and we don't touch that branch. So the
+//!   substitution applies only once the player is at least Super. For `Wild`
+//!   this means the downgrade outcomes (Small/Big) can only ever *reduce* a
+//!   big-or-better Mario — a small Mario can't get "more small".
+
+use crate::randomizer::FireFlowerMode;
+use crate::rom::Rom;
+
+use super::rom_data::{FIRE_FLOWER_SUB_CPU, FS_FIRE_FLOWER};
+use super::world_order::WORLD_INIT_OPERAND;
+
+/// File offset of the suit-store inside `ObjHit_FireFlower` (PRG001). The 12
+/// bytes here are vanilla `BEQ +0x0A / LDA #$1F / STA $0555 / LDA #$03 /
+/// STA $0578` — the `BEQ` "already Fire, skip" early-out followed by the
+/// transition-sparkle write and the hardcoded Fire store.
+const HOOK_SITE: usize = 0x02A17;
+
+// `Player_QueueSuit` values (= `Player_Suit` + 1) for each power state.
+const Q_SMALL: u8 = 0x01; // Small Mario
+const Q_BIG: u8 = 0x02; // Super (big) Mario
+const Q_FIRE: u8 = 0x03; // Fire Mario
+const Q_FROG: u8 = 0x05; // Frog Suit
+const Q_TANOOKI: u8 = 0x06; // Tanooki Suit
+const Q_HAMMER: u8 = 0x07; // Hammer Suit
+
+/// `On` pool: the four "safe" big-form suits. Raccoon is deliberately excluded.
+const POOL_ON: &[u8] = &[Q_FIRE, Q_FROG, Q_TANOOKI, Q_HAMMER];
+/// `Wild` pool: adds the two downgrade outcomes (Small, Big) to the `On` pool.
+const POOL_WILD: &[u8] = &[Q_SMALL, Q_BIG, Q_FIRE, Q_FROG, Q_TANOOKI, Q_HAMMER];
+
+/// Length of the injected routine code (excluding the trailing pool table).
+const ROUTINE_LEN: u16 = 28;
+
+/// Install the Random Fire Flower patch. `Off` is a no-op.
+///
+/// Must run after [`super::world_order`] so the starting-world salt is read from
+/// its final value (the orchestrator guarantees this ordering).
+pub fn apply(rom: &mut Rom, mode: FireFlowerMode) {
+    let pool: &[u8] = match mode {
+        FireFlowerMode::Off => return,
+        FireFlowerMode::On => POOL_ON,
+        FireFlowerMode::Wild => POOL_WILD,
+    };
+    let n = pool.len() as u8;
+
+    // Seed-derived salt: the starting world of the shuffled progression (0 when
+    // world order shuffling is off). Baked in as an immediate so the result is
+    // fully deterministic per seed but rotates seed-to-seed.
+    let salt = rom.read_byte(WORLD_INIT_OPERAND);
+
+    // The pool table sits immediately after the routine code.
+    let table_cpu = FIRE_FLOWER_SUB_CPU + ROUTINE_LEN;
+    let tlo = (table_cpu & 0xFF) as u8;
+    let thi = (table_cpu >> 8) as u8;
+
+    // Injected routine (X = colliding object's slot index):
+    //   LDA #salt        ; seed-derived starting-world salt
+    //   CLC
+    //   ADC $0727        ; + World_Num  (current world)
+    //   ADC $76,X        ; + Objects_XHi,X  (screen number, absolute)
+    //   ADC $91,X        ; + Objects_X,X    (low X within screen, absolute)
+    //   ADC $A3,X        ; + Objects_Y,X    (absolute Y)
+    // modloop:
+    //   CMP #n           ; reduce the (carry-folded) sum mod pool_len
+    //   BCC moddone
+    //   SBC #n
+    //   BCS modloop
+    // moddone:
+    //   TAY
+    //   LDA POOL,Y       ; Player_QueueSuit value for this flower
+    //   STA $0578        ; Player_QueueSuit
+    //   RTS
+    #[rustfmt::skip]
+    let mut code: Vec<u8> = vec![
+        0xA9, salt,         // LDA #salt
+        0x18,               // CLC
+        0x6D, 0x27, 0x07,   // ADC $0727  (World_Num)
+        0x75, 0x76,         // ADC $76,X  (Objects_XHi,X)
+        0x75, 0x91,         // ADC $91,X  (Objects_X,X)
+        0x75, 0xA3,         // ADC $A3,X  (Objects_Y,X)
+        0xC9, n,            // CMP #n            (modloop @ +12)
+        0x90, 0x04,         // BCC +4 -> moddone (+20)
+        0xE9, n,            // SBC #n
+        0xB0, 0xF8,         // BCS -8 -> modloop (+12)
+        0xA8,               // TAY               (moddone @ +20)
+        0xB9, tlo, thi,     // LDA POOL,Y
+        0x8D, 0x78, 0x05,   // STA $0578  (Player_QueueSuit)
+        0x60,               // RTS
+    ];
+    debug_assert_eq!(code.len() as u16, ROUTINE_LEN);
+    code.extend_from_slice(pool);
+    rom.write_range(FS_FIRE_FLOWER, &code);
+
+    // Hook ObjHit_FireFlower: NOP the "already Fire" early-out (so the suit is
+    // always recomputed) and the hardcoded `LDA #$03`, keep the transition
+    // sparkle (`LDA #$1F / STA $0555`), and divert the suit store to our
+    // routine. Execution falls through afterward into the vanilla
+    // collect/sound tail at $AA13.
+    let lo = (FIRE_FLOWER_SUB_CPU & 0xFF) as u8;
+    let hi = (FIRE_FLOWER_SUB_CPU >> 8) as u8;
+    #[rustfmt::skip]
+    rom.write_range(HOOK_SITE, &[
+        0xEA, 0xEA,                     // NOP NOP   (was BEQ "already Fire")
+        0xA9, 0x1F, 0x8D, 0x55, 0x05,   // LDA #$1F / STA $0555  (transition sparkle)
+        0xEA, 0xEA,                     // NOP NOP   (was LDA #$03)
+        0x20, lo, hi,                   // JSR fire_flower routine
+    ]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rom::Rom;
+
+    /// Mirror the injected 6502 routine in Rust to confirm the table index math.
+    fn sim(salt: u8, world: u8, xhi: u8, x: u8, y: u8, pool: &[u8]) -> u8 {
+        let sum = salt
+            .wrapping_add(world)
+            .wrapping_add(xhi)
+            .wrapping_add(x)
+            .wrapping_add(y);
+        pool[(sum % pool.len() as u8) as usize]
+    }
+
+    fn blank_rom() -> Rom {
+        // Minimal valid iNES image: header + 256 KiB PRG + 128 KiB CHR, zeroed.
+        let mut data = vec![0u8; 393232];
+        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
+        data[4] = 16; // PRG pages
+        data[5] = 16; // CHR pages
+        data[6] = 0x40; // mapper 4 lower nibble
+        Rom::from_bytes_lax(&data, true).unwrap()
+    }
+
+    #[test]
+    fn off_is_noop() {
+        let mut rom = blank_rom();
+        let before = rom.read_range(0, 393232).to_vec();
+        apply(&mut rom, FireFlowerMode::Off);
+        assert_eq!(rom.read_range(0, 393232), &before[..], "Off must not touch the ROM");
+    }
+
+    #[test]
+    fn on_writes_hook_and_routine() {
+        let mut rom = blank_rom();
+        apply(&mut rom, FireFlowerMode::On);
+
+        // Hook: BEQ + LDA#$03 NOP'd, JSR to the routine.
+        let lo = (FIRE_FLOWER_SUB_CPU & 0xFF) as u8;
+        let hi = (FIRE_FLOWER_SUB_CPU >> 8) as u8;
+        assert_eq!(
+            rom.read_range(HOOK_SITE, 12),
+            &[0xEA, 0xEA, 0xA9, 0x1F, 0x8D, 0x55, 0x05, 0xEA, 0xEA, 0x20, lo, hi],
+        );
+        // CMP immediate is the pool length; table follows the routine.
+        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 12), 0xC9);
+        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 13), POOL_ON.len() as u8);
+        assert_eq!(
+            rom.read_range(FS_FIRE_FLOWER + ROUTINE_LEN as usize, POOL_ON.len()),
+            POOL_ON,
+        );
+    }
+
+    #[test]
+    fn wild_uses_six_entry_pool() {
+        let mut rom = blank_rom();
+        apply(&mut rom, FireFlowerMode::Wild);
+        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 13), POOL_WILD.len() as u8);
+        assert_eq!(
+            rom.read_range(FS_FIRE_FLOWER + ROUTINE_LEN as usize, POOL_WILD.len()),
+            POOL_WILD,
+        );
+    }
+
+    #[test]
+    fn routine_stays_within_allocation() {
+        // 28-byte routine + the larger (Wild) 6-byte table must fit the 36-byte
+        // reservation and not spill past the PRG001 bank end (0x4010).
+        const _: () = assert!(ROUTINE_LEN as usize + POOL_WILD.len() <= 36);
+        const _: () = assert!(FS_FIRE_FLOWER + 36 <= 0x4010);
+    }
+
+    #[test]
+    fn index_is_deterministic_and_in_pool() {
+        // Same inputs -> same suit; result always a pool member.
+        for &pool in &[POOL_ON, POOL_WILD] {
+            for salt in 0..8u8 {
+                for world in 0..8u8 {
+                    for &(xhi, x, y) in &[(0u8, 0u8, 0u8), (1, 0x40, 0x80), (15, 0xFF, 0xFF)] {
+                        let a = sim(salt, world, xhi, x, y, pool);
+                        let b = sim(salt, world, xhi, x, y, pool);
+                        assert_eq!(a, b);
+                        assert!(pool.contains(&a));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/randomize/mod.rs
+++ b/src/randomize/mod.rs
@@ -3,6 +3,7 @@ pub mod autoscroll;
 pub mod bowser_castle;
 pub mod enemies;
 pub mod enemy_protections;
+pub mod fire_flower;
 pub mod hand_rooms;
 pub mod hands_levels;
 pub mod items;

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -54,6 +54,7 @@ const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x0384E, 16, "koopa_vram_clear: clear VRAM buffer on defeat"),
     (0x0385E, 12, "koopa_fire_preset: set stomp counter from threshold table for fireball defeat"),
     (0x03FD0, 22, "koopa_y_clamp: clamp Koopaling Y position to screen"),
+    (0x03FE6, 36, "fire_flower: position-hash suit routine + pool table"),
     // PRG006 (file 0x0C010, CPU $C000–$DFFF) — level enemy data bank
     (0x0DA74, 22, "hand_rooms: 2 cloned enemy streams for unique 8-Hnd treasure rooms"),
     // PRG029 (file 0x3A010, CPU $C000–$DFFF) — swim physics bank
@@ -167,6 +168,16 @@ pub(super) const KOOPA_VRAM_CLEAR_CPU: u16  = 0xB83E;  // $A000 + (0x0384E - 0x0
 // Source: Fred's Koopaling fixes.
 pub(super) const FS_KOOPA_Y_CLAMP: usize = 0x03FD0; // 22 bytes
 pub(super) const KOOPA_Y_CLAMP_CPU: u16  = 0xBFC0;  // $A000 + (0x03FD0 - 0x02010)
+
+// Random Fire Flower (issue #22) — injected routine that derives the granted
+// power state from a seed-derived salt (the shuffled starting world) + the
+// current World_Num + the flower's absolute level position, instead of the
+// vanilla hardcoded Fire. Sits in the PRG001 bank-end gap right after
+// koopa_y_clamp (which ends at 0x3FE6). Up to 36 bytes: 28-byte routine + a
+// 4- or 6-byte pool table. ObjHit_FireFlower runs with PRG001 banked at
+// $A000, so the JSR from the hook is bank-local.
+pub(super) const FS_FIRE_FLOWER: usize     = 0x03FE6;
+pub(super) const FIRE_FLOWER_SUB_CPU: u16  = 0xBFD6; // $A000 + (0x03FE6 - 0x02010)
 
 // Fireball defeat preset — load per-world stomp threshold from table so the
 // fireball→stomp handoff always triggers defeat after INC.

--- a/src/randomize/world_order.rs
+++ b/src/randomize/world_order.rs
@@ -10,7 +10,13 @@ const WORLD_INC_OFFSET: usize = 0x3D0A1;
 /// File offset of the `LDA #$00` operand that initializes World_Num at game start.
 /// Original: `LDA #$00; STA $0727; STA $0160`. We patch the #$00 to the starting world
 /// and NOP out the `STA $0160` so the debug flag isn't set to the world number.
-const WORLD_INIT_OPERAND: usize = 0x30CC3;
+///
+/// Exposed so [`super::fire_flower`] can read the baked starting world (the
+/// first world in the shuffled progression, or 0 when world order is off) and
+/// use it as a seed-derived salt. Reading it is only meaningful after this
+/// module has run, which the orchestrator guarantees (world order is applied
+/// before fire_flower).
+pub(super) const WORLD_INIT_OPERAND: usize = 0x30CC3;
 
 /// File offset of the `STA $0160` (Debug_Flag) instruction (3 bytes).
 /// We NOP this out because patching the LDA operand above would otherwise

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -52,6 +52,20 @@ pub enum EnemyMode {
 fn default_shuffle() -> EnemyMode { EnemyMode::Shuffle }
 fn default_off() -> EnemyMode { EnemyMode::Off }
 
+/// Random Fire Flower mode (issue #22). Collecting an in-level Fire Flower
+/// grants a power state derived deterministically from the world and the
+/// flower's level position, instead of always Fire. `On` substitutes among the
+/// four big-form suits (Fire/Frog/Tanooki/Hammer); `Wild` adds the Small/Big
+/// downgrade outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FireFlowerMode {
+    #[default]
+    Off,
+    On,
+    Wild,
+}
+
 /// Tri-state toggle for player-hidden flags: forced `Off`, forced `On`, or
 /// left to the seed (`Maybe`). A `Maybe` flag is resolved to a concrete
 /// on/off at generation time from a dedicated RNG substream (see
@@ -211,6 +225,12 @@ pub struct Options {
     /// always-on tail-attack-while-swimming routine.)
     #[serde(default)]
     pub faster_frog: bool,
+    /// Random Fire Flower (issue #22): an in-level Fire Flower grants a power
+    /// state derived deterministically from the world + the flower's level
+    /// position, instead of always Fire. `Off`/`On`/`Wild` (see
+    /// [`FireFlowerMode`]). The flower sprite is unchanged.
+    #[serde(default)]
+    pub fire_flower: FireFlowerMode,
     /// When true, the 19 vanilla spade-game tiles are picked up by the overworld
     /// builder and re-placed at random HammerBro slots, freeing their original
     /// positions for level placement. When false, spade games stay at vanilla
@@ -524,13 +544,24 @@ impl Options {
             | (item_mode(i1) << 2)
             | item_mode(i2);
 
-        // b11: "maybe" bits for the four player-hidden tri-state flags. When a
-        // bit is set the flag is resolved from the seed at generation time, and
-        // its value bit (in b1/b2/b3) is ignored on decode.
+        // Encode FireFlowerMode as 2 bits (off=0, on=1, wild=2).
+        fn ffm(m: FireFlowerMode) -> u8 {
+            match m {
+                FireFlowerMode::Off => 0,
+                FireFlowerMode::On => 1,
+                FireFlowerMode::Wild => 2,
+            }
+        }
+
+        // b11: "maybe" bits for the four player-hidden tri-state flags (bits
+        // 0-3). When a maybe bit is set the flag is resolved from the seed at
+        // generation time, and its value bit (in b1/b2/b3) is ignored on decode.
+        // Bits 4-5 hold the Random Fire Flower mode; bits 6-7 are free.
         let b11 = (self.hammer_breaks_locks.is_maybe() as u8)
             | (self.hammer_breaks_bridges.is_maybe() as u8) << 1
             | (self.troll_pipes.is_maybe() as u8) << 2
-            | (self.w1_hammer_rock.is_maybe() as u8) << 3;
+            | (self.w1_hammer_rock.is_maybe() as u8) << 3
+            | ffm(self.fire_flower) << 4;
 
         [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11]
     }
@@ -585,6 +616,15 @@ impl Options {
             if maybe { Tri::Maybe } else if value { Tri::On } else { Tri::Off }
         }
 
+        // Decode the 2-bit Random Fire Flower mode (b11 bits 4-5).
+        fn dffm(bits: u8) -> FireFlowerMode {
+            match bits & 0x03 {
+                1 => FireFlowerMode::On,
+                2 => FireFlowerMode::Wild,
+                _ => FireFlowerMode::Off,
+            }
+        }
+
         Ok(Options {
             powerups: (b1 >> 7) & 1 != 0,
             palettes: true,
@@ -623,6 +663,7 @@ impl Options {
             random_koopalings: (b10 >> 7) & 1 != 0,
             include_beta_stages: (b10 >> 6) & 1 != 0,
             hammer_breaks_bridges: dtri((b3 >> 7) & 1 != 0, (b11 >> 1) & 1 != 0),
+            fire_flower: dffm(b11 >> 4),
             ground: dem(b5 >> 6),
             shell: dem(b5 >> 4),
             flying: dem(b5 >> 2),
@@ -710,6 +751,7 @@ impl Default for Options {
             faster_tail_speed: false,
             no_game_over_penalty: false,
             faster_frog: false,
+            fire_flower: FireFlowerMode::Off,
             shuffle_spade_games: true,
             shuffle_toad_houses: true,
             hands_levels: true,
@@ -1097,6 +1139,14 @@ fn randomize_inner(
         randomize::qol::apply_faster_frog(rom);
     }
 
+    // Random Fire Flower — in-level Fire Flower grants a position-derived suit
+    // instead of always Fire. Pure static patch (no RNG): the substitution is a
+    // deterministic function of World_Num + the flower's level position.
+    if options.fire_flower != FireFlowerMode::Off {
+        rom.set_tag("fire_flower");
+        randomize::fire_flower::apply(rom, options.fire_flower);
+    }
+
     // Stamp flag key + seed into free space at STAMP_OFFSET (PRG012). 24 bytes:
     //   [0..4]   "S3R\xNN" magic + version
     //   [4..16]  flag key bytes (12 bytes in v18)
@@ -1307,6 +1357,7 @@ mod tests {
     #[test]
     fn flag_key_round_trip_all_wild() {
         let opts = Options {
+            fire_flower: FireFlowerMode::Wild,
             powerups: true,
             palettes: true,
             palette_themed: false,
@@ -1383,6 +1434,7 @@ mod tests {
     #[test]
     fn flag_key_round_trip_all_off() {
         let opts = Options {
+            fire_flower: FireFlowerMode::Off,
             powerups: false,
             palettes: false,
             palette_themed: false,
@@ -1777,6 +1829,7 @@ mod tests {
     /// Build an Options with everything disabled (exercises "skip everything" branches).
     fn all_off_options() -> Options {
         Options {
+            fire_flower: FireFlowerMode::Off,
             powerups: false,
             palettes: false,
             palette_themed: false,
@@ -1837,6 +1890,7 @@ mod tests {
     /// Palettes disabled because they use OS entropy (cosmetic, decoupled from seed).
     fn all_on_options() -> Options {
         Options {
+            fire_flower: FireFlowerMode::On,
             powerups: true,
             palettes: false,
             palette_themed: false,

--- a/web/options.js
+++ b/web/options.js
@@ -56,6 +56,15 @@ const ON_OFF_MAYBE = [
 	{ value: "maybe", label: "Maybe" },
 ];
 
+// Off / On / Wild pill for Random Fire Flower. "Wild" widens the pool to also
+// include the Small/Big downgrade outcomes. Values match the Rust
+// `FireFlowerMode` enum's serde representation.
+const OFF_ON_WILD = [
+	{ value: "off", label: "Off" },
+	{ value: "on", label: "On" },
+	{ value: "wild", label: "Wild" },
+];
+
 // Categories rendered as <fieldset> sections, in order.
 export const GROUPS = [
 	{ id: "map", label: "Map" },
@@ -269,6 +278,11 @@ export const SCHEMA = [
 		label: "Chest Items",
 		tip: "Randomize chest and Toad House reward items",
 		icon: { x: 525, y: 292, w: 16, h: 16 },
+		group: "items", inFlagKey: true },
+	{ id: "fire_flower", type: "tri", options: OFF_ON_WILD, default: "off",
+		label: "Random Fire Flower",
+		tip: "Fire Flowers still look the same, but each one gives a different suit based on where it is. On: Fire, Frog, Tanooki, or Hammer. Wild: also lets it shrink you to Big or Small.",
+		icon: { x: 453, y: 364, w: 16, h: 16 }, // fire flower
 		group: "items", inFlagKey: true },
 	{ id: "big_q_blocks", type: "bool", default: false,
 		label: "Big ? Blocks",


### PR DESCRIPTION
Closes #22.

Collecting an **in-level Fire Flower** keeps the Fire Flower sprite but grants a substituted power state. The result is **deterministic** — every player on a given seed gets the same suit from a given flower — with no live/in-game RNG.

## How it works

A 6502 patch hooks `ObjHit_FireFlower` (PRG001, file `0x2A17`): NOPs the "already Fire" early-out and the hardcoded `LDA #$03`, keeps the transition sparkle, and `JSR`s an injected routine in the PRG001 bank-end free space (`FS_FIRE_FLOWER = 0x3FE6`, CPU `$BFD6`). The routine computes:

```
suit = pool[(salt + World_Num + Objects_XHi,X + Objects_X,X + Objects_Y,X) mod n]
```

- **`salt`** — the shuffled **starting world**, baked in at patch time from `world_order`'s init operand (`0x30CC3`). It's seed-derived, so the mapping rotates per seed and even world-locked levels (e.g. **Bowser's castle**) vary across seeds.
- **`World_Num` + the flower's absolute level position** spread different worlds and individual flowers apart within a single playthrough. The object position arrays are absolute level coords (stable vs. camera scroll), so each flower tile resolves to one fixed suit.

Builds on the community "Random Fire Flower" patch (`patches/`) as the hook foundation, but uses our own routine and salt.

## Modes (`--fire-flower off|on|wild`)

- **off** — vanilla (always Fire)
- **on** — `{Fire, Frog, Tanooki, Hammer}`
- **wild** — also `{Small, Big}` downgrades

Exposed via `Options.fire_flower` (`FireFlowerMode`), flag key b11 bits 4-5, CLI, and the web UI (Items-group pill + tooltip). Pure static patch — consumes no RNG, so it doesn't perturb other randomization.

## Notes / caveats

- **World-order coupling:** when `--world-order` is **off**, the salt is `0`, so fixed levels resolve to the same suit across seeds (within-playthrough variation still works). A seed-derived fallback for the world-order-off case can be added later if wanted.
- **`wild` downgrades unplaytested:** Small/Big queue a downgrade through a path vanilla never uses — worth an emulator check before relying on it. The `on` pool is the proven set.
- **Small Mario** still follows the vanilla path (→ Super); in practice a flower only spawns once you're big, so this is moot.

## Testing

- New unit tests in `fire_flower.rs` (hook bytes, pool tables, allocation bounds, determinism).
- Full lib suite green (226 passed); `clippy --all-targets` clean.
- Verified on the real ROM: salt == baked starting world and varies per seed (seed 42→`0x01`, 43→`0x04`, 99→`0x06`, no-world-order→`0x00`); two runs of the same seed are byte-identical; `off` leaves the hook vanilla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)