### PR TITLE
fix: make Random Fire Flower deterministic per block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@ full history.
 - **Random Fire Flower** (`--fire-flower off|on|wild`, issue #22) — an in-level
   Fire Flower still looks the same but grants a power state derived
   deterministically from a seed salt (the shuffled starting world), the current
-  world, and the flower's level position, instead of always Fire. `on`
+  world, the level, and the flower's screen, instead of always Fire. `on`
   substitutes among Fire/Frog/Tanooki/Hammer; `wild` also allows the Small/Big
-  downgrades. Same seed and spot always give the same suit; the mapping rotates
-  per seed when world-order shuffle is enabled.
+  downgrades. Same seed always gives the same suit for a given flower; the
+  mapping rotates per seed when world-order shuffle is enabled.
 - **Overworld builder pipeline** — the core randomization system. A
   four-phase pipeline (catalog → pickup → build → write) that re-lays each
   world: assigns levels to map slots via BFS-ordered placement, places

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.8.22"
+version = "0.8.23"
 edition = "2024"
 
 [lib]

--- a/src/randomize/fire_flower.rs
+++ b/src/randomize/fire_flower.rs
@@ -17,34 +17,43 @@
 //! injected routine that computes:
 //!
 //! ```text
-//! index = (salt + World_Num + Objects_XHi,X + Objects_X,X + Objects_Y,X) mod pool_len
+//! index = (salt + World_Num + Level_LayPtr_AddrL + Objects_XHi,X) mod pool_len
 //! Player_QueueSuit = POOL[index]
 //! ```
 //!
-//! ## Where the variation comes from
+//! ## Where the variation comes from — and why every input must be stable
 //!
-//! - **`salt`** is a single byte baked in at patch-generation time: the
-//!   *starting world* of the shuffled progression (the first world in
-//!   `world_order`). It is seed-derived, so the whole suit mapping rotates from
-//!   seed to seed — which is the only way a level that **never moves worlds**
-//!   (e.g. Bowser's castle) can give a different suit across seeds, since every
-//!   pure-game-state input is identical for it on every seed. When world order
-//!   shuffling is off, the starting world is always 0, so the salt is constant
-//!   and fixed levels resolve to the same suit across seeds.
-//! - **`World_Num`** (`$0727`) spreads different worlds apart within a single
-//!   playthrough.
-//! - The three object arrays (all indexed by the colliding object's slot in
-//!   `X`) are the flower's *absolute* level coordinates — stable regardless of
-//!   camera scroll — so each flower tile resolves to one fixed suit, and two
-//!   flowers in the same level differ.
+//! The hash must use only values that **do not change between two collections
+//! of the same flower**, or the same block yields different suits. A flower
+//! popped from a `?` block *rises and drifts as it emerges*, so its fine
+//! position (`Objects_X` low byte, `Objects_Y`) is NOT stable at collision time
+//! — using them was a determinism bug. We key only on values that are fixed for
+//! the whole time the flower exists:
 //!
-//! Because the salt is baked into the ROM, the result is fully deterministic
-//! for a given seed (every player gets the same suit from a given flower) with
-//! no live/in-game RNG.
+//! - **`salt`** — a byte baked in at patch-generation time: the *starting
+//!   world* of the shuffled progression (`world_order`). Seed-derived, so the
+//!   whole suit mapping rotates seed to seed — the only way a level that **never
+//!   moves worlds** (e.g. Bowser's castle) can give a different suit across
+//!   seeds, since every pure-game-state input is identical for it on every seed.
+//!   With world-order shuffle off the starting world is 0, so fixed levels
+//!   resolve to the same suit across seeds.
+//! - **`World_Num`** (`$0727`) — spreads worlds apart; constant within a level.
+//! - **`Level_LayPtr_AddrL`** (`$61`) — the level layout pointer, a per-area
+//!   constant set at level load and not touched during play. Distinguishes
+//!   different levels/sub-areas that share a world and screen.
+//! - **`Objects_XHi,X`** (`$76,X`, the colliding object's slot in `X`) — the
+//!   flower's *screen number*. Unlike the low-byte X/Y it doesn't change as the
+//!   flower rises a few pixels, so it's stable per block. (Same input the
+//!   community "Random Fire Flower" patch used.)
+//!
+//! Granularity is therefore per-(seed, world, level/area, screen): two flowers
+//! on the *same screen of the same level* resolve to the same suit. Finer
+//! per-tile distinction isn't available because the flower's fine position isn't
+//! stable at collision time. Because the salt is baked into the ROM, the result
+//! is fully deterministic for a given seed with no live/in-game RNG.
 //!
 //! The hook mirrors the community "Random Fire Flower" patch's site but diverts
-//! to our own routine and uses the starting-world salt + `World_Num` (the
-//! original used `Level_LayPtr_AddrL`, which ties the suit to level *content*).
+//! to our own routine and adds the starting-world salt + `World_Num`.
 //!
 //! ## Scope / caveats
 //!
@@ -83,7 +92,7 @@ const POOL_ON: &[u8] = &[Q_FIRE, Q_FROG, Q_TANOOKI, Q_HAMMER];
 const POOL_WILD: &[u8] = &[Q_SMALL, Q_BIG, Q_FIRE, Q_FROG, Q_TANOOKI, Q_HAMMER];
 
 /// Length of the injected routine code (excluding the trailing pool table).
-const ROUTINE_LEN: u16 = 28;
+const ROUTINE_LEN: u16 = 26;
 
 /// Install the Random Fire Flower patch. `Off` is a no-op.
 ///
@@ -107,13 +116,14 @@ pub fn apply(rom: &mut Rom, mode: FireFlowerMode) {
     let tlo = (table_cpu & 0xFF) as u8;
     let thi = (table_cpu >> 8) as u8;
 
-    // Injected routine (X = colliding object's slot index):
+    // Injected routine (X = colliding object's slot index). Every summed input
+    // is stable for the flower's whole lifetime — see the module doc for why
+    // the fine position (Objects_X/Y) must NOT be used.
     //   LDA #salt        ; seed-derived starting-world salt
     //   CLC
     //   ADC $0727        ; + World_Num  (current world)
-    //   ADC $76,X        ; + Objects_XHi,X  (screen number, absolute)
-    //   ADC $91,X        ; + Objects_X,X    (low X within screen, absolute)
-    //   ADC $A3,X        ; + Objects_Y,X    (absolute Y)
+    //   ADC $61          ; + Level_LayPtr_AddrL  (per-area constant)
+    //   ADC $76,X        ; + Objects_XHi,X  (flower screen number)
     // modloop:
     //   CMP #n           ; reduce the (carry-folded) sum mod pool_len
     //   BCC moddone
@@ -129,14 +139,13 @@ pub fn apply(rom: &mut Rom, mode: FireFlowerMode) {
         0xA9, salt,         // LDA #salt
         0x18,               // CLC
         0x6D, 0x27, 0x07,   // ADC $0727  (World_Num)
+        0x65, 0x61,         // ADC $61    (Level_LayPtr_AddrL)
         0x75, 0x76,         // ADC $76,X  (Objects_XHi,X)
-        0x75, 0x91,         // ADC $91,X  (Objects_X,X)
-        0x75, 0xA3,         // ADC $A3,X  (Objects_Y,X)
-        0xC9, n,            // CMP #n            (modloop @ +12)
-        0x90, 0x04,         // BCC +4 -> moddone (+20)
+        0xC9, n,            // CMP #n            (modloop @ +10)
+        0x90, 0x04,         // BCC +4 -> moddone (+16)
         0xE9, n,            // SBC #n
-        0xB0, 0xF8,         // BCS -8 -> modloop (+12)
-        0xA8,               // TAY               (moddone @ +20)
+        0xB0, 0xF8,         // BCS -8 -> modloop (+10)
+        0xA8,               // TAY               (moddone @ +16)
         0xB9, tlo, thi,     // LDA POOL,Y
         0x8D, 0x78, 0x05,   // STA $0578  (Player_QueueSuit)
         0x60,               // RTS
@@ -167,12 +176,12 @@ mod tests {
     use crate::rom::Rom;
 
     /// Mirror the injected 6502 routine in Rust to confirm the table index math.
-    fn sim(salt: u8, world: u8, xhi: u8, x: u8, y: u8, pool: &[u8]) -> u8 {
+    /// Only stable inputs (salt, world, layout pointer, flower screen) feed it.
+    fn sim(salt: u8, world: u8, layptr: u8, xhi: u8, pool: &[u8]) -> u8 {
         let sum = salt
             .wrapping_add(world)
-            .wrapping_add(xhi)
-            .wrapping_add(x)
-            .wrapping_add(y);
+            .wrapping_add(layptr)
+            .wrapping_add(xhi);
         pool[(sum % pool.len() as u8) as usize]
     }
 
@@ -207,8 +216,8 @@ mod tests {
             &[0xEA, 0xEA, 0xA9, 0x1F, 0x8D, 0x55, 0x05, 0xEA, 0xEA, 0x20, lo, hi],
         );
         // CMP immediate is the pool length; table follows the routine.
-        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 12), 0xC9);
-        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 13), POOL_ON.len() as u8);
+        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 10), 0xC9);
+        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 11), POOL_ON.len() as u8);
         assert_eq!(
             rom.read_range(FS_FIRE_FLOWER + ROUTINE_LEN as usize, POOL_ON.len()),
             POOL_ON,
@@ -219,7 +228,7 @@ mod tests {
     fn wild_uses_six_entry_pool() {
         let mut rom = blank_rom();
         apply(&mut rom, FireFlowerMode::Wild);
-        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 13), POOL_WILD.len() as u8);
+        assert_eq!(rom.read_byte(FS_FIRE_FLOWER + 11), POOL_WILD.len() as u8);
         assert_eq!(
             rom.read_range(FS_FIRE_FLOWER + ROUTINE_LEN as usize, POOL_WILD.len()),
             POOL_WILD,
@@ -228,7 +237,7 @@ mod tests {
 
     #[test]
     fn routine_stays_within_allocation() {
-        // 28-byte routine + the larger (Wild) 6-byte table must fit the 36-byte
+        // 26-byte routine + the larger (Wild) 6-byte table must fit the 36-byte
         // reservation and not spill past the PRG001 bank end (0x4010).
         const _: () = assert!(ROUTINE_LEN as usize + POOL_WILD.len() <= 36);
         const _: () = assert!(FS_FIRE_FLOWER + 36 <= 0x4010);
@@ -240,9 +249,9 @@ mod tests {
         for &pool in &[POOL_ON, POOL_WILD] {
             for salt in 0..8u8 {
                 for world in 0..8u8 {
-                    for &(xhi, x, y) in &[(0u8, 0u8, 0u8), (1, 0x40, 0x80), (15, 0xFF, 0xFF)] {
-                        let a = sim(salt, world, xhi, x, y, pool);
-                        let b = sim(salt, world, xhi, x, y, pool);
+                    for &(layptr, xhi) in &[(0u8, 0u8), (0x40, 1), (0xFF, 15)] {
+                        let a = sim(salt, world, layptr, xhi, pool);
+                        let b = sim(salt, world, layptr, xhi, pool);
                         assert_eq!(a, b);
                         assert!(pool.contains(&a));
                     }

--- a/src/randomize/king_quotes.rs
+++ b/src/randomize/king_quotes.rs
@@ -500,6 +500,30 @@ const QUOTES: &[[&str; 6]] = &[
         "randomizer!",
         "",
     ],
+    [
+        "You may not be",
+        "the best but at",
+        "least you can",
+        "beat Dr. Torstol",
+        "",
+        "",
+    ],
+    [
+        "HAXOR",
+        "TO D",
+        "MAXOR",
+        "",
+        "",
+        "",
+    ],
+    [
+        "It looks like you're",
+        "trying to clip",
+        "through this wall.",
+        "Would you like help?",
+        "",
+        "",
+    ],
 ];
 
 /// Suit-specific quotes: shown when Mario visits the king wearing frog suit.

--- a/src/randomize/rom_data.rs
+++ b/src/randomize/rom_data.rs
@@ -171,10 +171,10 @@ pub(super) const KOOPA_Y_CLAMP_CPU: u16  = 0xBFC0;  // $A000 + (0x03FD0 - 0x0201
 
 // Random Fire Flower (issue #22) — injected routine that derives the granted
 // power state from a seed-derived salt (the shuffled starting world) + the
-// current World_Num + the flower's absolute level position, instead of the
-// vanilla hardcoded Fire. Sits in the PRG001 bank-end gap right after
-// koopa_y_clamp (which ends at 0x3FE6). Up to 36 bytes: 28-byte routine + a
-// 4- or 6-byte pool table. ObjHit_FireFlower runs with PRG001 banked at
+// current World_Num + the level layout pointer + the flower's screen number,
+// instead of the vanilla hardcoded Fire. Sits in the PRG001 bank-end gap right
+// after koopa_y_clamp (which ends at 0x3FE6). Up to 36 bytes: 26-byte routine +
+// a 4- or 6-byte pool table. ObjHit_FireFlower runs with PRG001 banked at
 // $A000, so the JSR from the hook is bank-local.
 pub(super) const FS_FIRE_FLOWER: usize     = 0x03FE6;
 pub(super) const FIRE_FLOWER_SUB_CPU: u16  = 0xBFD6; // $A000 + (0x03FE6 - 0x02010)


### PR DESCRIPTION
Follow-up to #52. Playtesting found the **same block giving different power-ups** between collections.

## Cause

The hash mixed in the flower's fine position (`Objects_X` low byte + `Objects_Y`). A Fire Flower **rises and drifts as it emerges from a block**, so those values differ depending on exactly when the player touches it — breaking the "same flower → same suit" guarantee. Everything else in the hash is constant during a playthrough; only those two terms drifted.

## Fix

Drop the unstable terms; key only on values fixed for the flower's whole lifetime:

```
suit = pool[(salt + World_Num + Level_LayPtr_AddrL + Objects_XHi,X) mod n]
```

- **`Level_LayPtr_AddrL`** (`$61`) — per-area constant set at level load; distinguishes levels/sub-areas that share a world and screen.
- **`Objects_XHi`** (`$76,X`) — the flower's screen number, which doesn't change as it rises a few pixels (the input the community reference patch used).

## Tradeoff

Granularity is now **per-(seed, world, level/area, screen)** instead of per-tile — two flowers on the *same screen of the same level* resolve to the same suit. Finer per-tile distinction isn't available because the flower's fine position isn't stable at collection time. Correctness (determinism) takes priority; if true per-tile is wanted later, it'd require stashing the flower's spawn position at `ObjInit` into a per-slot variable and reading that at collision.

## Testing

- Verified on the real ROM: the routine no longer references `Objects_X`/`Objects_Y`; only `salt + $0727 + $61 + $76,X` feed it.
- `clippy --all-targets` clean; full lib suite green (226 passed). Routine shrank 28→26 bytes (allocation unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)