### PR TITLE
Randomize Boom-Boom stomp counts (1-5 per fortress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Added
+
+- **Randomized Boom-Boom stomp counts** — each fortress's Boom-Boom now takes a
+  random 1–5 stomps to defeat (per-fortress, distinct within each world) instead
+  of the fixed 3. On by default; disable with `--keep-boomboom-stomps`. Fireball
+  defeats are unaffected.
+
 ## [0.9.5] - 2026-07-01
 
 ### Fixed

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -2985,6 +2985,63 @@ Fireballs use a separate counter `Objects_HitCount` (`$7CF6–$7CFA`), initializ
 to 2 and jumps into the stomp-kill path, forcing defeat as if the third stomp landed.
 Bowser uses only `Objects_HitCount` (initialized to 34), no stomp counter.
 
+### Boom-Boom Stomp Threshold (PRG003)
+
+Boom-Boom (object IDs `$4B` jumping / `$4C` flying) lives in PRG003 (file
+0x06010–0x0800F, CPU $A000–$BFFF; **8 KB bank** — `file = 0x06010 + (cpu - $A000)`).
+Unlike the Koopaling, its stomp count is **not** a standalone counter: `Objects_Var5`
+(`$9A,X`) is simultaneously the hit tally **and** the state index dispatched by the
+`DynJump` state machine (`LDA $9A,X; JSR DynJump` at `$AAD9`), whose 6-entry table is:
+
+| Var5 | State |
+|------|-------|
+| 0 | `BoomBoom_Init` — stand still, wait for player |
+| 1 | unused (falls through to 2) |
+| 2 | `BoomBoom_PrimaryAttack` — run/flail |
+| 3 | `BoomBoom_SecondaryAttack` — jump/fly |
+| 4 | `BoomBoom_FinalAttack` |
+| 5 | `BoomBoom_Death` — kaboom + crystal ball |
+
+The stomp handler in `BoomBoom_HitTest` at CPU `$AE68` advances Var5 and defeats when
+it reaches the Death state (Var5 starts the fight at 2, so 3 stomps kill it):
+
+```
+$AE68: B5 9A       LDA $9A,X        ; A = Var5 (pre-increment)
+$AE6A: F6 9A       INC $9A,X        ; advance state / tally
+$AE6C: C9 04       CMP #$04         ; pre-inc == 4 → Var5 is now 5 (Death)
+$AE6E: F0 12       BEQ $AE82        ; defeat tail (sets death Timer, RTS)
+$AE70: ...                          ; survive tail (clears state, Timer2=$30, RTS)
+```
+
+| Item | Value |
+|------|-------|
+| PRG bank | PRG003 (file 0x06010–0x0800F, CPU $A000–$BFFF, 8 KB) |
+| `ObjInit_BoomBoom` | CPU **$A9EA** (file 0x069FA) — copies Y-byte ordinal `$88,X`→`$7F,X` (Var4), sets `Objects_HitCount`=37 |
+| Crystal-ball handler | CPU **$A8F6** (file 0x06906) — `LDA $7F,X; STA $0745` (Map_DoFortressFX = fortress ordinal) |
+| Stomp patch site | File **0x06E78** (CPU $AE68, 8 bytes) |
+| Survive tail | CPU **$AE70** |
+| Defeat tail | CPU **$AE82** |
+| Free space | 0x07FCF–0x0800F (bank-end filler, 65 bytes, CPU $BFBF–$BFFF) |
+
+**Why randomizing this is different from the Koopaling.** You can't just change the
+`CMP #$04`: defeat requires Var5 to actually reach the Death state (5), and letting it
+climb past 5 indexes off the jump table (crash). The randomizer therefore **decouples**
+the tally from the state (`randomize_boomboom_hits`):
+
+- `Objects_Var12` (`$7CD2,X`) — cleared to 0 on spawn by `Level_PrepareNewObject`
+  (slots 0–4 branch, file 0x0150D) and never referenced anywhere in PRG003 — holds the
+  real stomp tally.
+- Var5 still advances (2→3→4) so the boss keeps cycling its attacks; when it would hit
+  the Death state early it is bounced back to Primary (state 2) instead.
+- Only when the tally reaches the per-fortress threshold is Var5 forced to 5 and the
+  vanilla defeat tail taken.
+- Threshold table: 16 bytes at CPU `$BFBF`, indexed by `(World_Num << 2 + ordinal) & $0F`
+  where the ordinal (1–4, this fortress's number within its world) is `Objects_Var4`
+  (`$7F,X`). That makes every fortress within a world distinct.
+
+Fireball defeat (`Objects_HitCount`=37, a separate path) is left unchanged — only the
+stomp count is randomized.
+
 ### Koopaling Softlock Fix (PRG001)
 
 When airship levels are shuffled across worlds, Koopalings can softlock due to an

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,10 @@ struct Cli {
     #[arg(long)]
     keep_koopaling_stomps: bool,
 
+    /// Keep vanilla Boom-Boom stomp counts (3 hits each; randomized 1–5 per fortress by default)
+    #[arg(long)]
+    keep_boomboom_stomps: bool,
+
     /// Make Koopalings vulnerable to thrown hammers (off by default)
     #[arg(long)]
     hammer_vulnerable_koopalings: bool,
@@ -432,6 +436,7 @@ fn main() {
             skip_wand_cutscene: !cli.keep_wand_cutscene,
             adjust_boss_hitboxes: !cli.keep_boss_hitboxes,
             koopaling_hits: !cli.keep_koopaling_stomps,
+            boomboom_hits: !cli.keep_boomboom_stomps,
             hammer_vulnerable_koopalings: cli.hammer_vulnerable_koopalings,
             random_koopalings: cli.random_koopalings,
             hammer_breaks_locks: parse_tri(&cli.hammer_breaks_locks, "hammer-breaks-locks"),

--- a/src/randomize/koopalings.rs
+++ b/src/randomize/koopalings.rs
@@ -401,6 +401,122 @@ pub fn randomize_koopaling_hits(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     rom.write_range(KOOPA_FIRE_HANDOFF, &[0x20, lo, hi, 0xEA]); // JSR + NOP
 }
 
+// Randomize per-fortress Boom-Boom stomp counts (1–5 hits each).
+//
+// Boom-Boom's boss AI lives in PRG003. Unlike the Koopaling, its stomp count is
+// entangled with its attack-state machine: `Objects_Var5` ($9A,X) is *both* the
+// hit counter *and* the index the DynJump dispatcher uses to pick the current
+// attack (2=Primary, 3=Secondary, 4=Final, 5=Death). The vanilla stomp handler
+// at CPU $AE68 does:
+//   LDA $9A,X ; INC $9A,X ; CMP #$04 ; BEQ death   (death when Var5 reaches 5)
+// Var5 starts the fight at 2, so 3 stomps (2→3→4→5) kill it.
+//
+// We can't just change the compare: death *requires* Var5 to reach the death
+// state (5), and letting Var5 climb past 5 would index off the 6-entry jump
+// table (crash). Instead we DECOUPLE the count from the state:
+//
+//   * `Objects_Var12` ($7CD2,X) — cleared to 0 on spawn by Level_PrepareNewObject
+//     and never touched by any Boom-Boom routine — is our real stomp tally.
+//   * Var5 keeps advancing (2→3→4) so the boss still cycles through its attacks;
+//     when it would hit the death state (5) but the tally hasn't reached the
+//     threshold yet, we bounce it back to Primary (state 2) so it keeps fighting.
+//   * Only when the tally reaches this fortress's threshold do we force Var5=5
+//     and take the vanilla death path.
+//
+// The per-fortress threshold comes from a 16-byte table indexed by
+// `(World_Num << 2 + ordinal) & $0F`, where the ordinal (1–4) is Boom-Boom's
+// fortress number within its world, sitting in `Objects_Var4` ($7F,X) at the
+// moment of the stomp. That index makes every fortress *within a world* distinct
+// (only far-apart cross-world fortresses can share a table slot, which is
+// invisible in play).
+//
+// Fireball defeat (37 fireballs via Objects_HitCount) is a separate path and is
+// intentionally left unchanged — only the stomp count is randomized.
+
+/// File offset of the vanilla Boom-Boom stomp handler
+/// `LDA $9A,X; INC $9A,X; CMP #$04; BEQ +$12` in BoomBoom_HitTest (8 bytes,
+/// CPU $AE68). We overwrite it with `JMP subroutine` + NOP padding.
+const BOOMBOOM_PATCH_SITE: usize = 0x06E78;
+/// CPU address of the vanilla "survive" tail (clears state vars, sets Timer2, RTS).
+const BOOMBOOM_SURVIVE_CPU: u16 = 0xAE70;
+/// CPU address of the vanilla "death" tail (sets death Timer, RTS).
+const BOOMBOOM_DEATH_CPU: u16 = 0xAE82;
+
+pub fn randomize_boomboom_hits(rom: &mut Rom, rng: &mut ChaCha8Rng) {
+    use rand::Rng;
+    use super::rom_data::{
+        BOOMBOOM_HITS_SUB_CPU, BOOMBOOM_HITS_TABLE_CPU, FS_BOOMBOOM_HITS_SUB,
+        FS_BOOMBOOM_HITS_TABLE,
+    };
+
+    // 16-entry threshold table: each fortress index gets an independent 1–5.
+    let table: [u8; 16] = std::array::from_fn(|_| rng.random_range(1..=5));
+    rom.write_range(FS_BOOMBOOM_HITS_TABLE, &table);
+
+    let tbl_lo = BOOMBOOM_HITS_TABLE_CPU as u8;
+    let tbl_hi = (BOOMBOOM_HITS_TABLE_CPU >> 8) as u8;
+    let surv_lo = BOOMBOOM_SURVIVE_CPU as u8;
+    let surv_hi = (BOOMBOOM_SURVIVE_CPU >> 8) as u8;
+    let death_lo = BOOMBOOM_DEATH_CPU as u8;
+    let death_hi = (BOOMBOOM_DEATH_CPU >> 8) as u8;
+
+    // Subroutine (44 bytes, CPU $BFCF):
+    //   INC $7CD2,X          ; Objects_Var12 — stomp tally (self-zeroed on spawn)
+    //   INC $9A,X            ; Objects_Var5  — advance attack state
+    //   LDA $0727            ; World_Num
+    //   ASL ; ASL            ; world * 4
+    //   CLC ; ADC $7F,X      ; + ordinal (Objects_Var4, 1–4)
+    //   AND #$0F             ; -> table index 0..15
+    //   TAY
+    //   LDA $7CD2,X          ; tally
+    //   CMP table,Y          ; tally - threshold
+    //   BCS .death           ; tally >= threshold -> defeat
+    //   LDA $9A,X            ; else keep Var5 a valid attack state:
+    //   CMP #$05
+    //   BCC .surv            ;   still 2–4 -> fine
+    //   LDA #$02 ; STA $9A,X ;   would be Death -> bounce back to Primary
+    // .surv:
+    //   JMP $AE70            ; vanilla survive tail
+    // .death:
+    //   LDA #$05 ; STA $9A,X ; force Death state
+    //   JMP $AE82            ; vanilla death tail
+    #[rustfmt::skip]
+    let code: [u8; 44] = [
+        0xFE, 0xD2, 0x7C,               // INC $7CD2,X
+        0xF6, 0x9A,                     // INC $9A,X
+        0xAD, 0x27, 0x07,               // LDA $0727
+        0x0A,                           // ASL
+        0x0A,                           // ASL
+        0x18,                           // CLC
+        0x75, 0x7F,                     // ADC $7F,X
+        0x29, 0x0F,                     // AND #$0F
+        0xA8,                           // TAY
+        0xBD, 0xD2, 0x7C,               // LDA $7CD2,X
+        0xD9, tbl_lo, tbl_hi,           // CMP table,Y
+        0xB0, 0x0D,                     // BCS .death (+$0D)
+        0xB5, 0x9A,                     // LDA $9A,X
+        0xC9, 0x05,                     // CMP #$05
+        0x90, 0x04,                     // BCC .surv (+$04)
+        0xA9, 0x02,                     // LDA #$02
+        0x95, 0x9A,                     // STA $9A,X
+        0x4C, surv_lo, surv_hi,         // .surv:  JMP $AE70
+        0xA9, 0x05,                     // .death: LDA #$05
+        0x95, 0x9A,                     // STA $9A,X
+        0x4C, death_lo, death_hi,       // JMP $AE82
+    ];
+    rom.write_range(FS_BOOMBOOM_HITS_SUB, &code);
+
+    // Patch the stomp handler: replace the 8-byte vanilla block with
+    // `JMP subroutine` + 5 NOPs (the NOPs are unreachable — the JMP is taken
+    // unconditionally — but keep the disassembly clean).
+    let sub_lo = BOOMBOOM_HITS_SUB_CPU as u8;
+    let sub_hi = (BOOMBOOM_HITS_SUB_CPU >> 8) as u8;
+    rom.write_range(BOOMBOOM_PATCH_SITE, &[
+        0x4C, sub_lo, sub_hi,           // JMP subroutine
+        0xEA, 0xEA, 0xEA, 0xEA, 0xEA,   // NOP × 5
+    ]);
+}
+
 /// Skip the wand falling cutscene after defeating a Koopaling.
 ///
 /// Lets the player jump for the wand grab instead of watching the wand drop.
@@ -486,6 +602,40 @@ mod tests {
         let fire = rom.read_range(crate::randomize::rom_data::FS_KOOPA_FIRE_PRESET, 12);
         assert_eq!(fire[0], 0xAC); // LDY abs
         assert_eq!(fire[11], 0x60); // RTS
+    }
+
+    #[test]
+    fn test_randomize_boomboom_hits() {
+        use rand::SeedableRng;
+        use crate::randomize::rom_data::{
+            BOOMBOOM_HITS_SUB_CPU, FS_BOOMBOOM_HITS_SUB, FS_BOOMBOOM_HITS_TABLE,
+        };
+
+        let mut rom = make_test_rom();
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        randomize_boomboom_hits(&mut rom, &mut rng);
+
+        // Patch site: JMP subroutine + 5 NOPs.
+        assert_eq!(rom.read_byte(BOOMBOOM_PATCH_SITE), 0x4C);
+        assert_eq!(rom.read_range(BOOMBOOM_PATCH_SITE + 1, 2), &[
+            BOOMBOOM_HITS_SUB_CPU as u8,
+            (BOOMBOOM_HITS_SUB_CPU >> 8) as u8,
+        ]);
+        assert_eq!(rom.read_range(BOOMBOOM_PATCH_SITE + 3, 5), &[0xEA; 5]);
+
+        // Subroutine head: INC $7CD2,X ; INC $9A,X ; and it ends in JMP $AE82.
+        assert_eq!(rom.read_range(FS_BOOMBOOM_HITS_SUB, 5), &[0xFE, 0xD2, 0x7C, 0xF6, 0x9A]);
+        assert_eq!(rom.read_range(FS_BOOMBOOM_HITS_SUB + 41, 3), &[
+            0x4C,
+            BOOMBOOM_DEATH_CPU as u8,
+            (BOOMBOOM_DEATH_CPU >> 8) as u8,
+        ]);
+
+        // Threshold table: 16 entries, each a valid 1–5 hit count.
+        let table = rom.read_range(FS_BOOMBOOM_HITS_TABLE, 16);
+        for &v in table {
+            assert!((1..=5).contains(&v), "threshold {v} out of range 1–5");
+        }
     }
 
     #[test]

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -36,6 +36,9 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x0385E, 12, "koopa_fire_preset: set stomp counter from threshold table for fireball defeat"),
     (0x03FD0, 22, "koopa_y_clamp: clamp Koopaling Y position to screen"),
     (0x03FE6, 36, "fire_flower: position-hash suit routine + pool table"),
+    // PRG003 (file 0x06010, CPU $A000–$BFFF) — object AI bank (Boom-Boom lives here)
+    (0x07FCF, 16, "boomboom_hits: per-fortress threshold table"),
+    (0x07FDF, 44, "boomboom_hits: decoupled stomp-count subroutine"),
     // PRG006 (file 0x0C010, CPU $C000–$DFFF) — level enemy data bank
     (0x0DA74, 22, "hand_rooms: 2 cloned enemy streams for unique 8-Hnd treasure rooms"),
     // PRG029 (file 0x3A010, CPU $C000–$DFFF) — swim physics bank
@@ -187,6 +190,20 @@ pub(crate) const FS_KOOPA_FIRE_PRESET: usize = 0x0385E; // 12 bytes
 
 pub(crate) const KOOPA_FIRE_PRESET_CPU: u16  = 0xB84E;  // $A000 + (0x0385E - 0x02010)
 
+// PRG003 (file 0x06010, CPU $A000–$BFFF) — Boom-Boom stomp-count randomization.
+// The Boom-Boom boss AI (ObjInit_BoomBoom, BoomBoom_HitTest, the DynJump state
+// machine) lives in this bank, so the stomp handler's JMP into these routines is
+// bank-local. Both allocations sit in the bank-end filler gap ($BFBF–$BFFF).
+//
+// Layout: 16-byte threshold table first, then the 44-byte subroutine.
+pub(crate) const FS_BOOMBOOM_HITS_TABLE: usize = 0x07FCF; // 16 bytes (CPU $BFBF)
+
+pub(crate) const BOOMBOOM_HITS_TABLE_CPU: u16  = 0xBFBF;  // $A000 + (0x07FCF - 0x06010)
+
+pub(crate) const FS_BOOMBOOM_HITS_SUB: usize   = 0x07FDF; // 44 bytes (CPU $BFCF)
+
+pub(crate) const BOOMBOOM_HITS_SUB_CPU: u16    = 0xBFCF;  // $A000 + (0x07FDF - 0x06010)
+
 // PRG006 — duplicated enemy streams for the W8 Hand sub-areas. Each clone is
 // 11 bytes (page byte + 3 enemy entries + 0xFF terminator); two clones give
 // the three Hand levels independent OBJ_TREASURESET item bytes.
@@ -230,6 +247,8 @@ mod free_space_tests {
         assert!(offsets.contains(&FS_CANOE_RESPAWN));
         assert!(offsets.contains(&FS_CANOE_BACKUP));
         assert!(offsets.contains(&FS_KOOPA_HITS_SUB));
+        assert!(offsets.contains(&FS_BOOMBOOM_HITS_TABLE));
+        assert!(offsets.contains(&FS_BOOMBOOM_HITS_SUB));
         assert!(offsets.contains(&FS_STARTING_ITEMS));
         assert!(offsets.contains(&FS_MYSTERY_ANCHOR));
         assert!(offsets.contains(&FS_HAMMER_LOCKS));

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -91,11 +91,12 @@ impl Options {
 
         // b2 bit 4 = faster_frog (reuses the slot formerly fix_drawbridges,
         // now always-on).
+        // b2 bit 3 = boomboom_hits (reuses the slot formerly remove_rocks).
         let b2 = (self.remove_whistles as u8) << 7
             | (self.hands_levels as u8) << 6
             | (self.shuffle_pipes as u8) << 5
             | (self.faster_frog as u8) << 4
-            // b2 bit 3 = free (was remove_rocks, now always-on and ungated).
+            | (self.boomboom_hits as u8) << 3
             | (self.troll_pipes.is_on() as u8) << 2
             | (self.shuffle_toad_houses as u8) << 1
             | (self.shuffle_airships as u8);
@@ -283,6 +284,7 @@ impl Options {
             palette_themed: false, // cosmetic — not encoded in flag key
             hammer_breaks_locks: dtri((b1 >> 6) & 1 != 0, b11 & 1 != 0),
             koopaling_hits: (b1 >> 5) & 1 != 0,
+            boomboom_hits: (b2 >> 3) & 1 != 0,
             world_order: (b1 >> 4) & 1 != 0,
             big_q_blocks: (b1 >> 3) & 1 != 0,
             disable_autoscroll: (b1 >> 2) & 1 != 0,

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -349,6 +349,12 @@ fn randomize_inner(
         randomize::koopalings::randomize_koopaling_hits(rom, &mut rng);
     }
 
+    // Per-fortress Boom-Boom random stomp counts (1–5 hits each).
+    if options.boomboom_hits {
+        rom.set_tag("boomboom/random_hits");
+        randomize::koopalings::randomize_boomboom_hits(rom, &mut rng);
+    }
+
     // Hammer breaks tiles on the overworld map (locks, bridges, or both).
     if hammer_breaks_locks || hammer_breaks_bridges {
         rom.set_tag("qol/hammer_breaks_tiles");

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -170,6 +170,9 @@ pub struct Options {
     /// Randomize per-Koopaling stomp counts (each gets 1–5 hits independently).
     #[serde(default = "default_true")]
     pub koopaling_hits: bool,
+    /// Randomize per-fortress Boom-Boom stomp counts (each gets 1–5 hits).
+    #[serde(default = "default_true")]
+    pub boomboom_hits: bool,
     /// Make Koopalings vulnerable to thrown hammers (clears invulnerability flag).
     #[serde(default)]
     pub hammer_vulnerable_koopalings: bool,
@@ -357,6 +360,7 @@ impl Default for Options {
             skip_wand_cutscene: true,
             adjust_boss_hitboxes: true,
             koopaling_hits: true,
+            boomboom_hits: true,
             hammer_vulnerable_koopalings: false,
             random_koopalings: false,
             include_beta_stages: false,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -181,6 +181,7 @@
             skip_wand_cutscene: true,
             adjust_boss_hitboxes: true,
             koopaling_hits: true,
+            boomboom_hits: true,
             hammer_vulnerable_koopalings: true,
             random_koopalings: true,
             include_beta_stages: true,
@@ -258,6 +259,7 @@
             skip_wand_cutscene: false,
             adjust_boss_hitboxes: false,
             koopaling_hits: false,
+            boomboom_hits: false,
             hammer_vulnerable_koopalings: false,
             random_koopalings: false,
             include_beta_stages: false,
@@ -419,6 +421,7 @@
             ("skip_wand_cutscene",           Box::new(|o| o.skip_wand_cutscene = !o.skip_wand_cutscene)),
             ("adjust_boss_hitboxes",         Box::new(|o| o.adjust_boss_hitboxes = !o.adjust_boss_hitboxes)),
             ("koopaling_hits",               Box::new(|o| o.koopaling_hits = !o.koopaling_hits)),
+            ("boomboom_hits",                Box::new(|o| o.boomboom_hits = !o.boomboom_hits)),
             ("hammer_vulnerable_koopalings", Box::new(|o| o.hammer_vulnerable_koopalings = !o.hammer_vulnerable_koopalings)),
             ("random_koopalings",            Box::new(|o| o.random_koopalings = !o.random_koopalings)),
             ("include_beta_stages",          Box::new(|o| o.include_beta_stages = !o.include_beta_stages)),
@@ -549,6 +552,7 @@
         everything.skip_wand_cutscene = !everything.skip_wand_cutscene;
         everything.adjust_boss_hitboxes = !everything.adjust_boss_hitboxes;
         everything.koopaling_hits = !everything.koopaling_hits;
+        everything.boomboom_hits = !everything.boomboom_hits;
         everything.hammer_vulnerable_koopalings = true;
         everything.random_koopalings = true;
         everything.include_beta_stages = true;
@@ -653,6 +657,7 @@
             skip_wand_cutscene: false,
             adjust_boss_hitboxes: false,
             koopaling_hits: false,
+            boomboom_hits: false,
             hammer_vulnerable_koopalings: false,
             random_koopalings: false,
             include_beta_stages: false,
@@ -714,6 +719,7 @@
             skip_wand_cutscene: true,
             adjust_boss_hitboxes: true,
             koopaling_hits: true,
+            boomboom_hits: true,
             hammer_vulnerable_koopalings: true,
             random_koopalings: true,
             include_beta_stages: false,


### PR DESCRIPTION
Each fortress's Boom-Boom now takes a random 1-5 stomps to defeat (distinct within each world) instead of the fixed 3. On by default; disable with --keep-boomboom-stomps. Fireball defeats (37 hits) are unaffected.

Boom-Boom's Objects_Var5 is both the hit tally and the DynJump state index (2/3/4 = attacks, 5 = death), so the count cannot simply be re-compared like the Koopaling. The tally is decoupled into Objects_Var12 (7CD2,X, self-zeroed on spawn, unused by Boom-Boom); Var5 keeps cycling attack states and is forced to the death state only when the tally reaches this fortress's threshold. Threshold table indexed by (World_Num<<2 + ordinal) & 0F, ordinal read from Objects_Var4. Subroutine + table live in PRG003's bank-end gap so the handler JMP is bank-local.

Verified: all tests pass, clippy clean, byte-checked a real patched ROM, offsets re-derived from actual ROM bytes, playtested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
