### PR TITLE
fix: SAS death respawn scroll-desync + centered start framing (0.10.1)

### DIFF
--- a/.claude/commands/wch.md
+++ b/.claude/commands/wch.md
@@ -1,0 +1,84 @@
+Generate a BizHawk / EmuHawk RAM Watch (`.wch`) file for a set of memory addresses.
+
+## Usage
+`/wch <addr:label> [addr:label ...] [--system NES] [-o path.wch]`
+
+You can also just describe what you want to watch in plain English (e.g. "watch Mario's
+world-map position and the camera scroll") and pick addresses from the reference below.
+
+Examples:
+- `/wch 0079:World_Map_X 0077:World_Map_XHi 0075:World_Map_Y`
+- `/wch 7982:Map_Previous_X 7980:Map_Previous_XHi 797E:Map_Previous_Y -o roms/debug.wch`
+- `/wch --preset overworld` — emit the full overworld-position watch set below
+
+## Instructions
+
+1. **Resolve addresses.** Each argument is `HEXADDR:label` (address is a CPU/System-Bus
+   address, hex, no `0x`). If the user described things in words, map them via the
+   reference tables below. If they ask for a preset, emit that whole set.
+
+2. **Write the file with a script** (real tab characters are mandatory — do not hand-type
+   tabs, they get mangled). Default domain is **System Bus** (literal CPU addresses, no
+   offset math — works for zero-page, RAM `$0000-$07FF`, and cartridge WRAM `$6000-$7FFF`
+   alike). Default output `roms/debug.wch` unless `-o` given.
+
+   ```sh
+   nix-shell -p python3 --run 'python3 - <<"PY"
+   rows = [
+       ("0079", "World_Map_X"),
+       ("0077", "World_Map_XHi"),
+       # (addr, label) ...
+   ]
+   system = "NES"          # SystemID header
+   lines = ["SystemID " + system]
+   for addr, note in rows:
+       # addr \t size(b=byte,w=word,d=dword) \t type(h=hex,u,s,b) \t bigendian(0/1) \t domain \t notes
+       lines.append("\t".join([addr, "b", "h", "0", "System Bus", note]))
+   open("roms/debug.wch", "w").write("\n".join(lines) + "\n")
+   print("\n".join(lines))
+   PY'
+   ```
+
+3. **Report** the path and remind the user to load it via **Tools → RAM Watch → File →
+   Open** (or **Append** to add to an existing watch list). All entries are 1-byte hex on
+   System Bus; for 2-byte values pass `w` instead of `b` in the row.
+
+## `.wch` file format (verified against BizHawk `WatchList`/`Watch` source)
+- Line 1: `SystemID <SYS>` (e.g. `SystemID NES`).
+- One line per watch, **tab-separated, 6 fields**:
+  `ADDRESS \t SIZE \t TYPE \t BIGENDIAN \t DOMAIN \t NOTES`
+  - `ADDRESS` — hex, no `0x` (leading zeros optional; loader parses hex regardless).
+  - `SIZE` — `b` byte, `w` word, `d` dword.
+  - `TYPE` — `h` hex, `u` unsigned, `s` signed, `b` binary.
+  - `BIGENDIAN` — `0` little, `1` big.
+  - `DOMAIN` — `System Bus` (recommended: literal CPU addresses). Alternatives on NES:
+    `RAM` (2 KB internal, address as-is `$0000-$07FF`), `WRAM` (cart SRAM, address =
+    CPU − `$6000`), `PRG ROM`, `CHR VROM`. If System Bus rejects an address, switch that
+    row's domain and adjust the address accordingly.
+  - `NOTES` — the label (must contain no tab).
+
+## SMB3 overworld reference (World_Num = `$0727`, `01` = World 2)
+Mario/Luigi are interleaved: the address shown is Mario; Luigi is `+1`.
+
+| Addr | Name | Meaning |
+|------|------|---------|
+| `0075` | World_Map_Y | live map row (ZP) |
+| `0077` | World_Map_XHi | live map page (ZP) |
+| `0079` | World_Map_X | live map column low-pixel (ZP) |
+| `7976` | Map_Entered_Y | tile you entered a level from (row) |
+| `7978` | Map_Entered_XHi | …page |
+| `797A` | Map_Entered_X | …column |
+| `797E` | Map_Previous_Y | "safe" tile you skid back to on death (row) |
+| `7980` | Map_Previous_XHi | …page |
+| `7982` | Map_Previous_X | …column |
+| `7986` | Map_Prev_XOff2 | secondary camera-scroll backup (low) — afar-skid target |
+| `7988` | Map_Prev_XHi2 | secondary camera-scroll backup (page) — afar-skid target |
+| `0722` | Map_Prev_XOff | primary camera-scroll backup (low) |
+| `0724` | Map_Prev_XHi | primary camera-scroll backup (page) |
+| `00FD` | Horz_Scroll | live camera scroll low |
+| `0012` | Horz_Scroll_Hi | live camera scroll page |
+
+## Preset: `overworld`
+Emit World_Num + the live position (`0075/0077/0079`), Map_Entered, Map_Previous, the two
+secondary backups (`7986/7988`), the primary backups (`0722/0724`), and live scroll
+(`00FD/0012`) — the full set used to debug the SAS death-respawn / scroll-desync.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !web/visual-patches/*.ips
 *.zip
 *.cht
+*.wch
 /new
 tools/rom_map.json
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 The project is pre-1.0; new work accumulates under **[Unreleased]** and is moved
 into a versioned section when a release is cut.
 
+## [0.10.1] - 2026-07-05
+
+### Fixed
+
+- **Start↔Airship swap — death respawn** — in a swapped world, dying with lives
+  remaining in a level on a different overworld page than the swapped start no
+  longer strands Mario on a blank tile with the map drawn on the wrong screen.
+  The engine's "skid back from afar" restores the camera from a secondary scroll
+  backup the swap scaffolding never seeded, so it scrolled to page 0; it is now
+  seeded (at both Map Init and the game-over finalize) so the skid scrolls to the
+  real start page.
+
+### Changed
+
+- **Start↔Airship swap — start framing** — a swapped start on a non-zero screen
+  is now centered half a screen back instead of pinned at the left edge of its
+  page, so the surrounding map is visible and the camera no longer auto-pans on
+  arrival. Page-0 / unswapped worlds are unaffected.
+
 ## [0.10.0] - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 
 [lib]

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -14,7 +14,7 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x35572, 13, "mystery_anchor: item redirect trampoline"),
     (0x3557F, 50, "hammer_locks: tile check subroutine + tables"),
     (0x3E260, 33, "starting_items: lives + intro skip + menu music + inventory init trampoline"),
-    (0x3E281, 64, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + X helper + XHi helper"),
+    (0x3E281, 69, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + Map_Init seed helper"),
     (0x3E965, 13, "title_screen: intro skip + menu music routine"),
     (0x3FFF0, 26, "card_speed_clear: XOR trampoline"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
@@ -26,7 +26,7 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x15554, 80, "fx_screen_check: cross-screen lock patch (Fred's algorithm verbatim)"),
     (0x15DF0, 35, "canoe_fix: death respawn position save"),
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
-    (0x17C87, 33, "start_airship_swap: game-over twirl finalize helper"),
+    (0x17C87, 36, "start_airship_swap: game-over twirl finalize helper"),
     (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
     (0x17D42, 8, "bros_no_hands: hand-trap tile bypass for overworld bro movement gate"),
     // PRG001 (file 0x02010, CPU $A000–$BFFF)
@@ -59,30 +59,32 @@ pub(crate) const FS_INTRO_SKIP: usize        = 0x3E965; // 13 bytes
 
 pub(crate) const FS_CARD_CLEAR: usize        = 0x3FFF0; // 26 bytes
 
-// PRG031 — start_airship_swap engine scaffolding. One 64-byte block: 4 × 8-byte
-// per-world tables followed by two assembled subroutines. PRG031 is always-mapped
-// at $E000-$FFFF so Map_Init / GameOver_TwirlToStart (PRG011) can read the tables
-// regardless of which bank is at $A000. NOTE: the PRG031 free run at 0x3E281 ends
-// at 0x3E2D0 (real code follows) — only ~79 bytes; do not grow this block past 64.
-pub(crate) const FS_SAS_BLOCK: usize             = 0x3E281;       // 64 bytes total
+// PRG031 — start_airship_swap engine scaffolding. One ~69-byte block: 4 × 8-byte
+// per-world tables followed by a single assembled seed subroutine. PRG031 is
+// always-mapped at $E000-$FFFF so Map_Init / GameOver_TwirlToStart (PRG011) can
+// read the tables regardless of which bank is at $A000. NOTE: the PRG031 free run
+// at 0x3E281 ends at 0x3E2D0 (real code follows) — only 79 bytes; do not grow this
+// block past that ceiling.
+pub(crate) const FS_SAS_BLOCK: usize             = 0x3E281;       // 69 bytes used (79 max)
 
 pub(crate) const FS_SAS_X_TABLE: usize           = FS_SAS_BLOCK;       // 8 bytes — Mario X-low pixel per world
 
 pub(crate) const FS_SAS_XHI_TABLE: usize         = FS_SAS_BLOCK + 8;   // 8 bytes — Mario screen index per world
 
-pub(crate) const FS_SAS_SCRL_TABLE: usize        = FS_SAS_BLOCK + 16;  // 8 bytes — camera scroll low per world ($0722)
+pub(crate) const FS_SAS_SCRL_TABLE: usize        = FS_SAS_BLOCK + 16;  // 8 bytes — camera scroll low per world ($0722 / $7986)
 
-pub(crate) const FS_SAS_SCRH_TABLE: usize        = FS_SAS_BLOCK + 24;  // 8 bytes — camera scroll high per world ($0724)
+pub(crate) const FS_SAS_SCRH_TABLE: usize        = FS_SAS_BLOCK + 24;  // 8 bytes — camera scroll high per world ($0724 / $7988)
 
-pub(crate) const FS_SAS_X_HELPER: usize          = FS_SAS_BLOCK + 32;  // 10 bytes — writes Map_Entered_X / $7982
-
-pub(crate) const FS_SAS_XHI_HELPER: usize        = FS_SAS_BLOCK + 42;  // 22 bytes — writes Map_Entered_XHi + death-respawn XHi + scroll seeds
+// Single Map_Init seed subroutine: writes Mario's start position plus the primary
+// AND secondary scroll backups from the four tables (replaces the former x/xhi
+// helper pair). Reached via `JSR` from the Map_Init scroll-store site.
+pub(crate) const FS_SAS_SEED_HELPER: usize       = FS_SAS_BLOCK + 32;  // 37 bytes
 
 // The game-over twirl finalize helper lives in PRG011 free space (not FS_SAS_BLOCK
-// — that PRG031 run has no room for 29 more bytes). PRG011 is the hook's own bank,
-// so the JSR is bank-local; the helper still reads the FS_SAS_* tables in
-// always-resident PRG031.
-pub(crate) const FS_SAS_GAMEOVER_FINALIZE: usize = 0x17C87;  // PRG011, 33 bytes — stamps World_Map_X/XHi + scroll backup + live Horz_Scroll/Hi at twirl finalize (clean gap before FS_CANOE_BACKUP)
+// — that PRG031 run has no room for it). PRG011 is the hook's own bank, so the JSR
+// is bank-local; the helper still reads the FS_SAS_* tables in always-resident
+// PRG031.
+pub(crate) const FS_SAS_GAMEOVER_FINALIZE: usize = 0x17C87;  // PRG011, 36 bytes — stamps World_Map_X/XHi + primary/secondary scroll backup + live Horz_Scroll/Hi at twirl finalize (clean gap before FS_CANOE_BACKUP)
 
 // Vanilla 8-byte Map_Y_Starts table (per-world Mario spawn Y-pixel). Lives in
 // PRG030's world-enter routine. The start_airship_swap module rewrites this
@@ -90,11 +92,12 @@ pub(crate) const FS_SAS_GAMEOVER_FINALIZE: usize = 0x17C87;  // PRG011, 33 bytes
 // vanilla start row.
 pub(crate) const MAP_Y_STARTS_OFF: usize  = 0x3C39A;
 
-// Map_Init inline patch sites in PRG011 (CPU $A237). The start_airship_swap
-// module replaces these with `JSR helper` so the per-world spawn position
-// loads from the FS_SAS_* tables instead of the vanilla inline immediates.
-pub(crate) const MAP_INIT_X_LOW_SITE: usize  = 0x16257;   // 8 bytes — `LDA #$20 / STA $797A,X / STA $7982,X`
-
+// Map_Init inline patch site in PRG011 (CPU $A237). The start_airship_swap module
+// replaces the vanilla `STA $0724,X` scroll-store with `JSR seed_helper`, which
+// overwrites the whole start position + scroll block from the FS_SAS_* tables. The
+// earlier vanilla `LDA #$20 / STA $797A,X / STA $7982,X` X-low store at 0x16257 is
+// left intact — the seed helper re-stamps $797A/$7982 later in the same loop
+// iteration (before any draw), so the vanilla value is harmlessly overwritten.
 pub(crate) const MAP_INIT_SCROLL_SITE: usize = 0x1627E;   // 3 bytes — `STA $0724,X`
 
 // GameOver_TwirlToStart finalize hook in PRG011 (CPU $A6AA). The twirl is a
@@ -105,9 +108,11 @@ pub(crate) const MAP_INIT_SCROLL_SITE: usize = 0x1627E;   // 3 bytes — `STA $0
 // by patching the delta. Instead we let the vanilla animation play and STAMP the
 // correct start position at finalize: replace `STA Map_Prev_XHi2,X` (the last
 // store before the World_Map → Map_Previous copies) with `JSR finalize helper`,
-// which overwrites World_Map_X ($79,X) / World_Map_XHi ($77,X) and the camera
-// scroll ($0722/$0724,X) from the FS_SAS_* tables. The subsequent vanilla copies
-// then propagate the corrected position into Map_Previous_X/XHi.
+// which overwrites World_Map_X ($79,X) / World_Map_XHi ($77,X), the camera scroll
+// ($0722/$0724,X) and both secondary backups ($7986/$7988) from the FS_SAS_*
+// tables. The displaced `STA $7988` (A=0) is intentionally dropped: the helper now
+// stamps $7988 with the start screen instead of zeroing it (nothing between the
+// hook and the following copies reads it).
 pub(crate) const GAMEOVER_FINALIZE_SITE: usize = 0x166BA;  // 3 bytes — `STA $7988,X` (Map_Prev_XHi2,X)
 
 // Map_Object slot 1 == the airship sprite per southbird's disassembly:

--- a/src/randomize/start_airship_swap.rs
+++ b/src/randomize/start_airship_swap.rs
@@ -13,10 +13,10 @@
 //! and leaves the path tile intact — the relocated airship loses its
 //! decorative top half, but the world stays playable.
 //!
-//! The engine-side scaffolding (per-world camera + Mario-position tables,
-//! three helper routines, Map_Init + GameOver_TwirlToStart JSR patches, and
-//! Map_Object slot-1 sprite moves) is committed once at the tail of the
-//! writer via `write_engine_scaffolding`.
+//! The engine-side scaffolding (per-world camera + Mario-position tables, a
+//! Map_Init seed helper and a game-over finalize helper, their JSR patches, and
+//! Map_Object slot-1 sprite moves) is committed once at the tail of the writer
+//! via `write_engine_scaffolding`.
 //!
 //! Background and POC derivation: see `docs/start_airship_swap_findings.md`.
 
@@ -28,9 +28,8 @@ use super::node_catalog::{NodeCatalog, NodeKind};
 use super::pipe_helpers::grid_pos_to_dest_nibbles;
 use super::rom_data::{
     self, AIRSHIP_OBJ_SLOT, FS_SAS_GAMEOVER_FINALIZE, FS_SAS_SCRH_TABLE, FS_SAS_SCRL_TABLE,
-    FS_SAS_X_HELPER, FS_SAS_X_TABLE, FS_SAS_XHI_HELPER, FS_SAS_XHI_TABLE,
-    GAMEOVER_FINALIZE_SITE, Grid, MAP_INIT_SCROLL_SITE, MAP_INIT_X_LOW_SITE,
-    MAP_Y_STARTS_OFF, WORLDS,
+    FS_SAS_SEED_HELPER, FS_SAS_X_TABLE, FS_SAS_XHI_TABLE, GAMEOVER_FINALIZE_SITE, Grid,
+    MAP_INIT_SCROLL_SITE, MAP_TILE_GRIDS, MAP_Y_STARTS_OFF, WORLDS,
 };
 
 // ---------------------------------------------------------------------------
@@ -178,9 +177,9 @@ pub(super) fn write_swapped_world_entries(rom: &mut Rom, world_idx: usize, catal
 /// Writes:
 ///   * `Map_Y_Starts` (vanilla 8-byte table at `MAP_Y_STARTS_OFF`)
 ///   * Four per-world tables in PRG031 free space (X, XHi, ScrL, ScrH)
-///   * Two PRG031 helper subroutines (X-low setter, XHi + camera-scroll setter)
+///   * One PRG031 Map_Init seed helper (position + primary/secondary scroll backups)
 ///     plus a PRG011 game-over finalize helper (stamps World_Map_X/XHi + scroll)
-///   * `Map_Init` inline patches replaced with `JSR helper`
+///   * `Map_Init` scroll-store replaced with `JSR seed_helper`
 ///   * `GameOver_TwirlToStart` finalize store replaced with `JSR finalize` so
 ///     the spiral lands on the per-world start instead of vanilla column 2
 ///   * Per-swapped-world `Map_Object` slot-1 sprite position move
@@ -200,11 +199,17 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
         y_tbl[wi] = ((sr as u8) * 0x10).wrapping_add(0x20);
         x_tbl[wi] = ((sc % 16) as u8) * 0x10;
         xhi_tbl[wi] = (sc / 16) as u8;
-        // Page-aligned camera: $0722 = 0 (viewport at left of loaded slice),
-        // $0724 = Mario's screen index so Scroll_Update_Ranges loads cols
-        // (screen*16)..(screen*16+15).
-        scrl_tbl[wi] = 0;
-        scrh_tbl[wi] = (sc / 16) as u8;
+        // Camera framing: half a screen back from Mario, snapped to the nearest
+        // valid half-page scroll stop (Scroll_ColumnL a multiple of 8) and clamped
+        // to the map's scrollable range. Page-aligning instead would pin Mario at
+        // screen column 2 — the left auto-pan margin — and show the far edge of his
+        // page; the engine only rests cleanly on these half-page stops. Page-0 /
+        // unswapped starts collapse to column 0 (identical to vanilla).
+        let cols = MAP_TILE_GRIDS[wi].columns as i32;
+        let stop = (((sc as i32 - 8) + 4).max(0) / 8) * 8; // round-to-8, floored at 0
+        let col = stop.clamp(0, (cols - 16).max(0));
+        scrl_tbl[wi] = if col & 8 != 0 { 0x80 } else { 0x00 };
+        scrh_tbl[wi] = (col >> 4) as u8;
     }
 
     rom.set_tag("start_airship_swap/tables");
@@ -214,53 +219,48 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     rom.write_range(FS_SAS_SCRL_TABLE, &scrl_tbl);
     rom.write_range(FS_SAS_SCRH_TABLE, &scrh_tbl);
 
-    rom.set_tag("start_airship_swap/helpers");
+    rom.set_tag("start_airship_swap/helper");
     let x_tbl_cpu = file_to_prg031_cpu(FS_SAS_X_TABLE);
-    let x_helper = [
-        0xB9, (x_tbl_cpu & 0xFF) as u8, (x_tbl_cpu >> 8) as u8, // LDA Map_X_Starts,Y
-        0x9D, 0x7A, 0x79,                                       // STA Map_Entered_X,X
-        0x9D, 0x82, 0x79,                                       // STA $7982,X (mirror)
-        0x60,                                                   // RTS
-    ];
-    rom.write_range(FS_SAS_X_HELPER, &x_helper);
-
     let xhi_tbl_cpu = file_to_prg031_cpu(FS_SAS_XHI_TABLE);
     let scrl_tbl_cpu = file_to_prg031_cpu(FS_SAS_SCRL_TABLE);
     let scrh_tbl_cpu = file_to_prg031_cpu(FS_SAS_SCRH_TABLE);
-    // $7980,X is the death-respawn X-high (mirror of $7978,X). Vanilla Map_Init
-    // stamps it to 0 a few cycles earlier; without re-stamping it here, dying
-    // before saving in a swapped world whose new start is on screen ≥ 1 puts
-    // Mario back on screen 0 (off the path).
-    let xhi_helper = [
-        0xB9, (xhi_tbl_cpu & 0xFF) as u8, (xhi_tbl_cpu >> 8) as u8,   // LDA Map_XHi_Starts,Y
-        0x9D, 0x78, 0x79,                                             // STA Map_Entered_XHi,X     ($7978,X)
-        0x9D, 0x80, 0x79,                                             // STA Map_Respawn_XHi,X    ($7980,X)
-        0xB9, (scrl_tbl_cpu & 0xFF) as u8, (scrl_tbl_cpu >> 8) as u8, // LDA Map_ScrL_Starts,Y
-        0x9D, 0x22, 0x07,                                             // STA Map_Prev_XOff,X ($0722)
-        0xB9, (scrh_tbl_cpu & 0xFF) as u8, (scrh_tbl_cpu >> 8) as u8, // LDA Map_ScrH_Starts,Y
-        0x9D, 0x24, 0x07,                                             // STA Map_Prev_XHi,X  ($0724)
-        0x60,                                                         // RTS
+    // Single Map_Init seed subroutine (Y = World_Num, X = Player index — both live
+    // at the loop's scroll-store hook). Overwrites Mario's start position and BOTH
+    // scroll backups from the four tables:
+    //   X   -> Map_Entered_X ($797A) + Map_Previous_X ($7982)
+    //   XHi -> Map_Entered_XHi ($7978) + Map_Previous_XHi ($7980)
+    //   ScrL-> Map_Prev_XOff ($0722) + Map_Prev_XOff2 ($7986)
+    //   ScrH-> Map_Prev_XHi  ($0724) + Map_Prev_XHi2  ($7988)
+    // The secondary backups ($7986/$7988) are what the death-with-lives "skid from
+    // afar" restores the camera from; leaving them at the vanilla page-0 value
+    // strands Mario off-page after dying in a swapped world. The finalize helper
+    // below mirrors this exact store order for the game-over path.
+    let seed_helper = [
+        0xB9, (x_tbl_cpu & 0xFF) as u8, (x_tbl_cpu >> 8) as u8,       // LDA X_TABLE,Y
+        0x9D, 0x7A, 0x79,                                            // STA Map_Entered_X,X   ($797A)
+        0x9D, 0x82, 0x79,                                            // STA Map_Previous_X,X  ($7982)
+        0xB9, (xhi_tbl_cpu & 0xFF) as u8, (xhi_tbl_cpu >> 8) as u8,   // LDA XHI_TABLE,Y
+        0x9D, 0x78, 0x79,                                            // STA Map_Entered_XHi,X  ($7978)
+        0x9D, 0x80, 0x79,                                            // STA Map_Previous_XHi,X ($7980)
+        0xB9, (scrl_tbl_cpu & 0xFF) as u8, (scrl_tbl_cpu >> 8) as u8, // LDA SCRL_TABLE,Y
+        0x9D, 0x22, 0x07,                                            // STA Map_Prev_XOff,X  ($0722)
+        0x9D, 0x86, 0x79,                                            // STA Map_Prev_XOff2,X ($7986)
+        0xB9, (scrh_tbl_cpu & 0xFF) as u8, (scrh_tbl_cpu >> 8) as u8, // LDA SCRH_TABLE,Y
+        0x9D, 0x24, 0x07,                                            // STA Map_Prev_XHi,X  ($0724)
+        0x9D, 0x88, 0x79,                                            // STA Map_Prev_XHi2,X ($7988)
+        0x60,                                                        // RTS
     ];
-    rom.write_range(FS_SAS_XHI_HELPER, &xhi_helper);
+    rom.write_range(FS_SAS_SEED_HELPER, &seed_helper);
 
     rom.set_tag("start_airship_swap/map_init");
-    let x_helper_cpu = file_to_prg031_cpu(FS_SAS_X_HELPER);
-    let xhi_helper_cpu = file_to_prg031_cpu(FS_SAS_XHI_HELPER);
-    // Replace the 8-byte inline X-low immediate-store block with `JSR helper`
-    // followed by five NOPs to keep the surrounding flow intact.
-    rom.write_range(
-        MAP_INIT_X_LOW_SITE,
-        &[
-            0x20, (x_helper_cpu & 0xFF) as u8, (x_helper_cpu >> 8) as u8,
-            0xEA, 0xEA, 0xEA, 0xEA, 0xEA,
-        ],
-    );
-    // Replace `STA $0724,X` (the final store before DEX) with `JSR xhi_helper`.
-    // The helper writes $7978/$0722/$0724 as its tail, so its values win against
-    // the inline zero-store at `$0722` (left intact a few cycles earlier).
+    let seed_helper_cpu = file_to_prg031_cpu(FS_SAS_SEED_HELPER);
+    // Replace the vanilla `STA $0724,X` (the last store before DEX) with
+    // `JSR seed_helper`. The vanilla `LDA #$20 / STA $797A / STA $7982` X-low store
+    // earlier in the same iteration is left intact — the helper re-stamps those
+    // bytes here, so the table values win before any draw.
     rom.write_range(
         MAP_INIT_SCROLL_SITE,
-        &[0x20, (xhi_helper_cpu & 0xFF) as u8, (xhi_helper_cpu >> 8) as u8],
+        &[0x20, (seed_helper_cpu & 0xFF) as u8, (seed_helper_cpu >> 8) as u8],
     );
 
     // GameOver_TwirlToStart spirals Mario back to the start via a per-frame X/Y
@@ -271,12 +271,16 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     // animation play and STAMP the correct position at finalize.
     //
     // Hook: replace `STA Map_Prev_XHi2,X` (the last store before the World_Map →
-    // Map_Previous copies; A = 0 there) with `JSR finalize`. The helper re-does
-    // the displaced store, then overwrites World_Map_X ($79,X) / World_Map_XHi
-    // ($77,X) and camera scroll ($0722/$0724,X) from the FS_SAS_* tables. The
-    // vanilla copies that follow then propagate the corrected X/XHi into
+    // Map_Previous copies; A = 0 there) with `JSR finalize`. The helper overwrites
+    // World_Map_X ($79,X) / World_Map_XHi ($77,X), the camera scroll ($0722/$0724,X)
+    // and both secondary scroll backups ($7986/$7988,X) from the FS_SAS_* tables.
+    // The vanilla copies that follow then propagate the corrected X/XHi into
     // Map_Previous_X/XHi, so the continue lands on the real start tile. Y is
     // World_Num (re-loaded in the helper); X is Player_Current (live at the site).
+    // The displaced `STA $7988` (A = 0) is dropped: the helper stamps $7988 with
+    // the start screen instead, which is exactly what the death-with-lives afar
+    // skid later restores the camera page from. Nothing between the hook and the
+    // vanilla copies reads $7988.
     //
     // It is NOT enough to fix only the per-player scroll backup ($0722/$0724,X).
     // The vanilla twirl-to-start assumes the start is at page-0 hard-left and
@@ -291,23 +295,24 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     // Game Over happened on a different overworld page than the start tile.
     // Fix: also stamp the live scroll ZP `Horz_Scroll` ($FD) / `Horz_Scroll_Hi`
     // ($12) here (global, not per-player) so the subsequent re-enter redraws the
-    // nametable on the start page. The SCRL value is 0 and the SCRH value is the
-    // start screen index, identical to the Map_Init seeds; for unswapped /
-    // page-0 worlds these stores are no-ops.
+    // nametable on the start framing. SCRL/SCRH are the half-page framing scroll
+    // (identical to the Map_Init seeds); for unswapped / page-0 worlds they are 0,
+    // so these stores are no-ops. Store order mirrors `seed_helper`.
     rom.set_tag("start_airship_swap/gameover_finalize");
     let finalize_helper = [
-        0x9D, 0x88, 0x79,                                            // STA $7988,X (displaced Map_Prev_XHi2,X, A=0)
         0xAC, 0x27, 0x07,                                            // LDY World_Num ($0727)
         0xB9, (x_tbl_cpu & 0xFF) as u8, (x_tbl_cpu >> 8) as u8,      // LDA FS_SAS_X_TABLE,Y
         0x95, 0x79,                                                  // STA World_Map_X,X   ($79,X)
         0xB9, (xhi_tbl_cpu & 0xFF) as u8, (xhi_tbl_cpu >> 8) as u8,  // LDA FS_SAS_XHI_TABLE,Y
         0x95, 0x77,                                                  // STA World_Map_XHi,X ($77,X)
         0xB9, (scrl_tbl_cpu & 0xFF) as u8, (scrl_tbl_cpu >> 8) as u8,// LDA FS_SAS_SCRL_TABLE,Y
-        0x9D, 0x22, 0x07,                                            // STA Map_Prev_XOff,X ($0722)
-        0x85, 0xFD,                                                  // STA Horz_Scroll     ($FD, live scroll low)
+        0x9D, 0x22, 0x07,                                            // STA Map_Prev_XOff,X  ($0722)
+        0x85, 0xFD,                                                  // STA Horz_Scroll      ($FD, live scroll low)
+        0x9D, 0x86, 0x79,                                            // STA Map_Prev_XOff2,X ($7986)
         0xB9, (scrh_tbl_cpu & 0xFF) as u8, (scrh_tbl_cpu >> 8) as u8,// LDA FS_SAS_SCRH_TABLE,Y
-        0x9D, 0x24, 0x07,                                            // STA Map_Prev_XHi,X  ($0724)
-        0x85, 0x12,                                                  // STA Horz_Scroll_Hi  ($12, live scroll page)
+        0x9D, 0x24, 0x07,                                            // STA Map_Prev_XHi,X   ($0724)
+        0x85, 0x12,                                                  // STA Horz_Scroll_Hi   ($12, live scroll page)
+        0x9D, 0x88, 0x79,                                            // STA Map_Prev_XHi2,X  ($7988)
         0x60,                                                        // RTS
     ];
     rom.write_range(FS_SAS_GAMEOVER_FINALIZE, &finalize_helper);

--- a/src/randomize/start_airship_swap.rs
+++ b/src/randomize/start_airship_swap.rs
@@ -199,15 +199,22 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
         y_tbl[wi] = ((sr as u8) * 0x10).wrapping_add(0x20);
         x_tbl[wi] = ((sc % 16) as u8) * 0x10;
         xhi_tbl[wi] = (sc / 16) as u8;
-        // Camera framing: half a screen back from Mario, snapped to the nearest
-        // valid half-page scroll stop (Scroll_ColumnL a multiple of 8) and clamped
-        // to the map's scrollable range. Page-aligning instead would pin Mario at
-        // screen column 2 — the left auto-pan margin — and show the far edge of his
-        // page; the engine only rests cleanly on these half-page stops. Page-0 /
-        // unswapped starts collapse to column 0 (identical to vanilla).
+        // Camera framing. Most worlds smooth-scroll and rest cleanly on half-page
+        // stops (Scroll_ColumnL a multiple of 8): frame Mario half a screen back
+        // (page-aligning would pin him at the left auto-pan margin and show the far
+        // edge of his page). W5 (Sky) is the exception — it presents two *static*
+        // screens (ground / sky) with no smooth scroll, so any non-page-aligned
+        // scroll is invalid; snap to the start's whole screen instead. (W8 is the
+        // other edge-scroll-skipped world but is never swapped, so its col-2 start
+        // collapses to 0 regardless.) Page-0 / unswapped starts collapse to column 0
+        // in either branch (identical to vanilla).
         let cols = MAP_TILE_GRIDS[wi].columns as i32;
-        let stop = (((sc as i32 - 8) + 4).max(0) / 8) * 8; // round-to-8, floored at 0
-        let col = stop.clamp(0, (cols - 16).max(0));
+        let col = if wi == 4 {
+            (sc as i32 / 16) * 16 // W5: page-align to the start's static screen
+        } else {
+            (((sc as i32 - 8) + 4).max(0) / 8) * 8 // round-to-8, floored at 0
+        };
+        let col = col.clamp(0, (cols - 16).max(0));
         scrl_tbl[wi] = if col & 8 != 0 { 0x80 } else { 0x00 };
         scrh_tbl[wi] = (col >> 4) as u8;
     }


### PR DESCRIPTION
## Problem
In a Start↔Airship-swapped world, **dying with lives remaining** in a level on a *different overworld page* than the swapped start left Mario **stranded on a blank tile with the map drawn on the wrong screen** (right logical tile, wrong rendered page).

## Root cause
The vanilla "skid back from afar" (lives-remaining death return) restores the camera from the **secondary** scroll backup `Map_Prev_XOff2/XHi2` (`$7986/$7988`). The SAS scaffolding seeded the *primary* backup (`$0722/$0724`) but never the secondary one, so it stayed at the vanilla page-0 value and the skid scrolled the camera to page 0 while Mario's logical tile is page ≥1. (Vanilla never hits this because its start is always page-0/col-2.) Confirmed via RAM watch: logical `World_Map_XHi = 1`, camera `Horz_Scroll_Hi = 0`, `$7988 = 0`.

## Fix
- Seed `$7986/$7988` from the SCRL/SCRH tables at **both** Map_Init (`seed_helper`) and the **game-over finalize** helper (Map_Init doesn't re-run on continue, so both paths are needed).
- **Refactor:** merge the two Map_Init helpers into one `seed_helper` — drops the X-low hook (vanilla `LDA #$20` is left intact and harmlessly overwritten) and clears the `FS_SAS_BLOCK` free-space cliff (64→69 of 79).
- **Framing:** compute the start camera as a **half-page-back** scroll snapped to a valid stop and clamped to the map, instead of page-aligned — so a swapped start is centered and doesn't trip the left auto-pan on arrival. Page-0 / unswapped worlds collapse to column 0 (vanilla).

## Validation
- Emulator-verified end-to-end (game-over → die on other page → fade → scroll to correct page → Mario centered on the correct start tile).
- Generated `seed_helper` + `finalize` bytes decode byte-identical to the hand-validated patch; framing yields `Scroll_ColumnL=8` for a col-18 start (the tested value).
- Old-code vs new-code diff on the same seed is **67 bytes, all inside the SAS scaffolding** — no collateral.
- `cargo clippy --all-targets` clean; `cargo test` green (incl. `test_free_space_no_overlap` with updated sizes).

## Also
- Adds a `/wch` skill for generating BizHawk RAM Watch files (used throughout this debug).
- Cosmetic game-over twirl-to-wrong-spot (separate, self-correcting) tracked in #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)