### PR TITLE
fix: remove airship-lock patch that corrupted 4-4 sub-area (0.10.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 The project is pre-1.0; new work accumulates under **[Unreleased]** and is moved
 into a versioned section when a release is cut.
 
+## [0.10.3] - 2026-07-07
+
+### Fixed
+
+- **Airship-lock patch corrupted 4-4's sub-area** — removed a dead always-on
+  write (`A9 01 EA` at `0x1FABC`) that was intended to keep the airship from
+  moving. The offset actually landed in the middle of level 4-4's sub-area
+  layout data, so entering that sub-area black-screened. The write did nothing
+  for airship behavior — the mobile airship is a live map-object the builder
+  never spawns (the airship is placed as a static tile), so there is nothing to
+  lock — and removing it fixes the crash with no behavior change.
+
 ## [0.10.2] - 2026-07-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 
 [lib]

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -295,12 +295,6 @@ fn randomize_inner(
     rom.set_tag("qol/starting_lives");
     randomize::qol::set_starting_lives(rom, options.starting_lives);
 
-    // Airship lock (anchor effect): always applied. Patch at 0x1FABC
-    // ("KXUUXZVG" / Game Genie). The airship stays put after a loss instead of
-    // moving, which also keeps its Map_Object slot-1 sprite from ever spawning.
-    rom.set_tag("airship_lock");
-    // A9 01 EA = LDA #$01; NOP (forces anchor flag always set)
-    rom.write_range(0x1FABC, &[0xA9, 0x01, 0xEA]);
     // Anchors stay in inventory as mystery items — patch the item-use
     // dispatch so using an anchor triggers a random powerup effect.
     rom.set_tag("items/mystery_anchor");

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1,8 +1,6 @@
     use super::*;
     use crate::rom::Rom;
 
-    const ANCHOR_PATCH_OFFSET: usize = 0x1FABC;
-    const PATCHED_BYTES: [u8; 3] = [0xA9, 0x01, 0xEA];
     const ANCHOR: u8 = 0x0A;
 
     // Item table offsets (must match items.rs)
@@ -27,25 +25,6 @@
     fn make_test_rom() -> Option<Rom> {
         let bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
         Rom::from_bytes(&bytes).ok()
-    }
-
-    #[test]
-    fn randomized_rom_has_anchor_lock_patch_by_default() {
-        let Some(mut rom) = make_test_rom() else { return };
-        let original_bytes = rom.read_range(ANCHOR_PATCH_OFFSET, 3).to_vec();
-        let options = test_options();
-        randomize(&mut rom, 0x12345678, &options);
-
-        assert_eq!(
-            rom.read_range(ANCHOR_PATCH_OFFSET, 3),
-            &PATCHED_BYTES,
-            "Anchor lock patch should be present by default"
-        );
-        // Sanity: the patch actually changed something
-        assert_ne!(
-            original_bytes, PATCHED_BYTES,
-            "Test ROM should not already contain the patch bytes"
-        );
     }
 
     #[test]
@@ -894,14 +873,12 @@
         options.bros = EnemyMode::Off;
         options.world_order = false;
         // Keep this on — it writes to known offsets even on a zeroed ROM.
-        // (airship_lock is now unconditional, so its tag always appears.)
         options.disable_autoscroll = true;
         randomize(&mut rom, 42, &options);
 
         let tags: Vec<&str> = rom.write_log().iter().map(|r| r.tag.as_str()).collect();
         // These modules write to fixed offsets that differ from zero
         assert!(tags.iter().any(|t| t.starts_with("autoscroll")));
-        assert!(tags.iter().any(|t| t.starts_with("airship_lock")));
         // Disabled modules should not appear
         assert!(!tags.iter().any(|t| t.starts_with("enemies")));
         assert!(!tags.iter().any(|t| t.starts_with("world_order")));


### PR DESCRIPTION
## Summary

The always-on "airship lock" write (`A9 01 EA` at file offset `0x1FABC`) — hand-derived from a Game Genie code (`KXUUXZVG`) — actually lands **32 bytes into level 4-4's sub-area layout stream** (tileset 1, bank 15). Entering that sub-area black-screened as the level generator ran off the corrupted command data.

Investigation confirmed the write also did **nothing** for airship behavior:
- The relocate-on-death / "scurry away" sequence (`PRG011_A760`) and the airship-entry path both gate on a live `Map_Objects` slot with id `MAPOBJ_AIRSHIP` (`$02`) at the player's tile.
- That slot is `MAPOBJ_EMPTY` (`$00`) in the static map-object tables of every world (verified against the ROM and southbird's `World1O` data), and the overworld builder places the airship as a **static tile + pointer-table level entry** — it never spawns the live airship object.
- So there is no live airship to lock; the vanilla mechanic never engages in randomizer output regardless of this patch.

## Changes
- Remove the `0x1FABC` write, its `airship_lock` write-log tag, and the two tests that asserted the patch bytes/tag.
- Bump `0.10.2` → `0.10.3`; move the changelog entry into the versioned section.

## Verification
- `cargo clippy --all-targets` — clean.
- `cargo test --lib` — 231 passed, 0 failed.
- Confirmed a freshly generated ROM leaves `0x1FABC` at its vanilla bytes (`33 00 40`), so 4-4's sub-area loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)