### PR TITLE
feature: add king rescue quotes

### DIFF
--- a/src/randomize/king_quotes.rs
+++ b/src/randomize/king_quotes.rs
@@ -500,6 +500,30 @@ const QUOTES: &[[&str; 6]] = &[
         "randomizer!",
         "",
     ],
+    [
+        "You may not be",
+        "the best but at",
+        "least you can",
+        "beat Dr. Torstol",
+        "",
+        "",
+    ],
+    [
+        "HAXOR",
+        "TO D",
+        "MAXOR",
+        "",
+        "",
+        "",
+    ],
+    [
+        "It looks like you're",
+        "trying to clip",
+        "through this wall.",
+        "Would you like help?",
+        "",
+        "",
+    ],
 ];
 
 /// Suit-specific quotes: shown when Mario visits the king wearing frog suit.


### PR DESCRIPTION
Adds three new quotes to the standard `QUOTES` pool in `src/randomize/king_quotes.rs`:

- A Dr. Torstol ribbing
- A leetspeak `HAXOR / TO D / MAXOR` line
- A Clippy x speedrun-clip gag: "It looks like you're trying to clip through this wall. Would you like help?"

All wrapped to 6 lines, ≤20 chars each, valid SMB3 text-table characters only. `cargo test king_quotes` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)