### PR TITLE
release: 0.9.2 — hazard-protect 4-1 platform troopas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-28
+
+### Fixed
+
+- **4-1 hazard placement** — the three Big Red Troopas each sit on a small
+  platform Mario must land on to move forward; in Wild enemy mode they could be
+  swapped to a hazard (Thwomp/Ptooie/nipper/lotus/hotfoot), forcing an
+  unavoidable hit. Those spots are now hazard-protected.
+
 ## [0.9.1] - 2026-06-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 
 [lib]

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -234,6 +234,16 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
         ],
     },
     LevelProtection {
+        label: "4-1 (each troopa sits on a small platform Mario must land on to progress; a hazard here forces an unavoidable hit)",
+        enemy_ptr: 0xCE97,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0CEBD, rule: EntryProtection::ExcludeHazards }, // BigRedTroopa scr=5 col=8
+            EntryRule { offset: 0x0CEC0, rule: EntryProtection::ExcludeHazards }, // BigRedTroopa scr=5 col=15
+            EntryRule { offset: 0x0CEC3, rule: EntryProtection::ExcludeHazards }, // BigRedTroopa scr=6 col=4
+        ],
+    },
+    LevelProtection {
         label: "8F roto-disc narrow area makes hazards unfair",
         enemy_ptr: 0xD551,
         walker_segment: WalkerSegmentRule::Default,


### PR DESCRIPTION
## Summary

Bumps version to **0.9.2** with a single gameplay fix.

The three Big Red Troopas in **4-1** each sit on a small platform Mario must land on to progress. In Wild enemy mode (`0x7B` is in `SHELL_ENEMIES`, so it draws from the wild pool) they could be swapped to a hazard — Thwomp, Ptooie, nipper, lava lotus, or hotfoot — which forces an unavoidable hit to move forward.

This adds an `EntryProtection::ExcludeHazards` `LevelProtection` for 4-1's main area (`enemy_ptr: 0xCE97`) covering the three troopa entries (`0x0CEBD`, `0x0CEC0`, `0x0CEC3`). The filter is additive-only, so any same-category vanilla hazard is still allowed, and it also blocks wild injection at those offsets.

## Changes
- `src/randomize/enemy_protections.rs` — new 4-1 `LevelProtection` with three `ExcludeHazards` entries
- `CHANGELOG.md` — `[0.9.2]` section
- `Cargo.toml` / `Cargo.lock` — version `0.9.1` → `0.9.2`

## Testing
- `cargo test` — full suite passes (registry uniqueness invariants included)
- `cargo clippy --all-targets` — clean
- `cargo build` — compiles at v0.9.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)