### PR TITLE
Group builder flags into BuildFlags/WriteFlags structs with Default (#59)

### DIFF
--- a/src/randomize/overworld_build.rs
+++ b/src/randomize/overworld_build.rs
@@ -39,6 +39,16 @@ pub(crate) struct OverworldData<'a> {
     pub catalog: &'a NodeCatalog,
 }
 
+/// Feature flags consumed by the build phase. Construct exhaustively in
+/// production so a new flag forces a conscious wire-up; in tests use
+/// `BuildFlags { ..Default::default() }` so adding a flag leaves them untouched.
+#[derive(Copy, Clone, Default)]
+pub(crate) struct BuildFlags {
+    pub shuffle_toad_houses: bool,
+    pub eights_are_wild: bool,
+    pub shuffle_hammer_bros: bool,
+}
+
 /// What kind of node occupies a grid slot.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SlotKind {
@@ -212,10 +222,13 @@ pub(crate) fn build<R: Rng>(
     rom: &Rom,
     data: &OverworldData,
     rng: &mut R,
-    shuffle_toad_houses: bool,
-    eights_are_wild: bool,
-    shuffle_hammer_bros: bool,
+    flags: BuildFlags,
 ) -> BuildResult {
+    let BuildFlags {
+        shuffle_toad_houses,
+        eights_are_wild,
+        shuffle_hammer_bros,
+    } = flags;
     let pickup = data.pickup;
     let catalog = data.catalog;
     // Step 0: redistribute fortresses
@@ -2584,7 +2597,7 @@ mod tests {
             super::super::overworld_pickup::PickupFlags {
                 shuffle_spade_games: true,
                 shuffle_toad_houses: true,
-                shuffle_hammer_bros: false,
+                ..Default::default()
             },
         );
         (catalog, pickup)
@@ -2612,10 +2625,10 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
         let mut rng = ChaCha8Rng::seed_from_u64(42);
 
-        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         assert_eq!(result.worlds.len(), 8);
 
@@ -2666,9 +2679,7 @@ mod tests {
                 &rom,
                 &OverworldData { pickup: &pickup, catalog: &catalog },
                 &mut rng,
-                true,
-                false,
-                true,
+                BuildFlags { shuffle_toad_houses: true, shuffle_hammer_bros: true, ..Default::default() },
             );
 
             // The vanilla 15 encounters are always placed (W1-W6 alone have the
@@ -2725,11 +2736,11 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for seed in 0..10 {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             for built in &result.worlds {
                 let start_pos = rom_data::find_start(&built.grid);
@@ -2785,11 +2796,11 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for seed in [42, 123, 999] {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             let mut rom_copy = Rom::from_bytes(&rom.data).unwrap();
             debug_stamp_rom(&mut rom_copy, &result);
@@ -2820,10 +2831,10 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
         let mut rng = ChaCha8Rng::seed_from_u64(42);
 
-        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         for built in &result.worlds {
             eprintln!("\n=== World {} ({} sections) ===",
@@ -2860,7 +2871,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         let mut level_shortfalls = 0u32;
         let mut lock_shortfalls = 0u32;
@@ -2868,7 +2879,7 @@ mod tests {
 
         for seed in 0..seeds {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             let total_levels: usize = result.worlds.iter()
                 .map(|b| b.slots.iter().filter(|s| s.kind == SlotKind::Level).count())
@@ -2915,7 +2926,7 @@ mod tests {
         let mut no_safe_details: Vec<(u64, [usize; 8])> = Vec::new();
         for seed in 0..seeds {
             let mut rng2 = ChaCha8Rng::seed_from_u64(seed);
-            let result2 = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, true, false, false);
+            let result2 = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             let has_safe = result2.worlds.iter().any(|b| {
                 b.locks.iter().any(|l| l.secret_exit_safe)
             });
@@ -2954,11 +2965,11 @@ mod tests {
             }
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for seed in 0..6u64 {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             let built = &result.worlds[5]; // W6 (0-indexed)
 
             eprintln!("\n===== Seed {seed} — W6 =====");
@@ -3043,7 +3054,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
         let wi = 6; // W7
 
         let cw = &pickup.worlds[wi];
@@ -3058,7 +3069,7 @@ mod tests {
         // Run the actual build for several seeds and check coverage
         for seed in 0..5u64 {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             let built = &result.worlds[wi];
 
             // All positions that got a slot assignment
@@ -3123,11 +3134,11 @@ mod tests {
             }
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for seed in [42u64, 123, 999] {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             eprintln!("\n{}", "=".repeat(60));
             eprintln!("=== Seed {seed} ===");
@@ -3225,13 +3236,13 @@ mod tests {
             None => { eprintln!("ROM not found"); return; }
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         let seed = 42u64;
         let target_wi = 6; // 0-indexed: W7 = 6
 
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
         let built = &result.worlds[target_wi];
 
         let start_pos = rom_data::find_start(&built.grid);
@@ -3356,7 +3367,7 @@ mod tests {
         for seed in 0..seeds {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             let mut seed_has_close = false;
             let mut seed_has_close_pair = false;
 
@@ -3555,7 +3566,7 @@ mod tests {
         for seed in 0..seeds {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             for built in &result.worlds {
                 let wi = built.world_idx;
@@ -3710,7 +3721,7 @@ mod tests {
         for seed in 0..seeds {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             for built in &result.worlds {
                 let wi = built.world_idx;
@@ -3892,7 +3903,7 @@ mod tests {
         for seed in 0..seeds {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             for built in &result.worlds {
                 let wi = built.world_idx;
@@ -4095,11 +4106,11 @@ mod tests {
                 super::super::overworld_pickup::PickupFlags {
                     shuffle_spade_games: true,
                     shuffle_toad_houses: true,
-                    shuffle_hammer_bros: false,
+                    ..Default::default()
                 },
             );
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             let w3 = result.worlds.iter().find(|b| b.world_idx == 2).unwrap();
             assert!(
                 analyze_required_progression(w3, false).reachable,
@@ -4156,7 +4167,7 @@ mod tests {
         for seed in 0..seeds {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             for built in &result.worlds {
                 let wi = built.world_idx;
@@ -4370,9 +4381,7 @@ mod tests {
                 &rom,
                 &OverworldData { pickup: &pickup, catalog: &catalog },
                 &mut rng,
-                true,
-                false,
-                false,
+                BuildFlags { shuffle_toad_houses: true, ..Default::default() },
             );
             let sas_label = if std::env::var("SAS").is_ok() {
                 " [SAS=1]"

--- a/src/randomize/overworld_pickup.rs
+++ b/src/randomize/overworld_pickup.rs
@@ -62,7 +62,7 @@ pub(crate) struct PickupResult {
 /// Per-feature flags controlling which catalog entry kinds the pickup phase
 /// pulls into the shuffle pool. Each flag corresponds to a pickup-time option;
 /// when false, those entries stay at their vanilla positions.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub(crate) struct PickupFlags {
     pub shuffle_spade_games: bool,
     pub shuffle_toad_houses: bool,
@@ -330,7 +330,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         // 62 levels + 17 fortresses + 48 pipes + 151 hammer bros + 19 bonus games + 22 toad houses = 319
         // (Airships and Bowser excluded — their pointer table entries stay vanilla
@@ -349,7 +349,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for (pi, pe) in result.pool.iter().enumerate() {
             let entry = &catalog.entries[pe.catalog_idx];
@@ -375,7 +375,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         let fx_slots = rom_data::read_fx_slots(&rom);
         let fx_assignments = rom_data::read_world_fx_assignments(&rom);
@@ -406,7 +406,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for entry in &catalog.entries {
             if !matches!(entry.kind, NodeKind::Start) {
@@ -430,7 +430,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for cw in &result.worlds {
             for &pi in &cw.pool_indices {
@@ -459,7 +459,7 @@ mod tests {
             None => return,
         };
         let catalog = NodeCatalog::build(&rom, false);
-        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let result = pick_up(&rom, &catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for cw in &result.worlds {
             eprintln!("\n=== World {} ({} picked up) ===", cw.world_idx + 1, cw.pool_indices.len());
@@ -496,7 +496,7 @@ mod tests {
 
     /// Helper: write cleared grids into a ROM copy and save to disk.
     fn dump_filtered_rom(rom: &Rom, catalog: &NodeCatalog, pred: fn(&CatalogEntry, PickupFlags) -> bool, filename: &str) {
-        let result = pick_up_filtered(rom, catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false }, pred);
+        let result = pick_up_filtered(rom, catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() }, pred);
         let mut data = rom.data.clone();
         for cw in &result.worlds {
             for r in 0..cw.grid.rows {
@@ -558,7 +558,7 @@ mod tests {
         let result = pick_up(&rom, &catalog, PickupFlags {
             shuffle_spade_games: true,
             shuffle_toad_houses: true,
-            shuffle_hammer_bros: false,
+            ..Default::default()
         });
         let w5 = &result.worlds[4];
         assert_eq!(w5.grid.get(6, 20), 0xD9, "W5 (6,20) override should produce sky none-tile");

--- a/src/randomize/overworld_writer.rs
+++ b/src/randomize/overworld_writer.rs
@@ -146,16 +146,31 @@ struct WorldAssignments {
 // Public entry point
 // ---------------------------------------------------------------------------
 
+/// Feature/mode flags consumed by the writer. `cross_world` is the standard
+/// mode and defaults on; feature flags default off. Construct exhaustively in
+/// production so a new flag forces a conscious wire-up; in tests use
+/// `WriteFlags { ..Default::default() }` so adding a flag leaves them untouched.
+#[derive(Copy, Clone)]
+pub(crate) struct WriteFlags {
+    pub cross_world: bool,
+    pub shuffle_hammer_bros: bool,
+}
+
+impl Default for WriteFlags {
+    fn default() -> Self {
+        Self { cross_world: true, shuffle_hammer_bros: false }
+    }
+}
+
 /// Execute Phase 4: assign pool entries to slots and write all ROM data.
 pub(crate) fn write_overworld<R: Rng>(
     rom: &mut Rom,
     build: &BuildResult,
     data: &OverworldData,
     rng: &mut R,
-    cross_world: bool,
-    shuffle_hammer_bros: bool,
+    flags: WriteFlags,
 ) {
-    let assignments = assign_pool(rom, build, data, rng, cross_world, shuffle_hammer_bros);
+    let assignments = assign_pool(rom, build, data, rng, flags);
 
     // Compute W8 army sprite target positions before writing tiles,
     // so write_tile_grid can stamp connectivity-aware blank tiles under the sprites.
@@ -188,7 +203,7 @@ pub(crate) fn write_overworld<R: Rng>(
     }
 
     write_w8_sprites(rom, &w8_sprite_positions);
-    if shuffle_hammer_bros {
+    if flags.shuffle_hammer_bros {
         write_hb_sprites(rom, build, rng);
     }
     patch_fortress_fx_screen_check(rom);
@@ -209,9 +224,9 @@ fn assign_pool<R: Rng>(
     build: &BuildResult,
     data: &OverworldData,
     rng: &mut R,
-    cross_world: bool,
-    shuffle_hammer_bros: bool,
+    flags: WriteFlags,
 ) -> Vec<WorldAssignments> {
+    let WriteFlags { cross_world, shuffle_hammer_bros } = flags;
     let pickup = data.pickup;
     let catalog = data.catalog;
     // Partition pool by kind.
@@ -1354,12 +1369,12 @@ mod tests {
             None => return,
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         let mut rng2 = ChaCha8Rng::seed_from_u64(99);
-        let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, true, false);
+        let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, WriteFlags::default());
 
         // Collect all assigned pool indices.
         let mut used: Vec<usize> = Vec::new();
@@ -1421,11 +1436,11 @@ mod tests {
             None => return,
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for seed in 0u64..32 {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let mut build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let mut build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             super::super::troll_pipes::mark_troll_pipes(&mut build, &mut rng);
 
             let troll_positions: HashSet<(usize, (usize, usize))> = build.worlds.iter()
@@ -1434,7 +1449,7 @@ mod tests {
                     .map(move |s| (w.world_idx, s.pos)))
                 .collect();
 
-            let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false);
+            let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
 
             for (wi, wa) in assignments.iter().enumerate() {
                 for a in &wa.level {
@@ -1457,7 +1472,7 @@ mod tests {
             None => return,
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         let mut rom1 = rom.clone();
         let mut rom2 = rom.clone();
@@ -1465,8 +1480,8 @@ mod tests {
         for pass in 0..2 {
             let target = if pass == 0 { &mut rom1 } else { &mut rom2 };
             let mut rng = ChaCha8Rng::seed_from_u64(42);
-            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
-            write_overworld(target, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false);
+            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+            write_overworld(target, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
         }
 
         assert_eq!(rom1.data, rom2.data, "same seed must produce identical output");
@@ -1479,12 +1494,12 @@ mod tests {
             None => return,
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         let mut test_rom = rom.clone();
-        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false);
+        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
 
         // Read W8 sprite positions after write.
         let positions = rom_data::read_map_sprite_positions(&test_rom, 7);
@@ -1505,12 +1520,12 @@ mod tests {
             None => return,
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         let mut test_rom = rom.clone();
-        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false);
+        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
 
         // Count total locked fortresses across all worlds.
         let total_locks: usize = build.worlds.iter().map(|b| b.locks.len()).sum();
@@ -1555,10 +1570,10 @@ mod tests {
             );
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let data = OverworldData { pickup: &pickup, catalog: &catalog };
-            let build = super::super::overworld_build::build(&rom, &data, &mut rng, true, false, true);
+            let build = super::super::overworld_build::build(&rom, &data, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, shuffle_hammer_bros: true, ..Default::default() });
 
             let mut test_rom = rom.clone();
-            write_overworld(&mut test_rom, &build, &data, &mut rng, true, true);
+            write_overworld(&mut test_rom, &build, &data, &mut rng, WriteFlags { shuffle_hammer_bros: true, ..Default::default() });
 
             // Each world's written HB sprite count matches the build decision,
             // and every sprite landed on the position the builder chose.
@@ -1599,12 +1614,12 @@ mod tests {
             None => return,
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         let mut test_rom = rom.clone();
-        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false);
+        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
 
         // Verify each world's pointer table is sorted by (screen, row, col).
         for (wi, world) in WORLDS.iter().enumerate() {
@@ -1640,17 +1655,17 @@ mod tests {
             None => return,
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for seed in [42u64, 123, 999, 7777, 31337] {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             let mut test_rom = rom.clone();
             super::super::qol::fix_w3_drawbridges(&mut test_rom);
             super::super::qol::remove_rocks(&mut test_rom);
             super::super::qol::fix_big_q_block_rooms(&mut test_rom);
-            write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false);
+            write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
 
             let pipes_by_world = rom_data::read_pipe_pairs(&test_rom);
 
@@ -1702,11 +1717,11 @@ mod tests {
             }
         };
         let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
 
         for seed in [42u64, 123, 999] {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false, false);
+            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
             let mut out = rom.clone();
 
@@ -1715,7 +1730,7 @@ mod tests {
             super::super::qol::remove_rocks(&mut out);
             super::super::qol::fix_big_q_block_rooms(&mut out);
 
-            write_overworld(&mut out, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, true, false);
+            write_overworld(&mut out, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
 
             let filename = format!("writer_test_seed{seed}.nes");
             std::fs::write(&filename, &out.data).unwrap();

--- a/src/randomize/troll_pipes.rs
+++ b/src/randomize/troll_pipes.rs
@@ -76,9 +76,9 @@ mod tests {
         for seed in 0u64..SEEDS {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let catalog = node_catalog::NodeCatalog::build(&rom, false);
-            let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+            let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
             let data = overworld_build::OverworldData { pickup: &pickup, catalog: &catalog };
-            let mut build = overworld_build::build(&rom, &data, &mut rng, true, false, false);
+            let mut build = overworld_build::build(&rom, &data, &mut rng, overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             troll_pipes::mark_troll_pipes(&mut build, &mut rng);
             for w in &build.worlds {
                 let n = w.slots.iter().filter(|s| s.is_troll_pipe).count();
@@ -111,9 +111,9 @@ mod tests {
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(42);
             let catalog = node_catalog::NodeCatalog::build(&rom, false);
-            let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, shuffle_hammer_bros: false });
+            let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
             let data = overworld_build::OverworldData { pickup: &pickup, catalog: &catalog };
-            let mut build = overworld_build::build(&rom, &data, &mut rng, true, false, false);
+            let mut build = overworld_build::build(&rom, &data, &mut rng, overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
             troll_pipes::mark_troll_pipes(&mut build, &mut rng);
             build.worlds.iter()
                 .map(|w| w.slots.iter().filter(|s| s.is_troll_pipe).count())

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -972,8 +972,14 @@ fn randomize_inner(
         catalog: &catalog,
     };
     let mut build = randomize::overworld_build::build(
-        rom, &data, &mut rng, options.shuffle_toad_houses, eights_are_wild,
-        options.shuffle_hammer_bros,
+        rom,
+        &data,
+        &mut rng,
+        randomize::overworld_build::BuildFlags {
+            shuffle_toad_houses: options.shuffle_toad_houses,
+            eights_are_wild,
+            shuffle_hammer_bros: options.shuffle_hammer_bros,
+        },
     );
     if options.hands_levels {
         rom.set_tag("hands_levels");
@@ -995,7 +1001,14 @@ fn randomize_inner(
         *slot = Some(build.clone());
     }
     randomize::overworld_writer::write_overworld(
-        rom, &build, &data, &mut rng, true, options.shuffle_hammer_bros,
+        rom,
+        &build,
+        &data,
+        &mut rng,
+        randomize::overworld_writer::WriteFlags {
+            cross_world: true,
+            shuffle_hammer_bros: options.shuffle_hammer_bros,
+        },
     );
     // Give each W8 Hand its own treasure-room enemy stream so the chest
     // randomizer can roll a unique item per Hand. Runs before items::randomize


### PR DESCRIPTION
Closes #59.

## Problem

The overworld builder threaded feature flags as **trailing positional bools** through `build()` / `write_overworld()` / `assign_pool()` and as **bare `PickupFlags` literals**. Adding a single flag (e.g. `shuffle_hammer_bros` in #20) forced edits at ~40 unrelated test call sites, and left opaque call sites like `build(&rom, &data, &mut rng, true, false, true)`.

## Change

- New `BuildFlags { shuffle_toad_houses, eights_are_wild, shuffle_hammer_bros }` and `WriteFlags { cross_world, shuffle_hammer_bros }` structs; `build()`/`write_overworld()`/`assign_pool()` take them.
- `#[derive(Default)]` on all three flag structs (`PickupFlags`, `BuildFlags`, `WriteFlags`). `WriteFlags::default()` keeps `cross_world` on (the standard mode); feature flags default off.
- **Production** call sites construct the structs **exhaustively** — so adding a flag still breaks the one place that must wire it to `Options` (a deliberate nudge).
- **Test** call sites use `{ ..Default::default() }` — so future flags leave them untouched.

This is the pattern `Options` / `test_options()` already use; the builder flags just hadn't adopted it.

## Verification

- Pure refactor, **no behavior change**.
- **Byte-identical** generated ROM vs `main` (`--no-palettes`, seed 12345).
- `cargo build` / `clippy --all-targets -D warnings` / full suite (**226 pass**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)