### PR TITLE
Randomize which body carries the ring attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-06-30
+
+### Changed
+
+- **Randomized Koopalings — ring attack** — with random Koopalings on, Wendy's
+  ring attack (ring projectile + firing cadence + straight aim) now rides a
+  random Koopaling identity's body instead of always Wendy. There's still
+  exactly one ring boss; only which body carries it is randomized.
+
 ## [0.9.3] - 2026-06-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 
 [lib]

--- a/src/randomize/koopalings.rs
+++ b/src/randomize/koopalings.rs
@@ -198,6 +198,14 @@ const KOOPALING_REMAP_LUT: usize = 0x16018;
 const KOOPALING_HEAVY_CMP_ROY: usize = 0x03616;
 const KOOPALING_HEAVY_CMP_LUDWIG: usize = 0x0361A;
 
+/// Immediate operands of the three checks that together make up Wendy's ring
+/// attack: the ring-vs-wand projectile choice (`CMP` at 0x02FB2), the firing
+/// cadence (`CMP` at 0x02FFA), and the straight-aim / skip-homing branch
+/// (`CPY` at 0x03024). All three test the same identity (vanilla 0x02 = Wendy),
+/// so they must be rewritten *together* to the same value to move the whole
+/// ring package coherently onto another body.
+const KOOPALING_RING_CMP_SITES: [usize; 3] = [0x02FB2, 0x02FFA, 0x03024];
+
 pub fn random_koopalings(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     use rand::seq::SliceRandom;
 
@@ -223,6 +231,17 @@ pub fn random_koopalings(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     heavy.shuffle(rng);
     rom.write_byte(KOOPALING_HEAVY_CMP_ROY, heavy[0]);
     rom.write_byte(KOOPALING_HEAVY_CMP_LUDWIG, heavy[1]);
+
+    // Move Wendy's ring attack onto a random identity's body. There is exactly
+    // one ring boss (as in vanilla); randomizing the compare value picks which
+    // body carries it. All three ring sites take the SAME value to stay
+    // coherent. Lemmy (0x05) is excluded: his ball AI replaces the wand-fire
+    // path the ring gate lives on, so the ring would never fire on his body.
+    let mut ring: [u8; 6] = [0, 1, 2, 3, 4, 6];
+    ring.shuffle(rng);
+    for &site in &KOOPALING_RING_CMP_SITES {
+        rom.write_byte(site, ring[0]);
+    }
 }
 
 /// Adjust hitboxes for Bowser and Koopalings so they're easier to hit.
@@ -482,6 +501,22 @@ mod tests {
                 "heavy-physics identity 0x{id:02X} outside pool (Lemmy excluded)"
             );
         }
+
+        // Ring attack: all three sites rewritten to the SAME identity, drawn
+        // from the pool {0,1,2,3,4,6} (Lemmy/0x05 excluded).
+        let ring: Vec<u8> = KOOPALING_RING_CMP_SITES
+            .iter()
+            .map(|&s| rom.read_byte(s))
+            .collect();
+        assert!(
+            ring.iter().all(|&id| id == ring[0]),
+            "ring sites must all hold the same identity, got {ring:02X?}"
+        );
+        assert!(
+            [0, 1, 2, 3, 4, 6].contains(&ring[0]),
+            "ring identity 0x{:02X} outside pool (Lemmy excluded)",
+            ring[0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

With **random Koopalings** enabled, Wendy's ring attack now rides a **random Koopaling identity's body** instead of always Wendy. There's still exactly one ring boss (as in vanilla) — only *which body* carries it is randomized.

## How

Wendy's ring is three facets of one boss, all testing the same identity value (`0x02`): the ring-vs-wand projectile choice (`CMP` operand `0x02FB2`), the firing cadence (`CMP` operand `0x02FFA`), and the straight-aim / skip-homing branch (`CPY` operand `0x03024`). Unlike heavy physics (two *independent* gates), these must move as a unit, so `random_koopalings` picks one random identity and writes it into all three operands.

## Decisions

- **All three sites take the same value** — they're facets of one boss, not independent gates; moving them together keeps the ring coherent (projectile + cadence + straight aim on the same body).
- **Lemmy (`0x05`) excluded from the pool** — his ball AI replaces the wand-fire path the ring gate lives on, so the ring would never fire on his body.
- **Wendy (`0x02`) kept in the pool** — ~1/6 of seeds leave the ring on a Wendy-looking body, still a valid randomized outcome.
- **Overlap with heavy physics allowed** — a ring identity can coincide with a heavy-physics pick (ring-throwing, floor-shaking boss); separate sites, no conflict.
- Coupled to the existing `random_koopalings` flag; no separate toggle.

## Testing

- `test_random_koopalings` extended to assert the three ring operands are identical and drawn from `{0,1,2,3,4,6}`.
- Build + clippy clean; koopaling suite green.

Bumps to 0.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)