### PR TITLE
feature: β9 Tornado + rom_map.py directory fix; release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ into a versioned section when a release is cut.
   random 1–5 stomps to defeat (per-fortress, distinct within each world) instead
   of the fixed 3. On by default; disable with `--keep-boomboom-stomps`. Fireball
   defeats are unaffected.
+- **β9 Tornado** — when beta stages are included (`--include-beta-stages`), one of
+  the β9 beta stage's three Fire Chomps is randomly turned into a Tornado (borrowing
+  the World 2 quicksand Tornado's height).
 
 ## [0.9.5] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 The project is pre-1.0; new work accumulates under **[Unreleased]** and is moved
 into a versioned section when a release is cut.
 
-## [Unreleased]
+## [0.10.0] - 2026-07-01
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2024"
 
 [lib]

--- a/src/randomize/beta_tornado.rs
+++ b/src/randomize/beta_tornado.rs
@@ -1,0 +1,39 @@
+//! Turn one of β9's Fire Chomps into a Tornado.
+//!
+//! The β9 beta stage (tileset 13, obj `$CEBD`) has three Fire Chomps in its
+//! enemy stream. When beta stages are included, this picks one of the three at
+//! random and rewrites it into a Tornado, borrowing the vertical position from
+//! the World 2 quicksand level's Tornado so it spawns at a sensible height.
+//!
+//! The other two Fire Chomps are left alone (they remain subject to the normal
+//! enemy randomizer). Because a Fire Chomp is itself a randomizable id, this
+//! must run *after* `enemies::randomize` so the forced Tornado is final.
+
+use rand::Rng;
+
+use crate::rom::Rom;
+
+/// Tornado object id (as used by the W2 quicksand level at file `$0C866`).
+const TORNADO_ID: u8 = 0x5D;
+
+/// β9's three Fire Chomps, by file offset of the id byte. These sit in β9's own
+/// enemy stream (`$0CECD`..=`$0CEEC`), a gap between the W4-32 and W5-33 vanilla
+/// segments that no live pointer-table entry references — so overwriting them
+/// touches only β9.
+const BETA9_FIRE_CHOMP_OFFSETS: [usize; 3] = [0x0CEE3, 0x0CEE6, 0x0CEE9];
+
+/// The Tornado's y position byte from the W2 quicksand level (`$0C868`): row 2.
+/// Only the height is borrowed; the screen/column byte of the replaced Fire
+/// Chomp is kept as-is.
+const TORNADO_Y_BYTE: u8 = 0x12;
+
+/// Replace one random β9 Fire Chomp with a Tornado.
+///
+/// Gated on beta stages being included — otherwise β9's data is never loaded and
+/// there is no reason to touch it. Only the id and y (height) bytes change; the
+/// screen/column byte is preserved from the replaced Fire Chomp.
+pub fn randomize_beta9_tornado<R: Rng>(rom: &mut Rom, rng: &mut R) {
+    let id_offset = BETA9_FIRE_CHOMP_OFFSETS[rng.random_range(..BETA9_FIRE_CHOMP_OFFSETS.len())];
+    rom.write_byte(id_offset, TORNADO_ID);
+    rom.write_byte(id_offset + 2, TORNADO_Y_BYTE);
+}

--- a/src/randomize/mod.rs
+++ b/src/randomize/mod.rs
@@ -1,5 +1,6 @@
 pub mod anchor_visuals;
 pub mod autoscroll;
+pub mod beta_tornado;
 pub mod bowser_castle;
 pub mod enemies;
 pub mod enemy_protections;

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -162,6 +162,14 @@ fn randomize_inner(
         rom.set_tag("enemies");
         randomize::enemies::randomize(rom, &mut rng, options);
     }
+    // Force one of β9's Fire Chomps into a Tornado. Runs after the enemy pass
+    // (which may randomize β9's Fire Chomps when it's placed) so the Tornado is
+    // final, and only when beta stages are included so we don't touch β9's data
+    // for nothing.
+    if options.include_beta_stages {
+        rom.set_tag("beta_tornado");
+        randomize::beta_tornado::randomize_beta9_tornado(rom, &mut rng);
+    }
     randomize::bowser_castle::randomize(rom, &mut rng);
     randomize::podoboo_gauntlet::randomize(rom, &mut rng);
     if options.world_order {

--- a/tools/rom_map.py
+++ b/tools/rom_map.py
@@ -38,10 +38,15 @@ from collections import defaultdict, deque
 # only rom_data.rs needs to change.
 # --------------------------------------------------------------------------
 
-_ROM_DATA_RS = os.path.join(
+# rom_data was split from a single rom_data.rs into a rom_data/ submodule
+# directory (access.rs, free_space.rs, grid.rs, tables.rs, mod.rs). Support
+# both layouts: prefer the directory, fall back to the legacy single file.
+_RANDOMIZE_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
-    "..", "src", "randomize", "rom_data.rs",
+    "..", "src", "randomize",
 )
+_ROM_DATA_DIR = os.path.join(_RANDOMIZE_DIR, "rom_data")
+_ROM_DATA_RS = os.path.join(_RANDOMIZE_DIR, "rom_data.rs")
 
 
 def _parse_tuple_list(rs_src, name):
@@ -132,8 +137,20 @@ def _parse_beta_patches(rs_src):
     ]
 
 
-with open(_ROM_DATA_RS) as _f:
-    _RS_SRC = _f.read()
+def _read_rom_data_src():
+    """Read rom_data source, concatenating all .rs files if it's a directory."""
+    if os.path.isdir(_ROM_DATA_DIR):
+        parts = []
+        for fname in sorted(os.listdir(_ROM_DATA_DIR)):
+            if fname.endswith(".rs"):
+                with open(os.path.join(_ROM_DATA_DIR, fname)) as f:
+                    parts.append(f.read())
+        return "\n".join(parts)
+    with open(_ROM_DATA_RS) as f:
+        return f.read()
+
+
+_RS_SRC = _read_rom_data_src()
 
 # --------------------------------------------------------------------------
 # Constants


### PR DESCRIPTION
## Summary

- **β9 Tornado** — when beta stages are included (`--include-beta-stages`), randomly turns one of β9's three Fire Chomps into a Tornado, borrowing the World 2 quicksand Tornado's height (row 2) while keeping the replaced Fire Chomp's screen/column. Runs after the enemy pass so the forced Tornado is final; gated on `--include-beta-stages` so β9's data is untouched otherwise.
- **Tooling fix** — `rom_map.py` (and the `/level` skill) had been broken since `rom_data.rs` was split into the `rom_data/` submodule directory in f4a4de9. The tool now reads and concatenates the directory's `.rs` files, with a fallback to the legacy single file.
- **Release 0.10.0** — moves the accumulated `[Unreleased]` entries (Boom-Boom stomp counts + β9 Tornado) into a versioned section.

## Verification

- `cargo build`, `cargo clippy --all-targets` (zero warnings), `cargo test` all pass.
- The β9 edit is exactly 2 bytes (id `0x58`→`0x5D` and its y-byte→`0x12`); deterministic per seed; absent when betas are off.
- Confirmed the target bytes are unique to β9's enemy stream (`\$0CECD`–`\$0CEEC`), a gap no live pointer-table entry references, so no vanilla level is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)