### PR TITLE
fix: load ring CHR on the randomized ring Koopaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-07-01
+
+### Fixed
+
+- **Randomized Koopalings — ring graphics** — the moved ring attack now loads
+  its own sprite CHR page on whichever body carries it, so the ring no longer
+  renders as garbled tiles. Also fixes the reverse case where the (no-longer-
+  ring) Wendy identity drew a garbled wand blast.
+
 ## [0.9.4] - 2026-06-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 
 [lib]

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1830,6 +1830,29 @@ Not controlled by `$0727` (and therefore not remapped): hit count to defeat (har
 `#$0A` in `ObjInit_Koopaling`, then `#$03` in `PRG001_B185`), timer constants, and
 wand-state dispatch (`Level_GetWandState`).
 
+#### Sprite CHR Bank Tables (`ObjNorm_Koopaling`, `$AEC4`)
+
+`ObjNorm_Koopaling` loads two sprite CHR pages per Koopaling into `PatTable_BankSel`
+slots +4 / +5, indexed by `$0727` (remapped to `$7EEA`, i.e. by identity):
+
+```
+$AEC4: AC EA 7E   LDY $7EEA          ; identity 0-6 (post-remap; vanilla LDY $0727)
+$AEC7: B9 72 AE   LDA KoopalingPatSet4,Y   ; -> $071D (BankSel+4)
+$AECD: B9 79 AE   LDA KoopalingPatSet5,Y   ; -> $071E (BankSel+5)
+```
+
+| Table | CPU | File | Values (identity 0-6: Larry Morton Wendy Iggy Roy Lemmy Ludwig) |
+|-------|-----|------|-----------------------------------------------------------------|
+| `KoopalingPatSet4` (slot +4, **body**)       | `$AE72` | `0x02E82` | `48 49 4a 48 49 48 4a` |
+| `KoopalingPatSet5` (slot +5, **projectile**) | `$AE79` | `0x02E89` | `37 37 4a 37 37 48 37` |
+
+Slot +4 is the boss body; slot +5 is the projectile graphic. Slot +5 keys to attack
+type: **`0x4A` = ring** (Wendy only), **`0x48` = ball** (Lemmy), **`0x37` = plain wand
+blast** (everyone else). Moving the ring *behavior* to another identity (the three ring
+CMP sites) requires also moving the ring page: `qol::random_koopalings` rewrites
+`KoopalingPatSet5` so `0x4A` follows the ring identity, `0x48` stays on Lemmy, and all
+others get `0x37`. Without it the new ring boss loads `0x37` and the ring renders garbled.
+
 ### Airship Travel Data
 
 | Label | Description |

--- a/src/randomize/koopalings.rs
+++ b/src/randomize/koopalings.rs
@@ -206,6 +206,20 @@ const KOOPALING_HEAVY_CMP_LUDWIG: usize = 0x0361A;
 /// ring package coherently onto another body.
 const KOOPALING_RING_CMP_SITES: [usize; 3] = [0x02FB2, 0x02FFA, 0x03024];
 
+/// `KoopalingPatSet5` — the per-identity sprite CHR page loaded into `PatTable_BankSel+5`
+/// (the projectile window) by `ObjNorm_Koopaling` (`$AEC4: LDY $7EEA; LDA $AE79,Y`).
+/// 7 bytes, indexed by remapped Koopaling identity. Slot +4 (`KoopalingPatSet4`, the
+/// body window) needs no change — each identity already loads its own body page.
+const KOOPALING_PATSET5: usize = 0x02E89;
+/// CHR page holding Wendy's ring projectile tiles (vanilla: only Wendy's identity loads it).
+const CHR_PAGE_RING: u8 = 0x4A;
+/// CHR page holding Lemmy's ball tiles.
+const CHR_PAGE_BALL: u8 = 0x48;
+/// CHR page holding the plain wand-blast tiles (every non-ring, non-ball boss).
+const CHR_PAGE_WAND: u8 = 0x37;
+/// Lemmy's Koopaling identity value.
+const LEMMY_IDENTITY: usize = 0x05;
+
 pub fn random_koopalings(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     use rand::seq::SliceRandom;
 
@@ -242,6 +256,21 @@ pub fn random_koopalings(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     for &site in &KOOPALING_RING_CMP_SITES {
         rom.write_byte(site, ring[0]);
     }
+
+    // Move the ring's *graphics* to match the moved *behavior*. The projectile
+    // lives in its own 1KB sprite CHR page loaded into BankSel slot +5
+    // (KoopalingPatSet5); vanilla only maps the ring page (0x4A) for Wendy's
+    // identity, so retargeting the ring behavior without this leaves the new
+    // ring boss loading the plain wand-blast page and rendering garbled tiles.
+    // Rewrite the per-identity table so the projectile page follows assignment:
+    // the ring identity gets the ring page, Lemmy keeps his ball page, everyone
+    // else gets the wand-blast page. This also corrects the reverse case — the
+    // old Wendy identity no longer loads 0x4A, so her wand blast renders right.
+    // ring[0] is drawn from a pool excluding Lemmy (0x05), so it never collides.
+    let mut patset5 = [CHR_PAGE_WAND; 7];
+    patset5[LEMMY_IDENTITY] = CHR_PAGE_BALL;
+    patset5[ring[0] as usize] = CHR_PAGE_RING;
+    rom.write_range(KOOPALING_PATSET5, &patset5);
 }
 
 /// Adjust hitboxes for Bowser and Koopalings so they're easier to hit.


### PR DESCRIPTION
## Problem

The random-ring-body feature (#66) moved Wendy's ring attack *behavior* onto a random Koopaling identity but not its *graphics*, so the new ring boss rendered garbled tiles.

## Root cause

Sprite CHR is loaded as two 1KB pages per Koopaling (`ObjNorm_Koopaling`, `$AEC4`): slot +4 = body, slot +5 = projectile (`KoopalingPatSet5`). Slot +5 keys to attack type — `0x4A` = ring (Wendy only), `0x48` = ball (Lemmy), `0x37` = plain wand blast (everyone else). Retargeting the ring behavior left the new ring boss loading `0x37`, which lacks the ring tiles.

## Fix

Rewrite `KoopalingPatSet5` (file `0x02E89`) so the projectile page follows the assignment: `0x4A` on the ring identity, `0x48` on Lemmy, `0x37` on all others. This also fixes the reverse case — the no-longer-ring Wendy identity now loads `0x37` and draws a correct wand blast.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean, `cargo test` passes.
- Playtested a real seed (ring landed on Morton in World 7): ring renders cleanly on the reassigned body; Wendy's wand blast also renders correctly.
- Documented the `KoopalingPatSet4/5` tables in `docs/smb3_rom_reference.md`.

Version bump 0.9.4 → 0.9.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)