### PR TITLE
Randomize which Koopalings get heavy physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-30
+
+### Changed
+
+- **Randomized Koopalings — heavy physics** — with random Koopalings on, the
+  heavy-physics effect (enhanced gravity, floor-shake, player paralysis) is now
+  reassigned to two random Koopaling identities instead of always Roy and
+  Ludwig, so a differently-shaped boss can carry the crushing feel.
+
 ## [0.9.2] - 2026-06-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 
 [lib]

--- a/src/randomize/koopalings.rs
+++ b/src/randomize/koopalings.rs
@@ -190,6 +190,14 @@ const KOOPALING_REMAP_SITES: &[usize] = &[
 ];
 const KOOPALING_REMAP_LUT: usize = 0x16018;
 
+/// Immediate operands of the two `CMP #$imm` checks in `Koopaling_DetectWorld`
+/// (file 0x03612 / CPU $B602) that gate the heavy-physics effect (enhanced
+/// gravity, floor-shake, player paralysis). Vanilla compares against the Roy
+/// (0x04) and Ludwig (0x06) identity values; rewriting these operands moves the
+/// effect onto any two identities. See docs/smb3_rom_reference.md § "Map_Unused7EEA".
+const KOOPALING_HEAVY_CMP_ROY: usize = 0x03616;
+const KOOPALING_HEAVY_CMP_LUDWIG: usize = 0x0361A;
+
 pub fn random_koopalings(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     use rand::seq::SliceRandom;
 
@@ -204,6 +212,17 @@ pub fn random_koopalings(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     for &site in KOOPALING_REMAP_SITES {
         rom.write_range(site + 1, &[0xEA, 0x7E]);
     }
+
+    // Reassign the heavy-physics effect (vanilla: Roy + Ludwig) to two random
+    // identities. The two DetectWorld compares are equality tests, so the picks
+    // must be distinct to keep exactly two heavy bosses. Lemmy (0x05) is
+    // excluded from the pool: his AI is replaced wholesale by the ball routine,
+    // so it's unverified whether DetectWorld's heavy branch even runs for him —
+    // keeping him out guarantees the effect always lands on two live bosses.
+    let mut heavy: [u8; 6] = [0, 1, 2, 3, 4, 6];
+    heavy.shuffle(rng);
+    rom.write_byte(KOOPALING_HEAVY_CMP_ROY, heavy[0]);
+    rom.write_byte(KOOPALING_HEAVY_CMP_LUDWIG, heavy[1]);
 }
 
 /// Adjust hitboxes for Bowser and Koopalings so they're easier to hit.
@@ -450,6 +469,18 @@ mod tests {
             );
             // Opcode byte preserved
             assert_eq!(rom.read_byte(site), 0xAD);
+        }
+
+        // Heavy-physics compares reassigned to two distinct identities drawn
+        // from the pool {0,1,2,3,4,6} (Lemmy/0x05 excluded).
+        let a = rom.read_byte(KOOPALING_HEAVY_CMP_ROY);
+        let b = rom.read_byte(KOOPALING_HEAVY_CMP_LUDWIG);
+        assert_ne!(a, b, "heavy-physics identities must be distinct");
+        for id in [a, b] {
+            assert!(
+                [0, 1, 2, 3, 4, 6].contains(&id),
+                "heavy-physics identity 0x{id:02X} outside pool (Lemmy excluded)"
+            );
         }
     }
 


### PR DESCRIPTION
## What

With **random Koopalings** enabled, the heavy-physics effect (enhanced gravity, floor-shake, player paralysis) is reassigned from the fixed **Roy + Ludwig** pair to **two random Koopaling identities**.

## How

`Koopaling_DetectWorld` (file `0x03612` / CPU `$B602`) gates heavy physics with two `CMP #$imm` equality checks against the identity byte — vanilla compares `#$04` (Roy) and `#$06` (Ludwig). Since appearance is table-*indexed* off the identity while attacks/modifiers are *equality-gated*, rewriting just the two compare operands relocates the effect onto different bodies without touching how they look. `random_koopalings` now shuffles a pool and writes the two operands at `0x03616` / `0x0361A`.

## Decisions

- **Lemmy (`0x05`) excluded from the pool.** His AI is replaced wholesale by the ball routine; it's unverified whether `DetectWorld`'s heavy branch runs on that path, so excluding him guarantees the effect lands on two live bosses.
- **Picks are distinct** → exactly two heavy bosses (matches vanilla count).
- **Overlap with the ring attack is allowed** — a heavy pick can land on Wendy's identity, giving a ring-throwing, floor-shaking boss (separate sites, no conflict).
- Coupled to the existing `random_koopalings` flag; no separate toggle.

## Testing

- `test_random_koopalings` extended to assert the two heavy operands are distinct and drawn from `{0,1,2,3,4,6}`.
- Full suite green; clippy clean.

Bumps to 0.9.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)