### PR TITLE
refactor: simplicity review — cleanup across all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 The project is pre-1.0; new work accumulates under **[Unreleased]** and is moved
 into a versioned section when a release is cut.
 
+## [Unreleased]
+
+### Removed
+
+- The no-op `--shuffle-pipes` and `--shuffle-airships` CLI flags — both
+  features are on by default; use `--no-shuffle-pipes` /
+  `--no-shuffle-airships` to disable them.
+
 ## [0.11.1] - 2026-07-09
 
 ### Added

--- a/src/ips.rs
+++ b/src/ips.rs
@@ -11,6 +11,31 @@ const MAX_RECORD_LEN: usize = 0xFFFF;
 // RLE saves when N >= 4, but we use a higher threshold to avoid many tiny RLE records.
 const MIN_RLE_RUN: usize = 8;
 
+// Identical-byte gaps up to this long are absorbed into the surrounding diff
+// region (when more differing bytes follow), so nearby diffs share one record
+// instead of fragmenting into many tiny ones.
+const MAX_ABSORBED_GAP: usize = 4;
+
+/// End (exclusive) of the run of differing bytes starting at `from`.
+fn diff_run_end(original: &[u8], modified: &[u8], from: usize, len: usize) -> usize {
+    let mut i = from;
+    while i < len && original[i] != modified[i] {
+        i += 1;
+    }
+    i
+}
+
+/// A diff run just ended at `gap_start`. If at most `MAX_ABSORBED_GAP`
+/// identical bytes sit there followed by another differing byte, return that
+/// byte's position so the caller can absorb the gap; otherwise the region ends.
+fn next_diff_after_gap(original: &[u8], modified: &[u8], gap_start: usize, len: usize) -> Option<usize> {
+    let mut i = gap_start;
+    while i < len && i - gap_start < MAX_ABSORBED_GAP && original[i] == modified[i] {
+        i += 1;
+    }
+    (i < len && original[i] != modified[i]).then_some(i)
+}
+
 /// Build an IPS patch by diffing original and modified byte slices.
 pub fn build_ips_patch(original: &[u8], modified: &[u8]) -> Vec<u8> {
     assert_eq!(original.len(), modified.len(), "ROM sizes must match for diffing");
@@ -28,30 +53,15 @@ pub fn build_ips_patch(original: &[u8], modified: &[u8]) -> Vec<u8> {
             continue;
         }
 
-        // Found a diff region — find its extent
+        // Found a diff region: a run of differing bytes, extended across any
+        // short identical-byte gaps that have more diffs after them.
         let start = i;
-        while i < len && original[i] != modified[i] {
-            i += 1;
-            // Allow small gaps of identical bytes (up to 3) to be absorbed into the record
-            // to avoid fragmenting into many tiny records
-            if i < len && original[i] == modified[i] {
-                let gap_start = i;
-                while i < len && original[i] == modified[i] && (i - gap_start) < 4 {
-                    i += 1;
-                }
-                if i < len && original[i] != modified[i] {
-                    // Absorb the gap
-                    continue;
-                } else {
-                    // Gap was at the end of diffs, rewind
-                    i = gap_start;
-                    break;
-                }
-            }
+        i = diff_run_end(original, modified, i, len);
+        while let Some(next) = next_diff_after_gap(original, modified, i, len) {
+            i = diff_run_end(original, modified, next, len);
         }
 
-        let region = &modified[start..i];
-        write_records(&mut patch, start, region);
+        write_records(&mut patch, start, &modified[start..i]);
     }
 
     patch.extend_from_slice(FOOTER);
@@ -254,6 +264,39 @@ mod tests {
         let patch = build_ips_patch(&original, &modified);
         let result = apply_ips_patch(&original, &patch).unwrap();
         assert_eq!(result, modified);
+    }
+
+    #[test]
+    fn test_gap_absorption_record_layout() {
+        let original = vec![0u8; 64];
+        let mut modified = original.clone();
+        // 1-byte gap between diffs: absorbed into one record
+        modified[10] = 0xFF;
+        modified[12] = 0xFF;
+        // 3-byte gap: absorbed
+        modified[20] = 0xFF;
+        modified[24] = 0xFF;
+        // 4-byte gap: absorbed (MAX_ABSORBED_GAP)
+        modified[30] = 0xFF;
+        modified[35] = 0xFF;
+        // 5-byte gap: too long — splits into two records
+        modified[42] = 0xFF;
+        modified[48] = 0xFF;
+
+        let patch = build_ips_patch(&original, &modified);
+        let result = apply_ips_patch(&original, &patch).unwrap();
+        assert_eq!(result, modified);
+
+        // Pin the exact record layout.
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"PATCH");
+        expected.extend_from_slice(&[0, 0, 10, 0, 3, 0xFF, 0x00, 0xFF]);
+        expected.extend_from_slice(&[0, 0, 20, 0, 5, 0xFF, 0, 0, 0, 0xFF]);
+        expected.extend_from_slice(&[0, 0, 30, 0, 6, 0xFF, 0, 0, 0, 0, 0xFF]);
+        expected.extend_from_slice(&[0, 0, 42, 0, 1, 0xFF]);
+        expected.extend_from_slice(&[0, 0, 48, 0, 1, 0xFF]);
+        expected.extend_from_slice(b"EOF");
+        assert_eq!(patch, expected);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,6 @@ fn tri_str(t: Tri) -> &'static str {
     }
 }
 
-/// CLI validator for `--starting-lives` — only the four canonical values
-/// that map cleanly to the 2-bit flag-key encoding are accepted.
 /// Parse a NES color byte from hex ("16", "0x16", "$16") and require it to be
 /// chromatic (hue nibble 1-C, value <= 0x3C) so the palette scheme has a hue
 /// to anchor on.
@@ -32,6 +30,8 @@ fn parse_nes_color(s: &str) -> Result<u8, String> {
     }
 }
 
+/// CLI validator for `--starting-lives` — only the four canonical values
+/// that map cleanly to the 2-bit flag-key encoding are accepted.
 fn parse_starting_lives(s: &str) -> Result<u8, String> {
     let n: u8 = s.parse().map_err(|e: std::num::ParseIntError| e.to_string())?;
     if STARTING_LIVES_VALUES.contains(&n) {
@@ -47,6 +47,90 @@ fn parse_starting_lives(s: &str) -> Result<u8, String> {
             n
         ))
     }
+}
+
+/// clap value parser for the per-class enemy flags (off/shuffle/wild).
+fn parse_enemy_mode(s: &str) -> Result<EnemyMode, String> {
+    match s {
+        "off" => Ok(EnemyMode::Off),
+        "shuffle" => Ok(EnemyMode::Shuffle),
+        "wild" => Ok(EnemyMode::Wild),
+        _ => Err("valid values: off, shuffle, wild".to_string()),
+    }
+}
+
+/// clap value parser for `--fire-flower` (off/on/wild).
+fn parse_fire_flower(s: &str) -> Result<FireFlowerMode, String> {
+    match s {
+        "off" => Ok(FireFlowerMode::Off),
+        "on" => Ok(FireFlowerMode::On),
+        "wild" => Ok(FireFlowerMode::Wild),
+        _ => Err("valid values: off, on, wild".to_string()),
+    }
+}
+
+/// clap value parser for `--piranha-shuffle` (off/on/wild).
+fn parse_piranha(s: &str) -> Result<PiranhaMode, String> {
+    match s {
+        "off" => Ok(PiranhaMode::Off),
+        "on" => Ok(PiranhaMode::On),
+        "wild" => Ok(PiranhaMode::Wild),
+        _ => Err("valid values: off, on, wild".to_string()),
+    }
+}
+
+/// clap value parser for the tri-state flags (off/on/maybe).
+fn parse_tri(s: &str) -> Result<Tri, String> {
+    match s {
+        "off" => Ok(Tri::Off),
+        "on" => Ok(Tri::On),
+        "maybe" => Ok(Tri::Maybe),
+        _ => Err("valid values: off, on, maybe".to_string()),
+    }
+}
+
+/// Inventory items: (CLI name, item ID, display name). Single source for the
+/// `--starting-items` parser and the run-summary printer; extra spellings are
+/// handled as aliases in `item_id`.
+const ITEMS: &[(&str, u8, &str)] = &[
+    ("mushroom", 0x01, "Mushroom"),
+    ("fire", 0x02, "Fire Flower"),
+    ("leaf", 0x03, "Super Leaf"),
+    ("frog", 0x04, "Frog Suit"),
+    ("tanooki", 0x05, "Tanooki Suit"),
+    ("hammer-suit", 0x06, "Hammer Suit"),
+    ("cloud", 0x07, "Cloud"),
+    ("p-wing", 0x08, "P-Wing"),
+    ("star", 0x09, "Starman"),
+    ("anchor", 0x0A, "Anchor"),
+    ("hammer", 0x0B, "Hammer"),
+    ("whistle", 0x0C, "Whistle"),
+    ("music-box", 0x0D, "Music Box"),
+    ("random", 0x0E, "Random"),
+    ("random-no-whistle", 0x0F, "Random (No Whistle)"),
+    ("random-suit-only", 0x10, "Random (Suit Only)"),
+];
+
+/// Look up a starting-item ID by CLI name (case-insensitive, with aliases).
+fn item_id(name: &str) -> Option<u8> {
+    let lower = name.to_lowercase();
+    let canonical = match lower.as_str() {
+        "fire-flower" | "fireflower" => "fire",
+        "frog-suit" => "frog",
+        "tanooki-suit" => "tanooki",
+        "hammersuit" => "hammer-suit",
+        "pwing" => "p-wing",
+        "starman" => "star",
+        "musicbox" => "music-box",
+        "random-suit" => "random-suit-only",
+        other => other,
+    };
+    ITEMS.iter().find(|&&(n, _, _)| n == canonical).map(|&(_, id, _)| id)
+}
+
+/// Display name for a starting-item ID in the run summary.
+fn item_display_name(id: u8) -> &'static str {
+    ITEMS.iter().find(|&&(_, i, _)| i == id).map_or("?", |&(_, _, n)| n)
 }
 
 #[derive(Parser)]
@@ -112,17 +196,9 @@ struct Cli {
     #[arg(long)]
     keep_whistles: bool,
 
-    /// Shuffle pipe endpoint positions during the overworld rebuild
-    #[arg(long)]
-    shuffle_pipes: bool,
-
     /// Disable pipe shuffle (on by default)
     #[arg(long)]
     no_shuffle_pipes: bool,
-
-    /// Shuffle airship levels across worlds
-    #[arg(long)]
-    shuffle_airships: bool,
 
     /// Disable airship shuffle (on by default)
     #[arg(long)]
@@ -134,14 +210,14 @@ struct Cli {
 
     /// Add extra hammer-breakable rocks (W1 6,5 and W8 3,37 decorations):
     /// off, on, or maybe (the seed decides, hidden from the flag key). Default: off.
-    #[arg(long, default_value = "off")]
-    more_hammer_rocks: String,
+    #[arg(long, default_value = "off", value_parser = parse_tri)]
+    more_hammer_rocks: Tri,
 
     /// 8s are Wild: enable the W8 Dark World canoe (screen 0) and extra paths
     /// (screen 2): off, on, or maybe (the seed decides, hidden from the flag
     /// key). Default: off.
-    #[arg(long, default_value = "off")]
-    eights_are_wild: String,
+    #[arg(long, default_value = "off", value_parser = parse_tri)]
+    eights_are_wild: Tri,
 
     /// Disable card speed clear (one-of-each skips cutscene, on by default)
     #[arg(long)]
@@ -177,13 +253,13 @@ struct Cli {
 
     /// Hammer item also breaks fortress lock tiles on the overworld map:
     /// off, on, or maybe (the seed decides, hidden from the flag key). Default: off.
-    #[arg(long, default_value = "off")]
-    hammer_breaks_locks: String,
+    #[arg(long, default_value = "off", value_parser = parse_tri)]
+    hammer_breaks_locks: Tri,
 
     /// Hammer item also breaks water gap (bridge) tiles on the overworld map:
     /// off, on, or maybe (the seed decides, hidden from the flag key). Default: off.
-    #[arg(long, default_value = "off")]
-    hammer_breaks_bridges: String,
+    #[arg(long, default_value = "off", value_parser = parse_tri)]
+    hammer_breaks_bridges: Tri,
 
     /// Angry Sun begins swooping immediately on spawn (MaCobra52's "Early Sun" patch)
     #[arg(long)]
@@ -220,14 +296,14 @@ struct Cli {
     /// Random Fire Flower: in-level Fire Flowers grant a position-derived power
     /// state instead of always Fire — off, on, or wild (default: off).
     /// `on` = Fire/Frog/Tanooki/Hammer; `wild` also allows Small/Big.
-    #[arg(long, default_value = "off")]
-    fire_flower: String,
+    #[arg(long, default_value = "off", value_parser = parse_fire_flower)]
+    fire_flower: FireFlowerMode,
 
     /// Piranha shuffle: release the two W7 piranha plant levels into the level
     /// pool — off, on, or wild (default: off). `on` = their plant sprites follow
     /// them; `wild` = plants scatter onto ~1 random level slot per world instead.
-    #[arg(long, default_value = "off")]
-    piranha_shuffle: String,
+    #[arg(long, default_value = "off", value_parser = parse_piranha)]
+    piranha_shuffle: PiranhaMode,
 
     /// Disable spade-game shuffle (on by default; off keeps vanilla spade positions)
     #[arg(long)]
@@ -244,8 +320,8 @@ struct Cli {
     /// Troll-pipe level slots (one regular level per world W2-W8 disguised as a
     /// pipe tile): off, on, or maybe (the seed decides, hidden from the flag
     /// key). Default: on.
-    #[arg(long, default_value = "on")]
-    troll_pipes: String,
+    #[arg(long, default_value = "on", value_parser = parse_tri)]
+    troll_pipes: Tri,
 
     /// Include ~9 unreferenced beta levels in the overworld shuffle pool (off by default)
     #[arg(long)]
@@ -264,48 +340,48 @@ struct Cli {
     anchor_visuals: bool,
 
     /// Ground enemies: off, shuffle, or wild (default: shuffle)
-    #[arg(long, default_value = "shuffle")]
-    ground: String,
+    #[arg(long, default_value = "shuffle", value_parser = parse_enemy_mode)]
+    ground: EnemyMode,
 
     /// Shell enemies: off, shuffle, or wild (default: shuffle)
-    #[arg(long, default_value = "shuffle")]
-    shell: String,
+    #[arg(long, default_value = "shuffle", value_parser = parse_enemy_mode)]
+    shell: EnemyMode,
 
     /// Flying enemies: off, shuffle, or wild (default: shuffle)
-    #[arg(long, default_value = "shuffle")]
-    flying: String,
+    #[arg(long, default_value = "shuffle", value_parser = parse_enemy_mode)]
+    flying: EnemyMode,
 
     /// Piranha plant variants: off, shuffle, or wild (default: shuffle)
-    #[arg(long, default_value = "shuffle")]
-    piranhas: String,
+    #[arg(long, default_value = "shuffle", value_parser = parse_enemy_mode)]
+    piranhas: EnemyMode,
 
     /// Ghost house enemies: off, shuffle, or wild (default: shuffle)
-    #[arg(long, default_value = "shuffle")]
-    ghosts: String,
+    #[arg(long, default_value = "shuffle", value_parser = parse_enemy_mode)]
+    ghosts: EnemyMode,
 
     /// Thwomp variants: off, shuffle, or wild (default: off)
-    #[arg(long, default_value = "off")]
-    thwomps: String,
+    #[arg(long, default_value = "off", value_parser = parse_enemy_mode)]
+    thwomps: EnemyMode,
 
     /// Rotodisc variants: off, shuffle, or wild (default: off)
-    #[arg(long, default_value = "off")]
-    rotodiscs: String,
+    #[arg(long, default_value = "off", value_parser = parse_enemy_mode)]
+    rotodiscs: EnemyMode,
 
     /// Cannon fire variants: off, shuffle, or wild (default: off)
-    #[arg(long, default_value = "off")]
-    cannons: String,
+    #[arg(long, default_value = "off", value_parser = parse_enemy_mode)]
+    cannons: EnemyMode,
 
     /// Water enemies: off, shuffle, or wild (default: shuffle)
-    #[arg(long, default_value = "shuffle")]
-    water: String,
+    #[arg(long, default_value = "shuffle", value_parser = parse_enemy_mode)]
+    water: EnemyMode,
 
     /// Hammer/Boomerang/Fire Bros: off, shuffle, or wild (default: shuffle)
-    #[arg(long, default_value = "shuffle")]
-    bros: String,
+    #[arg(long, default_value = "shuffle", value_parser = parse_enemy_mode)]
+    bros: EnemyMode,
 
     /// HB encounter segments: off, shuffle, or wild (default: off)
-    #[arg(long, default_value = "off")]
-    hb_encounters: String,
+    #[arg(long, default_value = "off", value_parser = parse_enemy_mode)]
+    hb_encounters: EnemyMode,
 
     /// Inject Lakitu/Angry Sun/Boss Bass into ~15% of segments
     #[arg(long)]
@@ -344,102 +420,24 @@ struct Cli {
     skip_rom_validation: bool,
 }
 
-fn main() {
-    let cli = Cli::parse();
-
-    let rom_data = match fs::read(&cli.rom) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!("Error reading ROM: {e}");
-            process::exit(1);
-        }
-    };
-
-    let seed = cli.seed.unwrap_or_else(rand::random);
-
-    fn parse_enemy_mode(s: &str, name: &str) -> EnemyMode {
-        match s {
-            "off" => EnemyMode::Off,
-            "shuffle" => EnemyMode::Shuffle,
-            "wild" => EnemyMode::Wild,
-            other => {
-                eprintln!("Invalid --{name} value: {other}");
-                eprintln!("Valid values: off, shuffle, wild");
-                process::exit(1);
-            }
-        }
-    }
-
-    fn parse_fire_flower(s: &str) -> FireFlowerMode {
-        match s {
-            "off" => FireFlowerMode::Off,
-            "on" => FireFlowerMode::On,
-            "wild" => FireFlowerMode::Wild,
-            other => {
-                eprintln!("Invalid --fire-flower value: {other}");
-                eprintln!("Valid values: off, on, wild");
-                process::exit(1);
-            }
-        }
-    }
-
-    fn parse_piranha(s: &str) -> PiranhaMode {
-        match s {
-            "off" => PiranhaMode::Off,
-            "on" => PiranhaMode::On,
-            "wild" => PiranhaMode::Wild,
-            other => {
-                eprintln!("Invalid --piranha-shuffle value: {other}");
-                eprintln!("Valid values: off, on, wild");
-                process::exit(1);
-            }
-        }
-    }
-
-    fn parse_tri(s: &str, name: &str) -> Tri {
-        match s {
-            "off" => Tri::Off,
-            "on" => Tri::On,
-            "maybe" => Tri::Maybe,
-            other => {
-                eprintln!("Invalid --{name} value: {other}");
-                eprintln!("Valid values: off, on, maybe");
-                process::exit(1);
-            }
-        }
-    }
-
+/// Assemble the randomizer `Options` from parsed CLI arguments (or from a
+/// `--flags` key, which overrides everything except the cosmetic overlays).
+/// Exits with an error message on invalid starting items or flag key.
+fn build_options(cli: &Cli) -> Options {
     let starting_items: Vec<u8> = cli.starting_items.iter().map(|name| {
-        match name.to_lowercase().as_str() {
-            "mushroom" => 0x01,
-            "fire" | "fire-flower" | "fireflower" => 0x02,
-            "leaf" => 0x03,
-            "frog" | "frog-suit" => 0x04,
-            "tanooki" | "tanooki-suit" => 0x05,
-            "hammer-suit" | "hammersuit" => 0x06,
-            "cloud" => 0x07,
-            "p-wing" | "pwing" => 0x08,
-            "star" | "starman" => 0x09,
-            "anchor" => 0x0A,
-            "hammer" => 0x0B,
-            "whistle" => 0x0C,
-            "music-box" | "musicbox" => 0x0D,
-            "random" => 0x0E,
-            "random-no-whistle" => 0x0F,
-            "random-suit-only" | "random-suit" => 0x10,
-            other => {
-                eprintln!("Unknown item: {other}");
-                eprintln!("Valid: mushroom, fire, leaf, frog, tanooki, hammer-suit, cloud, p-wing, star, anchor, hammer, whistle, music-box, random, random-no-whistle, random-suit-only");
-                process::exit(1);
-            }
-        }
+        item_id(name).unwrap_or_else(|| {
+            eprintln!("Unknown item: {name}");
+            let valid: Vec<&str> = ITEMS.iter().map(|&(n, _, _)| n).collect();
+            eprintln!("Valid: {}", valid.join(", "));
+            process::exit(1);
+        })
     }).collect();
     if starting_items.len() > 3 {
         eprintln!("At most 3 starting items allowed (got {})", starting_items.len());
         process::exit(1);
     }
 
-    let options = if let Some(ref flag_key) = cli.flags {
+    if let Some(ref flag_key) = cli.flags {
         match Options::from_flag_key(flag_key) {
             Ok(mut opts) => {
                 // palette_themed is cosmetic and deliberately not encoded in the
@@ -477,8 +475,8 @@ fn main() {
             disable_autoscroll: !cli.keep_autoscroll,
             chest_items: !cli.no_chest_items,
             remove_whistles: !cli.keep_whistles,
-            more_hammer_rocks: parse_tri(&cli.more_hammer_rocks, "more-hammer-rocks"),
-            eights_are_wild: parse_tri(&cli.eights_are_wild, "eights-are-wild"),
+            more_hammer_rocks: cli.more_hammer_rocks,
+            eights_are_wild: cli.eights_are_wild,
             card_speed_clear: !cli.no_card_speed_clear,
             remove_n_cards: !cli.keep_n_cards,
             skip_wand_cutscene: !cli.keep_wand_cutscene,
@@ -487,8 +485,8 @@ fn main() {
             boomboom_hits: !cli.keep_boomboom_stomps,
             hammer_vulnerable_koopalings: cli.hammer_vulnerable_koopalings,
             random_koopalings: cli.random_koopalings,
-            hammer_breaks_locks: parse_tri(&cli.hammer_breaks_locks, "hammer-breaks-locks"),
-            hammer_breaks_bridges: parse_tri(&cli.hammer_breaks_bridges, "hammer-breaks-bridges"),
+            hammer_breaks_locks: cli.hammer_breaks_locks,
+            hammer_breaks_bridges: cli.hammer_breaks_bridges,
             early_sun: cli.early_sun,
             limit_bro_movement: cli.limit_bro_movement,
             japanese_damage: cli.japanese_damage,
@@ -497,38 +495,36 @@ fn main() {
             faster_tail_speed: cli.faster_tail_speed,
             no_game_over_penalty: cli.no_game_over_penalty,
             faster_frog: cli.faster_frog,
-            fire_flower: parse_fire_flower(&cli.fire_flower),
-            piranha_shuffle: parse_piranha(&cli.piranha_shuffle),
+            fire_flower: cli.fire_flower,
+            piranha_shuffle: cli.piranha_shuffle,
             shuffle_spade_games: !cli.no_shuffle_spade_games,
             shuffle_toad_houses: !cli.no_shuffle_toad_houses,
             hands_levels: !cli.no_hands_levels,
-            troll_pipes: parse_tri(&cli.troll_pipes, "troll-pipes"),
+            troll_pipes: cli.troll_pipes,
             include_beta_stages: cli.include_beta_stages,
             swap_start_airship: cli.swap_start_airship,
             anchor_visuals: cli.anchor_visuals,
-            ground: parse_enemy_mode(&cli.ground, "ground"),
-            shell: parse_enemy_mode(&cli.shell, "shell"),
-            flying: parse_enemy_mode(&cli.flying, "flying"),
-            piranhas: parse_enemy_mode(&cli.piranhas, "piranhas"),
-            ghosts: parse_enemy_mode(&cli.ghosts, "ghosts"),
-            thwomps: parse_enemy_mode(&cli.thwomps, "thwomps"),
-            rotodiscs: parse_enemy_mode(&cli.rotodiscs, "rotodiscs"),
-            cannons: parse_enemy_mode(&cli.cannons, "cannons"),
-            water: parse_enemy_mode(&cli.water, "water"),
-            bros: parse_enemy_mode(&cli.bros, "bros"),
-            hb_encounters: parse_enemy_mode(&cli.hb_encounters, "hb-encounters"),
+            ground: cli.ground,
+            shell: cli.shell,
+            flying: cli.flying,
+            piranhas: cli.piranhas,
+            ghosts: cli.ghosts,
+            thwomps: cli.thwomps,
+            rotodiscs: cli.rotodiscs,
+            cannons: cli.cannons,
+            water: cli.water,
+            bros: cli.bros,
+            hb_encounters: cli.hb_encounters,
             wild_injections: cli.wild_injections,
             starting_lives: cli.starting_lives,
-            starting_items: starting_items.clone(),
+            starting_items,
             skip_rom_validation: cli.skip_rom_validation,
         }
-    };
+    }
+}
 
-    let ext = if cli.patched_rom { "nes" } else { "ips" };
-    let output_path = cli
-        .output
-        .unwrap_or_else(|| PathBuf::from(format!("smb3-rs_{seed}.{ext}")));
-
+/// Print the run summary (seed, flag key, active options, output path) to stderr.
+fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
     eprintln!("SMB3 Randomizer v{}", env!("CARGO_PKG_VERSION"));
     eprintln!("  Seed: {seed}");
     eprintln!("  Flags: {}", options.to_flag_key());
@@ -565,17 +561,35 @@ fn main() {
         PiranhaMode::Wild => "wild",
     });
     if !options.starting_items.is_empty() {
-        let item_names: Vec<&str> = options.starting_items.iter().map(|&id| match id {
-            0x01 => "Mushroom", 0x02 => "Fire Flower", 0x03 => "Super Leaf",
-            0x04 => "Frog Suit", 0x05 => "Tanooki Suit", 0x06 => "Hammer Suit",
-            0x07 => "Cloud", 0x08 => "P-Wing", 0x09 => "Starman",
-            0x0A => "Anchor", 0x0B => "Hammer", 0x0C => "Whistle", 0x0D => "Music Box",
-            0x0E => "Random", 0x0F => "Random (No Whistle)", 0x10 => "Random (Suit Only)",
-            _ => "?",
-        }).collect();
+        let item_names: Vec<&str> =
+            options.starting_items.iter().map(|&id| item_display_name(id)).collect();
         eprintln!("  Starting items: {}", item_names.join(", "));
     }
     eprintln!("  Output:   {}", output_path.display());
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let rom_data = match fs::read(&cli.rom) {
+        Ok(data) => data,
+        Err(e) => {
+            eprintln!("Error reading ROM: {e}");
+            process::exit(1);
+        }
+    };
+
+    let seed = cli.seed.unwrap_or_else(rand::random);
+
+    let options = build_options(&cli);
+
+    let ext = if cli.patched_rom { "nes" } else { "ips" };
+    let output_path = cli
+        .output
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(format!("smb3-rs_{seed}.{ext}")));
+
+    print_summary(&options, seed, &output_path);
 
     // Apply sprite patch before randomization so randomizer writes take priority.
     // --toad applies a bundled IPS first; --sprite-patch layers on top of that.

--- a/src/randomize/beta_tornado.rs
+++ b/src/randomize/beta_tornado.rs
@@ -10,6 +10,7 @@
 //! must run *after* `enemies::randomize` so the forced Tornado is final.
 
 use rand::Rng;
+use rand::seq::IndexedRandom;
 
 use crate::rom::Rom;
 
@@ -33,7 +34,7 @@ const TORNADO_Y_BYTE: u8 = 0x12;
 /// there is no reason to touch it. Only the id and y (height) bytes change; the
 /// screen/column byte is preserved from the replaced Fire Chomp.
 pub fn randomize_beta9_tornado<R: Rng>(rom: &mut Rom, rng: &mut R) {
-    let id_offset = BETA9_FIRE_CHOMP_OFFSETS[rng.random_range(..BETA9_FIRE_CHOMP_OFFSETS.len())];
+    let id_offset = *BETA9_FIRE_CHOMP_OFFSETS.choose(rng).unwrap();
     rom.write_byte(id_offset, TORNADO_ID);
     rom.write_byte(id_offset + 2, TORNADO_Y_BYTE);
 }

--- a/src/randomize/bowser_castle.rs
+++ b/src/randomize/bowser_castle.rs
@@ -118,27 +118,25 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R) {
 fn pick_fireball_x<R: Rng>(anchors: &[u8], rng: &mut R) -> u8 {
     // Build gap intervals: virtual boundaries at SEG_X_MIN - MIN_X_GAP and
     // SEG_X_MAX + MIN_X_GAP so the actual usable range is [SEG_X_MIN..=SEG_X_MAX].
+    let sentinel = SEG_X_MAX.saturating_add(MIN_X_GAP);
     let mut prev = SEG_X_MIN.saturating_sub(MIN_X_GAP);
-    let mut best: Option<(u8, u8, u32)> = None;  // (lo, hi, size)
-
-    let consider = |lo_raw: u8, hi_raw: u8, best: &mut Option<(u8, u8, u32)>| {
-        let lo = lo_raw.saturating_add(MIN_X_GAP).max(SEG_X_MIN);
-        let hi = hi_raw.saturating_sub(MIN_X_GAP).min(SEG_X_MAX);
+    let mut gaps: Vec<(u8, u8)> = Vec::new(); // usable (lo, hi) intervals
+    for &a in anchors.iter().chain(std::iter::once(&sentinel)) {
+        let lo = prev.saturating_add(MIN_X_GAP).max(SEG_X_MIN);
+        let hi = a.saturating_sub(MIN_X_GAP).min(SEG_X_MAX);
         if hi >= lo {
-            let size = (hi - lo + 1) as u32;
-            if best.is_none_or(|(_, _, s)| size > s) {
-                *best = Some((lo, hi, size));
-            }
+            gaps.push((lo, hi));
         }
-    };
-
-    for &a in anchors {
-        consider(prev, a, &mut best);
         prev = a;
     }
-    consider(prev, SEG_X_MAX.saturating_add(MIN_X_GAP), &mut best);
 
-    let (lo, hi, _) = best.expect("bowser_castle: no fireball gap available");
+    // Widest gap wins; ties keep the leftmost gap (`rev()` turns max_by_key's
+    // last-max-wins tie rule into first-max-wins in original order).
+    let &(lo, hi) = gaps
+        .iter()
+        .rev()
+        .max_by_key(|(lo, hi)| hi - lo)
+        .expect("bowser_castle: no fireball gap available");
     rng.random_range(lo..=hi)
 }
 

--- a/src/randomize/enemies/class_modes.rs
+++ b/src/randomize/enemies/class_modes.rs
@@ -85,19 +85,63 @@ impl ClassModes {
     }
 }
 
+/// A classified enemy's swap pool. The kind is explicit because callers pick
+/// differently per kind: `Wild` draws from the caller's wild pool with the
+/// uniform CHR-aware pick, the two piranha kinds use their self-contained
+/// category-equal strategies, and `Class` is a plain within-class pool.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) enum ClassPool {
+    /// The global wild pool (union of Wild-mode classes). Its members are
+    /// built per-Options at runtime, so callers supply the slice.
+    Wild,
+    /// Self-contained standard-piranha wild pool ([`PIRANHAS_WILD`]).
+    PiranhaStd,
+    /// Self-contained ceiling-piranha wild pool ([`PIRANHASC_WILD`]).
+    PiranhaCeil,
+    /// A plain class pool: Shuffle mode, or a self-contained Wild class
+    /// (cannons).
+    Class(&'static [u8]),
+}
+
+impl ClassPool {
+    /// The pool members. `wild_pool` supplies the `Wild` variant's slice;
+    /// the other variants ignore it.
+    pub(super) fn slice(self, wild_pool: &[u8]) -> &[u8] {
+        match self {
+            ClassPool::Wild => wild_pool,
+            ClassPool::PiranhaStd => PIRANHAS_WILD,
+            ClassPool::PiranhaCeil => PIRANHASC_WILD,
+            ClassPool::Class(class) => class,
+        }
+    }
+}
+
+/// Whether the walker's Pass 1 should pre-commit this object's CHR page
+/// before replacements are picked: non-swappable objects (except Boom-Booms,
+/// which are swapped separately via `BOOMBOOM_SWAP`) and uniform-CHR classes
+/// (every member shares the page/slot, so a swap can't change it). Wild
+/// entries never pre-commit — their page is decided by the pick itself.
+pub(super) fn should_precommit(obj_id: u8, modes: &ClassModes) -> bool {
+    match find_class_pool(obj_id, modes) {
+        None => !BOOMBOOM_IDS.contains(&obj_id),
+        Some(ClassPool::Wild) => false,
+        Some(ClassPool::PiranhaStd) => is_uniform_chr_class(PIRANHAS_WILD),
+        Some(ClassPool::PiranhaCeil) => is_uniform_chr_class(PIRANHASC_WILD),
+        Some(ClassPool::Class(class)) => is_uniform_chr_class(class),
+    }
+}
+
 /// Identify which class an enemy ID belongs to, and return the swap pool
 /// based on that class's mode. Returns None if the class is Off or unknown.
-pub(super) fn find_class_pool<'a>(
-    id: u8, modes: &ClassModes, wild_pool: &'a [u8],
-) -> Option<&'a [u8]> {
+pub(super) fn find_class_pool(id: u8, modes: &ClassModes) -> Option<ClassPool> {
     // Macro to check class membership and return appropriate pool
     macro_rules! check {
         ($ids:expr, $mode:expr) => {
             if $ids.contains(&id) {
                 return match $mode {
                     EnemyMode::Off => None,
-                    EnemyMode::Shuffle => Some($ids),
-                    EnemyMode::Wild => Some(wild_pool),
+                    EnemyMode::Shuffle => Some(ClassPool::Class($ids)),
+                    EnemyMode::Wild => Some(ClassPool::Wild),
                 };
             }
         };
@@ -115,18 +159,18 @@ pub(super) fn find_class_pool<'a>(
         return match modes.piranhas {
             EnemyMode::Off => None,
             EnemyMode::Shuffle => {
-                if PIRANHAS.contains(&id) { Some(PIRANHAS) } else { None }
+                if PIRANHAS.contains(&id) { Some(ClassPool::Class(PIRANHAS)) } else { None }
             }
-            EnemyMode::Wild => Some(PIRANHAS_WILD),
+            EnemyMode::Wild => Some(ClassPool::PiranhaStd),
         };
     }
     if PIRANHASC.contains(&id) || id == FIREJET_DOWN {
         return match modes.piranhas {
             EnemyMode::Off => None,
             EnemyMode::Shuffle => {
-                if PIRANHASC.contains(&id) { Some(PIRANHASC) } else { None }
+                if PIRANHASC.contains(&id) { Some(ClassPool::Class(PIRANHASC)) } else { None }
             }
-            EnemyMode::Wild => Some(PIRANHASC_WILD),
+            EnemyMode::Wild => Some(ClassPool::PiranhaCeil),
         };
     }
 
@@ -145,8 +189,10 @@ pub(super) fn find_class_pool<'a>(
             if sub.contains(&id) {
                 return match modes.cannons {
                     EnemyMode::Off => None,
-                    EnemyMode::Shuffle => Some(sub), // stay within sub-class
-                    EnemyMode::Wild => Some(ALL_CANNONS), // any cfire → any cfire
+                    // stay within sub-class
+                    EnemyMode::Shuffle => Some(ClassPool::Class(sub)),
+                    // any cfire → any cfire
+                    EnemyMode::Wild => Some(ClassPool::Class(ALL_CANNONS)),
                 };
             }
         }

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -35,18 +35,7 @@ pub fn enemy_entry_points(rom: &Rom) -> Vec<u16> {
                     i += 1;
                     break;
                 }
-                let b0 = data[i];
-                let b2 = data[i + 2];
-                let is_fixed = (b2 & 0xF0) == 0;
-                let mut cmd_size = 3;
-                if !is_fixed {
-                    let grp = (b0 >> 5) as usize;
-                    let dispatch = grp * 15 + ((b2 >> 4) as usize) - 1;
-                    if region.extra_byte_dispatches.contains(&(dispatch as u8)) {
-                        cmd_size = 4;
-                    }
-                }
-                i += cmd_size;
+                i += region.command_size(data[i], data[i + 2]);
             }
         }
     }
@@ -72,7 +61,6 @@ pub(super) fn inject_at_entry_points<R: Rng>(
     rng: &mut R,
 ) {
     let normal_modes = ClassModes::from_options(opts);
-    let normal_wild_pool = normal_modes.build_wild_pool();
 
     for &ep_u16 in entry_ptrs {
         let ep = ep_u16 as usize;
@@ -124,21 +112,14 @@ pub(super) fn inject_at_entry_points<R: Rng>(
 
         let entry = &entries[0];
         let fo = ENEMY_DATA_START + entry.data_index;
-        // Skip if the walker pass would override or filter our pick: the four
-        // force-* rules silently replace the injected enemy with a class pool
-        // member (e.g. 6-5's shell at 0xC5EB must stay shell for brick-break
-        // progression), and ExcludeHazards would filter a Lakitu/Boss Bass
-        // back out (e.g. 7F2's Boom-Boom arena).
-        let class_protected = matches!(
-            entry_protection_at(fo),
-            Some(EntryProtection::SkipSwap
-                | EntryProtection::ForceShell
-                | EntryProtection::ForceStompable
-                | EntryProtection::ForceTankBro
-                | EntryProtection::ExcludeHazards)
-        );
-        let swappable = !class_protected
-            && find_class_pool(entry.obj_id, &normal_modes, &normal_wild_pool).is_some();
+        // Skip if the walker pass would override or filter our pick: every
+        // protection either keeps the vanilla enemy (SkipSwap), silently
+        // replaces the injected enemy with a forced-pool member (e.g. 6-5's
+        // shell at 0xC5EB must stay shell for brick-break progression), or
+        // filters a Lakitu/Boss Bass back out (ExcludeHazards, e.g. 7F2's
+        // Boom-Boom arena).
+        let swappable = entry_protection_at(fo).is_none()
+            && find_class_pool(entry.obj_id, &normal_modes).is_some();
         if !swappable {
             continue;
         }
@@ -148,12 +129,7 @@ pub(super) fn inject_at_entry_points<R: Rng>(
         let mut s4 = ChrSlot::Free;
         let mut s5 = ChrSlot::Free;
         for e in &entries[1..] {
-            let should_precommit = match find_class_pool(e.obj_id, &normal_modes, &normal_wild_pool) {
-                None => !BOOMBOOM_IDS.contains(&e.obj_id),
-                Some(pool) if std::ptr::eq(pool, normal_wild_pool.as_slice()) => false,
-                Some(class) => is_uniform_chr_class(class),
-            };
-            if should_precommit {
+            if should_precommit(e.obj_id, &normal_modes) {
                 commit_chr_page(e.obj_id, &mut s4, &mut s5);
             }
         }

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -88,10 +88,9 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         skip_ranges.iter().find(|r| r.contains(&idx)).map(|r| r.end)
     };
 
-    // Build class modes, wild pool, and pre-bucketed page groups
+    // Build class modes and wild pools
     let normal_modes = ClassModes::from_options(opts);
     let normal_wild_pool = normal_modes.build_wild_pool();
-    let normal_page_buckets = PageBuckets::build(&normal_wild_pool);
     let hb_modes = hb_class_modes(opts.hb_encounters);
     let hb_wild_pool = hb_modes.build_wild_pool();
 
@@ -133,10 +132,10 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         }
 
         let is_hb_segment = segment_rule == WalkerSegmentRule::HammerBro;
-        let (modes, wild_pool, page_buckets) = if is_hb_segment {
-            (&hb_modes, hb_wild_pool.as_slice(), &normal_page_buckets) // HB uses own wild path
+        let (modes, wild_pool) = if is_hb_segment {
+            (&hb_modes, hb_wild_pool.as_slice()) // HB Wild is batch-handled below
         } else {
-            (&normal_modes, normal_wild_pool.as_slice(), &normal_page_buckets)
+            (&normal_modes, normal_wild_pool.as_slice())
         };
 
         // Collect all entries in this segment
@@ -152,7 +151,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
 
         // HB Wild: batch-assign enemies with stompability constraints.
         if is_hb_segment && opts.hb_encounters == EnemyMode::Wild && !big_q_only {
-            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, &hb_wild_pool, rng);
+            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, rng);
             continue;
         }
 
@@ -180,25 +179,16 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
             if !big_q_only {
                 for &idx in group {
                     let entry = &entries[idx];
-                    let should_precommit = match find_class_pool(entry.obj_id, modes, wild_pool) {
-                        None => !BOOMBOOM_IDS.contains(&entry.obj_id),
-                        Some(pool) if std::ptr::eq(pool, wild_pool) => false,
-                        Some(class) => is_uniform_chr_class(class),
-                    };
-                    if should_precommit {
+                    if should_precommit(entry.obj_id, modes) {
                         commit_chr_page(entry.obj_id, &mut committed_slot4, &mut committed_slot5);
                     }
                 }
             }
 
-            // Pass 2: pick a replacement for each swappable entry.
-            //
-            // Every entry funnels through one shape: choose a base pool + a
-            // primary (CHR-aware) pick, then filter through the placement
-            // constraints before committing. Applying the constraints uniformly
-            // — instead of only in the wild-swap branch — is what makes the
-            // bertha cap (and the giant-red / piranha-hazard guards) cover the
-            // Force*/ExcludeHazards paths too.
+            // Pass 2: pick a replacement for each swappable entry. The
+            // per-entry decision (pool choice, primary pick, placement
+            // constraints) lives in `pick_replacement`; this loop handles the
+            // special-cased swaps and the segment-level bookkeeping.
             for &idx in group {
                 let entry = &entries[idx];
                 let file_offset = ENEMY_DATA_START + entry.data_index;
@@ -222,103 +212,24 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                     continue;
                 }
 
-                // Base pool + primary pick. A pool-replacing protection
-                // (ForceShell/TankBro/Stompable/ExcludeHazards) chooses the pool;
-                // otherwise it's the normal class pool, picked via the
-                // wild/piranha/plain strategy. `None` => no swap for this entry.
-                let picked: Option<(Option<u8>, Cow<[u8]>)> = match protection {
-                    Some(EntryProtection::ForceShell) if modes.shell != EnemyMode::Off => Some((
-                        pick_compatible(SHELL_ENEMIES, committed_slot4, committed_slot5, rng),
-                        Cow::Borrowed(SHELL_ENEMIES),
-                    )),
-                    Some(EntryProtection::ForceTankBro) if modes.bros != EnemyMode::Off => Some((
-                        pick_compatible(TANK_BRO_POOL, committed_slot4, committed_slot5, rng),
-                        Cow::Borrowed(TANK_BRO_POOL),
-                    )),
-                    Some(EntryProtection::ForceStompable) => {
-                        find_class_pool(entry.obj_id, modes, wild_pool).map(|pool| {
-                            let sp: Vec<u8> = pool.iter().copied()
-                                .filter(|id| STOMPABLE_ENEMIES.contains(id)).collect();
-                            let pick = pick_compatible(&sp, committed_slot4, committed_slot5, rng);
-                            (pick, Cow::Owned(sp))
-                        })
-                    }
-                    Some(EntryProtection::ExcludeHazards) => {
-                        find_class_pool(entry.obj_id, modes, wild_pool).map(|pool| {
-                            // Drop hazards, but keep any of the same category as the
-                            // vanilla enemy here (additive-only: don't strip a
-                            // designed-in hazard, only block introducing a new one).
-                            let fp: Vec<u8> = pool.iter().copied()
-                                .filter(|&id| !hazard_excluded(id, entry.obj_id)).collect();
-                            let pick = pick_compatible(&fp, committed_slot4, committed_slot5, rng);
-                            (pick, Cow::Owned(fp))
-                        })
-                    }
-                    _ => find_class_pool(entry.obj_id, modes, wild_pool).map(|pool| {
-                        let pick = if std::ptr::eq(pool, wild_pool) {
-                            page_buckets.pick(committed_slot4, committed_slot5, rng)
-                        } else if std::ptr::eq(pool, PIRANHAS_WILD) {
-                            // Category-equal: piranha / upward jet / wrench each
-                            // get a uniform turn. Giant red (0x7F) only when this
-                            // slot already held one (keep filter covers the rest).
-                            let bucket: &[u8] = if entry.obj_id == GIANT_RED_PIRANHA {
-                                PIRANHAS
-                            } else {
-                                PIRANHAS_NO_RED
-                            };
-                            pick_bucket_first(&[bucket, BUCKET_UP_JET, BUCKET_WRENCH],
-                                committed_slot4, committed_slot5, rng)
-                        } else if std::ptr::eq(pool, PIRANHASC_WILD) {
-                            pick_bucket_first(&[PIRANHASC, BUCKET_DOWN_JET],
-                                committed_slot4, committed_slot5, rng)
-                        } else {
-                            pick_compatible(pool, committed_slot4, committed_slot5, rng)
-                        };
-                        (pick, Cow::Borrowed(pool))
-                    }),
-                };
-                let Some((primary, base_pool)) = picked else {
-                    continue; // protection mode off, or not a known class: no swap
-                };
-
-                // Placement constraints, applied to every pick. `keep(id)` is
-                // true when `id` is allowed in this slot.
                 let was_bertha = BERTHA_IDS.contains(&data[entry.data_index]);
                 let cap_full = bertha_count.saturating_sub(was_bertha as u8)
                     >= MAX_BERTHA_PER_SEGMENT;
-                let keep = |id: u8| -> bool {
-                    // Big Bertha cap: no new bertha once the segment is full.
-                    let over_cap = cap_full && BERTHA_IDS.contains(&id);
-                    // Giant red piranha (off-center hitbox) only where one was.
-                    let bad_giant = id == GIANT_RED_PIRANHA && entry.obj_id != GIANT_RED_PIRANHA;
-                    !(over_cap || bad_giant)
-                };
-                // (A piranha slot can't become a hazard: the piranha pools are
-                // self-contained and contain none — verified by the harness's
-                // piranha-hazard invariant, so no explicit guard is needed.)
-
-                // Accept the primary pick if it satisfies every constraint;
-                // otherwise re-pick once from the base pool filtered by all of
-                // them, so the constraints compose instead of undoing each other.
-                let chosen = match primary {
-                    Some(id) if keep(id) => Some(id),
-                    _ => {
-                        let filtered: Vec<u8> =
-                            base_pool.iter().copied().filter(|&id| keep(id)).collect();
-                        pick_compatible(&filtered, committed_slot4, committed_slot5, rng)
-                    }
+                let Some(chosen) = pick_replacement(
+                    entry, protection, modes, wild_pool,
+                    (committed_slot4, committed_slot5), cap_full, rng,
+                ) else {
+                    continue; // protection mode off, or not a known class: no swap
                 };
 
-                if let Some(chosen) = chosen {
-                    let chosen_is_bertha = BERTHA_IDS.contains(&chosen);
-                    if was_bertha && !chosen_is_bertha {
-                        bertha_count = bertha_count.saturating_sub(1);
-                    } else if !was_bertha && chosen_is_bertha {
-                        bertha_count = bertha_count.saturating_add(1);
-                    }
-                    swap_enemy(&mut data, entry.data_index, chosen);
-                    commit_chr_page(chosen, &mut committed_slot4, &mut committed_slot5);
+                let chosen_is_bertha = BERTHA_IDS.contains(&chosen);
+                if was_bertha && !chosen_is_bertha {
+                    bertha_count = bertha_count.saturating_sub(1);
+                } else if !was_bertha && chosen_is_bertha {
+                    bertha_count = bertha_count.saturating_add(1);
                 }
+                swap_enemy(&mut data, entry.data_index, chosen);
+                commit_chr_page(chosen, &mut committed_slot4, &mut committed_slot5);
             }
 
         }

--- a/src/randomize/enemies/picking.rs
+++ b/src/randomize/enemies/picking.rs
@@ -1,5 +1,6 @@
-//! Enemy-pick mechanics: CHR-compatible random selection, the per-segment
-//! page buckets, and the position-correcting swap writer.
+//! Enemy-pick mechanics: CHR-compatible random selection, category-equal
+//! bucket picking, the per-entry replacement decision, and the
+//! position-correcting swap writer.
 
 use super::*;
 
@@ -19,7 +20,9 @@ pub(super) fn piranha_pool_y_offset(id: u8) -> i8 {
 /// Write `new_id` into the enemy slot at `id_index` and nudge Y so the
 /// replacement lines up with the slot. Bundles the write + adjustment so call
 /// sites can't forget one. Adjustments:
-/// - Tall replacements get Y−1 to avoid floor clipping.
+/// - Tall replacements get Y−1 to avoid floor clipping. Note this keys off the
+///   *new* id only — a tall→tall swap (e.g. bro↔bro) also rises one row,
+///   unlike the delta-based jet shift below.
 /// - Fire jets self-position differently than a piranha/wrench, so Y shifts by
 ///   `offset(new) − offset(old)` (see `piranha_pool_y_offset`). This is
 ///   symmetric: a jet replacing a piranha/wrench rises/drops, and a piranha or
@@ -65,58 +68,103 @@ pub(super) fn pick_bucket_first<R: Rng>(
     pick_compatible(bucket, slot4, slot5, rng)
 }
 
-/// Pre-built page buckets for page-first picking. Built once per segment,
-/// reused for every Wild enemy in that segment.
-pub(super) struct PageBuckets {
-    /// Each entry is (slot, page, enemy_ids). No-bank enemies are appended to every bucket.
-    buckets: Vec<Vec<u8>>,
-}
-
-impl PageBuckets {
-    /// Build buckets from the wild pool. Groups enemies by (slot, chr_page);
-    /// no-bank enemies are added to every bucket so they don't get their own.
-    pub(super) fn build(pool: &[u8]) -> Self {
-        let mut map: Vec<((u8, u8), Vec<u8>)> = Vec::new();
-        let mut no_bank: Vec<u8> = Vec::new();
-        for &id in pool {
-            match sprite_bank(id) {
-                Some(sb) => {
-                    let key = (sb.slot, sb.chr_page);
-                    if let Some(entry) = map.iter_mut().find(|(k, _)| *k == key) {
-                        entry.1.push(id);
+/// Decide the replacement enemy for one swappable walker entry, or `None` to
+/// leave it unchanged. Callers handle Big ? blocks, Boom-Booms, and SkipSwap
+/// before calling; bertha bookkeeping and the actual write stay with them too.
+///
+/// Every entry funnels through one shape: choose a base pool + a primary
+/// (CHR-aware) pick, then filter through the placement constraints before
+/// committing. Applying the constraints uniformly — instead of only in the
+/// wild-swap branch — is what makes the bertha cap (and the giant-red /
+/// piranha-hazard guards) cover the Force*/ExcludeHazards paths too.
+pub(super) fn pick_replacement<R: Rng>(
+    entry: &SegmentEntry,
+    protection: Option<EntryProtection>,
+    modes: &ClassModes,
+    wild_pool: &[u8],
+    (slot4, slot5): (ChrSlot, ChrSlot),
+    cap_full: bool,
+    rng: &mut R,
+) -> Option<u8> {
+    // Base pool + primary pick. A pool-replacing protection
+    // (ForceShell/TankBro/Stompable/ExcludeHazards) chooses the pool;
+    // otherwise it's the normal class pool, picked via the
+    // wild/piranha/plain strategy. `None` => no swap for this entry.
+    let picked: Option<(Option<u8>, Cow<[u8]>)> = match protection {
+        Some(EntryProtection::ForceShell) if modes.shell != EnemyMode::Off => Some((
+            pick_compatible(SHELL_ENEMIES, slot4, slot5, rng),
+            Cow::Borrowed(SHELL_ENEMIES),
+        )),
+        Some(EntryProtection::ForceTankBro) if modes.bros != EnemyMode::Off => Some((
+            pick_compatible(TANK_BRO_POOL, slot4, slot5, rng),
+            Cow::Borrowed(TANK_BRO_POOL),
+        )),
+        Some(EntryProtection::ForceStompable) => {
+            find_class_pool(entry.obj_id, modes).map(|pool| {
+                let sp: Vec<u8> = pool.slice(wild_pool).iter().copied()
+                    .filter(|id| STOMPABLE_ENEMIES.contains(id)).collect();
+                let pick = pick_compatible(&sp, slot4, slot5, rng);
+                (pick, Cow::Owned(sp))
+            })
+        }
+        Some(EntryProtection::ExcludeHazards) => {
+            find_class_pool(entry.obj_id, modes).map(|pool| {
+                // Drop hazards, but keep any of the same category as the
+                // vanilla enemy here (additive-only: don't strip a
+                // designed-in hazard, only block introducing a new one).
+                let fp: Vec<u8> = pool.slice(wild_pool).iter().copied()
+                    .filter(|&id| !hazard_excluded(id, entry.obj_id)).collect();
+                let pick = pick_compatible(&fp, slot4, slot5, rng);
+                (pick, Cow::Owned(fp))
+            })
+        }
+        _ => find_class_pool(entry.obj_id, modes).map(|pool| {
+            let pick = match pool {
+                ClassPool::Wild => pick_compatible(wild_pool, slot4, slot5, rng),
+                ClassPool::PiranhaStd => {
+                    // Category-equal: piranha / upward jet / wrench each
+                    // get a uniform turn. Giant red (0x7F) only when this
+                    // slot already held one (keep filter covers the rest).
+                    let bucket: &[u8] = if entry.obj_id == GIANT_RED_PIRANHA {
+                        PIRANHAS
                     } else {
-                        map.push((key, vec![id]));
-                    }
+                        PIRANHAS_NO_RED
+                    };
+                    pick_bucket_first(&[bucket, BUCKET_UP_JET, BUCKET_WRENCH],
+                        slot4, slot5, rng)
                 }
-                None => no_bank.push(id),
-            }
-        }
-        if !no_bank.is_empty() {
-            for (_, bucket) in &mut map {
-                bucket.extend_from_slice(&no_bank);
-            }
-        }
-        PageBuckets { buckets: map.into_iter().map(|(_, v)| v).collect() }
-    }
+                ClassPool::PiranhaCeil => {
+                    pick_bucket_first(&[PIRANHASC, BUCKET_DOWN_JET], slot4, slot5, rng)
+                }
+                ClassPool::Class(class) => pick_compatible(class, slot4, slot5, rng),
+            };
+            (pick, Cow::Borrowed(pool.slice(wild_pool)))
+        }),
+    };
+    let (primary, base_pool) = picked?;
 
-    /// Pick a CHR-compatible enemy uniformly from the union of all buckets.
-    ///
-    /// Previously this picked a bucket uniformly *then* a member uniformly,
-    /// which gave any enemy alone in its (slot, chr_page) bucket a full
-    /// 1/N_buckets share of all draws — e.g. LavaLotus and DryBones each
-    /// occupied ~8% of the wild pool (chr_stats baseline at beta.5),
-    /// dominating every Wild seed.
-    ///
-    /// Flattening compatible members across all buckets and picking
-    /// uniformly gives each compatible enemy equal weight per draw.
-    /// Singletons drop to ~1/N_pool share. CHR-popular pages still see
-    /// more total picks (because more members live in them), but no one
-    /// enemy can outsize the pool.
-    pub(super) fn pick<R: Rng>(&self, slot4: ChrSlot, slot5: ChrSlot, rng: &mut R) -> Option<u8> {
-        let candidates: Vec<u8> = self.buckets.iter()
-            .flat_map(|b| b.iter().copied())
-            .filter(|&id| is_chr_compatible(id, slot4, slot5))
-            .collect();
-        candidates.choose(rng).copied()
+    // Placement constraints, applied to every pick. `keep(id)` is
+    // true when `id` is allowed in this slot.
+    let keep = |id: u8| -> bool {
+        // Big Bertha cap: no new bertha once the segment is full.
+        let over_cap = cap_full && BERTHA_IDS.contains(&id);
+        // Giant red piranha (off-center hitbox) only where one was.
+        let bad_giant = id == GIANT_RED_PIRANHA && entry.obj_id != GIANT_RED_PIRANHA;
+        !(over_cap || bad_giant)
+    };
+    // (A piranha slot can't become a hazard: the piranha pools are
+    // self-contained and contain none — verified by the harness's
+    // piranha-hazard invariant, so no explicit guard is needed.)
+
+    // Accept the primary pick if it satisfies every constraint;
+    // otherwise re-pick once from the base pool filtered by all of
+    // them, so the constraints compose instead of undoing each other.
+    match primary {
+        Some(id) if keep(id) => Some(id),
+        _ => {
+            let filtered: Vec<u8> =
+                base_pool.iter().copied().filter(|&id| keep(id)).collect();
+            pick_compatible(&filtered, slot4, slot5, rng)
+        }
     }
 }

--- a/src/randomize/enemies/segments.rs
+++ b/src/randomize/enemies/segments.rs
@@ -37,18 +37,18 @@ pub(super) fn chr_groups(entries: &[SegmentEntry]) -> Vec<Vec<usize>> {
 
 /// HB Wild segment randomization with stompability constraints.
 /// 1-enemy segments: pick from STOMPABLE_ENEMIES only.
-/// 2-enemy segments: 5/31 chance for non-stompable path (one from
-/// HB_NEEDS_SHELL_ENEMIES + one from SHELL_ENEMIES), otherwise both stompable.
+/// 2-enemy segments: `HB_NONSTOMPABLE_ODDS` chance for the non-stompable path
+/// (one from HB_NEEDS_SHELL_ENEMIES + one from SHELL_ENEMIES), otherwise both
+/// stompable.
 pub(super) fn randomize_hb_wild_segment<R: Rng>(
     data: &mut [u8],
     entries: &[SegmentEntry],
     hb_modes: &ClassModes,
-    hb_wild_pool: &[u8],
     rng: &mut R,
 ) {
     let swappable: Vec<usize> = entries.iter()
         .enumerate()
-        .filter(|(_, e)| find_class_pool(e.obj_id, hb_modes, hb_wild_pool).is_some())
+        .filter(|(_, e)| find_class_pool(e.obj_id, hb_modes).is_some())
         .map(|(idx, _)| idx)
         .collect();
 
@@ -66,8 +66,9 @@ pub(super) fn randomize_hb_wild_segment<R: Rng>(
             swap_enemy(data, entries[swappable[0]].data_index, chosen);
         }
     } else if swappable.len() == 2 {
-        // Roll whether this segment gets a non-stompable enemy (5/31 ≈ 16%)
-        if rng.random_range(..31u32) < 5 {
+        // Roll whether this segment gets a non-stompable enemy
+        let (num, den) = HB_NONSTOMPABLE_ODDS;
+        if rng.random_range(..den) < num {
             // Pick non-stompable, then a shell partner
             if let Some(ns) = pick_compatible(HB_NEEDS_SHELL_ENEMIES, slot4, slot5, rng) {
                 let mut s4 = slot4;

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -114,13 +114,7 @@ pub(super) const FIREJET_DOWN_Y_DROP: u8 = 1;
 /// upward fire jet. In Wild mode piranhas are *self-contained* (parallel to the
 /// cannons model) — they never merge into the global wild pool in either
 /// direction. Removing an extra member is a one-line edit on this list.
-// PIRANHAS_WILD / PIRANHASC_WILD are `static`, not `const`: the object walker
-// classifies find_class_pool's result with `std::ptr::eq` against these slices.
-// A const's promoted backing array has no guaranteed unique address and can be
-// duplicated per codegen-unit once the producer (class_modes) and the comparison
-// (the walker) live in different modules, silently breaking the identity check.
-// `static` guarantees one address, keeping the pointer identity stable.
-pub(super) static PIRANHAS_WILD: &[u8] = &[
+pub(super) const PIRANHAS_WILD: &[u8] = &[
     0x7D, // OBJ_BIGGREENPIRANHA
     0x7F, // OBJ_BIGREDPIRANHA
     0xA0, // OBJ_GREENPIRANHA
@@ -141,7 +135,7 @@ pub(super) const PIRANHASC: &[u8] = &[
 
 /// Wild-mode ceiling pool: the ceiling piranhas plus the downward fire jet.
 /// Self-contained (no crossover to the standard pool).
-pub(super) static PIRANHASC_WILD: &[u8] = &[
+pub(super) const PIRANHASC_WILD: &[u8] = &[
     0xA1, // OBJ_GREENPIRANHA_FLIPPED
     0xA3, // OBJ_REDPIRANHA_FLIPPED
     0xA5, // OBJ_GREENPIRANHA_FIREC
@@ -323,22 +317,6 @@ pub(super) const GHOST_ENEMIES: &[u8] = &[
     0x45, // OBJ_HOTFOOT (Hot Foot, walks on floor)
 ];
 
-// ---------------------------------------------------------------------------
-// CHR sprite bank data — extracted from ROM PatTableSel tables
-// (PRG001–PRG005, each at bank offset +0x144)
-// ---------------------------------------------------------------------------
-//
-// Each object requests a 1KB CHR page be loaded into one of two sprite bank
-// slots: PatTable_BankSel+4 (PPU $1800-$1BFF) or +5 (PPU $1C00-$1FFF).
-// If two on-screen objects request different CHR pages for the same slot,
-// one renders with garbled sprites (the last one rendered wins).
-//
-// We track CHR page commitments per enemy data segment (= one sub-area)
-// and only allow swaps that are compatible with already-committed pages.
-// The two-pass approach pre-commits CHR from ALL non-swappable objects
-// before randomizing swappable enemies, preventing ordering-dependent bugs.
-
-
 /// Big ? Block IDs — these can be swapped with each other to randomize
 /// which suit/powerup the player gets from Big ? Blocks.
 pub(super) const BIG_Q_BLOCKS: &[u8] = &[
@@ -356,8 +334,6 @@ pub(super) const BIG_Q_BLOCKS: &[u8] = &[
 /// The W7 room is at enemy_ptr 0xC9A3; the Tanooki is the second entry.
 pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
-
-
 /// Injection candidates for wild_injections mode: special enemies injected after
 /// normal swaps. CHR compatibility checked via `sprite_bank()` at filter time.
 pub(super) const WILD_INJECTION_IDS: &[u8] = &[
@@ -369,6 +345,11 @@ pub(super) const WILD_INJECTION_IDS: &[u8] = &[
 /// Probability (out of 256) that a segment will receive an injection when wild_injections is on.
 /// ~15% chance per segment.
 pub(super) const WILD_INJECTION_CHANCE: u8 = 38;
+
+/// Odds (numerator, denominator) that a 2-enemy HB wild segment takes the
+/// non-stompable path (one HB_NEEDS_SHELL enemy + one shell partner) instead
+/// of two stompables. 5/31 ≈ 16%.
+pub(super) const HB_NONSTOMPABLE_ODDS: (u32, u32) = (5, 31);
 
 /// Large "Big Bertha" fish that exhaust sprite slots when stacked: the leaping
 /// eater (0x2D, the injected "Boss Bass") and the cheep-spitting birther (0x63).

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -7,6 +7,25 @@
         Options::default()
     }
 
+    /// A blank 393,232-byte ROM image with a valid iNES header
+    /// (16 PRG pages, 16 CHR pages, mapper 4).
+    fn blank_rom_image() -> Vec<u8> {
+        let mut data = vec![0u8; 393232];
+        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
+        data[4] = 16;
+        data[5] = 16;
+        data[6] = 0x40;
+        data
+    }
+
+    /// A blank ROM with `seg` copied to ENEMY_DATA_START — the standard
+    /// fixture for walker tests that need one synthetic enemy segment.
+    fn rom_with_segment(seg: &[u8]) -> Rom {
+        let mut data = blank_rom_image();
+        data[ENEMY_DATA_START..ENEMY_DATA_START + seg.len()].copy_from_slice(seg);
+        Rom::from_bytes_lax(&data, true).unwrap()
+    }
+
     /// Install a synthetic 9-byte level header at the start of the Plains
     /// region whose `enemy_ptr` (header bytes 2-3) equals `ep`, followed
     /// by an immediate `0xFF` terminator. Used by wild-injection tests so
@@ -26,18 +45,10 @@
     }
 
     fn make_test_rom() -> Rom {
-        let mut data = vec![0u8; 393232];
-        // iNES header
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16; // PRG pages
-        data[5] = 16; // CHR pages
-        data[6] = 0x40; // mapper flags
-
-        // Set up a realistic enemy data segment at ENEMY_DATA_START:
-        // FF terminator, then a segment with page flag + entries + FF.
-        // Entries MUST be sorted by ascending X (real SMB3 format
-        // requirement, enforced by segment_writer).
-        let seg = &[
+        // A realistic enemy data segment: FF terminator, then a segment with
+        // page flag + entries + FF. Entries MUST be sorted by ascending X
+        // (real SMB3 format requirement, enforced by segment_writer).
+        rom_with_segment(&[
             0xFF, // leading terminator
             0x01, // page flag
             0x72, 0x0E, 0x19, // Goomba at (0x0E, 0x19)
@@ -46,11 +57,7 @@
             0x41, 0xA8, 0x15, // End Level Card at (0xA8, 0x15) — must not change
             0xD3, 0xC0, 0x50, // Autoscroll at (0xC0, 0x50) — must not change
             0xFF, // terminator
-        ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-
-        Rom::from_bytes_lax(&data, true).unwrap()
+        ])
     }
 
     #[test]
@@ -122,11 +129,7 @@
     }
 
     fn make_bigq_test_rom() -> Rom {
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
+        let mut data = blank_rom_image();
 
         // Pre-fill the enemy data region with 0xFF so gaps between fixture
         // segments don't look like one giant collision-prone segment to
@@ -190,12 +193,6 @@
     fn test_chr_compatibility_enforced() {
         // Place a Goomba ($4F/+5) and Dry Bones ($13/+5) in the same segment.
         // After randomization, both must use compatible CHR pages on slot +5.
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01, // page flag
@@ -205,9 +202,7 @@
             0x71, 0x40, 0x19, // Spiny (slot +4, page $0B)
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         // Run many times to exercise different random paths
         for seed in 0..200u64 {
@@ -267,12 +262,6 @@
     fn test_chr_resets_across_segments() {
         // Two segments: first has a Spike ($0A/+4), second has a Spiny ($0B/+4).
         // They should be able to choose independently since they're in different segments.
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,             // page flag
@@ -282,9 +271,7 @@
             0x71, 0x20, 0x19, // Spiny (slot +4, page $0B)
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         // Run many times — Spiny in second segment should freely choose
         // any ground enemy, not be constrained by first segment's Spike.
@@ -332,12 +319,6 @@
 
     #[test]
     fn test_ghost_enemies_stay_in_class() {
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,
@@ -345,9 +326,7 @@
             0x45, 0x20, 0x18, // Hot Foot
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         for seed in 0..100u64 {
             let mut rom_copy = rom.clone();
@@ -365,12 +344,6 @@
     fn test_big_enemies_in_regular_classes() {
         // Big enemies are merged into their regular-sized counterparts' classes:
         // BigGreenTroopa → SHELL_ENEMIES, BigGreenPiranha/BigRedPiranha → PIRANHAS
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,
@@ -379,9 +352,7 @@
             0x7F, 0x30, 0x10, // BigRedPiranha
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         for seed in 0..100u64 {
             let mut rom_copy = rom.clone();
@@ -400,21 +371,13 @@
     /// far-apart piranha slots (separate CHR groups): a regular green piranha
     /// (0xA0) and a giant red (0x7F).
     fn giant_red_test_rom() -> Rom {
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-        let seg = &[
+        rom_with_segment(&[
             0xFF,
             0x01,
             0xA0, 0x10, 0x17, // GreenPiranha — regular slot, X=0x10
             0x7F, 0x60, 0x10, // BigRedPiranha — X=0x60 (separate CHR group)
             0xFF,
-        ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        Rom::from_bytes_lax(&data, true).unwrap()
+        ])
     }
 
     #[test]
@@ -423,24 +386,22 @@
         // untouched. Wild: it joins the standard piranha pool both directions.
         let mut shuffle = ClassModes::from_options(&Options::default());
         shuffle.piranhas = EnemyMode::Shuffle;
-        assert!(find_class_pool(ROCKY_WRENCH, &shuffle, &[]).is_none());
+        assert!(find_class_pool(ROCKY_WRENCH, &shuffle).is_none());
 
         shuffle.piranhas = EnemyMode::Off;
-        assert!(find_class_pool(ROCKY_WRENCH, &shuffle, &[]).is_none());
+        assert!(find_class_pool(ROCKY_WRENCH, &shuffle).is_none());
 
         let mut wild = ClassModes::from_options(&Options::default());
         wild.piranhas = EnemyMode::Wild;
         // Rocky Wrench can become a standard piranha…
-        let pool = find_class_pool(ROCKY_WRENCH, &wild, &[]).expect("wrench wild pool");
-        assert_eq!(pool, PIRANHAS_WILD);
+        assert_eq!(find_class_pool(ROCKY_WRENCH, &wild), Some(ClassPool::PiranhaStd));
         // …and a standard piranha can become Rocky Wrench.
-        let pool = find_class_pool(0xA0, &wild, &[]).expect("piranha wild pool");
-        assert!(pool.contains(&ROCKY_WRENCH));
+        assert_eq!(find_class_pool(0xA0, &wild), Some(ClassPool::PiranhaStd));
+        assert!(PIRANHAS_WILD.contains(&ROCKY_WRENCH));
         // Ceiling piranhas stay self-contained (no Rocky Wrench, no upward jet).
-        let cpool = find_class_pool(0xA1, &wild, &[]).expect("ceiling wild pool");
-        assert_eq!(cpool, PIRANHASC_WILD);
-        assert!(!cpool.contains(&ROCKY_WRENCH));
-        assert!(!cpool.contains(&FIREJET_UP));
+        assert_eq!(find_class_pool(0xA1, &wild), Some(ClassPool::PiranhaCeil));
+        assert!(!PIRANHASC_WILD.contains(&ROCKY_WRENCH));
+        assert!(!PIRANHASC_WILD.contains(&FIREJET_UP));
     }
 
     #[test]
@@ -448,23 +409,25 @@
         // Shuffle / Off: the fire jets belong to no class → untouched.
         let mut shuffle = ClassModes::from_options(&Options::default());
         shuffle.piranhas = EnemyMode::Shuffle;
-        assert!(find_class_pool(FIREJET_UP, &shuffle, &[]).is_none());
-        assert!(find_class_pool(FIREJET_DOWN, &shuffle, &[]).is_none());
+        assert!(find_class_pool(FIREJET_UP, &shuffle).is_none());
+        assert!(find_class_pool(FIREJET_DOWN, &shuffle).is_none());
         shuffle.piranhas = EnemyMode::Off;
-        assert!(find_class_pool(FIREJET_UP, &shuffle, &[]).is_none());
-        assert!(find_class_pool(FIREJET_DOWN, &shuffle, &[]).is_none());
+        assert!(find_class_pool(FIREJET_UP, &shuffle).is_none());
+        assert!(find_class_pool(FIREJET_DOWN, &shuffle).is_none());
 
         let mut wild = ClassModes::from_options(&Options::default());
         wild.piranhas = EnemyMode::Wild;
         // Upward jet ↔ standard pool; downward jet ↔ ceiling pool.
-        assert_eq!(find_class_pool(FIREJET_UP, &wild, &[]).unwrap(), PIRANHAS_WILD);
-        assert_eq!(find_class_pool(FIREJET_DOWN, &wild, &[]).unwrap(), PIRANHASC_WILD);
+        assert_eq!(find_class_pool(FIREJET_UP, &wild), Some(ClassPool::PiranhaStd));
+        assert_eq!(find_class_pool(FIREJET_DOWN, &wild), Some(ClassPool::PiranhaCeil));
         // Standard piranha can become the upward jet; ceiling the downward jet.
-        assert!(find_class_pool(0xA0, &wild, &[]).unwrap().contains(&FIREJET_UP));
-        assert!(find_class_pool(0xA1, &wild, &[]).unwrap().contains(&FIREJET_DOWN));
+        assert_eq!(find_class_pool(0xA0, &wild), Some(ClassPool::PiranhaStd));
+        assert_eq!(find_class_pool(0xA1, &wild), Some(ClassPool::PiranhaCeil));
+        assert!(PIRANHAS_WILD.contains(&FIREJET_UP));
+        assert!(PIRANHASC_WILD.contains(&FIREJET_DOWN));
         // No crossover: up jet never in ceiling pool, down jet never in standard.
-        assert!(!find_class_pool(0xA0, &wild, &[]).unwrap().contains(&FIREJET_DOWN));
-        assert!(!find_class_pool(0xA1, &wild, &[]).unwrap().contains(&FIREJET_UP));
+        assert!(!PIRANHAS_WILD.contains(&FIREJET_DOWN));
+        assert!(!PIRANHASC_WILD.contains(&FIREJET_UP));
     }
 
     #[test]
@@ -520,6 +483,25 @@
     }
 
     #[test]
+    fn wild_pools_are_unions_of_their_parts() {
+        // The hand-restated union constants must stay in sync with the lists
+        // they combine — nothing else enforces this.
+        let mut piranhas_wild: Vec<u8> = PIRANHAS.to_vec();
+        piranhas_wild.extend([ROCKY_WRENCH, FIREJET_UP]);
+        assert_eq!(PIRANHAS_WILD, piranhas_wild.as_slice());
+
+        let mut piranhasc_wild: Vec<u8> = PIRANHASC.to_vec();
+        piranhasc_wild.push(FIREJET_DOWN);
+        assert_eq!(PIRANHASC_WILD, piranhasc_wild.as_slice());
+
+        let mut all_cannons: Vec<u8> = Vec::new();
+        all_cannons.extend_from_slice(CFIRE_LEFT);
+        all_cannons.extend_from_slice(CFIRE_RIGHT);
+        all_cannons.extend_from_slice(CFIRE_BILLS);
+        assert_eq!(ALL_CANNONS, all_cannons.as_slice());
+    }
+
+    #[test]
     fn piranhas_excluded_from_global_wild_pool() {
         // With every class Wild, piranhas (and Rocky Wrench) must NOT appear in
         // the shared wild pool — they're self-contained, so no other class can
@@ -562,12 +544,6 @@
         // A swappable ground enemy (Spike, $0A/+4) appears BEFORE a Boo ($12/+4,
         // uniform ghost class — pre-committed in pass 1). Without two-pass, the
         // Spike could be swapped to something that commits a conflicting slot+4 page.
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,
@@ -576,9 +552,7 @@
             0x2F, 0x20, 0x08, // Boo ($12/+4) — swappable, uniform-CHR class (pre-committed)
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         for seed in 0..500u64 {
             let mut rom_copy = rom.clone();
@@ -611,12 +585,6 @@
         // Boo ($12/+4, uniform ghost class) + ground enemy in same segment.
         // The ground enemy must never commit a conflicting slot+4 page because
         // uniform classes are pre-committed in pass 1.
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,
@@ -624,9 +592,7 @@
             0x2F, 0x20, 0x08, // Boo ($12/+4) — ghost, uniform-CHR
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         for seed in 0..500u64 {
             let mut rom_copy = rom.clone();
@@ -657,12 +623,6 @@
         // Two non-swappable objects with different +4 pages in the same segment.
         // Slot+4 becomes Conflicted, so any swappable enemy needing slot+4 gets
         // no compatible candidates and must keep its original ID.
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,
@@ -671,9 +631,7 @@
             0x29, 0x30, 0x19, // Spike ($0A/+4) — swappable ground enemy
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         for seed in 0..100u64 {
             let mut rom_copy = rom.clone();
@@ -706,8 +664,7 @@
     fn test_kuribo_shoe_in_ground_class() {
         assert!(GROUND_ENEMIES.contains(&0x2B), "Kuribo's Shoe Goomba missing from ground class");
         let modes = ClassModes::from_options(&enemy_opts());
-        let wild_pool = modes.build_wild_pool();
-        assert_eq!(find_class_pool(0x2B, &modes, &wild_pool), Some(GROUND_ENEMIES as &[u8]));
+        assert_eq!(find_class_pool(0x2B, &modes), Some(ClassPool::Class(GROUND_ENEMIES)));
     }
 
     #[test]
@@ -716,9 +673,8 @@
         assert!(!GROUND_ENEMIES.contains(&0x2C), "0x2C (cloud platform) must NOT be in ground class");
         assert!(GROUND_ENEMIES.contains(&0x58), "Fire Chomp missing from ground class");
         let modes = ClassModes::from_options(&enemy_opts());
-        let wild_pool = modes.build_wild_pool();
-        assert_eq!(find_class_pool(0x4F, &modes, &wild_pool), Some(GROUND_ENEMIES as &[u8]));
-        assert_eq!(find_class_pool(0x58, &modes, &wild_pool), Some(GROUND_ENEMIES as &[u8]));
+        assert_eq!(find_class_pool(0x4F, &modes), Some(ClassPool::Class(GROUND_ENEMIES)));
+        assert_eq!(find_class_pool(0x58, &modes), Some(ClassPool::Class(GROUND_ENEMIES)));
     }
 
     #[test]
@@ -737,25 +693,18 @@
         assert!(wild_pool.contains(&0x6C)); // GreenTroopa
         // Flying should NOT be in wild pool (it's Shuffle, not Wild)
         assert!(!wild_pool.contains(&0x6E)); // Paratroopa
-        // Ground enemy → returns wild pool
-        let pool = find_class_pool(0x72, &modes, &wild_pool).unwrap();
-        assert!(pool.contains(&0x6C), "wild pool should contain shell enemies");
+        // Ground enemy → resolves to the wild pool
+        assert_eq!(find_class_pool(0x72, &modes), Some(ClassPool::Wild));
         // Flying → returns own class only
-        let fly_pool = find_class_pool(0x6E, &modes, &wild_pool).unwrap();
-        assert_eq!(fly_pool, FLYING_ENEMIES);
+        assert_eq!(find_class_pool(0x6E, &modes), Some(ClassPool::Class(FLYING_ENEMIES)));
 
         // Run many seeds and confirm cross-class swaps happen
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16; data[5] = 16; data[6] = 0x40;
         let seg = &[
             0xFF, 0x01,
             0x72, 0x10, 0x19, // Goomba (ground)
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         let mut saw_shell = false;
         for seed in 0..500u64 {
@@ -782,18 +731,13 @@
             shell: EnemyMode::Shuffle,
             ..Options::default()
         };
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16; data[5] = 16; data[6] = 0x40;
         let seg = &[
             0xFF, 0x01,
             0x72, 0x10, 0x19, // Goomba (ground - Off)
             0x6C, 0x20, 0x16, // GreenTroopa (shell - Shuffle)
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         for seed in 0..100u64 {
             let mut rom_copy = rom.clone();
@@ -823,10 +767,10 @@
         assert!(wild_pool.contains(&0x2F)); // Boo
         assert!(wild_pool.contains(&0x8A)); // Thwomp
         assert!(wild_pool.contains(&0x51)); // Rotodisc
-        // All return the same wild pool
-        assert_eq!(find_class_pool(0x2F, &modes, &wild_pool), Some(wild_pool.as_slice()));
-        assert_eq!(find_class_pool(0x8A, &modes, &wild_pool), Some(wild_pool.as_slice()));
-        assert_eq!(find_class_pool(0x51, &modes, &wild_pool), Some(wild_pool.as_slice()));
+        // All resolve to the shared wild pool
+        assert_eq!(find_class_pool(0x2F, &modes), Some(ClassPool::Wild));
+        assert_eq!(find_class_pool(0x8A, &modes), Some(ClassPool::Wild));
+        assert_eq!(find_class_pool(0x51, &modes), Some(ClassPool::Wild));
     }
 
     #[test]
@@ -836,9 +780,7 @@
             wild_injections: true,
             ..Options::default()
         };
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16; data[5] = 16; data[6] = 0x40;
+        let mut data = blank_rom_image();
         let seg = &[
             0xFF, 0x01,
             0x72, 0x10, 0x19, // Goomba
@@ -879,9 +821,7 @@
             wild_injections: true,
             ..Options::default()
         };
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16; data[5] = 16; data[6] = 0x40;
+        let mut data = blank_rom_image();
         let seg = &[
             0xFF, 0x01,
             0x18, 0x05, 0x10, // Bowser (slot 4, page 0x3A — incompatible with all injections)
@@ -915,12 +855,6 @@
         // Two enemies far apart (screen 0 vs screen 5) should get independent
         // CHR groups. A Boo ($12/+4) on screen 0 should NOT block a ground enemy
         // on screen 5 from picking a non-$12 slot+4 page.
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,
@@ -928,9 +862,7 @@
             0x29, 0x50, 0x19, // Spike ($0A/+4) at x=80 (screen 5)
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         // Under segment-wide tracking, Spike would be locked to $12/+4 enemies only.
         // Under distance-based grouping, Spike should freely pick any ground enemy.
@@ -959,12 +891,6 @@
         // CHR constraints — same behavior as before grouping.
         // Goomba ($4F/+5) won't conflict with Boo ($12/+4) on slot+4,
         // so we can verify that any slot+4 ground enemy picked must be $12.
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16;
-        data[5] = 16;
-        data[6] = 0x40;
-
         let seg = &[
             0xFF,
             0x01,
@@ -972,9 +898,7 @@
             0x72, 0x12, 0x19, // Goomba ($4F/+5) at x=18 (10 tiles away, same group)
             0xFF,
         ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        let rom = rom_with_segment(seg);
 
         // Boo pre-commits $12/+4 as uniform ghost class, so the ground enemy
         // must be compatible — any slot+4 pick must be $12 (or use slot+5 only).
@@ -1031,9 +955,7 @@
             wild_injections: true,
             ..Options::default()
         };
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16; data[5] = 16; data[6] = 0x40;
+        let mut data = blank_rom_image();
         // 6 water enemies clustered close together (so they share one CHR group)
         let seg = &[
             0xFF, 0x01,
@@ -1080,9 +1002,7 @@
     /// segment survives byte-for-byte.
     #[test]
     fn ghost_segment_does_not_corrupt_trailing_segment() {
-        let mut data = vec![0u8; 393232];
-        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
-        data[4] = 16; data[5] = 16; data[6] = 0x40;
+        let mut data = blank_rom_image();
         data[ENEMY_DATA_START..ENEMY_DATA_END].fill(0xFF);
 
         // Place the bug pattern at the real $0CFE2 (covered by a
@@ -1182,7 +1102,6 @@
         base: &Rom,
         vanilla: &[u8],
         modes: &ClassModes,
-        wild: &[u8],
     ) -> std::collections::HashSet<usize> {
         let mut set = std::collections::HashSet::new();
         for ep in enemy_entry_points(base) {
@@ -1205,18 +1124,10 @@
             if first >= vanilla.len() || vanilla[first] == 0xFF {
                 continue;
             }
-            let class_protected = matches!(
-                entry_protection_at(ENEMY_DATA_START + first),
-                Some(EntryProtection::SkipSwap
-                    | EntryProtection::ForceShell
-                    | EntryProtection::ForceStompable
-                    | EntryProtection::ForceTankBro
-                    | EntryProtection::ExcludeHazards)
-            );
-            if class_protected {
+            if entry_protection_at(ENEMY_DATA_START + first).is_some() {
                 continue;
             }
-            if find_class_pool(vanilla[first], modes, wild).is_none() {
+            if find_class_pool(vanilla[first], modes).is_none() {
                 continue;
             }
             set.insert(first);
@@ -1312,8 +1223,8 @@
                 if injectable.contains(&off) {
                     let ok = WILD_INJECTION_IDS.contains(&new)
                         || normal_wild.contains(&new)
-                        || find_class_pool(orig, &normal_modes, &normal_wild)
-                            .is_some_and(|p| p.contains(&new));
+                        || find_class_pool(orig, &normal_modes)
+                            .is_some_and(|p| p.slice(&normal_wild).contains(&new));
                     if !ok {
                         bad("injectable slot: not a wild-pool member or injection id".into());
                     }
@@ -1366,8 +1277,8 @@
                     Some(EntryProtection::ForceShell | EntryProtection::ForceTankBro)
                 );
                 if !forced_pool {
-                    let in_class = find_class_pool(orig, modes, wild_pool)
-                        .is_some_and(|p| p.contains(&new));
+                    let in_class = find_class_pool(orig, modes)
+                        .is_some_and(|p| p.slice(wild_pool).contains(&new));
                     let boomboom = BOOMBOOM_SWAP.contains(&orig) && BOOMBOOM_SWAP.contains(&new);
                     if !in_class && !boomboom {
                         bad("swap not in original's class pool (and not boom-boom)".into());
@@ -1409,9 +1320,8 @@
         let mut stats = PlacementStats::default();
         let mut violations = Vec::new();
         let modes = ClassModes::from_options(opts);
-        let wild = modes.build_wild_pool();
         let injectable = if opts.wild_injections {
-            injectable_offsets(base, vanilla, &modes, &wild)
+            injectable_offsets(base, vanilla, &modes)
         } else {
             std::collections::HashSet::new()
         };

--- a/src/randomize/items.rs
+++ b/src/randomize/items.rs
@@ -51,8 +51,6 @@ const GOOD_ITEMS_WITH_WHISTLE: &[u8] = &[
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0B, 0x0C, 0x0D,
 ];
 
-
-
 // Hammer Bros map items: 8 worlds x 9 object slots = 72 bytes.
 // Non-zero entries are item rewards from defeating Hammer Bros.
 const HAMMER_BROS_ITEMS_OFFSET: usize = 0x16190;
@@ -87,6 +85,16 @@ const WHISTLE_OFFSETS: &[usize] = &[
     0x0D36A, // In-level treasure D6 Y-byte
 ];
 
+/// Read `len` bytes at `offset`, map each through `f` (in table order, so any
+/// RNG the closure consumes is drawn per byte first-to-last), and write back.
+fn map_table(rom: &mut Rom, offset: usize, len: usize, mut f: impl FnMut(u8) -> u8) {
+    let mut bytes = rom.read_range(offset, len).to_vec();
+    for byte in &mut bytes {
+        *byte = f(*byte);
+    }
+    rom.write_range(offset, &bytes);
+}
+
 /// Randomize all chest and reward items: Hammer Bros drops, Princess letter
 /// rewards, Toad House chests, and in-level treasure chests.
 ///
@@ -105,29 +113,19 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, remove_whistles: bool, pira
     };
 
     // Hammer Bros map items: randomize non-zero entries only (zero = no item).
-    let mut hb = rom.read_range(HAMMER_BROS_ITEMS_OFFSET, HAMMER_BROS_ITEMS_LEN).to_vec();
-    for byte in &mut hb {
-        if *byte != 0 {
-            *byte = *pool.choose(rng).unwrap();
-        }
-    }
-    rom.write_range(HAMMER_BROS_ITEMS_OFFSET, &hb);
+    map_table(rom, HAMMER_BROS_ITEMS_OFFSET, HAMMER_BROS_ITEMS_LEN, |b| {
+        if b != 0 { *pool.choose(rng).unwrap() } else { b }
+    });
 
     // Princess letter rewards: randomize non-zero entries (0x00 = no reward).
-    let mut pr = rom.read_range(PRINCESS_REWARDS_OFFSET, PRINCESS_REWARDS_LEN).to_vec();
-    for byte in &mut pr {
-        if *byte != 0 {
-            *byte = *pool.choose(rng).unwrap();
-        }
-    }
-    rom.write_range(PRINCESS_REWARDS_OFFSET, &pr);
+    map_table(rom, PRINCESS_REWARDS_OFFSET, PRINCESS_REWARDS_LEN, |b| {
+        if b != 0 { *pool.choose(rng).unwrap() } else { b }
+    });
 
     // Toad House chests: use restricted pool (no cloud/hammer/music box/whistle).
-    let mut th = rom.read_range(TOAD_HOUSE_ITEMS_OFFSET, TOAD_HOUSE_ITEMS_LEN).to_vec();
-    for byte in &mut th {
-        *byte = *TOAD_HOUSE_ITEMS.choose(rng).unwrap();
-    }
-    rom.write_range(TOAD_HOUSE_ITEMS_OFFSET, &th);
+    map_table(rom, TOAD_HOUSE_ITEMS_OFFSET, TOAD_HOUSE_ITEMS_LEN, |_| {
+        *TOAD_HOUSE_ITEMS.choose(rng).unwrap()
+    });
 
     // In-level treasure chests: randomize each D6 Y-byte.
     for &offset in TREASURE_CHEST_OFFSETS {
@@ -149,33 +147,11 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, remove_whistles: bool, pira
 /// only the item ID in the data tables.
 pub fn replace_anchors<R: Rng>(rom: &mut Rom, rng: &mut R) {
     let replacement = *POWERUP_ITEMS.choose(rng).unwrap();
+    let swap_anchor = |b: u8| if b == ANCHOR { replacement } else { b };
 
-    // Hammer Bros map items
-    let mut hb = rom.read_range(HAMMER_BROS_ITEMS_OFFSET, HAMMER_BROS_ITEMS_LEN).to_vec();
-    for byte in &mut hb {
-        if *byte == ANCHOR {
-            *byte = replacement;
-        }
-    }
-    rom.write_range(HAMMER_BROS_ITEMS_OFFSET, &hb);
-
-    // Princess letter rewards
-    let mut pr = rom.read_range(PRINCESS_REWARDS_OFFSET, PRINCESS_REWARDS_LEN).to_vec();
-    for byte in &mut pr {
-        if *byte == ANCHOR {
-            *byte = replacement;
-        }
-    }
-    rom.write_range(PRINCESS_REWARDS_OFFSET, &pr);
-
-    // Toad House chests
-    let mut th = rom.read_range(TOAD_HOUSE_ITEMS_OFFSET, TOAD_HOUSE_ITEMS_LEN).to_vec();
-    for byte in &mut th {
-        if *byte == ANCHOR {
-            *byte = replacement;
-        }
-    }
-    rom.write_range(TOAD_HOUSE_ITEMS_OFFSET, &th);
+    map_table(rom, HAMMER_BROS_ITEMS_OFFSET, HAMMER_BROS_ITEMS_LEN, swap_anchor);
+    map_table(rom, PRINCESS_REWARDS_OFFSET, PRINCESS_REWARDS_LEN, swap_anchor);
+    map_table(rom, TOAD_HOUSE_ITEMS_OFFSET, TOAD_HOUSE_ITEMS_LEN, swap_anchor);
 }
 
 /// Remove warp whistles without full item randomization. Replaces the 3 known
@@ -279,6 +255,19 @@ mod tests {
         data[0x0D36A] = WARP_WHISTLE;
 
         Rom::from_bytes_lax(&data, true).unwrap()
+    }
+
+    #[test]
+    fn test_whistle_pool_is_good_items_plus_whistle() {
+        let mut expected: Vec<u8> = GOOD_ITEMS.to_vec();
+        expected.push(WARP_WHISTLE);
+        expected.sort();
+        let mut actual: Vec<u8> = GOOD_ITEMS_WITH_WHISTLE.to_vec();
+        actual.sort();
+        assert_eq!(
+            actual, expected,
+            "GOOD_ITEMS_WITH_WHISTLE must equal GOOD_ITEMS plus WARP_WHISTLE"
+        );
     }
 
     #[test]

--- a/src/randomize/king_quotes.rs
+++ b/src/randomize/king_quotes.rs
@@ -635,9 +635,9 @@ const HAMMER_QUOTE_OFFSET: usize = 0x3642C;
 /// Free space in PRG027 for standard quote data + ASM hook.
 const KING_QUOTE_BASE: usize = super::rom_data::FS_KING_QUOTES;
 
-/// PRG027 file offset 0x36010 maps to CPU $A000.
+/// PRG027 (file 0x36010) is an $A000-window bank.
 fn cpu_addr(file_offset: usize) -> u16 {
-    0xA000 + (file_offset - 0x36010) as u16
+    super::rom_data::prg_bank_file_to_cpu(27, file_offset)
 }
 
 /// ROM offset of the vanilla quote selection code at CPU $A293.
@@ -650,17 +650,10 @@ const QUOTE_SELECT_PATCH: usize = 0x362A3;
 /// Write randomized king quotes into the ROM.
 pub fn randomize(rom: &mut Rom, rng: &mut ChaCha8Rng) {
     // --- 1. Write 7 unique standard quotes into free space ---
-    let mut pool: Vec<usize> = (0..QUOTES.len()).collect();
-    let mut chosen = Vec::with_capacity(7);
-    for _ in 0..7 {
-        let idx = pool.choose(rng).copied().unwrap();
-        pool.retain(|&x| x != idx);
-        chosen.push(idx);
-    }
-
+    // choose_multiple samples without replacement, so the 7 quotes are unique.
     let mut std_addrs = Vec::with_capacity(7);
-    for (world, &quote_idx) in chosen.iter().enumerate() {
-        let encoded = encode_quote(&QUOTES[quote_idx]);
+    for (world, quote) in QUOTES.choose_multiple(rng, 7).enumerate() {
+        let encoded = encode_quote(quote);
         let file_offset = KING_QUOTE_BASE + world * 120;
         rom.write_range(file_offset, &encoded);
         std_addrs.push(cpu_addr(file_offset));

--- a/src/randomize/koopalings.rs
+++ b/src/randomize/koopalings.rs
@@ -1,5 +1,8 @@
+use rand::Rng;
+
 use crate::rom::Rom;
-use rand_chacha::ChaCha8Rng;
+
+use super::rom_data::{KOOPA_HITS_SUB_CPU, KOOPA_HITS_TABLE_CPU};
 
 /// Fix Koopaling softlock when airships are shuffled across worlds.
 ///
@@ -220,7 +223,7 @@ const CHR_PAGE_WAND: u8 = 0x37;
 /// Lemmy's Koopaling identity value.
 const LEMMY_IDENTITY: usize = 0x05;
 
-pub fn random_koopalings(rom: &mut Rom, rng: &mut ChaCha8Rng) {
+pub fn random_koopalings<R: Rng>(rom: &mut Rom, rng: &mut R) {
     use rand::seq::SliceRandom;
 
     let mut koopalings: [u8; 7] = [0, 1, 2, 3, 4, 5, 6];
@@ -317,8 +320,6 @@ const KOOPA_SURVIVE_CPU: u16 = 0xB18D;
 /// CPU address of the vanilla "defeated" path.
 const KOOPA_DEFEAT_CPU: u16 = 0xB193;
 
-use super::rom_data::{KOOPA_HITS_SUB_CPU, KOOPA_HITS_TABLE_CPU};
-
 /// Subroutine machine code (13 bytes):
 /// ```asm
 ///   LDA $7F,X              ; load stomp counter (original instruction)
@@ -335,9 +336,8 @@ const KOOPA_HITS_CODE: [u8; 13] = [
     0xB0, 0x03,                                                  // BCS +3 (to JMP defeat)
     0x4C, KOOPA_SURVIVE_CPU as u8, (KOOPA_SURVIVE_CPU >> 8) as u8, // JMP $B18D
 ];
-// Note: defeat JMP ($B193) follows immediately after in the table area,
-// but we can just let BCS fall through to the table bytes — instead we
-// place the defeat JMP right after the code, before the table.
+// Layout: the defeat JMP ($B193) sits right after the code (sub + 13),
+// followed by the 7-byte threshold table.
 // Total: 13 bytes code + 3 bytes JMP defeat + 7 bytes table = 23 bytes.
 
 /// File offset of fireball→stomp handoff: `LDA #$02; STA $7F,X` (4 bytes).
@@ -353,11 +353,8 @@ const KOOPA_HITS_CODE: [u8; 13] = [
 /// threshold, guaranteeing defeat.
 const KOOPA_FIRE_HANDOFF: usize = 0x03035;
 
-pub fn randomize_koopaling_hits(rom: &mut Rom, rng: &mut ChaCha8Rng) {
-    use rand::Rng;
-    use super::rom_data::{
-        FS_KOOPA_FIRE_PRESET, KOOPA_FIRE_PRESET_CPU, KOOPA_HITS_TABLE_CPU,
-    };
+pub fn randomize_koopaling_hits<R: Rng>(rom: &mut Rom, rng: &mut R) {
+    use super::rom_data::{FS_KOOPA_FIRE_PRESET, KOOPA_FIRE_PRESET_CPU};
 
     // Write stomp threshold subroutine into free space
     rom.write_range(super::rom_data::FS_KOOPA_HITS_SUB, &KOOPA_HITS_CODE);
@@ -442,8 +439,7 @@ const BOOMBOOM_SURVIVE_CPU: u16 = 0xAE70;
 /// CPU address of the vanilla "death" tail (sets death Timer, RTS).
 const BOOMBOOM_DEATH_CPU: u16 = 0xAE82;
 
-pub fn randomize_boomboom_hits(rom: &mut Rom, rng: &mut ChaCha8Rng) {
-    use rand::Rng;
+pub fn randomize_boomboom_hits<R: Rng>(rom: &mut Rom, rng: &mut R) {
     use super::rom_data::{
         BOOMBOOM_HITS_SUB_CPU, BOOMBOOM_HITS_TABLE_CPU, FS_BOOMBOOM_HITS_SUB,
         FS_BOOMBOOM_HITS_TABLE,
@@ -531,6 +527,7 @@ pub fn skip_wand_cutscene(rom: &mut Rom) {
 mod tests {
     use super::*;
     use crate::rom::Rom;
+    use rand_chacha::ChaCha8Rng;
 
     fn make_test_rom() -> Rom {
         let mut data = vec![0u8; 393232];

--- a/src/randomize/levels.rs
+++ b/src/randomize/levels.rs
@@ -13,8 +13,7 @@ use super::rom_data::AIRSHIP_ENTRIES;
 /// this shuffle runs, so airship shuffle only has a visible effect
 /// when autoscroll is kept enabled.
 pub fn randomize_airships<R: Rng>(rom: &mut Rom, rng: &mut R) {
-    let indices: Vec<(usize, usize)> = AIRSHIP_ENTRIES.to_vec();
-    level_helpers::shuffle_entries(rom, rng, &indices);
+    level_helpers::shuffle_entries(rom, rng, AIRSHIP_ENTRIES);
 }
 
 #[cfg(test)]

--- a/src/randomize/map_walker.rs
+++ b/src/randomize/map_walker.rs
@@ -58,6 +58,18 @@ pub(super) struct WalkResult {
 // BFS map walker
 // ---------------------------------------------------------------------------
 
+/// Position → teleport destinations, built from bidirectional edge pairs.
+type TeleportLookup = HashMap<(usize, usize), Vec<(usize, usize)>>;
+
+fn teleport_lookup(pairs: &[TeleportEdge]) -> TeleportLookup {
+    let mut lookup = TeleportLookup::new();
+    for &(a, b) in pairs {
+        lookup.entry(a).or_default().push(b);
+        lookup.entry(b).or_default().push(a);
+    }
+    lookup
+}
+
 /// First-pass reachability check: can the player walk (using pipes only — no
 /// canoes) to ANY canoe mainland dock from `start`? If yes, canoes become
 /// usable for the main BFS. If no, canoes stay disabled.
@@ -82,55 +94,10 @@ fn canoes_reachable(
         return true;
     }
 
-    let mut pipe_lookup: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
-    for &(a, b) in pipe_pairs {
-        pipe_lookup.entry(a).or_default().push(b);
-        pipe_lookup.entry(b).or_default().push(a);
-    }
-
-    let mut visited: HashSet<(usize, usize)> = HashSet::new();
-    let mut queue = VecDeque::new();
-    visited.insert(start);
-    queue.push_back(start);
-
-    while let Some((r, c)) = queue.pop_front() {
-        if docks.contains(&(r, c)) {
-            return true;
-        }
-        for &(dr, dc, is_horz) in &DIRECTIONS {
-            let pr = r as i16 + dr as i16;
-            let pc = c as i16 + dc as i16;
-            if pr < 0 || pr >= grid.rows as i16 || pc < 0 || pc >= grid.cols as i16 {
-                continue;
-            }
-            let (pr, pc) = (pr as usize, pc as usize);
-            let path_tile = grid.get(pr, pc);
-            let valid = if is_horz { VALID_HORZ } else { VALID_VERT };
-            if !valid.contains(&path_tile) {
-                continue;
-            }
-            let nr = r as i16 + 2 * dr as i16;
-            let nc = c as i16 + 2 * dc as i16;
-            if nr < 0 || nr >= grid.rows as i16 || nc < 0 || nc >= grid.cols as i16 {
-                continue;
-            }
-            let (nr, nc) = (nr as usize, nc as usize);
-            if BACKGROUND_TILES.contains(&grid.get(nr, nc)) {
-                continue;
-            }
-            if visited.insert((nr, nc)) {
-                queue.push_back((nr, nc));
-            }
-        }
-        if let Some(dests) = pipe_lookup.get(&(r, c)) {
-            for &dest in dests {
-                if visited.insert(dest) {
-                    queue.push_back(dest);
-                }
-            }
-        }
-    }
-    false
+    // Same BFS as the main walk, just with no canoe edges (a 9×64 grid, so
+    // running it to completion instead of early-exiting at a dock is cheap).
+    let no_canoes = walk_from(grid, start, &teleport_lookup(pipe_pairs), &TeleportLookup::new());
+    docks.iter().any(|d| no_canoes.nodes.contains(d))
 }
 
 /// BFS walk from a start position, returning reachable nodes, edges, and path tiles.
@@ -157,12 +124,7 @@ pub(super) fn walk_map(
         }
     };
 
-    // Build pipe lookup: position → list of destinations
-    let mut pipe_lookup: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
-    for &(a, b) in pipe_pairs {
-        pipe_lookup.entry(a).or_default().push(b);
-        pipe_lookup.entry(b).or_default().push(a);
-    }
+    let pipe_lookup = teleport_lookup(pipe_pairs);
 
     // Canoes: the boat starts at the mainland dock (the `a` side of each
     // `CANOE_EDGES` tuple). The player must be able to *walk* to that dock
@@ -176,14 +138,23 @@ pub(super) fn walk_map(
     // we omit the edges entirely so the BFS reflects reality. This is the
     // structural fix for the SAS-W3 deadlock where the swap moves the start
     // into a region with no walking path to the dock.
-    let mut canoe_lookup: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
-    if canoes_reachable(grid, pipe_pairs, start, world_idx) {
-        for (a, b) in rom_data::active_canoe_edges(world_idx, grid.eights_are_wild) {
-            canoe_lookup.entry(a).or_default().push(b);
-            canoe_lookup.entry(b).or_default().push(a);
-        }
-    }
+    let canoe_lookup = if canoes_reachable(grid, pipe_pairs, start, world_idx) {
+        teleport_lookup(&rom_data::active_canoe_edges(world_idx, grid.eights_are_wild))
+    } else {
+        TeleportLookup::new()
+    };
 
+    walk_from(grid, start, &pipe_lookup, &canoe_lookup)
+}
+
+/// The BFS core shared by `walk_map` and the canoe first pass: walk from
+/// `start` expanding orthogonal 2-tile moves plus the given teleport edges.
+fn walk_from(
+    grid: &Grid,
+    start: (usize, usize),
+    pipe_lookup: &TeleportLookup,
+    canoe_lookup: &TeleportLookup,
+) -> WalkResult {
     let mut nodes = HashSet::new();
     let mut distances: HashMap<(usize, usize), usize> = HashMap::new();
     let mut edges: HashMap<(usize, usize), Vec<Edge>> = HashMap::new();
@@ -237,33 +208,20 @@ pub(super) fn walk_map(
             }
         }
 
-        // Pipe edges: direct teleport
-        if let Some(dests) = pipe_lookup.get(&(r, c)) {
-            for &dest in dests {
-                edges.entry((r, c)).or_default().push(Edge {
-                    dest,
-                    path_pos: None,
-                });
-                if !nodes.contains(&dest) {
-                    nodes.insert(dest);
-                    distances.insert(dest, distances[&(r, c)] + 1);
-                    queue.push_back(dest);
-                }
-            }
-        }
-
-        // Canoe edges: only present when the mainland dock was reachable
-        // via the first pass (see canoe_lookup construction above).
-        if let Some(dests) = canoe_lookup.get(&(r, c)) {
-            for &dest in dests {
-                edges.entry((r, c)).or_default().push(Edge {
-                    dest,
-                    path_pos: None,
-                });
-                if !nodes.contains(&dest) {
-                    nodes.insert(dest);
-                    distances.insert(dest, distances[&(r, c)] + 1);
-                    queue.push_back(dest);
+        // Teleport edges: pipes, then canoes (canoe edges are only present
+        // when the mainland dock was reachable — see canoe_lookup above).
+        for lookup in [pipe_lookup, canoe_lookup] {
+            if let Some(dests) = lookup.get(&(r, c)) {
+                for &dest in dests {
+                    edges.entry((r, c)).or_default().push(Edge {
+                        dest,
+                        path_pos: None,
+                    });
+                    if !nodes.contains(&dest) {
+                        nodes.insert(dest);
+                        distances.insert(dest, distances[&(r, c)] + 1);
+                        queue.push_back(dest);
+                    }
                 }
             }
         }

--- a/src/randomize/map_walker.rs
+++ b/src/randomize/map_walker.rs
@@ -172,7 +172,7 @@ fn walk_from(
         for &(dr, dc, is_horz) in &DIRECTIONS {
             let pr = r as i16 + dr as i16;
             let pc = c as i16 + dc as i16;
-            if pr < 0 || pr >= grid.rows as i16 || pc < 0 || pc >= grid.cols as i16 {
+            if pr < 0 || pr >= grid.rows() as i16 || pc < 0 || pc >= grid.cols as i16 {
                 continue;
             }
             let (pr, pc) = (pr as usize, pc as usize);
@@ -185,7 +185,7 @@ fn walk_from(
 
             let nr = r as i16 + 2 * dr as i16;
             let nc = c as i16 + 2 * dc as i16;
-            if nr < 0 || nr >= grid.rows as i16 || nc < 0 || nc >= grid.cols as i16 {
+            if nr < 0 || nr >= grid.rows() as i16 || nc < 0 || nc >= grid.cols as i16 {
                 continue;
             }
             let (nr, nc) = (nr as usize, nc as usize);
@@ -329,7 +329,7 @@ pub(super) fn render_debug(
     out.push_str(&format!("{RESET}\n"));
 
     // Grid rows
-    for r in 0..grid.rows {
+    for r in 0..grid.rows() {
         out.push_str(&format!("{DIM}{r} {RESET}"));
         for c in 0..grid.cols {
             let tile = grid.get(r, c);
@@ -377,7 +377,7 @@ pub(super) fn render_debug(
 #[cfg(test)]
 fn find_fortress_tiles(grid: &Grid) -> Vec<(usize, usize)> {
     let mut positions = Vec::new();
-    for r in 0..grid.rows {
+    for r in 0..grid.rows() {
         for c in 0..grid.cols {
             let t = grid.get(r, c);
             if t == TILE_FORTRESS || t == 0xEB || t == 0x6A {
@@ -584,7 +584,6 @@ mod tests {
             // W8 edges resolve.
             let mut grid = Grid {
                 tiles: vec![vec![0xB4u8; 48]; 9],
-                rows: 9,
                 cols: 48,
                 eights_are_wild: true,
             };

--- a/src/randomize/node_catalog/classify.rs
+++ b/src/randomize/node_catalog/classify.rs
@@ -65,7 +65,7 @@ pub(super) fn classify_world(
         let (row, col) = rom_data::entry_grid_position(rom, world, i);
         let obj = rom_data::read_word(rom, objsets + i * 2);
         let lay = rom_data::read_word(rom, layouts + i * 2);
-        let map_tile = if row < grid.rows && col < grid.cols {
+        let map_tile = if row < grid.rows() && col < grid.cols {
             grid.get(row, col)
         } else {
             0xFF

--- a/src/randomize/node_catalog/mod.rs
+++ b/src/randomize/node_catalog/mod.rs
@@ -172,12 +172,6 @@ impl NodeCatalog {
         self.entries.iter().filter(move |e| e.world_idx == world_idx)
     }
 
-    /// Iterate entries matching a kind predicate.
-    #[allow(dead_code)] // used in tests
-    pub(super) fn by_kind(&self, pred: fn(&NodeKind) -> bool) -> impl Iterator<Item = &CatalogEntry> {
-        self.entries.iter().filter(move |e| pred(&e.kind))
-    }
-
     /// Collect unique real HammerBro levels (obj >= 0xC000).
     /// Excludes toad house / bonus game pointer formats.
     pub(super) fn unique_hammer_bro_levels(&self) -> Vec<rom_data::LevelEntry> {

--- a/src/randomize/node_catalog/naming.rs
+++ b/src/randomize/node_catalog/naming.rs
@@ -23,39 +23,47 @@ const LEVEL_NAME_OVERRIDES: &[(usize, usize, &str)] = &[
     (7, 36, "8-STnk"),   // super tank
 ];
 
+/// Number of kinds that get per-world ordinal suffixes (see `ordinal_slot`).
+const ORDINAL_SLOTS: usize = 6;
+
+/// Slot index + name abbreviation for kinds that get ordinal suffixes.
+fn ordinal_slot(kind: &NodeKind) -> Option<(usize, &'static str)> {
+    match kind {
+        NodeKind::Fortress { .. } => Some((0, "F")),
+        NodeKind::Pipe { .. } => Some((1, "Pi")),
+        NodeKind::ToadHouse => Some((2, "TH")),
+        NodeKind::BonusGame => Some((3, "BG")),
+        NodeKind::HammerBro => Some((4, "HB")),
+        NodeKind::MapObject => Some((5, "MO")),
+        _ => None,
+    }
+}
+
+/// "prefix" when the world has exactly one of the kind, "prefix<ord>" otherwise.
+fn suffixed(prefix: &str, count: usize, ord: usize) -> String {
+    if count == 1 {
+        prefix.to_string()
+    } else {
+        format!("{prefix}{ord}")
+    }
+}
+
 /// Assign human-readable names to all catalog entries.
 ///
 /// Two-pass: first count per-world per-kind totals, then assign names
 /// with ordinal suffixes when a world has multiples of the same kind.
 pub(super) fn assign_names(entries: &mut [CatalogEntry]) {
     // Count per-world kind totals for ordinal suffixes
-    let mut fortress_counts: [usize; 8] = [0; 8];
-    let mut toad_counts: [usize; 8] = [0; 8];
-    let mut bonus_counts: [usize; 8] = [0; 8];
-    let mut hammer_counts: [usize; 8] = [0; 8];
-    let mut map_obj_counts: [usize; 8] = [0; 8];
-    let mut pipe_counts: [usize; 8] = [0; 8];
-
+    let mut counts = [[0usize; 8]; ORDINAL_SLOTS];
     for e in entries.iter() {
         if e.world_idx == usize::MAX { continue; } // skip synthetic (beta) entries
-        match e.kind {
-            NodeKind::Fortress { .. } => fortress_counts[e.world_idx] += 1,
-            NodeKind::ToadHouse => toad_counts[e.world_idx] += 1,
-            NodeKind::BonusGame => bonus_counts[e.world_idx] += 1,
-            NodeKind::HammerBro => hammer_counts[e.world_idx] += 1,
-            NodeKind::MapObject => map_obj_counts[e.world_idx] += 1,
-            NodeKind::Pipe { .. } => pipe_counts[e.world_idx] += 1,
-            _ => {}
+        if let Some((slot, _)) = ordinal_slot(&e.kind) {
+            counts[slot][e.world_idx] += 1;
         }
     }
 
     // Track ordinals per world per kind
-    let mut fortress_ord: [usize; 8] = [0; 8];
-    let mut toad_ord: [usize; 8] = [0; 8];
-    let mut bonus_ord: [usize; 8] = [0; 8];
-    let mut hammer_ord: [usize; 8] = [0; 8];
-    let mut map_obj_ord: [usize; 8] = [0; 8];
-    let mut pipe_ord: [usize; 8] = [0; 8];
+    let mut ords = [[0usize; 8]; ORDINAL_SLOTS];
 
     for e in entries.iter_mut() {
         // Skip synthetic entries (betas) — they already have names.
@@ -75,54 +83,21 @@ pub(super) fn assign_names(entries: &mut [CatalogEntry]) {
             continue;
         }
 
+        if let Some((slot, abbr)) = ordinal_slot(&e.kind) {
+            ords[slot][w] += 1;
+            e.name = if matches!(e.kind, NodeKind::Pipe { .. }) {
+                // Pipes are always numbered, even when a world has just one.
+                format!("{w1}{abbr}{}", ords[slot][w])
+            } else {
+                suffixed(&format!("{w1}{abbr}"), counts[slot][w], ords[slot][w])
+            };
+            continue;
+        }
+
         e.name = match &e.kind {
             NodeKind::Start => format!("{w1}S"),
             NodeKind::Bowser => "8B".to_string(),
             NodeKind::Airship => format!("{w1}A"),
-            NodeKind::Fortress { .. } => {
-                fortress_ord[w] += 1;
-                if fortress_counts[w] == 1 {
-                    format!("{w1}F")
-                } else {
-                    format!("{w1}F{}", fortress_ord[w])
-                }
-            }
-            NodeKind::Pipe { .. } => {
-                pipe_ord[w] += 1;
-                format!("{w1}Pi{}", pipe_ord[w])
-            }
-            NodeKind::ToadHouse => {
-                toad_ord[w] += 1;
-                if toad_counts[w] == 1 {
-                    format!("{w1}TH")
-                } else {
-                    format!("{w1}TH{}", toad_ord[w])
-                }
-            }
-            NodeKind::BonusGame => {
-                bonus_ord[w] += 1;
-                if bonus_counts[w] == 1 {
-                    format!("{w1}BG")
-                } else {
-                    format!("{w1}BG{}", bonus_ord[w])
-                }
-            }
-            NodeKind::HammerBro => {
-                hammer_ord[w] += 1;
-                if hammer_counts[w] == 1 {
-                    format!("{w1}HB")
-                } else {
-                    format!("{w1}HB{}", hammer_ord[w])
-                }
-            }
-            NodeKind::MapObject => {
-                map_obj_ord[w] += 1;
-                if map_obj_counts[w] == 1 {
-                    format!("{w1}MO")
-                } else {
-                    format!("{w1}MO{}", map_obj_ord[w])
-                }
-            }
             NodeKind::Level => {
                 // Numbered levels: tile 0x03-0x0F → level number = tile - 2
                 if e.tile >= 0x03 && e.tile <= 0x0F {
@@ -132,6 +107,8 @@ pub(super) fn assign_names(entries: &mut [CatalogEntry]) {
                     format!("{w1}L[{}]", e.entry_idx)
                 }
             }
+            // Suffixed kinds are handled by `ordinal_slot` above.
+            _ => unreachable!("ordinal kinds handled above"),
         };
     }
 }

--- a/src/randomize/node_catalog/tests.rs
+++ b/src/randomize/node_catalog/tests.rs
@@ -142,15 +142,16 @@ fn test_fortress_boomboom_offsets() {
 }
 
 #[test]
-fn test_regression_vs_old_classification() {
+fn test_kind_totals_sum_to_340() {
     let rom = match load_rom() {
         Some(r) => r,
         None => return,
     };
     let catalog = NodeCatalog::build(&rom, false);
 
-    // Verify aggregate counts match known vanilla totals:
-    // 17 fortresses, 7 airships, 1 bowser, 48 pipes, 8 starts
+    // Aggregate counts plus the known vanilla fixed totals
+    // (17 fortresses, 48 pipes, 7 airships, 1 bowser, 8 starts)
+    // must cover all 340 pointer table entries.
     let levels: usize = catalog.entries.iter()
         .filter(|e| matches!(e.kind, NodeKind::Level))
         .count();

--- a/src/randomize/overworld_build/capacity.rs
+++ b/src/randomize/overworld_build/capacity.rs
@@ -193,7 +193,7 @@ pub(super) fn prepare_capacities(
             }
             if matches!(entry.kind, NodeKind::Airship | NodeKind::Bowser | NodeKind::Start) {
                 let (r, c) = entry.grid_pos;
-                if r < grid.rows && c < grid.cols {
+                if r < grid.rows() && c < grid.cols {
                     grid.set(r, c, entry.tile);
                 }
             }

--- a/src/randomize/overworld_build/capacity.rs
+++ b/src/randomize/overworld_build/capacity.rs
@@ -2,6 +2,11 @@
 
 use super::*;
 
+use super::pipes::VANILLA_PIPE_PAIRS;
+use super::scoring::is_row78_conflict;
+use super::sections::{completable_positions, find_blank_slots};
+use super::types::{BuiltWorld, CapacityPrep, HbSprite, OverworldData, SlotKind};
+
 pub(super) const SPADE_BUDGET: usize = 19;
 
 /// Promote HammerBro slots to a target `SlotKind`, distributing picked-up pool

--- a/src/randomize/overworld_build/locks.rs
+++ b/src/randomize/overworld_build/locks.rs
@@ -75,7 +75,7 @@ pub(super) fn place_locks<R: Rng>(
         // Find all lockable path tiles not yet used
         let reference_grid = build_test_grid(None);
         let mut candidates: Vec<(usize, usize)> = Vec::new();
-        for r in 0..reference_grid.rows {
+        for r in 0..reference_grid.rows() {
             for c in 0..reference_grid.cols {
                 let tile = reference_grid.get(r, c);
                 if LOCKABLE_TILES.contains(&tile) && !locked_tiles.contains(&(r, c)) {
@@ -263,7 +263,7 @@ pub(super) fn debug_stamp_rom(rom: &mut crate::rom::Rom, result: &BuildResult) {
         let wi = built.world_idx;
 
         // First write the cleared grid (with pipes already placed)
-        for r in 0..built.grid.rows {
+        for r in 0..built.grid.rows() {
             for c in 0..built.grid.cols {
                 let offset = rom_data::map_tile_offset(wi, r, c);
                 rom.data[offset] = built.grid.get(r, c);

--- a/src/randomize/overworld_build/locks.rs
+++ b/src/randomize/overworld_build/locks.rs
@@ -2,6 +2,19 @@
 
 use super::*;
 
+use super::types::{BuildResult, LockAssignment, SlotAssignment, SlotKind, stamp_slots};
+
+/// A scored lock candidate tracked during selection.
+#[derive(Clone, Copy)]
+struct ScoredLock {
+    pos: Pos,
+    gap_tile: u8,
+    replace_tile: u8,
+    score: i32,
+    safe: bool,
+    blocks_target: bool,
+}
+
 // Reason: every argument represents a distinct, independent input to lock
 // placement (geometry, slot list, count, safety flag, RNG). No subset
 // clusters into a meaningful concept — bundling would be a clippy bandage,
@@ -24,21 +37,7 @@ pub(super) fn place_locks<R: Rng>(
     // Build a base grid with forts/levels stamped so BFS sees them as nodes.
     // This grid does NOT have any locks on it.
     let mut base_grid = grid.clone();
-    for slot in slots {
-        match slot.kind {
-            SlotKind::Fortress => base_grid.set(slot.pos.0, slot.pos.1, TILE_FORTRESS),
-            SlotKind::Level => {
-                let tile = base_grid.get(slot.pos.0, slot.pos.1);
-                if BACKGROUND_TILES.contains(&tile) {
-                    base_grid.set(slot.pos.0, slot.pos.1, TILE_NODE);
-                }
-            }
-            SlotKind::Pipe => {} // already stamped on grid
-            SlotKind::HammerBro => {} // blank path tile, no stamp needed
-            SlotKind::BonusGame => base_grid.set(slot.pos.0, slot.pos.1, TILE_BONUS_GAME),
-            SlotKind::ToadHouse => base_grid.set(slot.pos.0, slot.pos.1, TILE_TOAD_HOUSE),
-        }
-    }
+    stamp_slots(&mut base_grid, slots);
 
     // Process each fortress in section order
     for section_idx in 0..fort_count {
@@ -104,13 +103,8 @@ pub(super) fn place_locks<R: Rng>(
         // Prefer safe when forced (retry path) or when the best candidate
         // is weak anyway (score < 5) — don't sacrifice a high-scoring lock.
         // Evaluated after scoring all candidates, see below.
-        // (pos, gap_tile, replace_tile, score, safe, blocks_target)
-        type LockCandidate = (Pos, u8, u8, i32, bool, bool);
-        // Subset of LockCandidate without the safe/blocks_target flags.
-        type SafeLockCandidate = (Pos, u8, u8, i32);
-
-        let mut best: Option<LockCandidate> = None;
-        let mut best_safe: Option<SafeLockCandidate> = None;
+        let mut best: Option<ScoredLock> = None;
+        let mut best_safe: Option<ScoredLock> = None;
 
         // Open grid (no candidate lock) is constant for all candidates in this
         // section — hoist the BFS to avoid redundant walks per candidate.
@@ -218,47 +212,40 @@ pub(super) fn place_locks<R: Rng>(
                 score += 1;
             }
 
-            // Track best overall and best safe separately.
-            let dominated = match &best {
-                Some((_, _, _, best_score, _, _)) => score > *best_score,
-                None => true,
+            // Track best overall and best safe separately. (A safe lock
+            // never blocks the target, so its blocks_target is false.)
+            let cand = ScoredLock {
+                pos: cand_pos,
+                gap_tile: gap,
+                replace_tile: tile,
+                score,
+                safe,
+                blocks_target: !target_reachable,
             };
-            if dominated {
-                best = Some((cand_pos, gap, tile, score, safe, !target_reachable));
+            if best.is_none_or(|b| score > b.score) {
+                best = Some(cand);
             }
-
-            if safe {
-                let safe_dominated = match &best_safe {
-                    Some((_, _, _, best_score)) => score > *best_score,
-                    None => true,
-                };
-                if safe_dominated {
-                    best_safe = Some((cand_pos, gap, tile, score));
-                }
+            if safe && best_safe.is_none_or(|b| score > b.score) {
+                best_safe = Some(cand);
             }
         }
 
         // Prefer safe when forced (retry) or when best score is low —
         // no point picking an impactful lock if there are none.
-        let best_score = best.map(|(_, _, _, s, _, _)| s).unwrap_or(0);
+        let best_score = best.map(|b| b.score).unwrap_or(0);
         let prefer_safe = force_safe || best_score < 5;
 
-        let chosen = if prefer_safe {
-            best_safe.map(|(pos, gap, replace, score)| (pos, gap, replace, score, true, false))
-                .or(best)
-        } else {
-            best
-        };
+        let chosen = if prefer_safe { best_safe.or(best) } else { best };
 
-        if let Some((pos, gap, replace, _score, safe, blocks_target)) = chosen {
-            locked_tiles.insert(pos);
+        if let Some(c) = chosen {
+            locked_tiles.insert(c.pos);
             locks.push(LockAssignment {
-                pos,
-                gap_tile: gap,
-                replace_tile: replace,
+                pos: c.pos,
+                gap_tile: c.gap_tile,
+                replace_tile: c.replace_tile,
                 fort_section: section_idx,
-                secret_exit_safe: safe,
-                blocks_target,
+                secret_exit_safe: c.safe,
+                blocks_target: c.blocks_target,
             });
         }
     }

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -27,18 +27,21 @@ mod pipes;
 mod locks;
 mod progression;
 
-use types::*;
-use scoring::*;
-use capacity::*;
-use sections::*;
-use pipes::*;
-use locks::*;
+use capacity::{
+    SPADE_BUDGET, assign_hb_sprites, distribute_levels, prepare_capacities, promote_hb_slots,
+    redistribute_fortresses,
+};
+use locks::place_locks;
+use pipes::VANILLA_PIPE_PAIRS;
+use scoring::{LEVEL_SPREAD_EXPONENT, VANILLA_LEVEL_COUNT};
+use sections::build_world;
+use types::{CapacityPrep, WorldSlotCounts};
 
 // Public API consumed by the randomizer and the overworld writer.
 pub use {types::SlotAssignment, types::SlotKind};
 pub(crate) use sections::bfs_ordered;
 pub(crate) use capacity::RESERVED_DYNAMIC_SLOTS;
-pub(crate) use types::{BuildFlags, BuildResult, BuiltWorld, HbSprite, LockAssignment, OverworldData};
+pub(crate) use types::{BuildFlags, BuildResult, BuiltWorld, OverworldData};
 // Progression analysis is exercised only by the test suite today (reserved for a
 // future WASM single-seed dump), so surface it just for `tests`.
 #[cfg(test)]

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -2,6 +2,12 @@
 
 use super::*;
 
+use super::scoring::{
+    PIPE_SOFTMAX_T, TARGET_MAX_DIST, pick_softmax_by_score, score_pipe_endpoint,
+    score_pipe_pair, target_proximity_penalty,
+};
+use super::sections::split_blanks_by_reachability;
+
 /// Number of pipe pairs (not endpoints) per world in the vanilla ROM.
 pub(super) const VANILLA_PIPE_PAIRS: [usize; 8] = [
     0,  // W1
@@ -45,19 +51,15 @@ pub(super) fn place_pipes<R: Rng>(
         return Vec::new();
     }
 
-    // Hard exclusion: forbid pipe endpoints adjacent (≤1 walking hop) to
-    // start or target. Diagnostic on 1000-seed sweeps showed 100% of
-    // "trivial bypass" (0 forts + 0 levels) playthroughs were caused by
-    // pipes sitting next to start, next to target, or both — eliminating
-    // both ends of that pattern eliminates the failure mode. Fixed
-    // endpoints (W3 boat dock) are exempt: their position is dictated by
-    // ROM data, not chosen by the builder.
-    // No-pipe exclusion zone, split by anchor. A pipe within one walking hop of
-    // start or target trivially skips the world, so both are barred by default.
-    // The halves are kept separate so the START side can be lifted when
-    // connectivity demands it (completability outranks the anti-skip rule); the
-    // TARGET side is never lifted, since a pipe next to the airship is the skip
-    // we actually care about.
+    // No-pipe exclusion zone, split by anchor. Diagnostic on 1000-seed sweeps
+    // showed 100% of "trivial bypass" (0 forts + 0 levels) playthroughs were
+    // caused by pipes within one walking hop of start or target, so both are
+    // barred by default. The halves are kept separate so the START side can be
+    // lifted when connectivity demands it (completability outranks the
+    // anti-skip rule); the TARGET side is never lifted, since a pipe next to
+    // the airship is the skip we actually care about. Fixed endpoints (W3 boat
+    // dock) are exempt: their position is dictated by ROM data, not chosen by
+    // the builder.
     let zone_within_1_hop = |anchor: Option<(usize, usize)>| -> HashSet<(usize, usize)> {
         let mut z = HashSet::new();
         if let Some(a) = anchor {
@@ -89,7 +91,6 @@ pub(super) fn place_pipes<R: Rng>(
         .copied()
         .filter(|p| !target_zone.contains(p))
         .collect();
-    let blank_positions = strict.as_slice();
 
     let mut placed_pairs: Vec<TeleportEdge> = Vec::new();
     let mut used_positions: HashSet<(usize, usize)> = HashSet::new();
@@ -112,7 +113,7 @@ pub(super) fn place_pipes<R: Rng>(
 
         // Pick partner from opposite side: if fixed is on an island,
         // partner must be reachable (and vice versa).
-        let available: Vec<(usize, usize)> = blank_positions
+        let available: Vec<(usize, usize)> = strict
             .iter()
             .copied()
             .filter(|p| !used_positions.contains(p))
@@ -121,7 +122,7 @@ pub(super) fn place_pipes<R: Rng>(
 
         // Fall back to any available blank if no opposite-side candidates.
         let fallback: Vec<(usize, usize)> = if available.is_empty() {
-            blank_positions
+            strict
                 .iter()
                 .copied()
                 .filter(|p| !used_positions.contains(p))
@@ -158,7 +159,7 @@ pub(super) fn place_pipes<R: Rng>(
     // `active` is the candidate pool the loop draws from. It starts strict and
     // is lifted to `relaxed` at most once, only when the loop would otherwise
     // give up with the target still unreachable.
-    let mut active: &[(usize, usize)] = blank_positions;
+    let mut active: &[(usize, usize)] = &strict;
     let mut lifted = false;
 
     let mut must_connect_target = true;

--- a/src/randomize/overworld_build/progression.rs
+++ b/src/randomize/overworld_build/progression.rs
@@ -1,10 +1,16 @@
 //! Required-progression analysis and diagnostic dumps.
 
+// Reason: this whole module is exercised only by the test suite today
+// (reserved for a future WASM single-seed dump), so in non-test builds
+// everything here is dead code.
+#![allow(dead_code)]
+
 use super::*;
+
+use super::types::{BuiltWorld, SlotKind, stamp_slots};
 
 /// What occupies a grid position visited along the required path.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code)] // variants are inspected only by the dump helper today.
 pub(crate) enum PathNodeKind {
     Start,
     Level,
@@ -19,7 +25,6 @@ pub(crate) enum PathNodeKind {
 }
 
 #[derive(Clone, Debug, Default)]
-#[allow(dead_code)] // read by tests today; consumed by the WASM single-seed dump later.
 pub(crate) struct RequiredProgression {
     /// Distinct fortress slots the player must clear (excludes the objective
     /// itself if it happens to live at a fortress tile).
@@ -44,7 +49,6 @@ pub(crate) struct RequiredProgression {
 /// When `hammer` is true: the player has one hammer that can break exactly
 /// ONE overworld lock for free. We try every individual lock-break and pick
 /// the option that minimises total clears (including "don't use hammer").
-#[allow(dead_code)] // read by tests today; consumed by the WASM single-seed dump later.
 pub(crate) fn analyze_required_progression(
     built: &BuiltWorld,
     hammer: bool,
@@ -76,7 +80,6 @@ pub(crate) fn analyze_required_progression(
 
 /// Inner Dijkstra: returns the minimum-cost progression with `hammered_section`
 /// pre-opened (if `Some`) or no locks pre-opened (`None`).
-#[allow(dead_code)]
 pub(super) fn analyze_with_pre_opened(
     built: &BuiltWorld,
     hammered_section: Option<usize>,
@@ -90,7 +93,6 @@ pub(super) fn analyze_with_pre_opened(
 
 /// Same as `analyze_with_pre_opened` but takes an arbitrary opened-section
 /// mask. Useful for the all-locks-open sanity check in the dump.
-#[allow(dead_code)]
 pub(super) fn analyze_with_pre_opened_mask(
     built: &BuiltWorld,
     initial_mask: u32,
@@ -98,19 +100,7 @@ pub(super) fn analyze_with_pre_opened_mask(
     // 1. Stamp slots onto a working grid so walk_map sees them as nodes.
     //    Skip locks — we model them as conditional edges instead.
     let mut grid = built.grid.clone();
-    for slot in &built.slots {
-        match slot.kind {
-            SlotKind::Fortress => grid.set(slot.pos.0, slot.pos.1, TILE_FORTRESS),
-            SlotKind::Level
-                if BACKGROUND_TILES.contains(&grid.get(slot.pos.0, slot.pos.1)) =>
-            {
-                grid.set(slot.pos.0, slot.pos.1, TILE_NODE);
-            }
-            SlotKind::BonusGame => grid.set(slot.pos.0, slot.pos.1, TILE_BONUS_GAME),
-            SlotKind::ToadHouse => grid.set(slot.pos.0, slot.pos.1, TILE_TOAD_HOUSE),
-            _ => {}
-        }
-    }
+    stamp_slots(&mut grid, &built.slots);
 
     let start = match rom_data::find_start(&grid) {
         Some(s) => s,
@@ -197,6 +187,24 @@ pub(super) fn analyze_with_pre_opened_mask(
             break;
         }
 
+        // Relax one edge from the current state: entering a fortress flips
+        // its section bit; standard Dijkstra decrease-key + heap push.
+        let mut relax = |dest: (usize, usize), boat_after: Option<(usize, usize)>| {
+            let (edge_cost, is_fort) = entry_cost(dest);
+            let new_mask = if is_fort {
+                mask | (1u32 << section_at[&dest])
+            } else {
+                mask
+            };
+            let key = (dest, new_mask, boat_after);
+            let new_cost = cost + edge_cost;
+            if new_cost < *dist.get(&key).unwrap_or(&usize::MAX) {
+                dist.insert(key, new_cost);
+                prev.insert(key, state);
+                heap.push(Reverse((new_cost, dest, new_mask, boat_after)));
+            }
+        };
+
         // Walk / pipe edges from walk_map. Skip canoe edges — those are
         // handled below with explicit boat-state tracking.
         if let Some(edges) = walk.edges.get(&pos) {
@@ -211,24 +219,12 @@ pub(super) fn analyze_with_pre_opened_mask(
                 {
                     continue;
                 }
-                let dest = edge.dest;
-                let (edge_cost, is_fort) = entry_cost(dest);
-                let new_mask = if is_fort {
-                    mask | (1u32 << section_at[&dest])
-                } else {
-                    mask
-                };
-                let key = (dest, new_mask, boat);
-                let new_cost = cost + edge_cost;
-                if new_cost < *dist.get(&key).unwrap_or(&usize::MAX) {
-                    dist.insert(key, new_cost);
-                    prev.insert(key, state);
-                    heap.push(Reverse((new_cost, dest, new_mask, boat)));
-                }
+                relax(edge.dest, boat);
             }
         }
 
         // Canoe edges: usable only if the boat sits at the current position.
+        // Riding moves the boat with the player to the destination.
         if boat == Some(pos) {
             for &(a, b) in &canoe_edges {
                 let dest = if a == pos {
@@ -238,20 +234,7 @@ pub(super) fn analyze_with_pre_opened_mask(
                 } else {
                     continue;
                 };
-                let (edge_cost, is_fort) = entry_cost(dest);
-                let new_mask = if is_fort {
-                    mask | (1u32 << section_at[&dest])
-                } else {
-                    mask
-                };
-                let new_boat = Some(dest);
-                let key = (dest, new_mask, new_boat);
-                let new_cost = cost + edge_cost;
-                if new_cost < *dist.get(&key).unwrap_or(&usize::MAX) {
-                    dist.insert(key, new_cost);
-                    prev.insert(key, state);
-                    heap.push(Reverse((new_cost, dest, new_mask, new_boat)));
-                }
+                relax(dest, Some(dest));
             }
         }
     }
@@ -335,7 +318,6 @@ pub(super) fn analyze_with_pre_opened_mask(
 
 /// Pretty-print a `RequiredProgression` result for one world. Use for
 /// verification + as a reference for the WASM single-seed dump.
-#[allow(dead_code)]
 pub(crate) fn dump_required_progression(built: &BuiltWorld) {
     let no_hammer = analyze_required_progression(built, false);
     let with_hammer = analyze_required_progression(built, true);
@@ -426,10 +408,8 @@ pub(crate) fn dump_required_progression(built: &BuiltWorld) {
 }
 
 /// Set of directed teleport edges (pipe-pair / canoe-pair, both orientations).
-#[allow(dead_code)]
 type EdgeSet = HashSet<((usize, usize), (usize, usize))>;
 
-#[allow(dead_code)]
 pub(super) fn print_progression(
     label: &str,
     p: &RequiredProgression,

--- a/src/randomize/overworld_build/scoring.rs
+++ b/src/randomize/overworld_build/scoring.rs
@@ -65,7 +65,7 @@ pub(super) fn is_dead_end(grid: &Grid, pos: (usize, usize)) -> bool {
     if c >= 2 && VALID_HORZ.contains(&grid.get(r, c - 1)) { exits += 1; }
     if c + 2 < grid.cols && VALID_HORZ.contains(&grid.get(r, c + 1)) { exits += 1; }
     if r >= 2 && VALID_VERT.contains(&grid.get(r - 1, c)) { exits += 1; }
-    if r + 2 < grid.rows && VALID_VERT.contains(&grid.get(r + 1, c)) { exits += 1; }
+    if r + 2 < grid.rows() && VALID_VERT.contains(&grid.get(r + 1, c)) { exits += 1; }
     exits == 1
 }
 

--- a/src/randomize/overworld_build/scoring.rs
+++ b/src/randomize/overworld_build/scoring.rs
@@ -86,39 +86,39 @@ pub(super) fn is_row78_conflict(
     }
 }
 
-/// Core scoring logic shared by level and fortress placement.
-pub(super) fn score_with_weights(
-    grid: &Grid,
+// Shared spread/density weights (used by level, fortress, and pipe scoring).
+const W_MANHATTAN: f64 = 1.0;    // visual/spatial spread
+const W_BFS: f64 = 1.5;          // traversal spread (weighted higher than grid distance)
+const W_DENSITY: f64 = 3.0;      // penalty per nearby occupied tile
+const DENSITY_RADIUS: usize = 4; // combined manhattan+BFS distance threshold
+const SEP_CAP: f64 = 8.0;        // max separation contribution per metric
+
+/// Shared spread/density quantities of `pos` relative to a set of reference
+/// positions: (min manhattan distance, min BFS-distance difference, count of
+/// reference positions within DENSITY_RADIUS). The min values are
+/// `usize::MAX` / `None` when they can't be computed (empty set / no BFS
+/// data) — callers apply their own fallbacks.
+fn spread_and_density(
     pos: (usize, usize),
-    completable: &HashSet<(usize, usize)>,
+    others: &HashSet<(usize, usize)>,
     bfs_distances: &HashMap<(usize, usize), usize>,
-    dead_end_bonus_value: f64,
-) -> f64 {
+) -> (usize, Option<usize>, usize) {
     let (r, c) = pos;
     let my_bfs = bfs_distances.get(&pos).copied().unwrap_or(0);
 
-    const W_MANHATTAN: f64 = 1.0;    // visual/spatial spread
-    const W_BFS: f64 = 1.5;          // traversal spread (weighted higher than grid distance)
-    const W_DENSITY: f64 = 3.0;      // penalty per nearby completable tile
-    const DENSITY_RADIUS: usize = 4; // combined manhattan+BFS distance threshold
-    const SEP_CAP: f64 = 8.0;        // max separation contribution per metric
-
-    let min_manhattan = completable
+    let min_manhattan = others
         .iter()
         .map(|&(cr, cc)| r.abs_diff(cr) + c.abs_diff(cc))
         .min()
         .unwrap_or(usize::MAX);
-    let manhattan_score = (min_manhattan as f64).min(SEP_CAP) * W_MANHATTAN;
 
-    let min_bfs_diff = completable
+    let min_bfs_diff = others
         .iter()
         .filter_map(|p| bfs_distances.get(p))
         .map(|&d| my_bfs.abs_diff(d))
-        .min()
-        .unwrap_or(usize::MAX);
-    let bfs_score = (min_bfs_diff as f64).min(SEP_CAP) * W_BFS;
+        .min();
 
-    let nearby = completable
+    let nearby = others
         .iter()
         .filter(|&&(cr, cc)| {
             let manhattan = r.abs_diff(cr) + c.abs_diff(cc);
@@ -129,6 +129,24 @@ pub(super) fn score_with_weights(
             manhattan.max(bfs_diff) <= DENSITY_RADIUS
         })
         .count();
+
+    (min_manhattan, min_bfs_diff, nearby)
+}
+
+/// Core scoring logic shared by level and fortress placement.
+pub(super) fn score_with_weights(
+    grid: &Grid,
+    pos: (usize, usize),
+    completable: &HashSet<(usize, usize)>,
+    bfs_distances: &HashMap<(usize, usize), usize>,
+    dead_end_bonus_value: f64,
+) -> f64 {
+    let (min_manhattan, min_bfs_diff, nearby) =
+        spread_and_density(pos, completable, bfs_distances);
+    let min_bfs_diff = min_bfs_diff.unwrap_or(usize::MAX);
+
+    let manhattan_score = (min_manhattan as f64).min(SEP_CAP) * W_MANHATTAN;
+    let bfs_score = (min_bfs_diff as f64).min(SEP_CAP) * W_BFS;
     let density_penalty = nearby as f64 * W_DENSITY;
 
     let dead_end_bonus = if is_dead_end(grid, pos) { dead_end_bonus_value } else { 0.0 };
@@ -240,46 +258,20 @@ pub(super) fn score_pipe_endpoint(
     bfs_distances: &HashMap<(usize, usize), usize>,
     target_pos: Option<(usize, usize)>,
 ) -> f64 {
-    const W_MANHATTAN: f64 = 1.0;
-    const W_BFS: f64 = 1.5;
-    const W_DENSITY: f64 = 3.0;
-    const DENSITY_RADIUS: usize = 4;
-    const SEP_CAP: f64 = 8.0;
     const DEAD_END_BONUS: f64 = 1.0;
 
-    let (r, c) = pos;
-    let my_bfs = bfs_distances.get(&pos).copied().unwrap_or(0);
+    let (min_manhattan, min_bfs_diff, nearby) =
+        spread_and_density(pos, pipe_positions, bfs_distances);
 
     let spread = if pipe_positions.is_empty() {
         0.0
     } else {
-        let min_manhattan = pipe_positions
-            .iter()
-            .map(|&(cr, cc)| r.abs_diff(cr) + c.abs_diff(cc))
-            .min()
-            .unwrap();
-        let min_bfs_diff = pipe_positions
-            .iter()
-            .filter_map(|p| bfs_distances.get(p))
-            .map(|&d| my_bfs.abs_diff(d))
-            .min()
-            .unwrap_or(min_manhattan);
+        let min_bfs_diff = min_bfs_diff.unwrap_or(min_manhattan);
         let m = (min_manhattan as f64).min(SEP_CAP) * W_MANHATTAN;
         let b = (min_bfs_diff as f64).min(SEP_CAP) * W_BFS;
         (m + b).min(PIPE_SPREAD_CAP)
     };
 
-    let nearby = pipe_positions
-        .iter()
-        .filter(|&&(cr, cc)| {
-            let manhattan = r.abs_diff(cr) + c.abs_diff(cc);
-            let bfs_diff = bfs_distances
-                .get(&(cr, cc))
-                .map(|&d| my_bfs.abs_diff(d))
-                .unwrap_or(manhattan);
-            manhattan.max(bfs_diff) <= DENSITY_RADIUS
-        })
-        .count();
     let density_penalty = nearby as f64 * W_DENSITY;
 
     let dead_end_bonus = if is_dead_end(grid, pos) { DEAD_END_BONUS } else { 0.0 };

--- a/src/randomize/overworld_build/sections.rs
+++ b/src/randomize/overworld_build/sections.rs
@@ -2,6 +2,14 @@
 
 use super::*;
 
+use super::locks::place_locks;
+use super::pipes::{FIXED_PIPE_ENDPOINTS, PIPE_EXCLUDED_POSITIONS, place_pipes};
+use super::scoring::{
+    FORTRESS_SOFTMAX_T, is_row78_conflict, pick_softmax_by_score, score_candidate,
+    score_fortress_candidate,
+};
+use super::types::{BuiltWorld, SlotAssignment, SlotKind, WorldSlotCounts};
+
 pub(super) fn build_world<R: Rng>(
     world_idx: usize,
     rom: &Rom,
@@ -230,7 +238,6 @@ pub(super) fn completable_positions(grid: &Grid, slots: &[SlotAssignment]) -> Ha
     set
 }
 
-/// BFS from start, returning nodes in visit order with their distances.
 /// BFS-ordered list of (position, distance) using the canonical `walk_map`.
 ///
 /// This is the single source of truth for map traversal — all BFS-dependent
@@ -421,18 +428,21 @@ pub(super) fn populate_sections<R: Rng>(
     let mut level_positions: HashSet<(usize, usize)> = HashSet::new();
 
     for _ in 0..level_count {
+        // Score each candidate once, then pick the max on the cached score.
+        // (`max_by` returns the LAST maximal element on ties, matching the
+        // pre-caching behavior.)
         let best = global_candidates
             .iter()
             .filter(|(pos, _)| !level_positions.contains(pos))
             .filter(|(pos, _)| !is_row78_conflict(*pos, &completable))
-            .max_by(|(a, _), (b, _)| {
-                let sa = score_candidate(grid, *a, &placed_levels_and_forts, bfs_distances, reverse_bfs, target_bfs_dist);
-                let sb = score_candidate(grid, *b, &placed_levels_and_forts, bfs_distances, reverse_bfs, target_bfs_dist);
-                sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal)
-            });
+            .map(|&(pos, _)| {
+                let score = score_candidate(grid, pos, &placed_levels_and_forts, bfs_distances, reverse_bfs, target_bfs_dist);
+                (pos, score)
+            })
+            .max_by(|(_, sa), (_, sb)| sa.partial_cmp(sb).unwrap_or(std::cmp::Ordering::Equal));
 
         match best {
-            Some(&(pos, _)) => {
+            Some((pos, _)) => {
                 level_positions.insert(pos);
                 completable.insert(pos);
                 placed_levels_and_forts.insert(pos);

--- a/src/randomize/overworld_build/sections.rs
+++ b/src/randomize/overworld_build/sections.rs
@@ -173,7 +173,7 @@ pub(super) fn find_blank_slots(
     fixed_positions: &HashSet<(usize, usize)>,
 ) -> Vec<(usize, usize)> {
     let mut blanks = Vec::new();
-    for r in 0..grid.rows {
+    for r in 0..grid.rows() {
         for c in 0..grid.cols {
             let pos = (r, c);
             if fixed_positions.contains(&pos) {
@@ -220,7 +220,7 @@ pub(super) fn is_completion_unsafe(tile: u8) -> bool {
 /// (which will be stamped as completion-unsafe tiles by the writer).
 pub(super) fn completable_positions(grid: &Grid, slots: &[SlotAssignment]) -> HashSet<(usize, usize)> {
     let mut set: HashSet<(usize, usize)> = HashSet::new();
-    for r in 0..grid.rows {
+    for r in 0..grid.rows() {
         for c in 0..grid.cols {
             if is_completion_unsafe(grid.get(r, c)) {
                 set.insert((r, c));

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1,156 +1,1587 @@
-    use super::*;
-    use crate::rom::Rom;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
+use super::*;
+use super::capacity::{
+    W8_HB_CAP, distribute_levels, fixed_positions_for_world, prepare_capacities,
+    redistribute_fortresses,
+};
+use super::locks::debug_stamp_rom;
+use super::pipes::VANILLA_PIPE_PAIRS;
+use super::scoring::{VANILLA_LEVEL_COUNT, is_dead_end};
+use super::sections::find_blank_slots;
+use super::types::stamp_slots;
+use crate::rom::Rom;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
-    fn load_rom() -> Option<Rom> {
-        let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
-        Rom::from_bytes(&data).ok()
+/// Shannon entropy (bits) of a count distribution summing to `total`.
+fn shannon_entropy<'a>(counts: impl IntoIterator<Item = &'a u32>, total: f64) -> f64 {
+    counts
+        .into_iter()
+        .map(|&c| {
+            let p = c as f64 / total;
+            -p * p.log2()
+        })
+        .sum()
+}
+
+fn load_rom() -> Option<Rom> {
+    let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+    Rom::from_bytes(&data).ok()
+}
+
+/// Apply the QoL patches that the real pipeline runs before the overworld
+/// builder (`randomizer.rs` ~L657-670). These mutate the world-map grid —
+/// rocks blocking pipe shortcuts, W3 drawbridge tiles, big-Q rooms — so
+/// the catalog must see the post-patch state, not vanilla.
+fn apply_qol_for_overworld(rom: &Rom) -> Rom {
+    let mut out = rom.clone();
+    super::super::qol::fix_w3_drawbridges(&mut out);
+    super::super::qol::remove_rocks(&mut out);
+    super::super::qol::fix_big_q_block_rooms(&mut out);
+    out
+}
+
+/// Build `(catalog, pickup)` for one seed. When the `SAS` env var is set,
+/// applies per-seed start↔airship swap before pickup runs, matching the
+/// real pipeline in `randomizer.rs` when `swap_start_airship` is on.
+fn build_catalog_pickup(rom: &Rom, seed: u64) -> (NodeCatalog, PickupResult) {
+    let mut catalog = NodeCatalog::build(rom, false);
+    if std::env::var("SAS").is_ok() {
+        let mut swap_rng = ChaCha8Rng::seed_from_u64(seed);
+        super::super::start_airship_swap::pick_swaps(&mut catalog, &mut swap_rng);
     }
+    let pickup = super::super::overworld_pickup::pick_up(
+        rom,
+        &catalog,
+        super::super::overworld_pickup::PickupFlags {
+            shuffle_spade_games: true,
+            shuffle_toad_houses: true,
+            ..Default::default()
+        },
+    );
+    (catalog, pickup)
+}
 
-    /// Apply the QoL patches that the real pipeline runs before the overworld
-    /// builder (`randomizer.rs` ~L657-670). These mutate the world-map grid —
-    /// rocks blocking pipe shortcuts, W3 drawbridge tiles, big-Q rooms — so
-    /// the catalog must see the post-patch state, not vanilla.
-    fn apply_qol_for_overworld(rom: &Rom) -> Rom {
-        let mut out = rom.clone();
-        super::super::qol::fix_w3_drawbridges(&mut out);
-        super::super::qol::remove_rocks(&mut out);
-        super::super::qol::fix_big_q_block_rooms(&mut out);
-        out
-    }
-
-    /// Build `(catalog, pickup)` for one seed. When the `SAS` env var is set,
-    /// applies per-seed start↔airship swap before pickup runs, matching the
-    /// real pipeline in `randomizer.rs` when `swap_start_airship` is on.
-    fn build_catalog_pickup(rom: &Rom, seed: u64) -> (NodeCatalog, PickupResult) {
-        let mut catalog = NodeCatalog::build(rom, false);
-        if std::env::var("SAS").is_ok() {
-            let mut swap_rng = ChaCha8Rng::seed_from_u64(seed);
-            super::super::start_airship_swap::pick_swaps(&mut catalog, &mut swap_rng);
+#[test]
+fn test_fortress_redistribution() {
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    for _ in 0..100 {
+        let counts = redistribute_fortresses(&mut rng);
+        let total: usize = counts.iter().sum();
+        assert_eq!(total, 17, "total fortresses must be 17");
+        assert_eq!(counts[7], 4, "W8 must keep 4");
+        for (w, &count) in counts[..7].iter().enumerate() {
+            assert!((1..=3).contains(&count),
+                "W{} got {count} forts, expected 1-3", w + 1);
         }
+    }
+}
+
+#[test]
+fn test_build_all_worlds() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 42);
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+
+    let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+
+    assert_eq!(result.worlds.len(), 8);
+
+    for built in &result.worlds {
+        let wi = built.world_idx;
+        let forts = built.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count();
+        let pipes = built.pipe_pairs.len();
+        let locks = built.locks.len();
+
+        assert_eq!(forts, result.fort_counts[wi],
+            "W{}: fort slots {} != expected {}", wi + 1, forts, result.fort_counts[wi]);
+        assert_eq!(pipes, VANILLA_PIPE_PAIRS[wi],
+            "W{}: pipe pairs {} != expected {}", wi + 1, pipes, VANILLA_PIPE_PAIRS[wi]);
+        assert!(locks <= result.fort_counts[wi],
+            "W{}: locks {} > fort count {}", wi + 1, locks, result.fort_counts[wi]);
+    }
+
+    let total_levels: usize = result.worlds.iter()
+        .map(|b| b.slots.iter().filter(|s| s.kind == SlotKind::Level).count())
+        .sum();
+    let total_forts: usize = result.worlds.iter()
+        .map(|b| b.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count())
+        .sum();
+    assert_eq!(total_levels, VANILLA_LEVEL_COUNT,
+        "total levels {} != {}", total_levels, VANILLA_LEVEL_COUNT);
+    assert_eq!(total_forts, 17, "total forts {} != 17", total_forts);
+}
+
+/// Regression: the overworld builder must never strand a world's target
+/// (airship/Bowser) — that would be an unbeatable world. Covers SAS on/off,
+/// hammer-bro shuffle on/off, and both the raw ROM and the QoL-patched ROM.
+/// The raw-ROM arm (path rocks still present) locks in that the pipe
+/// island-connect logic recovers connectivity even when a rock blocks a
+/// path, so this can't regress if the rock-removal QoL ever changes.
+#[test]
+fn all_world_targets_reachable() {
+    let raw = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let qol = apply_qol_for_overworld(&raw);
+    let names = ["W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8"];
+
+    for (rom_label, rom) in [("raw", &raw), ("qol", &qol)] {
+        for hb in [false, true] {
+            for sas in [false, true] {
+                for seed in 0..40u64 {
+                    let mut catalog = NodeCatalog::build(rom, false);
+                    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+                    if sas {
+                        super::super::start_airship_swap::pick_swaps(&mut catalog, &mut rng);
+                    }
+                    let pickup = super::super::overworld_pickup::pick_up(
+                        rom,
+                        &catalog,
+                        super::super::overworld_pickup::PickupFlags {
+                            shuffle_spade_games: true,
+                            shuffle_toad_houses: true,
+                            shuffle_hammer_bros: hb,
+                        },
+                    );
+                    let result = build(
+                        rom,
+                        &OverworldData { pickup: &pickup, catalog: &catalog },
+                        &mut rng,
+                        BuildFlags {
+                            shuffle_toad_houses: true,
+                            shuffle_hammer_bros: hb,
+                            ..Default::default()
+                        },
+                    );
+                    for built in &result.worlds {
+                        let wi = built.world_idx;
+                        let start = rom_data::find_start(&built.grid);
+                        if let Some(t) = find_target(&built.grid, wi) {
+                            assert!(
+                                walk_map(&built.grid, &built.pipe_pairs, start, wi)
+                                    .nodes
+                                    .contains(&t),
+                                "{rom_label} hb={hb} sas={sas} seed={seed}: \
+                                 {} target unreachable from start",
+                                names[wi],
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Tuning diagnostic: sweep the level-spread exponent and show the resulting
+/// per-world mean assigned-level count, plus how often we hit "overflow" —
+/// a world's fair share exceeding its hard capacity (clamp), or the total
+/// not fully placeable (underfill). Uses the same capacity + distribution
+/// code as production. Run with:
+///   cargo test --lib report_distribution_by_exponent -- --nocapture
+#[test]
+fn report_distribution_by_exponent() {
+    let raw = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let rom = apply_qol_for_overworld(&raw);
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let mut vanilla = [0usize; 8];
+    for e in &catalog.entries {
+        if matches!(e.kind, NodeKind::Level) {
+            vanilla[e.world_idx] += 1;
+        }
+    }
+
+    const SEEDS: u64 = 300;
+    let names = ["W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8"];
+    let header: String = names.iter().map(|n| format!("{n:>6}")).collect();
+    eprintln!("\nLevel distribution by exponent ({SEEDS} seeds, mean assigned per world):");
+    eprintln!("  exp  {header}");
+    let van: String = vanilla.iter().map(|v| format!("{v:>6}")).collect();
+    eprintln!("  van  {van}");
+
+    for &exp in &[1.0_f64, 0.7, 0.6, 0.5, 0.4] {
+        let mut sums = [0usize; 8];
+        let mut clamp_events = 0usize; // (seed,world) share floored > capacity
+        let mut underfill_seeds = 0usize; // seeds where total placed < 62
+        for seed in 0..SEEDS {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let fort_counts = redistribute_fortresses(&mut rng);
+            let caps = prepare_capacities(&rom, &catalog, &pickup, &fort_counts, false, true, false)
+                .capacities;
+
+            // Detect clamp events (a world's fair share exceeds its capacity).
+            let weights: [f64; 8] = std::array::from_fn(|wi| {
+                if caps[wi] == 0 { 0.0 } else { (caps[wi] as f64).powf(exp) }
+            });
+            let tw: f64 = weights.iter().sum();
+            for wi in 0..8 {
+                let share = weights[wi] / tw * VANILLA_LEVEL_COUNT as f64;
+                if share.floor() as usize > caps[wi] {
+                    clamp_events += 1;
+                }
+            }
+
+            let counts = distribute_levels(&caps, VANILLA_LEVEL_COUNT, exp, &mut rng);
+            if counts.iter().sum::<usize>() < VANILLA_LEVEL_COUNT {
+                underfill_seeds += 1;
+            }
+            for wi in 0..8 {
+                sums[wi] += counts[wi];
+            }
+        }
+        let row: String = (0..8)
+            .map(|wi| format!("{:>6.1}", sums[wi] as f64 / SEEDS as f64))
+            .collect();
+        eprintln!("  {exp:<3}  {row}    clamp_events={clamp_events} underfill_seeds={underfill_seeds}");
+    }
+}
+
+/// Diagnostic (not an assertion): tabulate how many levels the builder
+/// places in each world across many seeds, next to the vanilla count, plus
+/// the number of leftover open path tiles (placeable blank nodes left with
+/// nothing on them). Run with:
+///   cargo test report_levels_per_world -- --nocapture
+#[test]
+fn report_levels_per_world() {
+    let raw = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    // QoL map edits (incl. remove_rocks) run before the builder in the real
+    // pipeline; build from the patched ROM so capacities/connectivity match
+    // what players actually get.
+    let rom = apply_qol_for_overworld(&raw);
+
+    const SEEDS: u64 = 200;
+
+    // Vanilla per-world Level counts, straight from the catalog (the same
+    // source VANILLA_LEVEL_COUNT is derived from).
+    let vanilla_catalog = NodeCatalog::build(&rom, false);
+    let mut vanilla_levels = [0usize; 8];
+    for e in &vanilla_catalog.entries {
+        if matches!(e.kind, NodeKind::Level) {
+            vanilla_levels[e.world_idx] += 1;
+        }
+    }
+
+    // Per world, collect the placed-level count and open-tile count per seed.
+    let mut levels: [Vec<usize>; 8] = Default::default();
+    let mut opens: [Vec<usize>; 8] = Default::default();
+
+    for seed in 0..SEEDS {
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            let lv = built.slots.iter().filter(|s| s.kind == SlotKind::Level).count();
+
+            // Open path = currently-blank placeable node tiles not occupied
+            // by a non-pipe slot. The build phase stamps pipe tiles onto the
+            // grid but leaves level/fort/HB/bonus/toad slots blank, so those
+            // slot positions still read as blank here and must be subtracted.
+            let fixed = fixed_positions_for_world(&rom, &catalog, wi, true, false);
+            let blank = find_blank_slots(&built.grid, &fixed).len();
+            let non_pipe_slots =
+                built.slots.iter().filter(|s| s.kind != SlotKind::Pipe).count();
+            let open = blank.saturating_sub(non_pipe_slots);
+
+            levels[wi].push(lv);
+            opens[wi].push(open);
+        }
+    }
+
+    let stats = |v: &[usize]| -> (usize, f64, usize) {
+        let min = *v.iter().min().unwrap();
+        let max = *v.iter().max().unwrap();
+        let mean = v.iter().sum::<usize>() as f64 / v.len() as f64;
+        (min, mean, max)
+    };
+
+    let names = ["Grass", "Desert", "Water", "Giant", "Sky", "Ice", "Pipe", "Dark"];
+    eprintln!("\nLevels placed per world over {SEEDS} seeds (shuffle_toad_houses on):\n");
+    eprintln!(
+        "  {:<14} {:>7} | {:>18} | {:>18}",
+        "World", "Vanilla", "Levels min/mean/max", "Open min/mean/max"
+    );
+    eprintln!("  {}", "-".repeat(66));
+    let mut van_total = 0usize;
+    let mut lvl_mean_total = 0.0f64;
+    let mut open_mean_total = 0.0f64;
+    for wi in 0..8 {
+        let (lmin, lmean, lmax) = stats(&levels[wi]);
+        let (omin, omean, omax) = stats(&opens[wi]);
+        van_total += vanilla_levels[wi];
+        lvl_mean_total += lmean;
+        open_mean_total += omean;
+        eprintln!(
+            "  W{} {:<11} {:>7} | {:>5} {:>6.1} {:>4} | {:>5} {:>6.1} {:>4}",
+            wi + 1, names[wi], vanilla_levels[wi],
+            lmin, lmean, lmax, omin, omean, omax,
+        );
+    }
+    eprintln!("  {}", "-".repeat(66));
+    eprintln!(
+        "  {:<14} {:>7} | {:>5} {:>6.1} {:>4} | {:>5} {:>6.1} {:>4}",
+        "Total", van_total, "", lvl_mean_total, "", "", open_mean_total, "",
+    );
+}
+
+#[test]
+fn hammer_bro_redistribution_invariants() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    for seed in 0..32u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let catalog = NodeCatalog::build(&rom, false);
         let pickup = super::super::overworld_pickup::pick_up(
-            rom,
+            &rom,
             &catalog,
             super::super::overworld_pickup::PickupFlags {
                 shuffle_spade_games: true,
                 shuffle_toad_houses: true,
-                ..Default::default()
+                shuffle_hammer_bros: true,
             },
         );
-        (catalog, pickup)
-    }
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, shuffle_hammer_bros: true, ..Default::default() },
+        );
 
-    #[test]
-    fn test_fortress_redistribution() {
-        let mut rng = ChaCha8Rng::seed_from_u64(42);
-        for _ in 0..100 {
-            let counts = redistribute_fortresses(&mut rng);
-            let total: usize = counts.iter().sum();
-            assert_eq!(total, 17, "total fortresses must be 17");
-            assert_eq!(counts[7], 4, "W8 must keep 4");
-            for (w, &count) in counts[..7].iter().enumerate() {
-                assert!((1..=3).contains(&count),
-                    "W{} got {count} forts, expected 1-3", w + 1);
+        // The vanilla 15 encounters are always placed (W1-W6 alone have the
+        // capacity), spread across the worlds.
+        let total: usize = result.worlds.iter().map(|w| w.hb_sprites.len()).sum();
+        assert_eq!(total, 15, "seed {seed}: total HB sprites {total} != 15");
+
+        for w in &result.worlds {
+            let n = w.hb_sprites.len();
+            // Best-effort 1-3 per world (W8 capped lower); a feature-dense
+            // world (e.g. W7's 8 pipe pairs) can be left with no spare
+            // HammerBro tile and get 0, with its share spilling elsewhere.
+            let max = if w.world_idx == 7 { W8_HB_CAP } else { 3 };
+            assert!(
+                n <= max,
+                "seed {seed} W{}: {n} HB sprites (max {max})", w.world_idx + 1
+            );
+            // At least RESERVED_DYNAMIC_SLOTS eligible map-object slots stay
+            // free for a runtime white-house spawn.
+            let eligible = rom_data::eligible_hb_map_slots(&rom, w.world_idx).len();
+            assert!(
+                eligible.saturating_sub(n) >= RESERVED_DYNAMIC_SLOTS,
+                "seed {seed} W{}: only {} eligible slots free after {n} HBs",
+                w.world_idx + 1, eligible.saturating_sub(n)
+            );
+            // Every sprite sits on one of this world's HammerBro slot tiles.
+            let hb_tiles: HashSet<(usize, usize)> = w
+                .slots
+                .iter()
+                .filter(|s| s.kind == SlotKind::HammerBro)
+                .map(|s| s.pos)
+                .collect();
+            let mut seen: HashSet<(usize, usize)> = HashSet::new();
+            for sprite in &w.hb_sprites {
+                assert!(
+                    hb_tiles.contains(&sprite.grid_pos),
+                    "seed {seed} W{}: HB sprite at {:?} is not a HammerBro slot",
+                    w.world_idx + 1, sprite.grid_pos
+                );
+                assert!(
+                    seen.insert(sprite.grid_pos),
+                    "seed {seed} W{}: duplicate HB sprite position {:?}",
+                    w.world_idx + 1, sprite.grid_pos
+                );
             }
         }
     }
+}
 
-    #[test]
-    fn test_build_all_worlds() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-        let mut rng = ChaCha8Rng::seed_from_u64(42);
+#[test]
+fn test_locks_dont_block_own_fort() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
 
+    for seed in 0..10 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
-        assert_eq!(result.worlds.len(), 8);
-
         for built in &result.worlds {
-            let wi = built.world_idx;
+            let start_pos = rom_data::find_start(&built.grid);
+
+            // Build grid with all assignments stamped (same as production)
+            let mut test_grid = built.grid.clone();
+            stamp_slots(&mut test_grid, &built.slots);
+
+            // For each lock, verify its fort is still reachable
+            for lock in &built.locks {
+                // Place ALL locks
+                let mut locked_grid = test_grid.clone();
+                for l in &built.locks {
+                    locked_grid.set(l.pos.0, l.pos.1, l.gap_tile);
+                }
+                // But open THIS lock (as if its fort was beaten)
+                locked_grid.set(lock.pos.0, lock.pos.1, lock.replace_tile);
+
+                // Open all locks from earlier sections too
+                for earlier in &built.locks {
+                    if earlier.fort_section < lock.fort_section {
+                        locked_grid.set(earlier.pos.0, earlier.pos.1, earlier.replace_tile);
+                    }
+                }
+
+                let fort_pos = built.slots.iter()
+                    .find(|s| s.section == lock.fort_section && s.kind == SlotKind::Fortress)
+                    .map(|s| s.pos);
+
+                if let Some(fp) = fort_pos {
+                    let walk = walk_map(&locked_grid, &built.pipe_pairs, start_pos, built.world_idx);
+                    assert!(walk.nodes.contains(&fp),
+                        "Seed {seed} W{}: lock at {:?} blocks its own fort at {:?}",
+                        built.world_idx + 1, lock.pos, fp);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_dump_debug_rom() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+
+    for seed in [42, 123, 999] {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+
+        let mut rom_copy = Rom::from_bytes(&rom.data).unwrap();
+        debug_stamp_rom(&mut rom_copy, &result);
+
+        let filename = format!("debug_build_seed{seed}.nes");
+        std::fs::write(&filename, &rom_copy.data).unwrap();
+
+        eprintln!("\n=== Seed {seed} ===");
+        for built in &result.worlds {
             let forts = built.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count();
+            let levels = built.slots.iter().filter(|s| s.kind == SlotKind::Level).count();
             let pipes = built.pipe_pairs.len();
             let locks = built.locks.len();
-
-            assert_eq!(forts, result.fort_counts[wi],
-                "W{}: fort slots {} != expected {}", wi + 1, forts, result.fort_counts[wi]);
-            assert_eq!(pipes, VANILLA_PIPE_PAIRS[wi],
-                "W{}: pipe pairs {} != expected {}", wi + 1, pipes, VANILLA_PIPE_PAIRS[wi]);
-            assert!(locks <= result.fort_counts[wi],
-                "W{}: locks {} > fort count {}", wi + 1, locks, result.fort_counts[wi]);
+            eprintln!(
+                "  W{}: {} forts, {} levels, {} pipe pairs, {} locks",
+                built.world_idx + 1, forts, levels, pipes, locks,
+            );
         }
+        eprintln!("  Wrote {filename}");
+    }
+}
+
+#[test]
+#[ignore]
+fn test_print_build() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 42);
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+
+    let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+
+    for built in &result.worlds {
+        eprintln!("\n=== World {} ({} sections) ===",
+            built.world_idx + 1, built.section_count);
+
+        for (si, section_slots) in (0..built.section_count).map(|si| {
+            (si, built.slots.iter().filter(|s| s.section == si).collect::<Vec<_>>())
+        }) {
+            let fort = section_slots.iter().find(|s| s.kind == SlotKind::Fortress);
+            let levels = section_slots.iter().filter(|s| s.kind == SlotKind::Level).count();
+            let lock = built.locks.iter().find(|l| l.fort_section == si);
+
+            eprintln!("  Section {si}: {} slots ({} levels, fort at {:?})",
+                section_slots.len(), levels,
+                fort.map(|f| f.pos));
+            if let Some(l) = lock {
+                eprintln!("    Lock at {:?} (gap=${:02X}, restore=${:02X})",
+                    l.pos, l.gap_tile, l.replace_tile);
+            }
+        }
+
+        eprintln!("  Pipes: {} pairs", built.pipe_pairs.len());
+        for (i, &(a, b)) in built.pipe_pairs.iter().enumerate() {
+            eprintln!("    Pair {i}: ({},{}) ↔ ({},{})", a.0, a.1, b.0, b.1);
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_measure_shortfalls() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+
+    let mut level_shortfalls = 0u32;
+    let mut lock_shortfalls = 0u32;
+    let seeds = 1000;
+
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         let total_levels: usize = result.worlds.iter()
             .map(|b| b.slots.iter().filter(|s| s.kind == SlotKind::Level).count())
             .sum();
-        let total_forts: usize = result.worlds.iter()
-            .map(|b| b.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count())
-            .sum();
-        assert_eq!(total_levels, VANILLA_LEVEL_COUNT,
-            "total levels {} != {}", total_levels, VANILLA_LEVEL_COUNT);
-        assert_eq!(total_forts, 17, "total forts {} != 17", total_forts);
+        if total_levels < VANILLA_LEVEL_COUNT {
+            level_shortfalls += 1;
+            let deficit = VANILLA_LEVEL_COUNT - total_levels;
+            // Show per-world breakdown
+            let mut detail = String::new();
+            for built in &result.worlds {
+                let levels = built.slots.iter().filter(|s| s.kind == SlotKind::Level).count();
+                let section_sizes: Vec<usize> = (0..built.section_count)
+                    .map(|si| built.slots.iter().filter(|s| s.section == si).count())
+                    .collect();
+                if levels < 3 {
+                    detail.push_str(&format!(" W{}={levels}(sections={section_sizes:?})", built.world_idx + 1));
+                }
+            }
+            eprintln!("Seed {seed}: {total_levels}/{VANILLA_LEVEL_COUNT} (-{deficit}){detail}");
+        }
+
+        for built in &result.worlds {
+            let expected_locks = result.fort_counts[built.world_idx];
+            if built.locks.len() < expected_locks {
+                lock_shortfalls += 1;
+                // Find which section(s) are missing locks
+                let placed: HashSet<usize> = built.locks.iter().map(|l| l.fort_section).collect();
+                for si in 0..built.section_count {
+                    if !placed.contains(&si) {
+                        let section_size = built.slots.iter().filter(|s| s.section == si).count();
+                        let fort = built.slots.iter().find(|s| s.section == si && s.kind == SlotKind::Fortress);
+                        eprintln!("Seed {seed} W{} section {si}: NO LOCK, section_size={section_size}, fort={:?}, total_slots={}",
+                            built.world_idx + 1, fort.map(|f| f.pos),
+                            built.slots.len());
+                    }
+                }
+            }
+        }
     }
 
-    /// Regression: the overworld builder must never strand a world's target
-    /// (airship/Bowser) — that would be an unbeatable world. Covers SAS on/off,
-    /// hammer-bro shuffle on/off, and both the raw ROM and the QoL-patched ROM.
-    /// The raw-ROM arm (path rocks still present) locks in that the pipe
-    /// island-connect logic recovers connectivity even when a rock blocks a
-    /// path, so this can't regress if the rock-removal QoL ever changes.
-    #[test]
-    fn all_world_targets_reachable() {
-        let raw = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let qol = apply_qol_for_overworld(&raw);
-        let names = ["W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8"];
+    // Count seeds with at least one secret_exit_safe lock and
+    // track which worlds have safe locks in failing seeds
+    let mut safe_count = 0u32;
+    let mut no_safe_details: Vec<(u64, [usize; 8])> = Vec::new();
+    for seed in 0..seeds {
+        let mut rng2 = ChaCha8Rng::seed_from_u64(seed);
+        let result2 = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+        let has_safe = result2.worlds.iter().any(|b| {
+            b.locks.iter().any(|l| l.secret_exit_safe)
+        });
+        if has_safe {
+            safe_count += 1;
+        } else {
+            // For failing seeds, count locks per world to see which have room
+            let mut lock_counts = [0usize; 8];
+            for b in &result2.worlds {
+                lock_counts[b.world_idx] = b.locks.len();
+            }
+            no_safe_details.push((seed, lock_counts));
+        }
+    }
 
-        for (rom_label, rom) in [("raw", &raw), ("qol", &qol)] {
-            for hb in [false, true] {
-                for sas in [false, true] {
-                    for seed in 0..40u64 {
-                        let mut catalog = NodeCatalog::build(rom, false);
-                        let mut rng = ChaCha8Rng::seed_from_u64(seed);
-                        if sas {
-                            super::super::start_airship_swap::pick_swaps(&mut catalog, &mut rng);
+    eprintln!("\n=== {seeds} seeds ===");
+    eprintln!("Level shortfalls: {level_shortfalls}/{seeds}");
+    eprintln!("Lock shortfalls:  {lock_shortfalls}/{seeds} (world-level)");
+    eprintln!("Seeds with >=1 secret_exit_safe lock: {safe_count}/{seeds}");
+    if !no_safe_details.is_empty() {
+        eprintln!("No-safe seeds (first 10):");
+        for (seed, counts) in no_safe_details.iter().take(10) {
+            eprintln!("  Seed {seed}: locks per world = {counts:?}");
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_w6_slot_distribution() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+
+    for seed in 0..6u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+        let built = &result.worlds[5]; // W6 (0-indexed)
+
+        eprintln!("\n===== Seed {seed} — W6 =====");
+        eprintln!("level_count received: {} (from distribute_levels)",
+            built.slots.iter().filter(|s| s.kind == SlotKind::Level).count());
+        eprintln!("fort_count: {}", result.fort_counts[5]);
+        eprintln!("total slots: {}", built.slots.len());
+        eprintln!("section_count: {}", built.section_count);
+        eprintln!("pipe_pairs: {}", built.pipe_pairs.len());
+
+        // Group by kind
+        let mut fortresses = Vec::new();
+        let mut levels = Vec::new();
+        let mut hammer_bros = Vec::new();
+        let mut pipes = Vec::new();
+        let mut bonus_games = Vec::new();
+        let mut toad_houses = Vec::new();
+        for slot in &built.slots {
+            match slot.kind {
+                SlotKind::Fortress => fortresses.push(slot),
+                SlotKind::Level => levels.push(slot),
+                SlotKind::HammerBro => hammer_bros.push(slot),
+                SlotKind::Pipe => pipes.push(slot),
+                SlotKind::BonusGame => bonus_games.push(slot),
+                SlotKind::ToadHouse => toad_houses.push(slot),
+            }
+        }
+
+        eprintln!("\nFortresses ({}):", fortresses.len());
+        for s in &fortresses {
+            eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
+        }
+
+        eprintln!("\nLevels ({}):", levels.len());
+        for s in &levels {
+            // Compute min Manhattan distance to nearest other Level slot
+            let min_dist = levels.iter()
+                .filter(|o| o.pos != s.pos)
+                .map(|o| {
+                    let dr = (s.pos.0 as isize - o.pos.0 as isize).unsigned_abs();
+                    let dc = (s.pos.1 as isize - o.pos.1 as isize).unsigned_abs();
+                    dr + dc
+                })
+                .min()
+                .unwrap_or(0);
+            eprintln!("  ({:2}, {:2})  section={}  min_dist_to_level={}", s.pos.0, s.pos.1, s.section, min_dist);
+        }
+
+        eprintln!("\nHammerBros ({}):", hammer_bros.len());
+        for s in &hammer_bros {
+            eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
+        }
+
+        eprintln!("\nPipes ({}):", pipes.len());
+        for s in &pipes {
+            eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
+        }
+
+        eprintln!("\nBonus Games ({}):", bonus_games.len());
+        for s in &bonus_games {
+            eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
+        }
+
+        eprintln!("\nToad Houses ({}):", toad_houses.len());
+        for s in &toad_houses {
+            eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
+        }
+
+        eprintln!("\nLocks ({}):", built.locks.len());
+        for l in &built.locks {
+            eprintln!("  ({:2}, {:2})  gap=0x{:02X}  replace=0x{:02X}  fort_section={}  safe={}",
+                l.pos.0, l.pos.1, l.gap_tile, l.replace_tile, l.fort_section, l.secret_exit_safe);
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_dump_w7_blank_vs_bfs() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let wi = 6; // W7
+
+    let cw = &pickup.worlds[wi];
+    eprintln!("\n=== W7 Pickup: {} pool entries ===", cw.pool_indices.len());
+
+    let fixed = fixed_positions_for_world(&rom, &catalog, wi, true, false);
+    eprintln!("Fixed positions: {} {:?}", fixed.len(), fixed);
+
+    let blank_positions = find_blank_slots(&cw.grid, &fixed);
+    eprintln!("Blank tiles on grid: {}", blank_positions.len());
+
+    // Run the actual build for several seeds and check coverage
+    for seed in 0..5u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+        let built = &result.worlds[wi];
+
+        // All positions that got a slot assignment
+        let slot_positions: HashSet<(usize, usize)> = built.slots.iter().map(|s| s.pos).collect();
+        // Add pipe positions
+        let pipe_positions: HashSet<(usize, usize)> = built.pipe_pairs.iter()
+            .flat_map(|&(a, b)| vec![a, b]).collect();
+        let all_assigned: HashSet<(usize, usize)> = slot_positions.union(&pipe_positions).copied().collect();
+
+        // Blank tiles with no assignment
+        let uncovered: Vec<(usize, usize)> = blank_positions.iter()
+            .filter(|p| !all_assigned.contains(p))
+            .copied()
+            .collect();
+
+        let total_slots = built.slots.len() + pipe_positions.len();
+        eprintln!("\n--- Seed {seed} ---");
+        eprintln!("  Slots: {} (L={}, F={}, P={}, HB={})",
+            total_slots,
+            built.slots.iter().filter(|s| s.kind == SlotKind::Level).count(),
+            built.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count(),
+            pipe_positions.len(),
+            built.slots.iter().filter(|s| s.kind == SlotKind::HammerBro).count(),
+        );
+        eprintln!("  Pool entries (ptr slots): {}", cw.pool_indices.len());
+        eprintln!("  max_non_pipe_slots: {}", cw.pool_indices.len() - VANILLA_PIPE_PAIRS[wi] * 2);
+        eprintln!("  Blanks on grid: {}", blank_positions.len());
+        eprintln!("  Assigned positions: {}", all_assigned.len());
+        eprintln!("  Uncovered blanks: {}", uncovered.len());
+
+        if !uncovered.is_empty() {
+            for (r, c) in &uncovered {
+                eprintln!("    UNCOVERED: ({},{}) tile=${:02X}", r, c, cw.grid.get(*r, *c));
+                // Check if BFS can reach it with the placed pipes
+                let bfs_all = bfs_ordered(&built.grid, &built.pipe_pairs, rom_data::find_start(&built.grid), built.world_idx);
+                let bfs_set: HashSet<(usize, usize)> = bfs_all.iter().map(|&(p, _)| p).collect();
+                eprintln!("      BFS reachable: {}", bfs_set.contains(&(*r, *c)));
+            }
+        }
+
+        // Check for assignments NOT on blank tiles (double-covering or wrong pos)
+        let non_blank_assignments: Vec<_> = all_assigned.iter()
+            .filter(|p| !blank_positions.contains(p) && !pipe_positions.contains(p))
+            .collect();
+        if !non_blank_assignments.is_empty() {
+            eprintln!("  Assignments on non-blank tiles:");
+            for &&(r, c) in &non_blank_assignments {
+                eprintln!("    ({},{}) tile=${:02X}", r, c, cw.grid.get(r, c));
+            }
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_lock_scoring_detail() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+
+    for seed in [42u64, 123, 999] {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+
+        eprintln!("\n{}", "=".repeat(60));
+        eprintln!("=== Seed {seed} ===");
+
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            let target_pos = find_target(&built.grid, wi);
+            let start_pos = rom_data::find_start(&built.grid);
+
+            let forts: Vec<_> = built.slots.iter()
+                .filter(|s| s.kind == SlotKind::Fortress)
+                .collect();
+            let levels: Vec<_> = built.slots.iter()
+                .filter(|s| s.kind == SlotKind::Level)
+                .collect();
+
+            eprintln!("\n  W{}: {} forts, {} levels, {} pipes, {} locks, target={:?}",
+                wi + 1, forts.len(), levels.len(), built.pipe_pairs.len(),
+                built.locks.len(), target_pos);
+
+            // Build stamped grid (no locks), same as production
+            let mut base_grid = built.grid.clone();
+            stamp_slots(&mut base_grid, &built.slots);
+
+            for lock in &built.locks {
+                // Open grid: no locks
+                let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos, built.world_idx);
+
+                // Locked grid: this lock closed
+                let mut locked_grid = base_grid.clone();
+                locked_grid.set(lock.pos.0, lock.pos.1, lock.gap_tile);
+                let walk_locked = walk_map(&locked_grid, &built.pipe_pairs, start_pos, built.world_idx);
+
+                let gated_count = walk_open.nodes.len() as i32 - walk_locked.nodes.len() as i32;
+
+                // What specifically gets gated?
+                let gated_forts: Vec<_> = forts.iter()
+                    .filter(|f| walk_open.nodes.contains(&f.pos) && !walk_locked.nodes.contains(&f.pos))
+                    .collect();
+                let gated_levels: Vec<_> = levels.iter()
+                    .filter(|l| walk_open.nodes.contains(&l.pos) && !walk_locked.nodes.contains(&l.pos))
+                    .collect();
+                let gates_target = target_pos
+                    .map(|tp| walk_open.nodes.contains(&tp) && !walk_locked.nodes.contains(&tp))
+                    .unwrap_or(false);
+
+                // BFS distance from lock to target (via adjacent nodes)
+                let target_dist = if let Some(tp) = target_pos {
+                    let walk_from_target = walk_map(&base_grid, &built.pipe_pairs, Some(tp), built.world_idx);
+                    let (lr, lc) = lock.pos;
+                    [(-1i16, 0i16), (1, 0), (0, -1), (0, 1)].iter()
+                        .filter_map(|&(dr, dc)| {
+                            let nr = lr as i16 + dr;
+                            let nc = lc as i16 + dc;
+                            if nr < 0 || nc < 0 { return None; }
+                            walk_from_target.distances.get(&(nr as usize, nc as usize)).copied()
+                        })
+                        .min()
+                } else {
+                    None
+                };
+
+                eprintln!("    Lock ({:2},{:2}) sect={} safe={:<5} gated={:<3} dist_to_target={:<4} gates: {} forts, {} levels{}",
+                    lock.pos.0, lock.pos.1,
+                    lock.fort_section,
+                    lock.secret_exit_safe,
+                    gated_count,
+                    target_dist.map(|d| d.to_string()).unwrap_or("-".into()),
+                    gated_forts.len(),
+                    gated_levels.len(),
+                    if gates_target { ", TARGET" } else { "" },
+                );
+            }
+        }
+    }
+}
+
+/// Dump all lock candidates and their scores for a specific world.
+/// Usage: change seed/target_wi below, then run with --nocapture.
+#[test]
+#[ignore]
+fn test_lock_candidates_dump() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => { eprintln!("ROM not found"); return; }
+    };
+    let seed = 42u64;
+    let target_wi = 6; // 0-indexed: W7 = 6
+
+    let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+    let built = &result.worlds[target_wi];
+
+    let start_pos = rom_data::find_start(&built.grid);
+    let target_pos = find_target(&built.grid, target_wi);
+
+    // Build base grid with slots stamped (no locks), same as production
+    let mut base_grid = built.grid.clone();
+    stamp_slots(&mut base_grid, &built.slots);
+
+    eprintln!("\n=== Seed {seed}, W{} — Lock Candidate Dump ===", target_wi + 1);
+    eprintln!("Target: {:?}, Start: {:?}", target_pos, start_pos);
+    eprintln!("Forts: {}, Sections: {}", result.fort_counts[target_wi], built.section_count);
+
+    // For each section, enumerate all lockable tiles and score them
+    for section_idx in 0..built.section_count {
+        let fort_pos = match built.slots.iter()
+            .find(|s| s.section == section_idx && s.kind == SlotKind::Fortress)
+        {
+            Some(s) => s.pos,
+            None => continue,
+        };
+
+        eprintln!("\n  Section {section_idx} (fort at {:?}):", fort_pos);
+
+        // Open grid for this section: earlier locks open, no current lock
+        let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos, built.world_idx);
+        let open_node_count = walk_open.nodes.len();
+
+        // Find all lockable path tiles
+        // (pos, gated, safe, score, blocks_later_fort, blocks_target)
+        type LockDebugCandidate = (Pos, i32, bool, i32, bool, bool);
+        let mut candidates: Vec<LockDebugCandidate> = Vec::new();
+
+        for r in 0..base_grid.rows {
+            for c in 0..base_grid.cols {
+                let tile = base_grid.get(r, c);
+                if !LOCKABLE_TILES.contains(&tile) { continue; }
+
+                let gap = gap_tile_for(tile);
+                let mut test_grid = base_grid.clone();
+                test_grid.set(r, c, gap);
+                let walk = walk_map(&test_grid, &built.pipe_pairs, start_pos, built.world_idx);
+
+                // Hard rule: fort must be reachable
+                if !walk.nodes.contains(&fort_pos) { continue; }
+
+                let gated = open_node_count as i32 - walk.nodes.len() as i32;
+                let target_reachable = target_pos
+                    .map(|tp| walk.nodes.contains(&tp))
+                    .unwrap_or(true);
+                let safe = target_reachable && built.slots.iter().all(|s| {
+                    s.kind != SlotKind::Fortress || walk.nodes.contains(&s.pos)
+                });
+                let blocks_later_fort = built.slots.iter().any(|s| {
+                    s.kind == SlotKind::Fortress
+                        && s.section > section_idx
+                        && !walk.nodes.contains(&s.pos)
+                });
+                let mut score = gated;
+                if blocks_later_fort { score += 100; }
+
+                candidates.push(((r, c), gated, safe, score, blocks_later_fort, !target_reachable));
+            }
+        }
+
+        // Sort by score descending
+        candidates.sort_by_key(|c| std::cmp::Reverse(c.3));
+
+        let chosen = built.locks.iter().find(|l| l.fort_section == section_idx);
+        eprintln!("    {} candidates pass hard rules, chosen={:?}",
+            candidates.len(),
+            chosen.map(|l| l.pos));
+
+        for (pos, gated, safe, score, blf, bt) in &candidates {
+            let marker = if chosen.map(|l| l.pos == *pos).unwrap_or(false) { " <-- CHOSEN" } else { "" };
+            eprintln!("    ({:2},{:2}) gated={:<3} score={:<4} safe={:<5} blk_fort={:<5} blk_target={}{marker}",
+                pos.0, pos.1, gated, score, safe, blf, bt);
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_lock_airship_distance() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let rom = apply_qol_for_overworld(&rom);
+
+    let seeds: u64 = std::env::var("LOCK_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    // BFS distance histogram: index = distance, value = count
+    let mut histogram = [0u32; 30];
+    let mut total_locks = 0u32;
+    let mut no_target_locks = 0u32;
+    // Per-world stats: (sum_of_distances, count)
+    let mut per_world: [(u64, u32); 8] = [(0, 0); 8];
+    // Track locks at distance <= 2 per seed for flagging
+    let mut close_lock_seeds = 0u32;
+    // Inter-lock Manhattan distance (only for worlds with 2+ locks)
+    let mut inter_hist = [0u32; 40];
+    let mut total_pairs = 0u32;
+    let mut per_world_pairs: [(u64, u32); 8] = [(0, 0); 8];
+    let mut close_pair_seeds = 0u32;
+
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+        let mut seed_has_close = false;
+        let mut seed_has_close_pair = false;
+
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            let target_pos = find_target(&built.grid, wi);
+
+            // Inter-lock Manhattan distance (works regardless of target).
+            if built.locks.len() >= 2 {
+                for i in 0..built.locks.len() {
+                    for j in (i + 1)..built.locks.len() {
+                        let (ar, ac) = built.locks[i].pos;
+                        let (br, bc) = built.locks[j].pos;
+                        let d = ar.abs_diff(br) + ac.abs_diff(bc);
+                        let idx = d.min(inter_hist.len() - 1);
+                        inter_hist[idx] += 1;
+                        total_pairs += 1;
+                        per_world_pairs[wi].0 += d as u64;
+                        per_world_pairs[wi].1 += 1;
+                        if d <= 3 {
+                            seed_has_close_pair = true;
                         }
-                        let pickup = super::super::overworld_pickup::pick_up(
-                            rom,
-                            &catalog,
-                            super::super::overworld_pickup::PickupFlags {
-                                shuffle_spade_games: true,
-                                shuffle_toad_houses: true,
-                                shuffle_hammer_bros: hb,
-                            },
-                        );
-                        let result = build(
-                            rom,
-                            &OverworldData { pickup: &pickup, catalog: &catalog },
-                            &mut rng,
-                            BuildFlags {
-                                shuffle_toad_houses: true,
-                                shuffle_hammer_bros: hb,
-                                ..Default::default()
-                            },
-                        );
-                        for built in &result.worlds {
-                            let wi = built.world_idx;
-                            let start = rom_data::find_start(&built.grid);
-                            if let Some(t) = find_target(&built.grid, wi) {
-                                assert!(
-                                    walk_map(&built.grid, &built.pipe_pairs, start, wi)
-                                        .nodes
-                                        .contains(&t),
-                                    "{rom_label} hb={hb} sas={sas} seed={seed}: \
-                                     {} target unreachable from start",
-                                    names[wi],
-                                );
-                            }
+                    }
+                }
+            }
+
+            if target_pos.is_none() {
+                no_target_locks += built.locks.len() as u32;
+                continue;
+            }
+            let tp = target_pos.unwrap();
+
+            // Build a fully-stamped grid with all locks open so BFS
+            // reflects the walkable map. walk_map uses node-to-node
+            // hops (nodes are 2 tiles apart), so lock path tiles
+            // won't appear in distances. Instead, BFS from the target
+            // and measure to the node(s) adjacent to each lock.
+            let mut stamped = built.grid.clone();
+            stamp_slots(&mut stamped, &built.slots);
+
+            // BFS from target — distances to every reachable node
+            let walk_from_target = walk_map(&stamped, &built.pipe_pairs, Some(tp), built.world_idx);
+
+            for lock in &built.locks {
+                total_locks += 1;
+
+                // Lock is on a path tile between two nodes. Find the
+                // closest adjacent node (in BFS hops from target).
+                let (lr, lc) = lock.pos;
+                let adjacent_nodes: Vec<(usize, usize)> = [(-1i16, 0i16), (1, 0), (0, -1), (0, 1)]
+                    .iter()
+                    .filter_map(|&(dr, dc)| {
+                        let nr = lr as i16 + dr;
+                        let nc = lc as i16 + dc;
+                        if nr < 0 || nr >= stamped.rows as i16 || nc < 0 || nc >= stamped.cols as i16 {
+                            return None;
+                        }
+                        let pos = (nr as usize, nc as usize);
+                        // Only count positions that are actual BFS nodes
+                        if walk_from_target.distances.contains_key(&pos) {
+                            Some(pos)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                // Use the minimum distance among adjacent nodes
+                // (the side closer to the target).
+                let min_dist = adjacent_nodes.iter()
+                    .filter_map(|pos| walk_from_target.distances.get(pos))
+                    .min()
+                    .copied();
+
+                if let Some(dist) = min_dist {
+                    let idx = dist.min(histogram.len() - 1);
+                    histogram[idx] += 1;
+                    per_world[wi].0 += dist as u64;
+                    per_world[wi].1 += 1;
+
+                    if dist <= 2 {
+                        seed_has_close = true;
+                    }
+                } else {
+                    no_target_locks += 1;
+                }
+            }
+        }
+        if seed_has_close {
+            close_lock_seeds += 1;
+        }
+        if seed_has_close_pair {
+            close_pair_seeds += 1;
+        }
+    }
+
+    eprintln!("\n=== Lock-to-Airship BFS Distance ({seeds} seeds, {total_locks} locks) ===\n");
+
+    // Histogram
+    eprintln!("Distance | Count | Bar");
+    eprintln!("---------+-------+----");
+    let max_dist_with_data = histogram.iter().rposition(|&c| c > 0).unwrap_or(0);
+    for (d, &count) in histogram[..=max_dist_with_data].iter().enumerate() {
+        let bar = "#".repeat((count as usize).min(60));
+        eprintln!("{d:>5}    | {count:<5} | {bar}");
+    }
+
+    // Summary stats
+    let total_dist: u64 = histogram.iter().enumerate().map(|(d, &c)| d as u64 * c as u64).sum();
+    let mean = total_dist as f64 / total_locks.max(1) as f64;
+    let close = histogram[0] + histogram[1] + histogram[2];
+    let close_pct = close as f64 / total_locks.max(1) as f64 * 100.0;
+
+    eprintln!("\nMean distance:         {mean:.1}");
+    eprintln!("Locks at dist <= 2:    {close}/{total_locks} ({close_pct:.1}%)");
+    eprintln!("Seeds with any <= 2:   {close_lock_seeds}/{seeds}");
+    if no_target_locks > 0 {
+        eprintln!("Locks without target:  {no_target_locks}");
+    }
+
+    eprintln!("\nPer-world averages:");
+    for (wi, &(sum, count)) in per_world.iter().enumerate() {
+        if count > 0 {
+            let avg = sum as f64 / count as f64;
+            eprintln!("  W{}: {avg:.1} avg ({count} locks)", wi + 1);
+        }
+    }
+
+    eprintln!("\n=== Inter-Lock Manhattan Distance ({total_pairs} pairs) ===\n");
+    eprintln!("Distance | Count | Bar");
+    eprintln!("---------+-------+----");
+    let max_inter = inter_hist.iter().rposition(|&c| c > 0).unwrap_or(0);
+    for (d, &count) in inter_hist[..=max_inter].iter().enumerate() {
+        let bar = "#".repeat((count as usize).min(60));
+        eprintln!("{d:>5}    | {count:<5} | {bar}");
+    }
+    let inter_total: u64 = inter_hist.iter().enumerate().map(|(d, &c)| d as u64 * c as u64).sum();
+    let inter_mean = inter_total as f64 / total_pairs.max(1) as f64;
+    let close_pairs: u32 = inter_hist[..=3].iter().sum();
+    let close_pair_pct = close_pairs as f64 / total_pairs.max(1) as f64 * 100.0;
+    eprintln!("\nMean pair distance:    {inter_mean:.1}");
+    eprintln!("Pairs at dist <= 3:    {close_pairs}/{total_pairs} ({close_pair_pct:.1}%)");
+    eprintln!("Seeds with any pair <=3: {close_pair_seeds}/{seeds}");
+    eprintln!("\nPer-world pair averages:");
+    for (wi, &(sum, count)) in per_world_pairs.iter().enumerate() {
+        if count > 0 {
+            let avg = sum as f64 / count as f64;
+            eprintln!("  W{}: {avg:.1} avg ({count} pairs)", wi + 1);
+        }
+    }
+}
+
+/// Distribution analyzer for pipe placement.
+///
+/// Runs the builder for N seeds and reports, per world:
+///   - endpoint frequency (how often each position appears as a pipe end)
+///   - unordered-pair frequency
+///   - Shannon entropy of the endpoint distribution (bits)
+///   - top-5 most-picked endpoints and pairs
+///
+/// Use the entropy number to compare scoring tweaks: higher = more variety.
+/// Run with: cargo test --release test_pipe_distribution -- --ignored --nocapture
+#[test]
+#[ignore]
+fn test_pipe_distribution() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let rom = apply_qol_for_overworld(&rom);
+
+    let seeds: u64 = std::env::var("PIPE_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
+
+    // Per-world tallies
+    let mut endpoint_counts: [HashMap<(usize, usize), u32>; 8] = Default::default();
+    let mut pair_counts: [HashMap<TeleportEdge, u32>; 8] = Default::default();
+    let mut total_endpoints = [0u32; 8];
+    let mut total_pairs = [0u32; 8];
+
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            for &(a, b) in &built.pipe_pairs {
+                *endpoint_counts[wi].entry(a).or_insert(0) += 1;
+                *endpoint_counts[wi].entry(b).or_insert(0) += 1;
+                total_endpoints[wi] += 2;
+
+                // Normalize unordered pair (smaller first)
+                let pair = if a <= b { (a, b) } else { (b, a) };
+                *pair_counts[wi].entry(pair).or_insert(0) += 1;
+                total_pairs[wi] += 1;
+            }
+        }
+    }
+
+    eprintln!("\n=== Pipe Distribution over {seeds} seeds ===");
+
+    for wi in 0..8 {
+        let expected_pairs = VANILLA_PIPE_PAIRS[wi];
+        if expected_pairs == 0 {
+            continue;
+        }
+
+        let endpoints = &endpoint_counts[wi];
+        let pairs = &pair_counts[wi];
+        let total_ep = total_endpoints[wi] as f64;
+        let total_pr = total_pairs[wi] as f64;
+
+        // Shannon entropy (bits) over endpoint distribution
+        let entropy = shannon_entropy(endpoints.values(), total_ep);
+        // Max entropy if uniform over all observed endpoints
+        let max_entropy = (endpoints.len() as f64).log2();
+
+        // Same for pairs
+        let pair_entropy = shannon_entropy(pairs.values(), total_pr);
+        let pair_max_entropy = (pairs.len() as f64).log2();
+
+        eprintln!(
+            "\n--- W{} ({} pair{}/seed) ---",
+            wi + 1,
+            expected_pairs,
+            if expected_pairs == 1 { "" } else { "s" },
+        );
+        eprintln!(
+            "  Endpoints: {} unique  |  entropy {:.2} / {:.2} bits ({:.0}%)",
+            endpoints.len(),
+            entropy,
+            max_entropy,
+            if max_entropy > 0.0 { entropy / max_entropy * 100.0 } else { 0.0 },
+        );
+        eprintln!(
+            "  Pairs:     {} unique  |  entropy {:.2} / {:.2} bits ({:.0}%)",
+            pairs.len(),
+            pair_entropy,
+            pair_max_entropy,
+            if pair_max_entropy > 0.0 { pair_entropy / pair_max_entropy * 100.0 } else { 0.0 },
+        );
+
+        let mut ep_sorted: Vec<_> = endpoints.iter().collect();
+        ep_sorted.sort_by(|a, b| b.1.cmp(a.1));
+        eprintln!("  Top endpoints:");
+        for (pos, count) in ep_sorted.iter().take(5) {
+            let count = **count;
+            let pct = count as f64 / total_ep * 100.0;
+            let bar = "#".repeat((pct as usize).min(40));
+            eprintln!(
+                "    ({:2},{:2})  {:>5} ({:5.1}%)  {bar}",
+                pos.0, pos.1, count, pct,
+            );
+        }
+
+        let mut pr_sorted: Vec<_> = pairs.iter().collect();
+        pr_sorted.sort_by(|a, b| b.1.cmp(a.1));
+        eprintln!("  Top pairs:");
+        for (pair, count) in pr_sorted.iter().take(5) {
+            let count = **count;
+            let pct = count as f64 / total_pr * 100.0;
+            let bar = "#".repeat((pct as usize).min(40));
+            eprintln!(
+                "    ({:2},{:2}) <-> ({:2},{:2})  {:>5} ({:5.1}%)  {bar}",
+                pair.0.0, pair.0.1, pair.1.0, pair.1.1, count, pct,
+            );
+        }
+    }
+
+    // One-line summary line for easy before/after diffing
+    eprintln!("\n=== Endpoint entropy summary (bits) ===");
+    let summary: Vec<String> = (0..8)
+        .filter(|&wi| VANILLA_PIPE_PAIRS[wi] > 0)
+        .map(|wi| {
+            let entropy = shannon_entropy(endpoint_counts[wi].values(), total_endpoints[wi] as f64);
+            format!("W{}={entropy:.2}", wi + 1)
+        })
+        .collect();
+    eprintln!("  {}", summary.join("  "));
+}
+
+/// Distribution analyzer for fortress placement.
+///
+/// Runs the builder for N seeds and reports, per world:
+///   - unique fortress positions and Shannon entropy (bits)
+///   - top-5 most-picked positions
+///   - per-section breakdown (each section places exactly one fortress)
+///
+/// Use the entropy number to compare scoring tweaks: higher = more variety.
+/// Run with: cargo test --release test_fortress_distribution -- --ignored --nocapture
+/// Override seed count with FORT_SEEDS=N.
+#[test]
+#[ignore]
+fn test_fortress_distribution() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let rom = apply_qol_for_overworld(&rom);
+
+    let seeds: u64 = std::env::var("FORT_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
+
+    // Per-world tallies
+    let mut world_counts: [HashMap<(usize, usize), u32>; 8] = Default::default();
+    let mut world_total = [0u32; 8];
+    // Per-section tallies: [world][section] -> position frequency
+    let mut section_counts: [Vec<HashMap<(usize, usize), u32>>; 8] = Default::default();
+    let mut section_total: [Vec<u32>; 8] = Default::default();
+
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+
+        for built in &result.worlds {
+            let wi = built.world_idx;
+
+            // Grow per-section storage to match observed section_count.
+            if section_counts[wi].len() < built.section_count {
+                section_counts[wi].resize(built.section_count, HashMap::new());
+                section_total[wi].resize(built.section_count, 0);
+            }
+
+            for slot in &built.slots {
+                if slot.kind != SlotKind::Fortress {
+                    continue;
+                }
+                *world_counts[wi].entry(slot.pos).or_insert(0) += 1;
+                world_total[wi] += 1;
+
+                if slot.section < section_counts[wi].len() {
+                    *section_counts[wi][slot.section].entry(slot.pos).or_insert(0) += 1;
+                    section_total[wi][slot.section] += 1;
+                }
+            }
+        }
+    }
+
+    eprintln!("\n=== Fortress Distribution over {seeds} seeds ===");
+
+    for wi in 0..8 {
+        let counts = &world_counts[wi];
+        let total = world_total[wi];
+        if total == 0 {
+            continue;
+        }
+        let total_f = total as f64;
+
+        let entropy = shannon_entropy(counts.values(), total_f);
+        let max_entropy = (counts.len() as f64).log2();
+        let forts_per_seed = total as f64 / seeds as f64;
+
+        eprintln!(
+            "\n--- W{} ({:.0} fort{}/seed) ---",
+            wi + 1,
+            forts_per_seed,
+            if forts_per_seed == 1.0 { "" } else { "s" },
+        );
+        eprintln!(
+            "  Positions: {} unique  |  entropy {:.2} / {:.2} bits ({:.0}%)",
+            counts.len(),
+            entropy,
+            max_entropy,
+            if max_entropy > 0.0 { entropy / max_entropy * 100.0 } else { 0.0 },
+        );
+
+        let mut sorted: Vec<_> = counts.iter().collect();
+        sorted.sort_by(|a, b| b.1.cmp(a.1));
+        eprintln!("  Top positions:");
+        for (pos, count) in sorted.iter().take(5) {
+            let count = **count;
+            let pct = count as f64 / total_f * 100.0;
+            let bar = "#".repeat((pct as usize).min(40));
+            eprintln!(
+                "    ({:2},{:2})  {:>5} ({:5.1}%)  {bar}",
+                pos.0, pos.1, count, pct,
+            );
+        }
+
+        // Per-section breakdown
+        for (si, sec_counts) in section_counts[wi].iter().enumerate() {
+            if sec_counts.is_empty() {
+                continue;
+            }
+            let sec_total = section_total[wi][si] as f64;
+            let sec_entropy = shannon_entropy(sec_counts.values(), sec_total);
+            let sec_max = (sec_counts.len() as f64).log2();
+            let mut sec_sorted: Vec<_> = sec_counts.iter().collect();
+            sec_sorted.sort_by(|a, b| b.1.cmp(a.1));
+            let top: Vec<String> = sec_sorted
+                .iter()
+                .take(3)
+                .map(|(p, c)| {
+                    let pct = **c as f64 / sec_total * 100.0;
+                    format!("({},{})={:.0}%", p.0, p.1, pct)
+                })
+                .collect();
+            eprintln!(
+                "    Section {si}: {} unique, entropy {:.2}/{:.2} bits, top: {}",
+                sec_counts.len(),
+                sec_entropy,
+                sec_max,
+                top.join("  "),
+            );
+        }
+    }
+
+    eprintln!("\n=== Fortress entropy summary (bits) ===");
+    let summary: Vec<String> = (0..8)
+        .filter(|&wi| world_total[wi] > 0)
+        .map(|wi| {
+            let entropy = shannon_entropy(world_counts[wi].values(), world_total[wi] as f64);
+            format!("W{}={entropy:.2}", wi + 1)
+        })
+        .collect();
+    eprintln!("  {}", summary.join("  "));
+
+    // Sanity: 17 fortresses per seed total
+    let grand_total: u32 = world_total.iter().sum();
+    let expected = 17 * seeds as u32;
+    eprintln!("\nGrand total: {grand_total} fortresses across {seeds} seeds (expected {expected})");
+    assert_eq!(grand_total, expected, "fortress count invariant broken");
+}
+
+/// Quality analyzer for level placement.
+///
+/// Level placement is deterministic given pipes+forts, so a position-entropy
+/// test would mostly just measure upstream randomness. Instead, this measures
+/// whether the scoring achieves its stated goals:
+///
+///   - Spread: avg pairwise distance between placed levels, density-rule
+///     violations (pairs within combined radius 4). Anti-clumping is the
+///     primary anti-degeneracy signal.
+///   - Path bonus: avg detour from start→target shortest path for placed
+///     levels vs all candidates. Negative bias = levels biased toward main
+///     route, the intended design goal.
+///   - Dead-end bonus: % of dead-end candidates that became levels vs the
+///     random baseline. Treated as a tiebreaker — it should win where it
+///     doesn't conflict with path bias, but not override it.
+///
+/// Run with: cargo test --release test_level_placement_quality -- --ignored --nocapture
+/// Override seed count with LEVEL_SEEDS=N.
+#[test]
+#[ignore]
+fn test_level_placement_quality() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let rom = apply_qol_for_overworld(&rom);
+
+    let seeds: u64 = std::env::var("LEVEL_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
+
+    // Per-world aggregates
+    let mut total_pairwise_dist = [0u64; 8];
+    let mut total_pairs = [0u64; 8];
+    let mut density_violations = [0u64; 8];
+    let mut dead_ends_picked = [0u64; 8];
+    let mut total_dead_end_candidates = [0u64; 8];
+    let mut levels_picked = [0u64; 8];
+    let mut total_candidates = [0u64; 8];
+    let mut total_level_detour = [0u64; 8];
+    let mut total_levels_for_detour = [0u64; 8];
+    let mut total_candidate_detour = [0u64; 8];
+    let mut total_candidates_for_detour = [0u64; 8];
+
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            let start_pos = rom_data::find_start(&built.grid);
+            let target_pos = find_target(&built.grid, wi);
+
+            let levels: Vec<(usize, usize)> = built.slots.iter()
+                .filter(|s| s.kind == SlotKind::Level)
+                .map(|s| s.pos)
+                .collect();
+
+            // Candidate pool seen by level placement: all non-fort, non-pipe
+            // section positions. In the final state, these became Level or
+            // HammerBro slots.
+            let candidates: Vec<(usize, usize)> = built.slots.iter()
+                .filter(|s| matches!(s.kind, SlotKind::Level | SlotKind::HammerBro))
+                .map(|s| s.pos)
+                .collect();
+
+            // BFS from start (matches what scoring used).
+            let walk = walk_map(&built.grid, &built.pipe_pairs, start_pos, built.world_idx);
+            let bfs_distances = &walk.distances;
+
+            // === Spread: avg pairwise distance between placed levels ===
+            for i in 0..levels.len() {
+                for j in (i + 1)..levels.len() {
+                    let manhattan = levels[i].0.abs_diff(levels[j].0)
+                        + levels[i].1.abs_diff(levels[j].1);
+                    total_pairwise_dist[wi] += manhattan as u64;
+                    total_pairs[wi] += 1;
+
+                    // Density rule: max(manhattan, |bfs_diff|) <= 4
+                    let bfs_diff = match (bfs_distances.get(&levels[i]), bfs_distances.get(&levels[j])) {
+                        (Some(&a), Some(&b)) => a.abs_diff(b),
+                        _ => manhattan,
+                    };
+                    if manhattan.max(bfs_diff) <= 4 {
+                        density_violations[wi] += 1;
+                    }
+                }
+            }
+
+            // === Dead-end utilization ===
+            for &pos in &candidates {
+                if is_dead_end(&built.grid, pos) {
+                    total_dead_end_candidates[wi] += 1;
+                    if levels.contains(&pos) {
+                        dead_ends_picked[wi] += 1;
+                    }
+                }
+            }
+            levels_picked[wi] += levels.len() as u64;
+            total_candidates[wi] += candidates.len() as u64;
+
+            // === Path detour: levels vs candidate baseline ===
+            // Only positions reachable in BOTH directions count — unreachable
+            // positions can't have a meaningful detour relative to a route
+            // they're not on.
+            if let Some(tp) = target_pos {
+                let reverse_walk = walk_map(&built.grid, &built.pipe_pairs, Some(tp), built.world_idx);
+                if let Some(&td) = bfs_distances.get(&tp) {
+                    for &pos in &levels {
+                        if let (Some(&fwd), Some(&rev)) = (
+                            bfs_distances.get(&pos),
+                            reverse_walk.distances.get(&pos),
+                        ) {
+                            let detour = (fwd + rev).saturating_sub(td);
+                            total_level_detour[wi] += detour as u64;
+                            total_levels_for_detour[wi] += 1;
+                        }
+                    }
+                    for &pos in &candidates {
+                        if let (Some(&fwd), Some(&rev)) = (
+                            bfs_distances.get(&pos),
+                            reverse_walk.distances.get(&pos),
+                        ) {
+                            let detour = (fwd + rev).saturating_sub(td);
+                            total_candidate_detour[wi] += detour as u64;
+                            total_candidates_for_detour[wi] += 1;
                         }
                     }
                 }
@@ -158,20 +1589,107 @@
         }
     }
 
-    /// Tuning diagnostic: sweep the level-spread exponent and show the resulting
-    /// per-world mean assigned-level count, plus how often we hit "overflow" —
-    /// a world's fair share exceeding its hard capacity (clamp), or the total
-    /// not fully placeable (underfill). Uses the same capacity + distribution
-    /// code as production. Run with:
-    ///   cargo test --lib report_distribution_by_exponent -- --nocapture
-    #[test]
-    fn report_distribution_by_exponent() {
-        let raw = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let rom = apply_qol_for_overworld(&raw);
-        let catalog = NodeCatalog::build(&rom, false);
+    eprintln!("\n=== Level Placement Quality over {seeds} seeds ===");
+
+    for wi in 0..8 {
+        if total_candidates[wi] == 0 {
+            continue;
+        }
+
+        eprintln!("\n--- W{} ---", wi + 1);
+
+        // Spread
+        if total_pairs[wi] > 0 {
+            let avg_pair = total_pairwise_dist[wi] as f64 / total_pairs[wi] as f64;
+            let dens_pct = density_violations[wi] as f64 / total_pairs[wi] as f64 * 100.0;
+            eprintln!("  Spread:");
+            eprintln!("    Avg pairwise level distance: {avg_pair:.1} tiles");
+            eprintln!(
+                "    Density violations (combined radius <=4): {} / {} pairs ({:.1}%)",
+                density_violations[wi], total_pairs[wi], dens_pct,
+            );
+        }
+
+        // Dead-end bonus
+        let dead_end_util = if total_dead_end_candidates[wi] > 0 {
+            dead_ends_picked[wi] as f64 / total_dead_end_candidates[wi] as f64 * 100.0
+        } else { 0.0 };
+        let random_baseline = levels_picked[wi] as f64 / total_candidates[wi] as f64 * 100.0;
+        let lift = dead_end_util - random_baseline;
+        eprintln!("  Dead-end bonus (+0.5):");
+        eprintln!(
+            "    Dead-end candidates: {} ({:.1}% of all candidates)",
+            total_dead_end_candidates[wi],
+            total_dead_end_candidates[wi] as f64 / total_candidates[wi] as f64 * 100.0,
+        );
+        eprintln!("    Picked as level:     {dead_end_util:.1}%");
+        eprintln!("    Random baseline:     {random_baseline:.1}%");
+        eprintln!(
+            "    Lift: {lift:+.1} pp  ({})",
+            if lift.abs() < 2.0 { "negligible" }
+            else if lift > 0.0 { "bias toward dead-ends" }
+            else { "bias against dead-ends" },
+        );
+
+        // Path bonus
+        if total_levels_for_detour[wi] > 0 && total_candidates_for_detour[wi] > 0 {
+            let avg_lvl = total_level_detour[wi] as f64 / total_levels_for_detour[wi] as f64;
+            let avg_cand = total_candidate_detour[wi] as f64 / total_candidates_for_detour[wi] as f64;
+            let bias = avg_lvl - avg_cand;
+            eprintln!("  Path bonus (max = PATH_DETOUR_CAP * W_PATH):");
+            eprintln!("    Avg detour for placed levels: {avg_lvl:.2} hops");
+            eprintln!("    Avg detour for all candidates: {avg_cand:.2} hops");
+            eprintln!(
+                "    Bias: {bias:+.2} hops  ({})",
+                if bias.abs() < 0.3 { "negligible" }
+                else if bias < 0.0 { "toward main route" }
+                else { "off main route" },
+            );
+        }
+    }
+
+    // One-line summary for diffing
+    eprintln!("\n=== Summary (avg pairwise distance / dead-end lift / path bias) ===");
+    for wi in 0..8 {
+        if total_candidates[wi] == 0 { continue; }
+        let avg_pair = if total_pairs[wi] > 0 {
+            total_pairwise_dist[wi] as f64 / total_pairs[wi] as f64
+        } else { 0.0 };
+        let dead_end_util = if total_dead_end_candidates[wi] > 0 {
+            dead_ends_picked[wi] as f64 / total_dead_end_candidates[wi] as f64 * 100.0
+        } else { 0.0 };
+        let random_baseline = levels_picked[wi] as f64 / total_candidates[wi] as f64 * 100.0;
+        let lift = dead_end_util - random_baseline;
+        let path_bias = if total_levels_for_detour[wi] > 0 && total_candidates_for_detour[wi] > 0 {
+            let avg_lvl = total_level_detour[wi] as f64 / total_levels_for_detour[wi] as f64;
+            let avg_cand = total_candidate_detour[wi] as f64 / total_candidates_for_detour[wi] as f64;
+            avg_lvl - avg_cand
+        } else { 0.0 };
+        eprintln!(
+            "  W{}: dist={avg_pair:5.1}  dead-end-lift={lift:+5.1}pp  path-bias={path_bias:+5.2}",
+            wi + 1,
+        );
+    }
+}
+
+/// Regression: under start↔airship swap, the W3 fixed pipe used to be
+/// paired with a random opposite-side blank, which could land on a dead
+/// canoe island and strand the start — leaving the airship unreachable
+/// (~1.6% of SAS seeds). `place_pipes` now biases the fixed pipe's partner
+/// toward a blank that actually reconnects start to target. These seeds all
+/// failed before that fix; they must stay reachable.
+#[test]
+fn test_sas_w3_fixed_pipe_keeps_target_reachable() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return, // ROM not present in this environment; skip.
+    };
+    let rom = apply_qol_for_overworld(&rom);
+    // Previously-unreachable SAS W3 seeds (from the SAS=1 progression sweep).
+    for seed in [123u64, 385, 515, 559, 629] {
+        let mut catalog = NodeCatalog::build(&rom, false);
+        let mut swap_rng = ChaCha8Rng::seed_from_u64(seed);
+        super::super::start_airship_swap::pick_swaps(&mut catalog, &mut swap_rng);
         let pickup = super::super::overworld_pickup::pick_up(
             &rom,
             &catalog,
@@ -181,1992 +1699,295 @@
                 ..Default::default()
             },
         );
-        let mut vanilla = [0usize; 8];
-        for e in &catalog.entries {
-            if matches!(e.kind, NodeKind::Level) {
-                vanilla[e.world_idx] += 1;
-            }
-        }
-
-        const SEEDS: u64 = 300;
-        let names = ["W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8"];
-        let header: String = names.iter().map(|n| format!("{n:>6}")).collect();
-        eprintln!("\nLevel distribution by exponent ({SEEDS} seeds, mean assigned per world):");
-        eprintln!("  exp  {header}");
-        let van: String = vanilla.iter().map(|v| format!("{v:>6}")).collect();
-        eprintln!("  van  {van}");
-
-        for &exp in &[1.0_f64, 0.7, 0.6, 0.5, 0.4] {
-            let mut sums = [0usize; 8];
-            let mut clamp_events = 0usize; // (seed,world) share floored > capacity
-            let mut underfill_seeds = 0usize; // seeds where total placed < 62
-            for seed in 0..SEEDS {
-                let mut rng = ChaCha8Rng::seed_from_u64(seed);
-                let fort_counts = redistribute_fortresses(&mut rng);
-                let caps = prepare_capacities(&rom, &catalog, &pickup, &fort_counts, false, true, false)
-                    .capacities;
-
-                // Detect clamp events (a world's fair share exceeds its capacity).
-                let weights: [f64; 8] = std::array::from_fn(|wi| {
-                    if caps[wi] == 0 { 0.0 } else { (caps[wi] as f64).powf(exp) }
-                });
-                let tw: f64 = weights.iter().sum();
-                for wi in 0..8 {
-                    let share = weights[wi] / tw * VANILLA_LEVEL_COUNT as f64;
-                    if share.floor() as usize > caps[wi] {
-                        clamp_events += 1;
-                    }
-                }
-
-                let counts = distribute_levels(&caps, VANILLA_LEVEL_COUNT, exp, &mut rng);
-                if counts.iter().sum::<usize>() < VANILLA_LEVEL_COUNT {
-                    underfill_seeds += 1;
-                }
-                for wi in 0..8 {
-                    sums[wi] += counts[wi];
-                }
-            }
-            let row: String = (0..8)
-                .map(|wi| format!("{:>6.1}", sums[wi] as f64 / SEEDS as f64))
-                .collect();
-            eprintln!("  {exp:<3}  {row}    clamp_events={clamp_events} underfill_seeds={underfill_seeds}");
-        }
-    }
-
-    /// Diagnostic (not an assertion): tabulate how many levels the builder
-    /// places in each world across many seeds, next to the vanilla count, plus
-    /// the number of leftover open path tiles (placeable blank nodes left with
-    /// nothing on them). Run with:
-    ///   cargo test report_levels_per_world -- --nocapture
-    #[test]
-    fn report_levels_per_world() {
-        let raw = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        // QoL map edits (incl. remove_rocks) run before the builder in the real
-        // pipeline; build from the patched ROM so capacities/connectivity match
-        // what players actually get.
-        let rom = apply_qol_for_overworld(&raw);
-
-        const SEEDS: u64 = 200;
-
-        // Vanilla per-world Level counts, straight from the catalog (the same
-        // source VANILLA_LEVEL_COUNT is derived from).
-        let vanilla_catalog = NodeCatalog::build(&rom, false);
-        let mut vanilla_levels = [0usize; 8];
-        for e in &vanilla_catalog.entries {
-            if matches!(e.kind, NodeKind::Level) {
-                vanilla_levels[e.world_idx] += 1;
-            }
-        }
-
-        // Per world, collect the placed-level count and open-tile count per seed.
-        let mut levels: [Vec<usize>; 8] = Default::default();
-        let mut opens: [Vec<usize>; 8] = Default::default();
-
-        for seed in 0..SEEDS {
-            let catalog = NodeCatalog::build(&rom, false);
-            let pickup = super::super::overworld_pickup::pick_up(
-                &rom,
-                &catalog,
-                super::super::overworld_pickup::PickupFlags {
-                    shuffle_spade_games: true,
-                    shuffle_toad_houses: true,
-                    ..Default::default()
-                },
-            );
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(
-                &rom,
-                &OverworldData { pickup: &pickup, catalog: &catalog },
-                &mut rng,
-                BuildFlags { shuffle_toad_houses: true, ..Default::default() },
-            );
-
-            for built in &result.worlds {
-                let wi = built.world_idx;
-                let lv = built.slots.iter().filter(|s| s.kind == SlotKind::Level).count();
-
-                // Open path = currently-blank placeable node tiles not occupied
-                // by a non-pipe slot. The build phase stamps pipe tiles onto the
-                // grid but leaves level/fort/HB/bonus/toad slots blank, so those
-                // slot positions still read as blank here and must be subtracted.
-                let fixed = fixed_positions_for_world(&rom, &catalog, wi, true, false);
-                let blank = find_blank_slots(&built.grid, &fixed).len();
-                let non_pipe_slots =
-                    built.slots.iter().filter(|s| s.kind != SlotKind::Pipe).count();
-                let open = blank.saturating_sub(non_pipe_slots);
-
-                levels[wi].push(lv);
-                opens[wi].push(open);
-            }
-        }
-
-        let stats = |v: &[usize]| -> (usize, f64, usize) {
-            let min = *v.iter().min().unwrap();
-            let max = *v.iter().max().unwrap();
-            let mean = v.iter().sum::<usize>() as f64 / v.len() as f64;
-            (min, mean, max)
-        };
-
-        let names = ["Grass", "Desert", "Water", "Giant", "Sky", "Ice", "Pipe", "Dark"];
-        eprintln!("\nLevels placed per world over {SEEDS} seeds (shuffle_toad_houses on):\n");
-        eprintln!(
-            "  {:<14} {:>7} | {:>18} | {:>18}",
-            "World", "Vanilla", "Levels min/mean/max", "Open min/mean/max"
-        );
-        eprintln!("  {}", "-".repeat(66));
-        let mut van_total = 0usize;
-        let mut lvl_mean_total = 0.0f64;
-        let mut open_mean_total = 0.0f64;
-        for wi in 0..8 {
-            let (lmin, lmean, lmax) = stats(&levels[wi]);
-            let (omin, omean, omax) = stats(&opens[wi]);
-            van_total += vanilla_levels[wi];
-            lvl_mean_total += lmean;
-            open_mean_total += omean;
-            eprintln!(
-                "  W{} {:<11} {:>7} | {:>5} {:>6.1} {:>4} | {:>5} {:>6.1} {:>4}",
-                wi + 1, names[wi], vanilla_levels[wi],
-                lmin, lmean, lmax, omin, omean, omax,
-            );
-        }
-        eprintln!("  {}", "-".repeat(66));
-        eprintln!(
-            "  {:<14} {:>7} | {:>5} {:>6.1} {:>4} | {:>5} {:>6.1} {:>4}",
-            "Total", van_total, "", lvl_mean_total, "", "", open_mean_total, "",
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+        let w3 = result.worlds.iter().find(|b| b.world_idx == 2).unwrap();
+        assert!(
+            analyze_required_progression(w3, false).reachable,
+            "SAS seed {seed}: W3 airship must be reachable",
         );
     }
+}
 
-    #[test]
-    fn hammer_bro_redistribution_invariants() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        for seed in 0..32u64 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let catalog = NodeCatalog::build(&rom, false);
-            let pickup = super::super::overworld_pickup::pick_up(
-                &rom,
-                &catalog,
-                super::super::overworld_pickup::PickupFlags {
-                    shuffle_spade_games: true,
-                    shuffle_toad_houses: true,
-                    shuffle_hammer_bros: true,
-                },
-            );
-            let result = build(
-                &rom,
-                &OverworldData { pickup: &pickup, catalog: &catalog },
-                &mut rng,
-                BuildFlags { shuffle_toad_houses: true, shuffle_hammer_bros: true, ..Default::default() },
-            );
-
-            // The vanilla 15 encounters are always placed (W1-W6 alone have the
-            // capacity), spread across the worlds.
-            let total: usize = result.worlds.iter().map(|w| w.hb_sprites.len()).sum();
-            assert_eq!(total, 15, "seed {seed}: total HB sprites {total} != 15");
-
-            for w in &result.worlds {
-                let n = w.hb_sprites.len();
-                // Best-effort 1-3 per world (W8 capped lower); a feature-dense
-                // world (e.g. W7's 8 pipe pairs) can be left with no spare
-                // HammerBro tile and get 0, with its share spilling elsewhere.
-                let max = if w.world_idx == 7 { W8_HB_CAP } else { 3 };
-                assert!(
-                    n <= max,
-                    "seed {seed} W{}: {n} HB sprites (max {max})", w.world_idx + 1
-                );
-                // At least RESERVED_DYNAMIC_SLOTS eligible map-object slots stay
-                // free for a runtime white-house spawn.
-                let eligible = rom_data::eligible_hb_map_slots(&rom, w.world_idx).len();
-                assert!(
-                    eligible.saturating_sub(n) >= RESERVED_DYNAMIC_SLOTS,
-                    "seed {seed} W{}: only {} eligible slots free after {n} HBs",
-                    w.world_idx + 1, eligible.saturating_sub(n)
-                );
-                // Every sprite sits on one of this world's HammerBro slot tiles.
-                let hb_tiles: HashSet<(usize, usize)> = w
-                    .slots
-                    .iter()
-                    .filter(|s| s.kind == SlotKind::HammerBro)
-                    .map(|s| s.pos)
-                    .collect();
-                let mut seen: HashSet<(usize, usize)> = HashSet::new();
-                for sprite in &w.hb_sprites {
-                    assert!(
-                        hb_tiles.contains(&sprite.grid_pos),
-                        "seed {seed} W{}: HB sprite at {:?} is not a HammerBro slot",
-                        w.world_idx + 1, sprite.grid_pos
-                    );
-                    assert!(
-                        seen.insert(sprite.grid_pos),
-                        "seed {seed} W{}: duplicate HB sprite position {:?}",
-                        w.world_idx + 1, sprite.grid_pos
-                    );
-                }
-            }
+/// Required-progression analyzer.
+///
+/// Per world, computes the minimum number of fortress + level entries
+/// the player must clear to reach the airship/Bowser. Locks block path
+/// tiles until the fortress whose section opens them is cleared; pipes
+/// are taken whenever they shorten the route. Also reports a "hammer
+/// mode" where all locks start open, isolating fortresses that were
+/// only required because of lock gating.
+///
+/// Run with: cargo test --release test_required_progression -- --ignored --nocapture
+/// Override seed count with PROG_SEEDS=N.
+/// Toggle start↔airship swap with SAS=1.
+#[test]
+#[ignore]
+fn test_required_progression() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
         }
-    }
+    };
+    let rom = apply_qol_for_overworld(&rom);
 
-    #[test]
-    fn test_locks_dont_block_own_fort() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
+    let seeds: u64 = std::env::var("PROG_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
 
-        for seed in 0..10 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+    // Per-world tallies: sums for mean, plus min/max.
+    let mut sum_forts = [0u64; 8];
+    let mut sum_levels = [0u64; 8];
+    let mut sum_h_forts = [0u64; 8];
+    let mut sum_h_levels = [0u64; 8];
+    let mut min_forts = [usize::MAX; 8];
+    let mut max_forts = [0usize; 8];
+    let mut min_levels = [usize::MAX; 8];
+    let mut max_levels = [0usize; 8];
+    let mut min_h_forts = [usize::MAX; 8];
+    let mut max_h_forts = [0usize; 8];
+    let mut unreachable = [0u32; 8];
+    let mut unreachable_seeds: [Vec<u64>; 8] = Default::default();
+    // "Trivial bypass" = hammerless playthrough requires 0 forts AND 0
+    // levels (player walks/pipes straight to the airship). Tracked per
+    // world plus classified by whether the path uses a pipe right after
+    // start (pipe_start), right before target (pipe_target), both, or
+    // neither — diagnostic that pinpoints the failure mode.
+    let mut zero_zero = [0u32; 8];
+    let mut zero_zero_seeds: [Vec<u64>; 8] = Default::default();
+    let mut bypass_both = [0u32; 8];
+    let mut bypass_start = [0u32; 8];
+    let mut bypass_target = [0u32; 8];
+    let mut bypass_other = [0u32; 8];
 
-            for built in &result.worlds {
-                let start_pos = rom_data::find_start(&built.grid);
-
-                // Build grid with all assignments stamped
-                let mut test_grid = built.grid.clone();
-                for slot in &built.slots {
-                    match slot.kind {
-                        SlotKind::Fortress => test_grid.set(slot.pos.0, slot.pos.1, TILE_FORTRESS),
-                        SlotKind::BonusGame => test_grid.set(slot.pos.0, slot.pos.1, TILE_BONUS_GAME),
-                        SlotKind::ToadHouse => test_grid.set(slot.pos.0, slot.pos.1, TILE_TOAD_HOUSE),
-                        SlotKind::Level | SlotKind::Pipe | SlotKind::HammerBro => {}
-                    }
-                }
-
-                // For each lock, verify its fort is still reachable
-                for lock in &built.locks {
-                    // Place ALL locks
-                    let mut locked_grid = test_grid.clone();
-                    for l in &built.locks {
-                        locked_grid.set(l.pos.0, l.pos.1, l.gap_tile);
-                    }
-                    // But open THIS lock (as if its fort was beaten)
-                    locked_grid.set(lock.pos.0, lock.pos.1, lock.replace_tile);
-
-                    // Open all locks from earlier sections too
-                    for earlier in &built.locks {
-                        if earlier.fort_section < lock.fort_section {
-                            locked_grid.set(earlier.pos.0, earlier.pos.1, earlier.replace_tile);
-                        }
-                    }
-
-                    let fort_pos = built.slots.iter()
-                        .find(|s| s.section == lock.fort_section && s.kind == SlotKind::Fortress)
-                        .map(|s| s.pos);
-
-                    if let Some(fp) = fort_pos {
-                        let walk = walk_map(&locked_grid, &built.pipe_pairs, start_pos, built.world_idx);
-                        assert!(walk.nodes.contains(&fp),
-                            "Seed {seed} W{}: lock at {:?} blocks its own fort at {:?}",
-                            built.world_idx + 1, lock.pos, fp);
-                    }
-                }
-            }
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn test_dump_debug_rom() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        for seed in [42, 123, 999] {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            let mut rom_copy = Rom::from_bytes(&rom.data).unwrap();
-            debug_stamp_rom(&mut rom_copy, &result);
-
-            let filename = format!("debug_build_seed{seed}.nes");
-            std::fs::write(&filename, &rom_copy.data).unwrap();
-
-            eprintln!("\n=== Seed {seed} ===");
-            for built in &result.worlds {
-                let forts = built.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count();
-                let levels = built.slots.iter().filter(|s| s.kind == SlotKind::Level).count();
-                let pipes = built.pipe_pairs.len();
-                let locks = built.locks.len();
-                eprintln!(
-                    "  W{}: {} forts, {} levels, {} pipe pairs, {} locks",
-                    built.world_idx + 1, forts, levels, pipes, locks,
-                );
-            }
-            eprintln!("  Wrote {filename}");
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn test_print_build() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-        let mut rng = ChaCha8Rng::seed_from_u64(42);
-
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
         let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
 
         for built in &result.worlds {
-            eprintln!("\n=== World {} ({} sections) ===",
-                built.world_idx + 1, built.section_count);
+            let wi = built.world_idx;
+            let no_hammer = analyze_required_progression(built, false);
+            let with_hammer = analyze_required_progression(built, true);
 
-            for (si, section_slots) in (0..built.section_count).map(|si| {
-                (si, built.slots.iter().filter(|s| s.section == si).collect::<Vec<_>>())
-            }) {
-                let fort = section_slots.iter().find(|s| s.kind == SlotKind::Fortress);
-                let levels = section_slots.iter().filter(|s| s.kind == SlotKind::Level).count();
-                let lock = built.locks.iter().find(|l| l.fort_section == si);
-
-                eprintln!("  Section {si}: {} slots ({} levels, fort at {:?})",
-                    section_slots.len(), levels,
-                    fort.map(|f| f.pos));
-                if let Some(l) = lock {
-                    eprintln!("    Lock at {:?} (gap=${:02X}, restore=${:02X})",
-                        l.pos, l.gap_tile, l.replace_tile);
+            if !no_hammer.reachable {
+                unreachable[wi] += 1;
+                if unreachable_seeds[wi].len() < 5 {
+                    unreachable_seeds[wi].push(seed);
                 }
-            }
-
-            eprintln!("  Pipes: {} pairs", built.pipe_pairs.len());
-            for (i, &(a, b)) in built.pipe_pairs.iter().enumerate() {
-                eprintln!("    Pair {i}: ({},{}) ↔ ({},{})", a.0, a.1, b.0, b.1);
-            }
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn test_measure_shortfalls() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        let mut level_shortfalls = 0u32;
-        let mut lock_shortfalls = 0u32;
-        let seeds = 1000;
-
-        for seed in 0..seeds {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            let total_levels: usize = result.worlds.iter()
-                .map(|b| b.slots.iter().filter(|s| s.kind == SlotKind::Level).count())
-                .sum();
-            if total_levels < VANILLA_LEVEL_COUNT {
-                level_shortfalls += 1;
-                let deficit = VANILLA_LEVEL_COUNT - total_levels;
-                // Show per-world breakdown
-                let mut detail = String::new();
-                for built in &result.worlds {
-                    let levels = built.slots.iter().filter(|s| s.kind == SlotKind::Level).count();
-                    let section_sizes: Vec<usize> = (0..built.section_count)
-                        .map(|si| built.slots.iter().filter(|s| s.section == si).count())
-                        .collect();
-                    if levels < 3 {
-                        detail.push_str(&format!(" W{}={levels}(sections={section_sizes:?})", built.world_idx + 1));
-                    }
-                }
-                eprintln!("Seed {seed}: {total_levels}/{VANILLA_LEVEL_COUNT} (-{deficit}){detail}");
-            }
-
-            for built in &result.worlds {
-                let expected_locks = result.fort_counts[built.world_idx];
-                if built.locks.len() < expected_locks {
-                    lock_shortfalls += 1;
-                    // Find which section(s) are missing locks
-                    let placed: HashSet<usize> = built.locks.iter().map(|l| l.fort_section).collect();
-                    for si in 0..built.section_count {
-                        if !placed.contains(&si) {
-                            let section_size = built.slots.iter().filter(|s| s.section == si).count();
-                            let fort = built.slots.iter().find(|s| s.section == si && s.kind == SlotKind::Fortress);
-                            eprintln!("Seed {seed} W{} section {si}: NO LOCK, section_size={section_size}, fort={:?}, total_slots={}",
-                                built.world_idx + 1, fort.map(|f| f.pos),
-                                built.slots.len());
-                        }
-                    }
-                }
-            }
-        }
-
-        // Count seeds with at least one secret_exit_safe lock and
-        // track which worlds have safe locks in failing seeds
-        let mut safe_count = 0u32;
-        let mut no_safe_details: Vec<(u64, [usize; 8])> = Vec::new();
-        for seed in 0..seeds {
-            let mut rng2 = ChaCha8Rng::seed_from_u64(seed);
-            let result2 = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            let has_safe = result2.worlds.iter().any(|b| {
-                b.locks.iter().any(|l| l.secret_exit_safe)
-            });
-            if has_safe {
-                safe_count += 1;
-            } else {
-                // For failing seeds, count locks per world to see which have room
-                let mut lock_counts = [0usize; 8];
-                for b in &result2.worlds {
-                    lock_counts[b.world_idx] = b.locks.len();
-                }
-                no_safe_details.push((seed, lock_counts));
-            }
-        }
-
-        eprintln!("\n=== {seeds} seeds ===");
-        eprintln!("Level shortfalls: {level_shortfalls}/{seeds}");
-        eprintln!("Lock shortfalls:  {lock_shortfalls}/{seeds} (world-level)");
-        eprintln!("Seeds with >=1 secret_exit_safe lock: {safe_count}/{seeds}");
-        if !no_safe_details.is_empty() {
-            eprintln!("No-safe seeds (first 10):");
-            for (seed, counts) in no_safe_details.iter().take(10) {
-                eprintln!("  Seed {seed}: locks per world = {counts:?}");
-            }
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn test_w6_slot_distribution() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        for seed in 0..6u64 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            let built = &result.worlds[5]; // W6 (0-indexed)
-
-            eprintln!("\n===== Seed {seed} — W6 =====");
-            eprintln!("level_count received: {} (from distribute_levels)",
-                built.slots.iter().filter(|s| s.kind == SlotKind::Level).count());
-            eprintln!("fort_count: {}", result.fort_counts[5]);
-            eprintln!("total slots: {}", built.slots.len());
-            eprintln!("section_count: {}", built.section_count);
-            eprintln!("pipe_pairs: {}", built.pipe_pairs.len());
-
-            // Group by kind
-            let mut fortresses = Vec::new();
-            let mut levels = Vec::new();
-            let mut hammer_bros = Vec::new();
-            let mut pipes = Vec::new();
-            let mut bonus_games = Vec::new();
-            let mut toad_houses = Vec::new();
-            for slot in &built.slots {
-                match slot.kind {
-                    SlotKind::Fortress => fortresses.push(slot),
-                    SlotKind::Level => levels.push(slot),
-                    SlotKind::HammerBro => hammer_bros.push(slot),
-                    SlotKind::Pipe => pipes.push(slot),
-                    SlotKind::BonusGame => bonus_games.push(slot),
-                    SlotKind::ToadHouse => toad_houses.push(slot),
-                }
-            }
-
-            eprintln!("\nFortresses ({}):", fortresses.len());
-            for s in &fortresses {
-                eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
-            }
-
-            eprintln!("\nLevels ({}):", levels.len());
-            for s in &levels {
-                // Compute min Manhattan distance to nearest other Level slot
-                let min_dist = levels.iter()
-                    .filter(|o| o.pos != s.pos)
-                    .map(|o| {
-                        let dr = (s.pos.0 as isize - o.pos.0 as isize).unsigned_abs();
-                        let dc = (s.pos.1 as isize - o.pos.1 as isize).unsigned_abs();
-                        dr + dc
-                    })
-                    .min()
-                    .unwrap_or(0);
-                eprintln!("  ({:2}, {:2})  section={}  min_dist_to_level={}", s.pos.0, s.pos.1, s.section, min_dist);
-            }
-
-            eprintln!("\nHammerBros ({}):", hammer_bros.len());
-            for s in &hammer_bros {
-                eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
-            }
-
-            eprintln!("\nPipes ({}):", pipes.len());
-            for s in &pipes {
-                eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
-            }
-
-            eprintln!("\nBonus Games ({}):", bonus_games.len());
-            for s in &bonus_games {
-                eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
-            }
-
-            eprintln!("\nToad Houses ({}):", toad_houses.len());
-            for s in &toad_houses {
-                eprintln!("  ({:2}, {:2})  section={}", s.pos.0, s.pos.1, s.section);
-            }
-
-            eprintln!("\nLocks ({}):", built.locks.len());
-            for l in &built.locks {
-                eprintln!("  ({:2}, {:2})  gap=0x{:02X}  replace=0x{:02X}  fort_section={}  safe={}",
-                    l.pos.0, l.pos.1, l.gap_tile, l.replace_tile, l.fort_section, l.secret_exit_safe);
-            }
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn test_dump_w7_blank_vs_bfs() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-        let wi = 6; // W7
-
-        let cw = &pickup.worlds[wi];
-        eprintln!("\n=== W7 Pickup: {} pool entries ===", cw.pool_indices.len());
-
-        let fixed = fixed_positions_for_world(&rom, &catalog, wi, true, false);
-        eprintln!("Fixed positions: {} {:?}", fixed.len(), fixed);
-
-        let blank_positions = find_blank_slots(&cw.grid, &fixed);
-        eprintln!("Blank tiles on grid: {}", blank_positions.len());
-
-        // Run the actual build for several seeds and check coverage
-        for seed in 0..5u64 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            let built = &result.worlds[wi];
-
-            // All positions that got a slot assignment
-            let slot_positions: HashSet<(usize, usize)> = built.slots.iter().map(|s| s.pos).collect();
-            // Add pipe positions
-            let pipe_positions: HashSet<(usize, usize)> = built.pipe_pairs.iter()
-                .flat_map(|&(a, b)| vec![a, b]).collect();
-            let all_assigned: HashSet<(usize, usize)> = slot_positions.union(&pipe_positions).copied().collect();
-
-            // Blank tiles with no assignment
-            let uncovered: Vec<(usize, usize)> = blank_positions.iter()
-                .filter(|p| !all_assigned.contains(p))
-                .copied()
-                .collect();
-
-            let total_slots = built.slots.len() + pipe_positions.len();
-            eprintln!("\n--- Seed {seed} ---");
-            eprintln!("  Slots: {} (L={}, F={}, P={}, HB={})",
-                total_slots,
-                built.slots.iter().filter(|s| s.kind == SlotKind::Level).count(),
-                built.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count(),
-                pipe_positions.len(),
-                built.slots.iter().filter(|s| s.kind == SlotKind::HammerBro).count(),
-            );
-            eprintln!("  Pool entries (ptr slots): {}", cw.pool_indices.len());
-            eprintln!("  max_non_pipe_slots: {}", cw.pool_indices.len() - VANILLA_PIPE_PAIRS[wi] * 2);
-            eprintln!("  Blanks on grid: {}", blank_positions.len());
-            eprintln!("  Assigned positions: {}", all_assigned.len());
-            eprintln!("  Uncovered blanks: {}", uncovered.len());
-
-            if !uncovered.is_empty() {
-                for (r, c) in &uncovered {
-                    eprintln!("    UNCOVERED: ({},{}) tile=${:02X}", r, c, cw.grid.get(*r, *c));
-                    // Check if BFS can reach it with the placed pipes
-                    let bfs_all = bfs_ordered(&built.grid, &built.pipe_pairs, rom_data::find_start(&built.grid), built.world_idx);
-                    let bfs_set: HashSet<(usize, usize)> = bfs_all.iter().map(|&(p, _)| p).collect();
-                    eprintln!("      BFS reachable: {}", bfs_set.contains(&(*r, *c)));
-                }
-            }
-
-            // Check for assignments NOT on blank tiles (double-covering or wrong pos)
-            let non_blank_assignments: Vec<_> = all_assigned.iter()
-                .filter(|p| !blank_positions.contains(p) && !pipe_positions.contains(p))
-                .collect();
-            if !non_blank_assignments.is_empty() {
-                eprintln!("  Assignments on non-blank tiles:");
-                for &&(r, c) in &non_blank_assignments {
-                    eprintln!("    ({},{}) tile=${:02X}", r, c, cw.grid.get(r, c));
-                }
-            }
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn test_lock_scoring_detail() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        for seed in [42u64, 123, 999] {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            eprintln!("\n{}", "=".repeat(60));
-            eprintln!("=== Seed {seed} ===");
-
-            for built in &result.worlds {
-                let wi = built.world_idx;
-                let target_pos = find_target(&built.grid, wi);
-                let start_pos = rom_data::find_start(&built.grid);
-
-                let forts: Vec<_> = built.slots.iter()
-                    .filter(|s| s.kind == SlotKind::Fortress)
-                    .collect();
-                let levels: Vec<_> = built.slots.iter()
-                    .filter(|s| s.kind == SlotKind::Level)
-                    .collect();
-
-                eprintln!("\n  W{}: {} forts, {} levels, {} pipes, {} locks, target={:?}",
-                    wi + 1, forts.len(), levels.len(), built.pipe_pairs.len(),
-                    built.locks.len(), target_pos);
-
-                // Build stamped grid (forts + levels, no locks)
-                let mut base_grid = built.grid.clone();
-                for slot in &built.slots {
-                    match slot.kind {
-                        SlotKind::Fortress => base_grid.set(slot.pos.0, slot.pos.1, TILE_FORTRESS),
-                        SlotKind::Level
-                            if BACKGROUND_TILES.contains(&base_grid.get(slot.pos.0, slot.pos.1)) =>
-                        {
-                            base_grid.set(slot.pos.0, slot.pos.1, TILE_NODE);
-                        }
-                        _ => {}
-                    }
-                }
-
-                for lock in &built.locks {
-                    // Open grid: no locks
-                    let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos, built.world_idx);
-
-                    // Locked grid: this lock closed
-                    let mut locked_grid = base_grid.clone();
-                    locked_grid.set(lock.pos.0, lock.pos.1, lock.gap_tile);
-                    let walk_locked = walk_map(&locked_grid, &built.pipe_pairs, start_pos, built.world_idx);
-
-                    let gated_count = walk_open.nodes.len() as i32 - walk_locked.nodes.len() as i32;
-
-                    // What specifically gets gated?
-                    let gated_forts: Vec<_> = forts.iter()
-                        .filter(|f| walk_open.nodes.contains(&f.pos) && !walk_locked.nodes.contains(&f.pos))
-                        .collect();
-                    let gated_levels: Vec<_> = levels.iter()
-                        .filter(|l| walk_open.nodes.contains(&l.pos) && !walk_locked.nodes.contains(&l.pos))
-                        .collect();
-                    let gates_target = target_pos
-                        .map(|tp| walk_open.nodes.contains(&tp) && !walk_locked.nodes.contains(&tp))
-                        .unwrap_or(false);
-
-                    // BFS distance from lock to target (via adjacent nodes)
-                    let target_dist = if let Some(tp) = target_pos {
-                        let walk_from_target = walk_map(&base_grid, &built.pipe_pairs, Some(tp), built.world_idx);
-                        let (lr, lc) = lock.pos;
-                        [(-1i16, 0i16), (1, 0), (0, -1), (0, 1)].iter()
-                            .filter_map(|&(dr, dc)| {
-                                let nr = lr as i16 + dr;
-                                let nc = lc as i16 + dc;
-                                if nr < 0 || nc < 0 { return None; }
-                                walk_from_target.distances.get(&(nr as usize, nc as usize)).copied()
-                            })
-                            .min()
-                    } else {
-                        None
-                    };
-
-                    eprintln!("    Lock ({:2},{:2}) sect={} safe={:<5} gated={:<3} dist_to_target={:<4} gates: {} forts, {} levels{}",
-                        lock.pos.0, lock.pos.1,
-                        lock.fort_section,
-                        lock.secret_exit_safe,
-                        gated_count,
-                        target_dist.map(|d| d.to_string()).unwrap_or("-".into()),
-                        gated_forts.len(),
-                        gated_levels.len(),
-                        if gates_target { ", TARGET" } else { "" },
-                    );
-                }
-            }
-        }
-    }
-
-    /// Dump all lock candidates and their scores for a specific world.
-    /// Usage: change seed/target_wi below, then run with --nocapture.
-    #[test]
-    #[ignore]
-    fn test_lock_candidates_dump() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => { eprintln!("ROM not found"); return; }
-        };
-        let catalog = NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        let seed = 42u64;
-        let target_wi = 6; // 0-indexed: W7 = 6
-
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-        let built = &result.worlds[target_wi];
-
-        let start_pos = rom_data::find_start(&built.grid);
-        let target_pos = find_target(&built.grid, target_wi);
-
-        // Build base grid with forts/levels stamped (no locks)
-        let mut base_grid = built.grid.clone();
-        for slot in &built.slots {
-            match slot.kind {
-                SlotKind::Fortress => base_grid.set(slot.pos.0, slot.pos.1, TILE_FORTRESS),
-                SlotKind::Level
-                    if BACKGROUND_TILES.contains(&base_grid.get(slot.pos.0, slot.pos.1)) =>
-                {
-                    base_grid.set(slot.pos.0, slot.pos.1, TILE_NODE);
-                }
-                _ => {}
-            }
-        }
-
-        eprintln!("\n=== Seed {seed}, W{} — Lock Candidate Dump ===", target_wi + 1);
-        eprintln!("Target: {:?}, Start: {:?}", target_pos, start_pos);
-        eprintln!("Forts: {}, Sections: {}", result.fort_counts[target_wi], built.section_count);
-
-        // For each section, enumerate all lockable tiles and score them
-        for section_idx in 0..built.section_count {
-            let fort_pos = match built.slots.iter()
-                .find(|s| s.section == section_idx && s.kind == SlotKind::Fortress)
-            {
-                Some(s) => s.pos,
-                None => continue,
-            };
-
-            eprintln!("\n  Section {section_idx} (fort at {:?}):", fort_pos);
-
-            // Open grid for this section: earlier locks open, no current lock
-            let walk_open = walk_map(&base_grid, &built.pipe_pairs, start_pos, built.world_idx);
-            let open_node_count = walk_open.nodes.len();
-
-            // Find all lockable path tiles
-            // (pos, gated, safe, score, blocks_later_fort, blocks_target)
-            type LockDebugCandidate = (Pos, i32, bool, i32, bool, bool);
-            let mut candidates: Vec<LockDebugCandidate> = Vec::new();
-
-            for r in 0..base_grid.rows {
-                for c in 0..base_grid.cols {
-                    let tile = base_grid.get(r, c);
-                    if !LOCKABLE_TILES.contains(&tile) { continue; }
-
-                    let gap = gap_tile_for(tile);
-                    let mut test_grid = base_grid.clone();
-                    test_grid.set(r, c, gap);
-                    let walk = walk_map(&test_grid, &built.pipe_pairs, start_pos, built.world_idx);
-
-                    // Hard rule: fort must be reachable
-                    if !walk.nodes.contains(&fort_pos) { continue; }
-
-                    let gated = open_node_count as i32 - walk.nodes.len() as i32;
-                    let target_reachable = target_pos
-                        .map(|tp| walk.nodes.contains(&tp))
-                        .unwrap_or(true);
-                    let safe = target_reachable && built.slots.iter().all(|s| {
-                        s.kind != SlotKind::Fortress || walk.nodes.contains(&s.pos)
-                    });
-                    let blocks_later_fort = built.slots.iter().any(|s| {
-                        s.kind == SlotKind::Fortress
-                            && s.section > section_idx
-                            && !walk.nodes.contains(&s.pos)
-                    });
-                    let mut score = gated;
-                    if blocks_later_fort { score += 100; }
-
-                    candidates.push(((r, c), gated, safe, score, blocks_later_fort, !target_reachable));
-                }
-            }
-
-            // Sort by score descending
-            candidates.sort_by_key(|c| std::cmp::Reverse(c.3));
-
-            let chosen = built.locks.iter().find(|l| l.fort_section == section_idx);
-            eprintln!("    {} candidates pass hard rules, chosen={:?}",
-                candidates.len(),
-                chosen.map(|l| l.pos));
-
-            for (pos, gated, safe, score, blf, bt) in &candidates {
-                let marker = if chosen.map(|l| l.pos == *pos).unwrap_or(false) { " <-- CHOSEN" } else { "" };
-                eprintln!("    ({:2},{:2}) gated={:<3} score={:<4} safe={:<5} blk_fort={:<5} blk_target={}{marker}",
-                    pos.0, pos.1, gated, score, safe, blf, bt);
-            }
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn test_lock_airship_distance() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-        let rom = apply_qol_for_overworld(&rom);
-
-        let seeds: u64 = std::env::var("LOCK_SEEDS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(100);
-        // BFS distance histogram: index = distance, value = count
-        let mut histogram = [0u32; 30];
-        let mut total_locks = 0u32;
-        let mut no_target_locks = 0u32;
-        // Per-world stats: (sum_of_distances, count)
-        let mut per_world: [(u64, u32); 8] = [(0, 0); 8];
-        // Track locks at distance <= 2 per seed for flagging
-        let mut close_lock_seeds = 0u32;
-        // Inter-lock Manhattan distance (only for worlds with 2+ locks)
-        let mut inter_hist = [0u32; 40];
-        let mut total_pairs = 0u32;
-        let mut per_world_pairs: [(u64, u32); 8] = [(0, 0); 8];
-        let mut close_pair_seeds = 0u32;
-
-        for seed in 0..seeds {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            let mut seed_has_close = false;
-            let mut seed_has_close_pair = false;
-
-            for built in &result.worlds {
-                let wi = built.world_idx;
-                let target_pos = find_target(&built.grid, wi);
-
-                // Inter-lock Manhattan distance (works regardless of target).
-                if built.locks.len() >= 2 {
-                    for i in 0..built.locks.len() {
-                        for j in (i + 1)..built.locks.len() {
-                            let (ar, ac) = built.locks[i].pos;
-                            let (br, bc) = built.locks[j].pos;
-                            let d = ar.abs_diff(br) + ac.abs_diff(bc);
-                            let idx = d.min(inter_hist.len() - 1);
-                            inter_hist[idx] += 1;
-                            total_pairs += 1;
-                            per_world_pairs[wi].0 += d as u64;
-                            per_world_pairs[wi].1 += 1;
-                            if d <= 3 {
-                                seed_has_close_pair = true;
-                            }
-                        }
-                    }
-                }
-
-                if target_pos.is_none() {
-                    no_target_locks += built.locks.len() as u32;
-                    continue;
-                }
-                let tp = target_pos.unwrap();
-
-                // Build a fully-stamped grid with all locks open so BFS
-                // reflects the walkable map. walk_map uses node-to-node
-                // hops (nodes are 2 tiles apart), so lock path tiles
-                // won't appear in distances. Instead, BFS from the target
-                // and measure to the node(s) adjacent to each lock.
-                let mut stamped = built.grid.clone();
-                for slot in &built.slots {
-                    match slot.kind {
-                        SlotKind::Fortress => stamped.set(slot.pos.0, slot.pos.1, TILE_FORTRESS),
-                        SlotKind::Level
-                            if BACKGROUND_TILES.contains(&stamped.get(slot.pos.0, slot.pos.1)) =>
-                        {
-                            stamped.set(slot.pos.0, slot.pos.1, TILE_NODE);
-                        }
-                        _ => {}
-                    }
-                }
-
-                // BFS from target — distances to every reachable node
-                let walk_from_target = walk_map(&stamped, &built.pipe_pairs, Some(tp), built.world_idx);
-
-                for lock in &built.locks {
-                    total_locks += 1;
-
-                    // Lock is on a path tile between two nodes. Find the
-                    // closest adjacent node (in BFS hops from target).
-                    let (lr, lc) = lock.pos;
-                    let adjacent_nodes: Vec<(usize, usize)> = [(-1i16, 0i16), (1, 0), (0, -1), (0, 1)]
-                        .iter()
-                        .filter_map(|&(dr, dc)| {
-                            let nr = lr as i16 + dr;
-                            let nc = lc as i16 + dc;
-                            if nr < 0 || nr >= stamped.rows as i16 || nc < 0 || nc >= stamped.cols as i16 {
-                                return None;
-                            }
-                            let pos = (nr as usize, nc as usize);
-                            // Only count positions that are actual BFS nodes
-                            if walk_from_target.distances.contains_key(&pos) {
-                                Some(pos)
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-
-                    // Use the minimum distance among adjacent nodes
-                    // (the side closer to the target).
-                    let min_dist = adjacent_nodes.iter()
-                        .filter_map(|pos| walk_from_target.distances.get(pos))
-                        .min()
-                        .copied();
-
-                    if let Some(dist) = min_dist {
-                        let idx = dist.min(histogram.len() - 1);
-                        histogram[idx] += 1;
-                        per_world[wi].0 += dist as u64;
-                        per_world[wi].1 += 1;
-
-                        if dist <= 2 {
-                            seed_has_close = true;
-                        }
-                    } else {
-                        no_target_locks += 1;
-                    }
-                }
-            }
-            if seed_has_close {
-                close_lock_seeds += 1;
-            }
-            if seed_has_close_pair {
-                close_pair_seeds += 1;
-            }
-        }
-
-        eprintln!("\n=== Lock-to-Airship BFS Distance ({seeds} seeds, {total_locks} locks) ===\n");
-
-        // Histogram
-        eprintln!("Distance | Count | Bar");
-        eprintln!("---------+-------+----");
-        let max_dist_with_data = histogram.iter().rposition(|&c| c > 0).unwrap_or(0);
-        for (d, &count) in histogram[..=max_dist_with_data].iter().enumerate() {
-            let bar = "#".repeat((count as usize).min(60));
-            eprintln!("{d:>5}    | {count:<5} | {bar}");
-        }
-
-        // Summary stats
-        let total_dist: u64 = histogram.iter().enumerate().map(|(d, &c)| d as u64 * c as u64).sum();
-        let mean = total_dist as f64 / total_locks.max(1) as f64;
-        let close = histogram[0] + histogram[1] + histogram[2];
-        let close_pct = close as f64 / total_locks.max(1) as f64 * 100.0;
-
-        eprintln!("\nMean distance:         {mean:.1}");
-        eprintln!("Locks at dist <= 2:    {close}/{total_locks} ({close_pct:.1}%)");
-        eprintln!("Seeds with any <= 2:   {close_lock_seeds}/{seeds}");
-        if no_target_locks > 0 {
-            eprintln!("Locks without target:  {no_target_locks}");
-        }
-
-        eprintln!("\nPer-world averages:");
-        for (wi, &(sum, count)) in per_world.iter().enumerate() {
-            if count > 0 {
-                let avg = sum as f64 / count as f64;
-                eprintln!("  W{}: {avg:.1} avg ({count} locks)", wi + 1);
-            }
-        }
-
-        eprintln!("\n=== Inter-Lock Manhattan Distance ({total_pairs} pairs) ===\n");
-        eprintln!("Distance | Count | Bar");
-        eprintln!("---------+-------+----");
-        let max_inter = inter_hist.iter().rposition(|&c| c > 0).unwrap_or(0);
-        for (d, &count) in inter_hist[..=max_inter].iter().enumerate() {
-            let bar = "#".repeat((count as usize).min(60));
-            eprintln!("{d:>5}    | {count:<5} | {bar}");
-        }
-        let inter_total: u64 = inter_hist.iter().enumerate().map(|(d, &c)| d as u64 * c as u64).sum();
-        let inter_mean = inter_total as f64 / total_pairs.max(1) as f64;
-        let close_pairs: u32 = inter_hist[..=3].iter().sum();
-        let close_pair_pct = close_pairs as f64 / total_pairs.max(1) as f64 * 100.0;
-        eprintln!("\nMean pair distance:    {inter_mean:.1}");
-        eprintln!("Pairs at dist <= 3:    {close_pairs}/{total_pairs} ({close_pair_pct:.1}%)");
-        eprintln!("Seeds with any pair <=3: {close_pair_seeds}/{seeds}");
-        eprintln!("\nPer-world pair averages:");
-        for (wi, &(sum, count)) in per_world_pairs.iter().enumerate() {
-            if count > 0 {
-                let avg = sum as f64 / count as f64;
-                eprintln!("  W{}: {avg:.1} avg ({count} pairs)", wi + 1);
-            }
-        }
-    }
-
-    /// Distribution analyzer for pipe placement.
-    ///
-    /// Runs the builder for N seeds and reports, per world:
-    ///   - endpoint frequency (how often each position appears as a pipe end)
-    ///   - unordered-pair frequency
-    ///   - Shannon entropy of the endpoint distribution (bits)
-    ///   - top-5 most-picked endpoints and pairs
-    ///
-    /// Use the entropy number to compare scoring tweaks: higher = more variety.
-    /// Run with: cargo test --release test_pipe_distribution -- --ignored --nocapture
-    #[test]
-    #[ignore]
-    fn test_pipe_distribution() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-        let rom = apply_qol_for_overworld(&rom);
-
-        let seeds: u64 = std::env::var("PIPE_SEEDS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1000);
-
-        // Per-world tallies
-        let mut endpoint_counts: [HashMap<(usize, usize), u32>; 8] = Default::default();
-        let mut pair_counts: [HashMap<TeleportEdge, u32>; 8] = Default::default();
-        let mut total_endpoints = [0u32; 8];
-        let mut total_pairs = [0u32; 8];
-
-        for seed in 0..seeds {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            for built in &result.worlds {
-                let wi = built.world_idx;
-                for &(a, b) in &built.pipe_pairs {
-                    *endpoint_counts[wi].entry(a).or_insert(0) += 1;
-                    *endpoint_counts[wi].entry(b).or_insert(0) += 1;
-                    total_endpoints[wi] += 2;
-
-                    // Normalize unordered pair (smaller first)
-                    let pair = if a <= b { (a, b) } else { (b, a) };
-                    *pair_counts[wi].entry(pair).or_insert(0) += 1;
-                    total_pairs[wi] += 1;
-                }
-            }
-        }
-
-        eprintln!("\n=== Pipe Distribution over {seeds} seeds ===");
-
-        for wi in 0..8 {
-            let expected_pairs = VANILLA_PIPE_PAIRS[wi];
-            if expected_pairs == 0 {
                 continue;
             }
-
-            let endpoints = &endpoint_counts[wi];
-            let pairs = &pair_counts[wi];
-            let total_ep = total_endpoints[wi] as f64;
-            let total_pr = total_pairs[wi] as f64;
-
-            // Shannon entropy (bits) over endpoint distribution
-            let entropy: f64 = endpoints
-                .values()
-                .map(|&c| {
-                    let p = c as f64 / total_ep;
-                    -p * p.log2()
-                })
-                .sum();
-            // Max entropy if uniform over all observed endpoints
-            let max_entropy = (endpoints.len() as f64).log2();
-
-            // Same for pairs
-            let pair_entropy: f64 = pairs
-                .values()
-                .map(|&c| {
-                    let p = c as f64 / total_pr;
-                    -p * p.log2()
-                })
-                .sum();
-            let pair_max_entropy = (pairs.len() as f64).log2();
-
-            eprintln!(
-                "\n--- W{} ({} pair{}/seed) ---",
-                wi + 1,
-                expected_pairs,
-                if expected_pairs == 1 { "" } else { "s" },
-            );
-            eprintln!(
-                "  Endpoints: {} unique  |  entropy {:.2} / {:.2} bits ({:.0}%)",
-                endpoints.len(),
-                entropy,
-                max_entropy,
-                if max_entropy > 0.0 { entropy / max_entropy * 100.0 } else { 0.0 },
-            );
-            eprintln!(
-                "  Pairs:     {} unique  |  entropy {:.2} / {:.2} bits ({:.0}%)",
-                pairs.len(),
-                pair_entropy,
-                pair_max_entropy,
-                if pair_max_entropy > 0.0 { pair_entropy / pair_max_entropy * 100.0 } else { 0.0 },
-            );
-
-            let mut ep_sorted: Vec<_> = endpoints.iter().collect();
-            ep_sorted.sort_by(|a, b| b.1.cmp(a.1));
-            eprintln!("  Top endpoints:");
-            for (pos, count) in ep_sorted.iter().take(5) {
-                let count = **count;
-                let pct = count as f64 / total_ep * 100.0;
-                let bar = "#".repeat((pct as usize).min(40));
-                eprintln!(
-                    "    ({:2},{:2})  {:>5} ({:5.1}%)  {bar}",
-                    pos.0, pos.1, count, pct,
-                );
+            if no_hammer.forts_required == 0 && no_hammer.levels_required == 0 {
+                zero_zero[wi] += 1;
+                if zero_zero_seeds[wi].len() < 5 {
+                    zero_zero_seeds[wi].push(seed);
+                }
+                let path = &no_hammer.path;
+                let pipe_after_start = path.get(1).is_some_and(|(_, k)| matches!(k, PathNodeKind::Pipe));
+                let pipe_before_target = path.len() >= 2
+                    && matches!(path[path.len() - 2].1, PathNodeKind::Pipe);
+                match (pipe_after_start, pipe_before_target) {
+                    (true, true)  => bypass_both[wi]  += 1,
+                    (true, false) => bypass_start[wi] += 1,
+                    (false, true) => bypass_target[wi] += 1,
+                    (false, false)=> bypass_other[wi] += 1,
+                }
             }
+            sum_forts[wi] += no_hammer.forts_required as u64;
+            sum_levels[wi] += no_hammer.levels_required as u64;
+            sum_h_forts[wi] += with_hammer.forts_required as u64;
+            sum_h_levels[wi] += with_hammer.levels_required as u64;
 
-            let mut pr_sorted: Vec<_> = pairs.iter().collect();
-            pr_sorted.sort_by(|a, b| b.1.cmp(a.1));
-            eprintln!("  Top pairs:");
-            for (pair, count) in pr_sorted.iter().take(5) {
-                let count = **count;
-                let pct = count as f64 / total_pr * 100.0;
-                let bar = "#".repeat((pct as usize).min(40));
-                eprintln!(
-                    "    ({:2},{:2}) <-> ({:2},{:2})  {:>5} ({:5.1}%)  {bar}",
-                    pair.0.0, pair.0.1, pair.1.0, pair.1.1, count, pct,
-                );
-            }
+            min_forts[wi] = min_forts[wi].min(no_hammer.forts_required);
+            max_forts[wi] = max_forts[wi].max(no_hammer.forts_required);
+            min_levels[wi] = min_levels[wi].min(no_hammer.levels_required);
+            max_levels[wi] = max_levels[wi].max(no_hammer.levels_required);
+            min_h_forts[wi] = min_h_forts[wi].min(with_hammer.forts_required);
+            max_h_forts[wi] = max_h_forts[wi].max(with_hammer.forts_required);
         }
-
-        // One-line summary line for easy before/after diffing
-        eprintln!("\n=== Endpoint entropy summary (bits) ===");
-        let summary: Vec<String> = (0..8)
-            .filter(|&wi| VANILLA_PIPE_PAIRS[wi] > 0)
-            .map(|wi| {
-                let total_ep = total_endpoints[wi] as f64;
-                let entropy: f64 = endpoint_counts[wi]
-                    .values()
-                    .map(|&c| {
-                        let p = c as f64 / total_ep;
-                        -p * p.log2()
-                    })
-                    .sum();
-                format!("W{}={entropy:.2}", wi + 1)
-            })
-            .collect();
-        eprintln!("  {}", summary.join("  "));
     }
 
-    /// Distribution analyzer for fortress placement.
-    ///
-    /// Runs the builder for N seeds and reports, per world:
-    ///   - unique fortress positions and Shannon entropy (bits)
-    ///   - top-5 most-picked positions
-    ///   - per-section breakdown (each section places exactly one fortress)
-    ///
-    /// Use the entropy number to compare scoring tweaks: higher = more variety.
-    /// Run with: cargo test --release test_fortress_distribution -- --ignored --nocapture
-    /// Override seed count with FORT_SEEDS=N.
-    #[test]
-    #[ignore]
-    fn test_fortress_distribution() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-        let rom = apply_qol_for_overworld(&rom);
+    let sas_label = if std::env::var("SAS").is_ok() { " [SAS=1]" } else { "" };
+    eprintln!("\n=== Required Progression to Airship ({seeds} seeds{sas_label}) ===");
+    eprintln!();
+    eprintln!(
+        "{:<4} {:>8} {:>8}  {:>8} {:>8}   {:>8} {:>8}  {:>8}",
+        "", "forts", "(range)", "levels", "(range)", "h-forts", "(range)", "saves",
+    );
 
-        let seeds: u64 = std::env::var("FORT_SEEDS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1000);
+    let mut grand_forts = 0u64;
+    let mut grand_levels = 0u64;
+    let mut grand_h_forts = 0u64;
+    let mut grand_h_levels = 0u64;
 
-        // Per-world tallies
-        let mut world_counts: [HashMap<(usize, usize), u32>; 8] = Default::default();
-        let mut world_total = [0u32; 8];
-        // Per-section tallies: [world][section] -> position frequency
-        let mut section_counts: [Vec<HashMap<(usize, usize), u32>>; 8] = Default::default();
-        let mut section_total: [Vec<u32>; 8] = Default::default();
-
-        for seed in 0..seeds {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            for built in &result.worlds {
-                let wi = built.world_idx;
-
-                // Grow per-section storage to match observed section_count.
-                if section_counts[wi].len() < built.section_count {
-                    section_counts[wi].resize(built.section_count, HashMap::new());
-                    section_total[wi].resize(built.section_count, 0);
-                }
-
-                for slot in &built.slots {
-                    if slot.kind != SlotKind::Fortress {
-                        continue;
-                    }
-                    *world_counts[wi].entry(slot.pos).or_insert(0) += 1;
-                    world_total[wi] += 1;
-
-                    if slot.section < section_counts[wi].len() {
-                        *section_counts[wi][slot.section].entry(slot.pos).or_insert(0) += 1;
-                        section_total[wi][slot.section] += 1;
-                    }
-                }
-            }
+    for wi in 0..8 {
+        let seeds_ok = (seeds as u32 - unreachable[wi]) as f64;
+        if seeds_ok == 0.0 {
+            eprintln!("  W{}: (no reachable seeds)", wi + 1);
+            continue;
         }
+        let avg_f = sum_forts[wi] as f64 / seeds_ok;
+        let avg_l = sum_levels[wi] as f64 / seeds_ok;
+        let avg_hf = sum_h_forts[wi] as f64 / seeds_ok;
+        let saves = avg_f - avg_hf;
 
-        eprintln!("\n=== Fortress Distribution over {seeds} seeds ===");
+        grand_forts += sum_forts[wi];
+        grand_levels += sum_levels[wi];
+        grand_h_forts += sum_h_forts[wi];
+        grand_h_levels += sum_h_levels[wi];
 
-        for wi in 0..8 {
-            let counts = &world_counts[wi];
-            let total = world_total[wi];
-            if total == 0 {
-                continue;
-            }
-            let total_f = total as f64;
+        eprintln!(
+            "  W{}  {:>6.2}   {}-{:<3}  {:>6.2}   {}-{:<3}    {:>6.2}   {}-{:<3}   {:>5.2}",
+            wi + 1,
+            avg_f, min_forts[wi], max_forts[wi],
+            avg_l, min_levels[wi], max_levels[wi],
+            avg_hf, min_h_forts[wi], max_h_forts[wi],
+            saves,
+        );
+    }
 
-            let entropy: f64 = counts
-                .values()
-                .map(|&c| {
-                    let p = c as f64 / total_f;
-                    -p * p.log2()
-                })
-                .sum();
-            let max_entropy = (counts.len() as f64).log2();
-            let forts_per_seed = total as f64 / seeds as f64;
+    let avg_total_forts = grand_forts as f64 / seeds as f64;
+    let avg_total_levels = grand_levels as f64 / seeds as f64;
+    let avg_total_h_forts = grand_h_forts as f64 / seeds as f64;
+    let avg_total_h_levels = grand_h_levels as f64 / seeds as f64;
+    eprintln!();
+    eprintln!("  Per-seed totals (excludes the 8 objectives):");
+    eprintln!(
+        "    Without hammer: {:.2} forts + {:.2} levels  =  {:.2} clears",
+        avg_total_forts, avg_total_levels, avg_total_forts + avg_total_levels,
+    );
+    eprintln!(
+        "    With hammer:    {:.2} forts + {:.2} levels  =  {:.2} clears  (saves {:.2})",
+        avg_total_h_forts, avg_total_h_levels,
+        avg_total_h_forts + avg_total_h_levels,
+        (avg_total_forts + avg_total_levels) - (avg_total_h_forts + avg_total_h_levels),
+    );
 
-            eprintln!(
-                "\n--- W{} ({:.0} fort{}/seed) ---",
-                wi + 1,
-                forts_per_seed,
-                if forts_per_seed == 1.0 { "" } else { "s" },
-            );
-            eprintln!(
-                "  Positions: {} unique  |  entropy {:.2} / {:.2} bits ({:.0}%)",
-                counts.len(),
-                entropy,
-                max_entropy,
-                if max_entropy > 0.0 { entropy / max_entropy * 100.0 } else { 0.0 },
-            );
-
-            let mut sorted: Vec<_> = counts.iter().collect();
-            sorted.sort_by(|a, b| b.1.cmp(a.1));
-            eprintln!("  Top positions:");
-            for (pos, count) in sorted.iter().take(5) {
-                let count = **count;
-                let pct = count as f64 / total_f * 100.0;
-                let bar = "#".repeat((pct as usize).min(40));
-                eprintln!(
-                    "    ({:2},{:2})  {:>5} ({:5.1}%)  {bar}",
-                    pos.0, pos.1, count, pct,
-                );
-            }
-
-            // Per-section breakdown
-            for (si, sec_counts) in section_counts[wi].iter().enumerate() {
-                if sec_counts.is_empty() {
-                    continue;
-                }
-                let sec_total = section_total[wi][si] as f64;
-                let sec_entropy: f64 = sec_counts
-                    .values()
-                    .map(|&c| {
-                        let p = c as f64 / sec_total;
-                        -p * p.log2()
-                    })
-                    .sum();
-                let sec_max = (sec_counts.len() as f64).log2();
-                let mut sec_sorted: Vec<_> = sec_counts.iter().collect();
-                sec_sorted.sort_by(|a, b| b.1.cmp(a.1));
-                let top: Vec<String> = sec_sorted
+    let total_unreach: u32 = unreachable.iter().sum();
+    if total_unreach > 0 {
+        eprintln!("\n  WARNING: {total_unreach} unreachable-target case(s) — builder bug?");
+        for (wi, &count) in unreachable.iter().enumerate() {
+            if count > 0 {
+                let pct = count as f64 / seeds as f64 * 100.0;
+                let seed_examples: Vec<String> = unreachable_seeds[wi]
                     .iter()
-                    .take(3)
-                    .map(|(p, c)| {
-                        let pct = **c as f64 / sec_total * 100.0;
-                        format!("({},{})={:.0}%", p.0, p.1, pct)
-                    })
+                    .map(u64::to_string)
                     .collect();
                 eprintln!(
-                    "    Section {si}: {} unique, entropy {:.2}/{:.2} bits, top: {}",
-                    sec_counts.len(),
-                    sec_entropy,
-                    sec_max,
-                    top.join("  "),
+                    "    W{}: {count}/{seeds} ({pct:.1}%)  example seeds: {}",
+                    wi + 1,
+                    seed_examples.join(", "),
                 );
             }
         }
-
-        eprintln!("\n=== Fortress entropy summary (bits) ===");
-        let summary: Vec<String> = (0..8)
-            .filter(|&wi| world_total[wi] > 0)
-            .map(|wi| {
-                let total_f = world_total[wi] as f64;
-                let entropy: f64 = world_counts[wi]
-                    .values()
-                    .map(|&c| {
-                        let p = c as f64 / total_f;
-                        -p * p.log2()
-                    })
-                    .sum();
-                format!("W{}={entropy:.2}", wi + 1)
-            })
-            .collect();
-        eprintln!("  {}", summary.join("  "));
-
-        // Sanity: 17 fortresses per seed total
-        let grand_total: u32 = world_total.iter().sum();
-        let expected = 17 * seeds as u32;
-        eprintln!("\nGrand total: {grand_total} fortresses across {seeds} seeds (expected {expected})");
-        assert_eq!(grand_total, expected, "fortress count invariant broken");
     }
 
-    /// Quality analyzer for level placement.
-    ///
-    /// Level placement is deterministic given pipes+forts, so a position-entropy
-    /// test would mostly just measure upstream randomness. Instead, this measures
-    /// whether the scoring achieves its stated goals:
-    ///
-    ///   - Spread: avg pairwise distance between placed levels, density-rule
-    ///     violations (pairs within combined radius 4). Anti-clumping is the
-    ///     primary anti-degeneracy signal.
-    ///   - Path bonus: avg detour from start→target shortest path for placed
-    ///     levels vs all candidates. Negative bias = levels biased toward main
-    ///     route, the intended design goal.
-    ///   - Dead-end bonus: % of dead-end candidates that became levels vs the
-    ///     random baseline. Treated as a tiebreaker — it should win where it
-    ///     doesn't conflict with path bias, but not override it.
-    ///
-    /// Run with: cargo test --release test_level_placement_quality -- --ignored --nocapture
-    /// Override seed count with LEVEL_SEEDS=N.
-    #[test]
-    #[ignore]
-    fn test_level_placement_quality() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
+    let total_zero_zero: u32 = zero_zero.iter().sum();
+    let total_world_seeds = seeds as u32 * 8;
+    let overall_pct = total_zero_zero as f64 / total_world_seeds as f64 * 100.0;
+    eprintln!(
+        "\n  Trivial-bypass (0 forts + 0 levels) — overall {total_zero_zero}/{total_world_seeds} ({overall_pct:.2}%):"
+    );
+    for (wi, &count) in zero_zero.iter().enumerate() {
+        let pct = count as f64 / seeds as f64 * 100.0;
+        let examples = if zero_zero_seeds[wi].is_empty() {
+            String::new()
+        } else {
+            let s: Vec<String> = zero_zero_seeds[wi].iter().map(u64::to_string).collect();
+            format!("  example seeds: {}", s.join(", "))
         };
-        let rom = apply_qol_for_overworld(&rom);
-
-        let seeds: u64 = std::env::var("LEVEL_SEEDS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1000);
-
-        // Per-world aggregates
-        let mut total_pairwise_dist = [0u64; 8];
-        let mut total_pairs = [0u64; 8];
-        let mut density_violations = [0u64; 8];
-        let mut dead_ends_picked = [0u64; 8];
-        let mut total_dead_end_candidates = [0u64; 8];
-        let mut levels_picked = [0u64; 8];
-        let mut total_candidates = [0u64; 8];
-        let mut total_level_detour = [0u64; 8];
-        let mut total_levels_for_detour = [0u64; 8];
-        let mut total_candidate_detour = [0u64; 8];
-        let mut total_candidates_for_detour = [0u64; 8];
-
-        for seed in 0..seeds {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            for built in &result.worlds {
-                let wi = built.world_idx;
-                let start_pos = rom_data::find_start(&built.grid);
-                let target_pos = find_target(&built.grid, wi);
-
-                let levels: Vec<(usize, usize)> = built.slots.iter()
-                    .filter(|s| s.kind == SlotKind::Level)
-                    .map(|s| s.pos)
-                    .collect();
-
-                // Candidate pool seen by level placement: all non-fort, non-pipe
-                // section positions. In the final state, these became Level or
-                // HammerBro slots.
-                let candidates: Vec<(usize, usize)> = built.slots.iter()
-                    .filter(|s| matches!(s.kind, SlotKind::Level | SlotKind::HammerBro))
-                    .map(|s| s.pos)
-                    .collect();
-
-                // BFS from start (matches what scoring used).
-                let walk = walk_map(&built.grid, &built.pipe_pairs, start_pos, built.world_idx);
-                let bfs_distances = &walk.distances;
-
-                // === Spread: avg pairwise distance between placed levels ===
-                for i in 0..levels.len() {
-                    for j in (i + 1)..levels.len() {
-                        let manhattan = levels[i].0.abs_diff(levels[j].0)
-                            + levels[i].1.abs_diff(levels[j].1);
-                        total_pairwise_dist[wi] += manhattan as u64;
-                        total_pairs[wi] += 1;
-
-                        // Density rule: max(manhattan, |bfs_diff|) <= 4
-                        let bfs_diff = match (bfs_distances.get(&levels[i]), bfs_distances.get(&levels[j])) {
-                            (Some(&a), Some(&b)) => a.abs_diff(b),
-                            _ => manhattan,
-                        };
-                        if manhattan.max(bfs_diff) <= 4 {
-                            density_violations[wi] += 1;
-                        }
-                    }
-                }
-
-                // === Dead-end utilization ===
-                for &pos in &candidates {
-                    if is_dead_end(&built.grid, pos) {
-                        total_dead_end_candidates[wi] += 1;
-                        if levels.contains(&pos) {
-                            dead_ends_picked[wi] += 1;
-                        }
-                    }
-                }
-                levels_picked[wi] += levels.len() as u64;
-                total_candidates[wi] += candidates.len() as u64;
-
-                // === Path detour: levels vs candidate baseline ===
-                // Only positions reachable in BOTH directions count — unreachable
-                // positions can't have a meaningful detour relative to a route
-                // they're not on.
-                if let Some(tp) = target_pos {
-                    let reverse_walk = walk_map(&built.grid, &built.pipe_pairs, Some(tp), built.world_idx);
-                    if let Some(&td) = bfs_distances.get(&tp) {
-                        for &pos in &levels {
-                            if let (Some(&fwd), Some(&rev)) = (
-                                bfs_distances.get(&pos),
-                                reverse_walk.distances.get(&pos),
-                            ) {
-                                let detour = (fwd + rev).saturating_sub(td);
-                                total_level_detour[wi] += detour as u64;
-                                total_levels_for_detour[wi] += 1;
-                            }
-                        }
-                        for &pos in &candidates {
-                            if let (Some(&fwd), Some(&rev)) = (
-                                bfs_distances.get(&pos),
-                                reverse_walk.distances.get(&pos),
-                            ) {
-                                let detour = (fwd + rev).saturating_sub(td);
-                                total_candidate_detour[wi] += detour as u64;
-                                total_candidates_for_detour[wi] += 1;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        eprintln!("\n=== Level Placement Quality over {seeds} seeds ===");
-
-        for wi in 0..8 {
-            if total_candidates[wi] == 0 {
-                continue;
-            }
-
-            eprintln!("\n--- W{} ---", wi + 1);
-
-            // Spread
-            if total_pairs[wi] > 0 {
-                let avg_pair = total_pairwise_dist[wi] as f64 / total_pairs[wi] as f64;
-                let dens_pct = density_violations[wi] as f64 / total_pairs[wi] as f64 * 100.0;
-                eprintln!("  Spread:");
-                eprintln!("    Avg pairwise level distance: {avg_pair:.1} tiles");
-                eprintln!(
-                    "    Density violations (combined radius <=4): {} / {} pairs ({:.1}%)",
-                    density_violations[wi], total_pairs[wi], dens_pct,
-                );
-            }
-
-            // Dead-end bonus
-            let dead_end_util = if total_dead_end_candidates[wi] > 0 {
-                dead_ends_picked[wi] as f64 / total_dead_end_candidates[wi] as f64 * 100.0
-            } else { 0.0 };
-            let random_baseline = levels_picked[wi] as f64 / total_candidates[wi] as f64 * 100.0;
-            let lift = dead_end_util - random_baseline;
-            eprintln!("  Dead-end bonus (+0.5):");
-            eprintln!(
-                "    Dead-end candidates: {} ({:.1}% of all candidates)",
-                total_dead_end_candidates[wi],
-                total_dead_end_candidates[wi] as f64 / total_candidates[wi] as f64 * 100.0,
-            );
-            eprintln!("    Picked as level:     {dead_end_util:.1}%");
-            eprintln!("    Random baseline:     {random_baseline:.1}%");
-            eprintln!(
-                "    Lift: {lift:+.1} pp  ({})",
-                if lift.abs() < 2.0 { "negligible" }
-                else if lift > 0.0 { "bias toward dead-ends" }
-                else { "bias against dead-ends" },
-            );
-
-            // Path bonus
-            if total_levels_for_detour[wi] > 0 && total_candidates_for_detour[wi] > 0 {
-                let avg_lvl = total_level_detour[wi] as f64 / total_levels_for_detour[wi] as f64;
-                let avg_cand = total_candidate_detour[wi] as f64 / total_candidates_for_detour[wi] as f64;
-                let bias = avg_lvl - avg_cand;
-                eprintln!("  Path bonus (max = PATH_DETOUR_CAP * W_PATH):");
-                eprintln!("    Avg detour for placed levels: {avg_lvl:.2} hops");
-                eprintln!("    Avg detour for all candidates: {avg_cand:.2} hops");
-                eprintln!(
-                    "    Bias: {bias:+.2} hops  ({})",
-                    if bias.abs() < 0.3 { "negligible" }
-                    else if bias < 0.0 { "toward main route" }
-                    else { "off main route" },
-                );
-            }
-        }
-
-        // One-line summary for diffing
-        eprintln!("\n=== Summary (avg pairwise distance / dead-end lift / path bias) ===");
-        for wi in 0..8 {
-            if total_candidates[wi] == 0 { continue; }
-            let avg_pair = if total_pairs[wi] > 0 {
-                total_pairwise_dist[wi] as f64 / total_pairs[wi] as f64
-            } else { 0.0 };
-            let dead_end_util = if total_dead_end_candidates[wi] > 0 {
-                dead_ends_picked[wi] as f64 / total_dead_end_candidates[wi] as f64 * 100.0
-            } else { 0.0 };
-            let random_baseline = levels_picked[wi] as f64 / total_candidates[wi] as f64 * 100.0;
-            let lift = dead_end_util - random_baseline;
-            let path_bias = if total_levels_for_detour[wi] > 0 && total_candidates_for_detour[wi] > 0 {
-                let avg_lvl = total_level_detour[wi] as f64 / total_levels_for_detour[wi] as f64;
-                let avg_cand = total_candidate_detour[wi] as f64 / total_candidates_for_detour[wi] as f64;
-                avg_lvl - avg_cand
-            } else { 0.0 };
-            eprintln!(
-                "  W{}: dist={avg_pair:5.1}  dead-end-lift={lift:+5.1}pp  path-bias={path_bias:+5.2}",
-                wi + 1,
-            );
-        }
+        eprintln!("    W{}: {count}/{seeds} ({pct:.1}%){examples}", wi + 1);
     }
-
-    /// Required-progression analyzer.
-    ///
-    /// Per world, computes the minimum number of fortress + level entries
-    /// the player must clear to reach the airship/Bowser. Locks block path
-    /// tiles until the fortress whose section opens them is cleared; pipes
-    /// are taken whenever they shorten the route. Also reports a "hammer
-    /// mode" where all locks start open, isolating fortresses that were
-    /// only required because of lock gating.
-    ///
-    /// Regression: under start↔airship swap, the W3 fixed pipe used to be
-    /// paired with a random opposite-side blank, which could land on a dead
-    /// canoe island and strand the start — leaving the airship unreachable
-    /// (~1.6% of SAS seeds). `place_pipes` now biases the fixed pipe's partner
-    /// toward a blank that actually reconnects start to target. These seeds all
-    /// failed before that fix; they must stay reachable.
-    #[test]
-    fn test_sas_w3_fixed_pipe_keeps_target_reachable() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return, // ROM not present in this environment; skip.
-        };
-        let rom = apply_qol_for_overworld(&rom);
-        // Previously-unreachable SAS W3 seeds (from the SAS=1 progression sweep).
-        for seed in [123u64, 385, 515, 559, 629] {
-            let mut catalog = NodeCatalog::build(&rom, false);
-            let mut swap_rng = ChaCha8Rng::seed_from_u64(seed);
-            super::super::start_airship_swap::pick_swaps(&mut catalog, &mut swap_rng);
-            let pickup = super::super::overworld_pickup::pick_up(
-                &rom,
-                &catalog,
-                super::super::overworld_pickup::PickupFlags {
-                    shuffle_spade_games: true,
-                    shuffle_toad_houses: true,
-                    ..Default::default()
-                },
-            );
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            let w3 = result.worlds.iter().find(|b| b.world_idx == 2).unwrap();
-            assert!(
-                analyze_required_progression(w3, false).reachable,
-                "SAS seed {seed}: W3 airship must be reachable",
-            );
-        }
+    let tb = bypass_both.iter().sum::<u32>();
+    let ts = bypass_start.iter().sum::<u32>();
+    let tt = bypass_target.iter().sum::<u32>();
+    let to_ = bypass_other.iter().sum::<u32>();
+    if total_zero_zero > 0 {
+        eprintln!(
+            "  Bypass classification — pipe-both: {tb}, pipe-start-only: {ts}, pipe-target-only: {tt}, neither: {to_}",
+        );
     }
+}
 
-    /// Run with: cargo test --release test_required_progression -- --ignored --nocapture
-    /// Override seed count with PROG_SEEDS=N.
-    /// Toggle start↔airship swap with SAS=1.
-    #[test]
-    #[ignore]
-    fn test_required_progression() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-        let rom = apply_qol_for_overworld(&rom);
+/// Single-seed dump of the required-progression analysis. Intended for
+/// verification by eye — prints the fortress/lock inventory and the
+/// step-by-step path Dijkstra picked, both without and with hammer.
+///
+/// Run with:
+///   DUMP_SEED=0 DUMP_WORLD=4 cargo test --release \
+///     test_dump_required_progression -- --ignored --nocapture
+/// Omit DUMP_WORLD to print all 8 worlds.
+#[test]
+#[ignore]
+fn test_dump_required_progression() {
+    use crate::Options;
 
-        let seeds: u64 = std::env::var("PROG_SEEDS")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1000);
-
-        // Per-world tallies: sums for mean, plus min/max.
-        let mut sum_forts = [0u64; 8];
-        let mut sum_levels = [0u64; 8];
-        let mut sum_h_forts = [0u64; 8];
-        let mut sum_h_levels = [0u64; 8];
-        let mut min_forts = [usize::MAX; 8];
-        let mut max_forts = [0usize; 8];
-        let mut min_levels = [usize::MAX; 8];
-        let mut max_levels = [0usize; 8];
-        let mut min_h_forts = [usize::MAX; 8];
-        let mut max_h_forts = [0usize; 8];
-        let mut unreachable = [0u32; 8];
-        let mut unreachable_seeds: [Vec<u64>; 8] = Default::default();
-        // "Trivial bypass" = hammerless playthrough requires 0 forts AND 0
-        // levels (player walks/pipes straight to the airship). Tracked per
-        // world plus classified by whether the path uses a pipe right after
-        // start (pipe_start), right before target (pipe_target), both, or
-        // neither — diagnostic that pinpoints the failure mode.
-        let mut zero_zero = [0u32; 8];
-        let mut zero_zero_seeds: [Vec<u64>; 8] = Default::default();
-        let mut bypass_both = [0u32; 8];
-        let mut bypass_start = [0u32; 8];
-        let mut bypass_target = [0u32; 8];
-        let mut bypass_other = [0u32; 8];
-
-        for seed in 0..seeds {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            for built in &result.worlds {
-                let wi = built.world_idx;
-                let no_hammer = analyze_required_progression(built, false);
-                let with_hammer = analyze_required_progression(built, true);
-
-                if !no_hammer.reachable {
-                    unreachable[wi] += 1;
-                    if unreachable_seeds[wi].len() < 5 {
-                        unreachable_seeds[wi].push(seed);
-                    }
-                    continue;
-                }
-                if no_hammer.forts_required == 0 && no_hammer.levels_required == 0 {
-                    zero_zero[wi] += 1;
-                    if zero_zero_seeds[wi].len() < 5 {
-                        zero_zero_seeds[wi].push(seed);
-                    }
-                    let path = &no_hammer.path;
-                    let pipe_after_start = path.get(1).is_some_and(|(_, k)| matches!(k, PathNodeKind::Pipe));
-                    let pipe_before_target = path.len() >= 2
-                        && matches!(path[path.len() - 2].1, PathNodeKind::Pipe);
-                    match (pipe_after_start, pipe_before_target) {
-                        (true, true)  => bypass_both[wi]  += 1,
-                        (true, false) => bypass_start[wi] += 1,
-                        (false, true) => bypass_target[wi] += 1,
-                        (false, false)=> bypass_other[wi] += 1,
-                    }
-                }
-                sum_forts[wi] += no_hammer.forts_required as u64;
-                sum_levels[wi] += no_hammer.levels_required as u64;
-                sum_h_forts[wi] += with_hammer.forts_required as u64;
-                sum_h_levels[wi] += with_hammer.levels_required as u64;
-
-                min_forts[wi] = min_forts[wi].min(no_hammer.forts_required);
-                max_forts[wi] = max_forts[wi].max(no_hammer.forts_required);
-                min_levels[wi] = min_levels[wi].min(no_hammer.levels_required);
-                max_levels[wi] = max_levels[wi].max(no_hammer.levels_required);
-                min_h_forts[wi] = min_h_forts[wi].min(with_hammer.forts_required);
-                max_h_forts[wi] = max_h_forts[wi].max(with_hammer.forts_required);
-            }
-        }
-
-        let sas_label = if std::env::var("SAS").is_ok() { " [SAS=1]" } else { "" };
-        eprintln!("\n=== Required Progression to Airship ({seeds} seeds{sas_label}) ===");
-        eprintln!();
-        eprintln!(
-            "{:<4} {:>8} {:>8}  {:>8} {:>8}   {:>8} {:>8}  {:>8}",
-            "", "forts", "(range)", "levels", "(range)", "h-forts", "(range)", "saves",
-        );
-
-        let mut grand_forts = 0u64;
-        let mut grand_levels = 0u64;
-        let mut grand_h_forts = 0u64;
-        let mut grand_h_levels = 0u64;
-
-        for wi in 0..8 {
-            let seeds_ok = (seeds as u32 - unreachable[wi]) as f64;
-            if seeds_ok == 0.0 {
-                eprintln!("  W{}: (no reachable seeds)", wi + 1);
-                continue;
-            }
-            let avg_f = sum_forts[wi] as f64 / seeds_ok;
-            let avg_l = sum_levels[wi] as f64 / seeds_ok;
-            let avg_hf = sum_h_forts[wi] as f64 / seeds_ok;
-            let saves = avg_f - avg_hf;
-
-            grand_forts += sum_forts[wi];
-            grand_levels += sum_levels[wi];
-            grand_h_forts += sum_h_forts[wi];
-            grand_h_levels += sum_h_levels[wi];
-
-            eprintln!(
-                "  W{}  {:>6.2}   {}-{:<3}  {:>6.2}   {}-{:<3}    {:>6.2}   {}-{:<3}   {:>5.2}",
-                wi + 1,
-                avg_f, min_forts[wi], max_forts[wi],
-                avg_l, min_levels[wi], max_levels[wi],
-                avg_hf, min_h_forts[wi], max_h_forts[wi],
-                saves,
-            );
-        }
-
-        let avg_total_forts = grand_forts as f64 / seeds as f64;
-        let avg_total_levels = grand_levels as f64 / seeds as f64;
-        let avg_total_h_forts = grand_h_forts as f64 / seeds as f64;
-        let avg_total_h_levels = grand_h_levels as f64 / seeds as f64;
-        eprintln!();
-        eprintln!("  Per-seed totals (excludes the 8 objectives):");
-        eprintln!(
-            "    Without hammer: {:.2} forts + {:.2} levels  =  {:.2} clears",
-            avg_total_forts, avg_total_levels, avg_total_forts + avg_total_levels,
-        );
-        eprintln!(
-            "    With hammer:    {:.2} forts + {:.2} levels  =  {:.2} clears  (saves {:.2})",
-            avg_total_h_forts, avg_total_h_levels,
-            avg_total_h_forts + avg_total_h_levels,
-            (avg_total_forts + avg_total_levels) - (avg_total_h_forts + avg_total_h_levels),
-        );
-
-        let total_unreach: u32 = unreachable.iter().sum();
-        if total_unreach > 0 {
-            eprintln!("\n  WARNING: {total_unreach} unreachable-target case(s) — builder bug?");
-            for (wi, &count) in unreachable.iter().enumerate() {
-                if count > 0 {
-                    let pct = count as f64 / seeds as f64 * 100.0;
-                    let seed_examples: Vec<String> = unreachable_seeds[wi]
-                        .iter()
-                        .map(u64::to_string)
-                        .collect();
-                    eprintln!(
-                        "    W{}: {count}/{seeds} ({pct:.1}%)  example seeds: {}",
-                        wi + 1,
-                        seed_examples.join(", "),
-                    );
-                }
-            }
-        }
-
-        let total_zero_zero: u32 = zero_zero.iter().sum();
-        let total_world_seeds = seeds as u32 * 8;
-        let overall_pct = total_zero_zero as f64 / total_world_seeds as f64 * 100.0;
-        eprintln!(
-            "\n  Trivial-bypass (0 forts + 0 levels) — overall {total_zero_zero}/{total_world_seeds} ({overall_pct:.2}%):"
-        );
-        for (wi, &count) in zero_zero.iter().enumerate() {
-            let pct = count as f64 / seeds as f64 * 100.0;
-            let examples = if zero_zero_seeds[wi].is_empty() {
-                String::new()
-            } else {
-                let s: Vec<String> = zero_zero_seeds[wi].iter().map(u64::to_string).collect();
-                format!("  example seeds: {}", s.join(", "))
-            };
-            eprintln!("    W{}: {count}/{seeds} ({pct:.1}%){examples}", wi + 1);
-        }
-        let tb = bypass_both.iter().sum::<u32>();
-        let ts = bypass_start.iter().sum::<u32>();
-        let tt = bypass_target.iter().sum::<u32>();
-        let to_ = bypass_other.iter().sum::<u32>();
-        if total_zero_zero > 0 {
-            eprintln!(
-                "  Bypass classification — pipe-both: {tb}, pipe-start-only: {ts}, pipe-target-only: {tt}, neither: {to_}",
-            );
-        }
-    }
-
-    /// Single-seed dump of the required-progression analysis. Intended for
-    /// verification by eye — prints the fortress/lock inventory and the
-    /// step-by-step path Dijkstra picked, both without and with hammer.
-    ///
-    /// Run with:
-    ///   DUMP_SEED=0 DUMP_WORLD=4 cargo test --release \
-    ///     test_dump_required_progression -- --ignored --nocapture
-    /// Omit DUMP_WORLD to print all 8 worlds.
-    #[test]
-    #[ignore]
-    fn test_dump_required_progression() {
-        use crate::Options;
-
-        let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
-            Ok(b) => b,
-            Err(_) => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-
-        let seed: u64 = std::env::var("DUMP_SEED")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-        let world_filter: Option<usize> = std::env::var("DUMP_WORLD")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .map(|w| w.saturating_sub(1));
-
-        // PROBE=1: print the vanilla world grid (post-QoL) for the chosen
-        // DUMP_WORLD, then exit. Used to inspect map topology without any
-        // build randomization.
-        if std::env::var("PROBE").is_ok() {
-            let rom = Rom::from_bytes(&rom_bytes).unwrap();
-            let rom = apply_qol_for_overworld(&rom);
-            let wi = world_filter.unwrap_or(2); // default W3
-            let grid = rom_data::read_tile_grid(&rom, wi);
-            eprintln!("=== Vanilla W{} grid (post-QoL) ===", wi + 1);
-            for r in 0..grid.rows {
-                eprint!("  r{r:1}:");
-                for c in 0..grid.cols {
-                    eprint!(" {:02X}", grid.get(r, c));
-                }
-                eprintln!();
-            }
+    let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("ROM not found, skipping");
             return;
         }
+    };
 
-        // STANDALONE=1 bypasses the full pipeline and runs the builder
-        // directly off a fresh `seed_from_u64(seed)` RNG, matching what the
-        // distribution analyzer (test_required_progression) sees. Use this
-        // to reproduce unreachable-target findings reported by that test.
-        if std::env::var("STANDALONE").is_ok() {
-            let rom = match Rom::from_bytes(&rom_bytes) {
-                Ok(r) => r,
-                Err(e) => {
-                    eprintln!("ROM parse failed: {e}");
-                    return;
-                }
-            };
-            let rom = apply_qol_for_overworld(&rom);
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-            let result = build(
-                &rom,
-                &OverworldData { pickup: &pickup, catalog: &catalog },
-                &mut rng,
-                BuildFlags { shuffle_toad_houses: true, ..Default::default() },
-            );
-            let sas_label = if std::env::var("SAS").is_ok() {
-                " [SAS=1]"
-            } else {
-                ""
-            };
-            eprintln!("=== Required Progression dump (seed={seed}{sas_label}, STANDALONE) ===");
-            for built in &result.worlds {
-                if let Some(w) = world_filter
-                    && built.world_idx != w
-                {
-                    continue;
-                }
-                dump_required_progression(built);
-                // GRID=1: also print the post-build grid for visual inspection.
-                if std::env::var("GRID").is_ok() {
-                    eprintln!("\n  Post-build grid:");
-                    for r in 0..built.grid.rows {
-                        eprint!("    r{r:1}:");
-                        for c in 0..built.grid.cols {
-                            eprint!(" {:02X}", built.grid.get(r, c));
-                        }
-                        eprintln!();
-                    }
-                    if let (Some(start), Some(target)) = (
-                        rom_data::find_start(&built.grid),
-                        find_target(&built.grid, built.world_idx),
-                    ) {
-                        let probe = |grid: &Grid, label: &str, pos: (usize, usize)| {
-                            let r = pos.0 as i32 - 1;
-                            let c = pos.1 as i32 - 1;
-                            let dirs = [
-                                ("N", r, pos.1 as i32),
-                                ("S", pos.0 as i32 + 1, pos.1 as i32),
-                                ("W", pos.0 as i32, c),
-                                ("E", pos.0 as i32, pos.1 as i32 + 1),
-                            ];
-                            eprintln!("  {label}={pos:?} tile=0x{:02X}", grid.get(pos.0, pos.1));
-                            for (d, rr, cc) in dirs {
-                                if rr < 0 || cc < 0 || rr as usize >= grid.rows || cc as usize >= grid.cols {
-                                    eprintln!("    {d} ({rr},{cc}): off-grid");
-                                } else {
-                                    eprintln!("    {d} ({rr},{cc}): 0x{:02X}", grid.get(rr as usize, cc as usize));
-                                }
-                            }
-                        };
-                        probe(&built.grid, "start", start);
-                        probe(&built.grid, "target", target);
+    let seed: u64 = std::env::var("DUMP_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let world_filter: Option<usize> = std::env::var("DUMP_WORLD")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|w| w.saturating_sub(1));
 
-                        // What does walk_map see as reachable from start?
-                        let walk = walk_map(&built.grid, &built.pipe_pairs, Some(start), built.world_idx);
-                        let mut reachable: Vec<(usize, usize)> = walk.nodes.iter().copied().collect();
-                        reachable.sort();
-                        eprintln!("\n  walk_map reachable from start ({} nodes):", reachable.len());
-                        for pos in &reachable {
-                            eprintln!("    {pos:?} tile=0x{:02X}", built.grid.get(pos.0, pos.1));
-                        }
-                    }
-                }
+    // PROBE=1: print the vanilla world grid (post-QoL) for the chosen
+    // DUMP_WORLD, then exit. Used to inspect map topology without any
+    // build randomization.
+    if std::env::var("PROBE").is_ok() {
+        let rom = Rom::from_bytes(&rom_bytes).unwrap();
+        let rom = apply_qol_for_overworld(&rom);
+        let wi = world_filter.unwrap_or(2); // default W3
+        let grid = rom_data::read_tile_grid(&rom, wi);
+        eprintln!("=== Vanilla W{} grid (post-QoL) ===", wi + 1);
+        for r in 0..grid.rows {
+            eprint!("  r{r:1}:");
+            for c in 0..grid.cols {
+                eprint!(" {:02X}", grid.get(r, c));
             }
-            return;
+            eprintln!();
         }
+        return;
+    }
 
-        // Build Options from either a FLAGS=SMB3R-... key (preferred — covers
-        // every randomizer toggle) or fall back to `Options::default()` plus
-        // an `SAS=1` override. This matches what the user would pass to the
-        // CLI/web, so the RNG sequence reaching the overworld builder is the
-        // one a real playthrough sees.
-        let mut options = match std::env::var("FLAGS") {
-            Ok(key) => match crate::Options::from_flag_key(&key) {
-                Ok(o) => o,
-                Err(e) => {
-                    eprintln!("Invalid FLAGS key: {e}");
-                    return;
-                }
-            },
-            Err(_) => Options::default(),
-        };
-        if std::env::var("SAS").is_ok() {
-            options.swap_start_airship = true;
-        }
-        // Palettes (both character-only and themed) use a fresh OS RNG, so
-        // they introduce noise that breaks reproducibility without affecting
-        // the topology this analyzer cares about. Force both off so identical
-        // (seed, flags) inputs produce identical ROM bytes.
-        options.palettes = false;
-        options.palette_themed = false;
-
-        let (rom, result) = match crate::randomize_rom_with_overworld_capture(
-            &rom_bytes, seed, &options, None,
-        ) {
-            Ok(pair) => pair,
+    // STANDALONE=1 bypasses the full pipeline and runs the builder
+    // directly off a fresh `seed_from_u64(seed)` RNG, matching what the
+    // distribution analyzer (test_required_progression) sees. Use this
+    // to reproduce unreachable-target findings reported by that test.
+    if std::env::var("STANDALONE").is_ok() {
+        let rom = match Rom::from_bytes(&rom_bytes) {
+            Ok(r) => r,
             Err(e) => {
-                eprintln!("randomize_rom_with_overworld_capture failed: {e}");
+                eprintln!("ROM parse failed: {e}");
                 return;
             }
         };
-
-        let sas_label = if options.swap_start_airship { " [SAS=1]" } else { "" };
-        let flag_key = options.to_flag_key();
-        eprintln!("=== Required Progression dump (seed={seed}{sas_label}) ===");
-        eprintln!("Flags: {flag_key}");
-
+        let rom = apply_qol_for_overworld(&rom);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        let sas_label = if std::env::var("SAS").is_ok() {
+            " [SAS=1]"
+        } else {
+            ""
+        };
+        eprintln!("=== Required Progression dump (seed={seed}{sas_label}, STANDALONE) ===");
         for built in &result.worlds {
             if let Some(w) = world_filter
                 && built.world_idx != w
@@ -2174,11 +1995,107 @@
                 continue;
             }
             dump_required_progression(built);
-        }
+            // GRID=1: also print the post-build grid for visual inspection.
+            if std::env::var("GRID").is_ok() {
+                eprintln!("\n  Post-build grid:");
+                for r in 0..built.grid.rows {
+                    eprint!("    r{r:1}:");
+                    for c in 0..built.grid.cols {
+                        eprint!(" {:02X}", built.grid.get(r, c));
+                    }
+                    eprintln!();
+                }
+                if let (Some(start), Some(target)) = (
+                    rom_data::find_start(&built.grid),
+                    find_target(&built.grid, built.world_idx),
+                ) {
+                    let probe = |grid: &Grid, label: &str, pos: (usize, usize)| {
+                        let r = pos.0 as i32 - 1;
+                        let c = pos.1 as i32 - 1;
+                        let dirs = [
+                            ("N", r, pos.1 as i32),
+                            ("S", pos.0 as i32 + 1, pos.1 as i32),
+                            ("W", pos.0 as i32, c),
+                            ("E", pos.0 as i32, pos.1 as i32 + 1),
+                        ];
+                        eprintln!("  {label}={pos:?} tile=0x{:02X}", grid.get(pos.0, pos.1));
+                        for (d, rr, cc) in dirs {
+                            if rr < 0 || cc < 0 || rr as usize >= grid.rows || cc as usize >= grid.cols {
+                                eprintln!("    {d} ({rr},{cc}): off-grid");
+                            } else {
+                                eprintln!("    {d} ({rr},{cc}): 0x{:02X}", grid.get(rr as usize, cc as usize));
+                            }
+                        }
+                    };
+                    probe(&built.grid, "start", start);
+                    probe(&built.grid, "target", target);
 
-        // Save the fully-randomized ROM (matches the real playthrough state).
-        let sas_tag = if options.swap_start_airship { "_sas" } else { "" };
-        let filename = format!("progression_seed{seed}{sas_tag}.nes");
-        std::fs::write(&filename, rom.output_bytes()).unwrap();
-        eprintln!("\nWrote {filename}");
+                    // What does walk_map see as reachable from start?
+                    let walk = walk_map(&built.grid, &built.pipe_pairs, Some(start), built.world_idx);
+                    let mut reachable: Vec<(usize, usize)> = walk.nodes.iter().copied().collect();
+                    reachable.sort();
+                    eprintln!("\n  walk_map reachable from start ({} nodes):", reachable.len());
+                    for pos in &reachable {
+                        eprintln!("    {pos:?} tile=0x{:02X}", built.grid.get(pos.0, pos.1));
+                    }
+                }
+            }
+        }
+        return;
     }
+
+    // Build Options from either a FLAGS=SMB3R-... key (preferred — covers
+    // every randomizer toggle) or fall back to `Options::default()` plus
+    // an `SAS=1` override. This matches what the user would pass to the
+    // CLI/web, so the RNG sequence reaching the overworld builder is the
+    // one a real playthrough sees.
+    let mut options = match std::env::var("FLAGS") {
+        Ok(key) => match crate::Options::from_flag_key(&key) {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("Invalid FLAGS key: {e}");
+                return;
+            }
+        },
+        Err(_) => Options::default(),
+    };
+    if std::env::var("SAS").is_ok() {
+        options.swap_start_airship = true;
+    }
+    // Palettes (both character-only and themed) use a fresh OS RNG, so
+    // they introduce noise that breaks reproducibility without affecting
+    // the topology this analyzer cares about. Force both off so identical
+    // (seed, flags) inputs produce identical ROM bytes.
+    options.palettes = false;
+    options.palette_themed = false;
+
+    let (rom, result) = match crate::randomize_rom_with_overworld_capture(
+        &rom_bytes, seed, &options, None,
+    ) {
+        Ok(pair) => pair,
+        Err(e) => {
+            eprintln!("randomize_rom_with_overworld_capture failed: {e}");
+            return;
+        }
+    };
+
+    let sas_label = if options.swap_start_airship { " [SAS=1]" } else { "" };
+    let flag_key = options.to_flag_key();
+    eprintln!("=== Required Progression dump (seed={seed}{sas_label}) ===");
+    eprintln!("Flags: {flag_key}");
+
+    for built in &result.worlds {
+        if let Some(w) = world_filter
+            && built.world_idx != w
+        {
+            continue;
+        }
+        dump_required_progression(built);
+    }
+
+    // Save the fully-randomized ROM (matches the real playthrough state).
+    let sas_tag = if options.swap_start_airship { "_sas" } else { "" };
+    let filename = format!("progression_seed{seed}{sas_tag}.nes");
+    std::fs::write(&filename, rom.output_bytes()).unwrap();
+    eprintln!("\nWrote {filename}");
+}

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -933,7 +933,7 @@ fn test_lock_candidates_dump() {
         type LockDebugCandidate = (Pos, i32, bool, i32, bool, bool);
         let mut candidates: Vec<LockDebugCandidate> = Vec::new();
 
-        for r in 0..base_grid.rows {
+        for r in 0..base_grid.rows() {
             for c in 0..base_grid.cols {
                 let tile = base_grid.get(r, c);
                 if !LOCKABLE_TILES.contains(&tile) { continue; }
@@ -1069,7 +1069,7 @@ fn test_lock_airship_distance() {
                     .filter_map(|&(dr, dc)| {
                         let nr = lr as i16 + dr;
                         let nc = lc as i16 + dc;
-                        if nr < 0 || nr >= stamped.rows as i16 || nc < 0 || nc >= stamped.cols as i16 {
+                        if nr < 0 || nr >= stamped.rows() as i16 || nc < 0 || nc >= stamped.cols as i16 {
                             return None;
                         }
                         let pos = (nr as usize, nc as usize);
@@ -1951,7 +1951,7 @@ fn test_dump_required_progression() {
         let wi = world_filter.unwrap_or(2); // default W3
         let grid = rom_data::read_tile_grid(&rom, wi);
         eprintln!("=== Vanilla W{} grid (post-QoL) ===", wi + 1);
-        for r in 0..grid.rows {
+        for r in 0..grid.rows() {
             eprint!("  r{r:1}:");
             for c in 0..grid.cols {
                 eprint!(" {:02X}", grid.get(r, c));
@@ -1998,7 +1998,7 @@ fn test_dump_required_progression() {
             // GRID=1: also print the post-build grid for visual inspection.
             if std::env::var("GRID").is_ok() {
                 eprintln!("\n  Post-build grid:");
-                for r in 0..built.grid.rows {
+                for r in 0..built.grid.rows() {
                     eprint!("    r{r:1}:");
                     for c in 0..built.grid.cols {
                         eprint!(" {:02X}", built.grid.get(r, c));
@@ -2020,7 +2020,7 @@ fn test_dump_required_progression() {
                         ];
                         eprintln!("  {label}={pos:?} tile=0x{:02X}", grid.get(pos.0, pos.1));
                         for (d, rr, cc) in dirs {
-                            if rr < 0 || cc < 0 || rr as usize >= grid.rows || cc as usize >= grid.cols {
+                            if rr < 0 || cc < 0 || rr as usize >= grid.rows() || cc as usize >= grid.cols {
                                 eprintln!("    {d} ({rr},{cc}): off-grid");
                             } else {
                                 eprintln!("    {d} ({rr},{cc}): 0x{:02X}", grid.get(rr as usize, cc as usize));

--- a/src/randomize/overworld_build/types.rs
+++ b/src/randomize/overworld_build/types.rs
@@ -49,6 +49,28 @@ pub struct SlotAssignment {
     pub is_troll_pipe: bool,
 }
 
+/// Stamp assigned slots onto a grid so `walk_map` sees them as nodes.
+/// Pipes are already stamped on the build grid and HammerBro slots stay
+/// blank path tiles, so neither needs a stamp. Locks are NOT stamped —
+/// callers model them separately (test grids / conditional edges).
+pub(super) fn stamp_slots(grid: &mut Grid, slots: &[SlotAssignment]) {
+    for slot in slots {
+        match slot.kind {
+            SlotKind::Fortress => grid.set(slot.pos.0, slot.pos.1, TILE_FORTRESS),
+            SlotKind::Level
+                if BACKGROUND_TILES.contains(&grid.get(slot.pos.0, slot.pos.1)) =>
+            {
+                grid.set(slot.pos.0, slot.pos.1, TILE_NODE);
+            }
+            SlotKind::BonusGame => grid.set(slot.pos.0, slot.pos.1, TILE_BONUS_GAME),
+            SlotKind::ToadHouse => grid.set(slot.pos.0, slot.pos.1, TILE_TOAD_HOUSE),
+            // Pipe: already stamped; HammerBro: stays a blank path tile;
+            // Level on a non-background tile: keep the existing tile.
+            _ => {}
+        }
+    }
+}
+
 /// A lock/bridge placed on a path tile.
 #[derive(Clone, Debug)]
 pub(crate) struct LockAssignment {

--- a/src/randomize/overworld_helpers.rs
+++ b/src/randomize/overworld_helpers.rs
@@ -40,14 +40,21 @@ pub(super) fn find_target(grid: &Grid, world_idx: usize) -> Option<(usize, usize
     None
 }
 
+/// Vertical path tiles (plain + variants + drawbridge). Both the gap-tile
+/// and FX-pattern lookups key on this — a new vertical variant added here
+/// gets the vertical lock AND its FX pattern together.
+fn is_vertical_path(tile: u8) -> bool {
+    matches!(tile, 0x46 | 0xAA | 0xAB | 0xB0 | 0xB1 | 0xDB | 0xBA)
+}
+
 /// Determine the lock/gap tile for a given path tile.
 /// 0x54 = vertical lock, 0x56 = horizontal lock, 0xE4 = sky lock, 0x9D = water gap.
 pub(super) fn gap_tile_for(tile: u8) -> u8 {
     match tile {
-        0xB3 => 0x9D,                                          // bridge → water gap
-        0xDA => 0xE4,                                          // sky path → sky lock
-        0x46 | 0xAA | 0xAB | 0xB0 | 0xB1 | 0xDB | 0xBA => 0x54, // vertical path → vertical lock
-        _ => 0x56,                                              // horizontal path → horizontal lock
+        0xB3 => 0x9D,                          // bridge → water gap
+        0xDA => 0xE4,                          // sky path → sky lock
+        t if is_vertical_path(t) => 0x54,      // vertical path → vertical lock
+        _ => 0x56,                             // horizontal path → horizontal lock
     }
 }
 
@@ -55,8 +62,7 @@ pub(super) fn gap_tile_for(tile: u8) -> u8 {
 pub(super) fn fx_patterns_for(tile: u8) -> [u8; 4] {
     match tile {
         0xB3 => [0xD4, 0xD6, 0xD5, 0xD7],                    // water bridge
-        0x46 | 0xAA | 0xAB | 0xB0 | 0xB1 | 0xDB | 0xBA =>
-            [0xFE, 0xC0, 0xFE, 0xC0],                          // lock (vertical)
+        t if is_vertical_path(t) => [0xFE, 0xC0, 0xFE, 0xC0], // lock (vertical)
         _ => [0xFE, 0xFE, 0xE1, 0xE1],                        // bridge gap / sky
     }
 }

--- a/src/randomize/overworld_helpers.rs
+++ b/src/randomize/overworld_helpers.rs
@@ -30,7 +30,7 @@ pub(super) const LOCKABLE_TILES: &[u8] = &[
 /// Find the airship or Bowser's castle position on the grid.
 pub(super) fn find_target(grid: &Grid, world_idx: usize) -> Option<(usize, usize)> {
     let target_tile = if world_idx == 7 { TILE_BOWSER } else { TILE_AIRSHIP };
-    for r in 0..grid.rows {
+    for r in 0..grid.rows() {
         for c in 0..grid.cols {
             if grid.get(r, c) == target_tile {
                 return Some((r, c));

--- a/src/randomize/overworld_pickup.rs
+++ b/src/randomize/overworld_pickup.rs
@@ -110,6 +110,9 @@ fn default_pickup_pred(entry: &CatalogEntry, flags: PickupFlags) -> bool {
 }
 
 /// Like `pick_up`, but only collects entries whose `CatalogEntry` satisfies `pred`.
+///
+/// The `pred` hook exists only for the `#[ignore]`d `test_dump_cleared_roms`
+/// diagnostic dump; production always passes `default_pickup_pred`.
 pub(super) fn pick_up_filtered(
     rom: &Rom,
     catalog: &NodeCatalog,

--- a/src/randomize/overworld_pickup.rs
+++ b/src/randomize/overworld_pickup.rs
@@ -202,7 +202,7 @@ fn pick_up_world(
         pickup_positions.push((row, col));
         pool_indices.push(pool_idx);
 
-        if row < grid.rows && col < grid.cols {
+        if row < grid.rows() && col < grid.cols {
             grid.set(row, col, blank_tile_for(&grid, world_idx, row, col));
         }
     }
@@ -307,7 +307,7 @@ pub(super) fn blank_tile_from_neighbors(grid: &Grid, world_idx: usize, row: usiz
 fn open_fx_gaps(grid: &mut Grid, fx_slots: &[FxSlot], world_fx: &[u8]) {
     for &slot_idx in world_fx {
         let slot = &fx_slots[slot_idx as usize];
-        if slot.grid_row < grid.rows && slot.grid_col < grid.cols {
+        if slot.grid_row < grid.rows() && slot.grid_col < grid.cols {
             grid.set(slot.grid_row, slot.grid_col, slot.replace_tile);
         }
     }
@@ -359,7 +359,7 @@ mod tests {
             let (row, col) = entry.grid_pos;
             let cw = &result.worlds[entry.world_idx];
 
-            if row < cw.grid.rows && col < cw.grid.cols {
+            if row < cw.grid.rows() && col < cw.grid.cols {
                 let tile = cw.grid.get(row, col);
                 let valid_blank = VALID_BLANK_TILES.contains(&tile);
                 assert!(
@@ -390,7 +390,7 @@ mod tests {
                 if !world_fx.contains(&(si as u8)) {
                     continue;
                 }
-                if slot.grid_row < grid.rows && slot.grid_col < grid.cols {
+                if slot.grid_row < grid.rows() && slot.grid_col < grid.cols {
                     let tile = grid.get(slot.grid_row, slot.grid_col);
                     assert!(
                         tile != 0x54 && tile != 0x56 && tile != 0x9D && tile != 0xE4,
@@ -502,7 +502,7 @@ mod tests {
         let result = pick_up_filtered(rom, catalog, PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() }, pred);
         let mut data = rom.data.clone();
         for cw in &result.worlds {
-            for r in 0..cw.grid.rows {
+            for r in 0..cw.grid.rows() {
                 for c in 0..cw.grid.cols {
                     let offset = rom_data::map_tile_offset(cw.world_idx, r, c);
                     data[offset] = cw.grid.get(r, c);

--- a/src/randomize/overworld_writer/assign.rs
+++ b/src/randomize/overworld_writer/assign.rs
@@ -17,20 +17,7 @@ pub(super) fn interleave_hb_by_obj_ptr<R: Rng>(
         return levels;
     }
 
-    // Group by obj_ptr using BTreeMap for deterministic iteration order.
-    let mut groups: std::collections::BTreeMap<u16, Vec<rom_data::LevelEntry>> =
-        std::collections::BTreeMap::new();
-    for le in levels {
-        let obj = u16::from_le_bytes([le.obj_lo, le.obj_hi]);
-        groups.entry(obj).or_default().push(le);
-    }
-
-    // Shuffle within each group and collect group keys in random order.
-    let mut keys: Vec<u16> = groups.keys().copied().collect();
-    keys.as_mut_slice().shuffle(rng);
-    for group in groups.values_mut() {
-        group.as_mut_slice().shuffle(rng);
-    }
+    let (keys, groups) = shuffled_obj_groups(levels, rng);
 
     // Round-robin: pick one from each group per round until all exhausted.
     let max_len = groups.values().map(|g| g.len()).max().unwrap_or(0);
@@ -45,6 +32,54 @@ pub(super) fn interleave_hb_by_obj_ptr<R: Rng>(
     }
 
     result
+}
+
+/// Group level entries by `obj_ptr` (BTreeMap for deterministic iteration
+/// order), shuffle the key order, then shuffle each group's contents.
+/// Shared by `interleave_hb_by_obj_ptr` and the sprite round-robin grouping
+/// in `assign_pool` — both consume the exact same RNG draw sequence.
+fn shuffled_obj_groups<R: Rng>(
+    levels: Vec<rom_data::LevelEntry>,
+    rng: &mut R,
+) -> (Vec<u16>, std::collections::BTreeMap<u16, Vec<rom_data::LevelEntry>>) {
+    let mut groups: std::collections::BTreeMap<u16, Vec<rom_data::LevelEntry>> =
+        std::collections::BTreeMap::new();
+    for le in levels {
+        let obj = u16::from_le_bytes([le.obj_lo, le.obj_hi]);
+        groups.entry(obj).or_default().push(le);
+    }
+    let mut keys: Vec<u16> = groups.keys().copied().collect();
+    keys.as_mut_slice().shuffle(rng);
+    for group in groups.values_mut() {
+        group.as_mut_slice().shuffle(rng);
+    }
+    (keys, groups)
+}
+
+/// Take the next level pool entry for a slot. `take_front` selects which end
+/// of the pool feeds regular slots: the cross-world deque drains from the
+/// front, the intra-world pools drain from the back (preserving the original
+/// per-mode take order). Troll-pipe slots scan from that same end for the
+/// first eligible entry; when none qualifies, the slot takes the plain next
+/// entry and reports itself demoted (second tuple field).
+fn take_level_slot(
+    pool: &mut VecDeque<usize>,
+    take_front: bool,
+    is_troll_pipe: bool,
+    is_ineligible: impl Fn(usize) -> bool,
+) -> (usize, bool) {
+    if is_troll_pipe {
+        let found = if take_front {
+            pool.iter().position(|&pi| !is_ineligible(pi))
+        } else {
+            pool.iter().rposition(|&pi| !is_ineligible(pi))
+        };
+        if let Some(idx) = found {
+            return (pool.remove(idx).unwrap(), false);
+        }
+    }
+    let pi = if take_front { pool.pop_front() } else { pool.pop_back() };
+    (pi.expect("level pool exhausted"), is_troll_pipe)
 }
 
 pub(super) fn assign_pool<R: Rng>(
@@ -99,18 +134,9 @@ pub(super) fn assign_pool<R: Rng>(
 
     // Build per-obj_ptr groups for sprite position round-robin assignment.
     // This ensures each HB sprite encounter in a world gets a different
-    // enemy set (different obj_ptr = different enemies).
-    let mut hb_obj_groups: std::collections::BTreeMap<u16, Vec<rom_data::LevelEntry>> =
-        std::collections::BTreeMap::new();
-    for le in &hb_levels {
-        let obj = u16::from_le_bytes([le.obj_lo, le.obj_hi]);
-        hb_obj_groups.entry(obj).or_default().push(le.clone());
-    }
-    let mut hb_group_keys: Vec<u16> = hb_obj_groups.keys().copied().collect();
-    hb_group_keys.as_mut_slice().shuffle(rng);
-    for group in hb_obj_groups.values_mut() {
-        group.as_mut_slice().shuffle(rng);
-    }
+    // enemy set (different obj_ptr = different enemies). Fresh shuffles on
+    // purpose — the RNG draws here are load-bearing for seed compatibility.
+    let (hb_group_keys, hb_obj_groups) = shuffled_obj_groups(hb_levels.clone(), rng);
 
     // --- Pre-assign the 1-F fortress to a secret-exit-safe slot ---
     //
@@ -165,7 +191,7 @@ pub(super) fn assign_pool<R: Rng>(
 
     // For intra-world mode, partition fort/level pools by origin world.
     let mut fort_by_world: HashMap<usize, Vec<usize>> = HashMap::new();
-    let mut level_by_world: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut level_by_world: HashMap<usize, VecDeque<usize>> = HashMap::new();
     if !cross_world {
         for &pi in &fort_pool {
             let wi = catalog.entries[pickup.pool[pi].catalog_idx].world_idx;
@@ -173,7 +199,7 @@ pub(super) fn assign_pool<R: Rng>(
         }
         for &pi in &level_pool {
             let wi = catalog.entries[pickup.pool[pi].catalog_idx].world_idx;
-            level_by_world.entry(wi).or_default().push(pi);
+            level_by_world.entry(wi).or_default().push_back(pi);
         }
     }
 
@@ -194,7 +220,7 @@ pub(super) fn assign_pool<R: Rng>(
     //    fortress, never a regular-level slot.
     let is_troll_pipe_ineligible = |pi: usize| -> bool {
         let ce = &catalog.entries[pickup.pool[pi].catalog_idx];
-        (ce.world_idx == 7 && matches!(ce.entry_idx, 14..=16))
+        rom_data::is_hand_level(ce.world_idx, ce.entry_idx)
             || rom_data::is_chest_level(ce.world_idx, ce.entry_idx)
     };
 
@@ -249,32 +275,18 @@ pub(super) fn assign_pool<R: Rng>(
         ordered.extend(level_slots.iter().copied().filter(|s| !s.is_troll_pipe));
 
         for slot in ordered {
-            let pi = if cross_world {
-                if slot.is_troll_pipe {
-                    if let Some(pos) = level_pool.iter().position(|&pi| !is_troll_pipe_ineligible(pi)) {
-                        level_pool.remove(pos).unwrap()
-                    } else {
-                        demoted_troll_pipes.insert(slot.pos);
-                        level_pool.pop_front().expect("level pool exhausted")
-                    }
-                } else {
-                    level_pool.pop_front().expect("level pool exhausted")
-                }
+            let pool = if cross_world {
+                &mut level_pool
             } else {
-                let v = level_by_world
+                level_by_world
                     .get_mut(&wi)
-                    .expect("intra-world level pool missing");
-                if slot.is_troll_pipe {
-                    if let Some(idx) = v.iter().rposition(|&pi| !is_troll_pipe_ineligible(pi)) {
-                        v.remove(idx)
-                    } else {
-                        demoted_troll_pipes.insert(slot.pos);
-                        v.pop().expect("intra-world level pool exhausted")
-                    }
-                } else {
-                    v.pop().expect("intra-world level pool exhausted")
-                }
+                    .expect("intra-world level pool missing")
             };
+            let (pi, demoted) =
+                take_level_slot(pool, cross_world, slot.is_troll_pipe, is_troll_pipe_ineligible);
+            if demoted {
+                demoted_troll_pipes.insert(slot.pos);
+            }
             level.push(Assignment { pool_idx: pi, pos: slot.pos });
         }
 

--- a/src/randomize/overworld_writer/fortress_fx.rs
+++ b/src/randomize/overworld_writer/fortress_fx.rs
@@ -13,16 +13,12 @@ pub(super) fn write_fortress_fx(
     let pickup = data.pickup;
     let catalog = data.catalog;
     // Pair each lock with its fortress assignment (matched by section).
+    // Fortress assignments are ordered by section in assign_pool, so
+    // assignment index == fort_section for this world.
     let locked_forts: Vec<_> = built
         .locks
         .iter()
-        .filter_map(|lock| {
-            wa.fortress.iter().enumerate().find(|(fi, _)| {
-                // Fortress assignments are ordered by section in assign_pool.
-                // Assignment index fi == fort_section for this world.
-                *fi == lock.fort_section
-            }).map(|(_, fa)| (lock, fa))
-        })
+        .filter_map(|lock| wa.fortress.get(lock.fort_section).map(|fa| (lock, fa)))
         .collect();
 
     // Write FX world table (up to 4 slots per world).

--- a/src/randomize/overworld_writer/grid.rs
+++ b/src/randomize/overworld_writer/grid.rs
@@ -156,7 +156,7 @@ pub(super) fn write_tile_grid<R: Rng>(
     }
 
     // Write grid to ROM.
-    for r in 0..grid.rows {
+    for r in 0..grid.rows() {
         for c in 0..grid.cols {
             let offset = rom_data::map_tile_offset(wi, r, c);
             rom.write_byte(offset, grid.get(r, c));

--- a/src/randomize/overworld_writer/grid.rs
+++ b/src/randomize/overworld_writer/grid.rs
@@ -15,12 +15,11 @@ pub(super) fn write_tile_grid<R: Rng>(
     let wi = built.world_idx;
     let mut grid = built.grid.clone();
 
-    // Stamp fortress tiles. The game treats $67, $EB, and $6A as fortress
-    // tiles (Map_Removable_Tiles + completion-unsafe), so pick per-fortress.
-    // $6A's CHR animation is frozen by patch_metatile_6a_freeze.
-    const FORTRESS_TILES: [u8; 3] = [0x67, 0xEB, 0x6A];
+    // Stamp fortress tiles — pick per-fortress from the game's fortress
+    // tile set (see rom_data::FORTRESS_TILES).
     for a in &wa.fortress {
-        let tile = FORTRESS_TILES[rng.random_range(..FORTRESS_TILES.len())];
+        let tile =
+            rom_data::FORTRESS_TILES[rng.random_range(..rom_data::FORTRESS_TILES.len())];
         grid.set(a.pos.0, a.pos.1, tile);
     }
 
@@ -114,21 +113,21 @@ pub(super) fn write_tile_grid<R: Rng>(
     let mut level_idx: usize = 0;
     let mut assigned: Vec<bool> = vec![false; wa.level.len()];
 
-    let pick_level_tile = |pos: (usize, usize), level_idx: &mut usize| -> u8 {
+    let mut pick_level_tile = |pos: (usize, usize)| -> u8 {
         if hand_trap_positions.contains(&pos) {
             TILE_HAND_TRAP
         } else if troll_pipe_positions.contains(&pos) {
             TILE_TROLL_PIPE
         } else {
-            let t = LEVEL_TILES[(*level_idx).min(LEVEL_TILES.len() - 1)];
-            *level_idx += 1;
+            let t = LEVEL_TILES[level_idx.min(LEVEL_TILES.len() - 1)];
+            level_idx += 1;
             t
         }
     };
 
     for &(pos, _dist) in &bfs {
         if let Some(&la_idx) = level_pos_set.get(&pos) && !assigned[la_idx] {
-            let tile = pick_level_tile(pos, &mut level_idx);
+            let tile = pick_level_tile(pos);
             grid.set(pos.0, pos.1, tile);
             assigned[la_idx] = true;
         }
@@ -137,7 +136,7 @@ pub(super) fn write_tile_grid<R: Rng>(
     // Any level slots not reached by BFS (safety fallback).
     for (i, a) in wa.level.iter().enumerate() {
         if !assigned[i] {
-            let tile = pick_level_tile(a.pos, &mut level_idx);
+            let tile = pick_level_tile(a.pos);
             grid.set(a.pos.0, a.pos.1, tile);
         }
     }

--- a/src/randomize/overworld_writer/metatiles.rs
+++ b/src/randomize/overworld_writer/metatiles.rs
@@ -2,33 +2,9 @@
 
 use super::*;
 
-/// Patches the MO_DoFortressFX engine routine so the lock-breaking visual
-/// animation (VRAM pattern write + poof sprites) is skipped when the lock is
-/// not on the currently visible screen.
-///
-/// In vanilla the fortress and its lock are always on the same screen, so the
-/// animation plays correctly.  When we shuffle fortress/lock positions, the
-/// lock can end up on a different screen.  Because the VRAM write and sprite
-/// positions are screen-relative, playing the animation on the wrong screen
-/// causes a visual glitch (tile placed at wrong spot + poof on wrong screen).
-///
-/// The map-data replacement (tile + Map_Completions) is NOT screen-relative
-/// and always works correctly, so we only need to skip the visual part.
-///
-/// The map viewport scrolls in 128-pixel half-screen steps.  ZP $12
-/// (Map_Scroll_XHi) is the scroll page and $FD (Map_Scroll_X) is either
-/// 0 or 128.  When $FD=128 the viewport straddles two grid screens, so
-/// the lock is visible if its screen == $12 OR (screen == $12+1 AND $FD≥128).
-///
-/// Hook: replace 3 bytes at file 0x148F6 (CPU $C8E6):
-///   vanilla: A9 01 85  (LDA #$01 / STA $20[hi])
-///   patched: 4C 44 D5  (JMP $D544)
-///
-/// Custom code at file 0x15554 (CPU $D544, PRG010 free space):
-///   Read lock screen from FortressFX_MapLocation[slot] & 0x0F.
-///   Compare with $12 — if equal, animate.
-///   Otherwise check if lock_screen == $12+1 AND $FD >= 128 — if so, animate.
-///   Else skip animation (data-only update via JMP $C952).
+/// File offset where the world-map CHR data begins.
+const CHR_BASE: usize = 0x40010;
+
 /// Patch metatile LL quadrant for double-digit level tiles (0x0D–0x15).
 ///
 /// Vanilla tiles 0x0D–0x15 have a blank LL (CHR 0xBE = solid fill). We write
@@ -58,13 +34,12 @@ use super::*;
 /// bank swapping); pages 0x16/0x17 are loaded only as the world-map BG bank
 /// (R1 = 0x16) and never as a sprite or level CHR source.
 pub(crate) fn patch_double_digit_metatiles(rom: &mut Rom) {
-    // Metatile quadrant tables at 0x18010: UL(256) LL(256) UR(256) LR(256).
-    const METATILE_LL_BASE: usize = 0x18010 + 256; // 0x18110
+    // Metatile quadrant tables at PRG012 base: UL(256) LL(256) UR(256) LR(256).
+    const METATILE_LL_BASE: usize = rom_data::PRG012_FILE_BASE + 256; // 0x18110
 
     // Overwrite CHR tile 0xFD with our custom "1" digit.
     // CHR page 0x17 covers tile IDs 0xC0–0xFF; tile 0xFD = local index 0x3D.
-    const CHR_START: usize = 0x40010;
-    const CHR_PAGE_17: usize = CHR_START + 0x17 * 0x400;
+    const CHR_PAGE_17: usize = CHR_BASE + 0x17 * 0x400;
     const TILE_FD_OFFSET: usize = CHR_PAGE_17 + 0x3D * 16;
     // Arrow shape (cols 2–5) + "1" serif (col 6 row 1) + right border (col 7 = color 2).
     #[rustfmt::skip]
@@ -92,7 +67,6 @@ pub(crate) fn patch_double_digit_metatiles(rom: &mut Rom) {
 /// Metatile 0x6A is the only metatile referencing CHR 0x64-0x67, so no other
 /// tile is affected.
 pub(crate) fn patch_metatile_6a_freeze(rom: &mut Rom) {
-    const CHR_BASE: usize = 0x40010;
     const BASE_PAGE: usize = 0x15;
     const ANIM_PAGES: [usize; 3] = [0x71, 0x73, 0x75];
     // Tiles 0x64-0x67 live in page 0x15 at local indices 0x24-0x27.

--- a/src/randomize/overworld_writer/mod.rs
+++ b/src/randomize/overworld_writer/mod.rs
@@ -27,12 +27,15 @@ mod fortress_fx;
 mod metatiles;
 mod sprites;
 
-use types::*;
-use assign::*;
-use grid::*;
-use pointers::*;
-use fortress_fx::*;
-use sprites::*;
+use assign::{assign_pool, interleave_hb_by_obj_ptr};
+use fortress_fx::{patch_fortress_fx_screen_check, write_fortress_fx};
+use grid::write_tile_grid;
+use pointers::{write_pipe_dests, write_pointer_entries};
+use sprites::{
+    pick_plant_positions, pick_w8_sprite_positions, write_hb_sprites, write_plant_sprites,
+    write_w8_sprites,
+};
+use types::{Assignment, HammerBroAssignment, PipeAssignment, WorldAssignments};
 
 // Public API consumed by the randomizer.
 pub(crate) use metatiles::{patch_double_digit_metatiles, patch_metatile_6a_freeze};

--- a/src/randomize/overworld_writer/pointers.rs
+++ b/src/randomize/overworld_writer/pointers.rs
@@ -132,7 +132,7 @@ pub(super) fn write_pointer_entries(
             .map(|e| e.grid_pos)
             .collect();
         let mut uncovered_blanks: Vec<(usize, usize)> = Vec::new();
-        for r in 0..built.grid.rows {
+        for r in 0..built.grid.rows() {
             for c in 0..built.grid.cols {
                 if rom_data::VALID_BLANK_TILES.contains(&built.grid.get(r, c))
                     && !covered.contains(&(r, c))

--- a/src/randomize/overworld_writer/pointers.rs
+++ b/src/randomize/overworld_writer/pointers.rs
@@ -2,6 +2,22 @@
 
 use super::*;
 
+/// Write an entry's rowtype/screencol bytes: row nibble + tileset into the
+/// rowtype table at `rt`, screen nibble + in-screen column into the
+/// screen-column table at `sc`.
+fn write_entry_pos(
+    rom: &mut Rom,
+    rt: usize,
+    sc: usize,
+    entry_idx: usize,
+    pos: (usize, usize),
+    tileset: u8,
+) {
+    let (screen, col_in_screen, row_nib) = pipe_helpers::grid_pos_to_dest_nibbles(pos.0, pos.1);
+    rom.write_byte(rt + entry_idx, (row_nib << 4) | (tileset & 0x0F));
+    rom.write_byte(sc + entry_idx, (screen << 4) | col_in_screen);
+}
+
 pub(super) fn write_pointer_entries(
     rom: &mut Rom,
     world_idx: usize,
@@ -73,14 +89,7 @@ pub(super) fn write_pointer_entries(
             .expect("assigned pool entry must have level_entry");
 
         rom_data::write_entry(rom, world, entry_idx, level_entry);
-
-        let (row, col) = pos;
-        let row_nib = (row + 2) as u8;
-        let screen = (col / 16) as u8;
-        let col_in_screen = (col % 16) as u8;
-
-        rom.write_byte(rt + entry_idx, (row_nib << 4) | (level_entry.tileset & 0x0F));
-        rom.write_byte(sc + entry_idx, (screen << 4) | col_in_screen);
+        write_entry_pos(rom, rt, sc, entry_idx, pos, level_entry.tileset);
     }
 
     // Write hammer bro entries (carry their own LevelEntry).
@@ -92,14 +101,7 @@ pub(super) fn write_pointer_entries(
         slot_i += 1;
 
         rom_data::write_entry(rom, world, entry_idx, &hb.level_entry);
-
-        let (row, col) = hb.pos;
-        let row_nib = (row + 2) as u8;
-        let screen = (col / 16) as u8;
-        let col_in_screen = (col % 16) as u8;
-
-        rom.write_byte(rt + entry_idx, (row_nib << 4) | (hb.level_entry.tileset & 0x0F));
-        rom.write_byte(sc + entry_idx, (screen << 4) | col_in_screen);
+        write_entry_pos(rom, rt, sc, entry_idx, hb.pos, hb.level_entry.tileset);
     }
 
     // Fill any remaining unused pointer table slots with valid HB levels.
@@ -148,13 +150,9 @@ pub(super) fn write_pointer_entries(
             let le = hb_level_iter.next().unwrap();
             rom_data::write_entry(rom, world, entry_idx, &le);
 
-            if let Some((row, col)) = blank_iter.next() {
+            if let Some(pos) = blank_iter.next() {
                 // Place at actual blank tile position.
-                let row_nib = (row + 2) as u8;
-                let screen = (col / 16) as u8;
-                let col_in_screen = (col % 16) as u8;
-                rom.write_byte(rt + entry_idx, (row_nib << 4) | (le.tileset & 0x0F));
-                rom.write_byte(sc + entry_idx, (screen << 4) | col_in_screen);
+                write_entry_pos(rom, rt, sc, entry_idx, pos, le.tileset);
             } else {
                 // No more blanks — park at unreachable position.
                 rom.write_byte(rt + entry_idx, le.tileset & 0x0F); // row_nib=0 → grid_row=-2

--- a/src/randomize/overworld_writer/sprites.rs
+++ b/src/randomize/overworld_writer/sprites.rs
@@ -2,6 +2,19 @@
 
 use super::*;
 
+/// W8 army sprite definitions: (map_object_slot, is_fortress).
+/// Tank goes on a level slot, the other 3 go on fortress slots.
+const W8_ARMY_SPRITES: &[(usize, bool)] = &[
+    (2, false), // Tank sprite (ID $0E) → level slot
+    (3, true),  // Navy/Battleship sprite (ID $0D) → fortress slot
+    (4, true),  // Air Force sprite (ID $0F) → fortress slot
+    (5, true),  // Super Tank sprite (ID $0E) → fortress slot
+];
+
+/// Hammer Bro map-sprite type ids. Cosmetic on the overworld (the battle is the
+/// node under the sprite); assigned at random per encounter.
+const HB_SPRITE_IDS: [u8; 4] = [0x03, 0x04, 0x05, 0x06];
+
 /// Decide where each W8 army sprite goes. Returns (sprite_slot, grid_pos).
 pub(super) fn pick_w8_sprite_positions<R: Rng>(
     wa_w8: &WorldAssignments,

--- a/src/randomize/overworld_writer/tests.rs
+++ b/src/randomize/overworld_writer/tests.rs
@@ -343,7 +343,7 @@ fn test_no_uncovered_blank_nodes() {
             let mut covered: HashSet<(usize, usize)> = HashSet::new();
             for i in 0..world.entry_count {
                 let pos = rom_data::entry_grid_position(&test_rom, world, i);
-                if pos.0 < grid.rows {
+                if pos.0 < grid.rows() {
                     covered.insert(pos);
                 }
             }
@@ -351,7 +351,7 @@ fn test_no_uncovered_blank_nodes() {
             // Every reachable blank tile must be covered.
             for &node in &walk.nodes {
                 let (r, c) = node;
-                if r >= grid.rows || c >= grid.cols {
+                if r >= grid.rows() || c >= grid.cols {
                     continue;
                 }
                 let tile = grid.get(r, c);

--- a/src/randomize/overworld_writer/tests.rs
+++ b/src/randomize/overworld_writer/tests.rs
@@ -1,562 +1,579 @@
-    use super::*;
-    use crate::rom::Rom;
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha8Rng;
+use super::*;
+use crate::randomize::{
+    map_walker, node_catalog, overworld_build, overworld_pickup, piranha_rooms, qol, troll_pipes,
+};
+use crate::rom::Rom;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 
-    fn load_rom() -> Option<Rom> {
-        let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
-        Rom::from_bytes(&data).ok()
+fn load_rom() -> Option<Rom> {
+    let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+    Rom::from_bytes(&data).ok()
+}
+
+/// Standard test pickup: spade games + toad houses shuffled.
+fn standard_pickup(
+    rom: &Rom,
+    catalog: &node_catalog::NodeCatalog,
+) -> overworld_pickup::PickupResult {
+    overworld_pickup::pick_up(rom, catalog, overworld_pickup::PickupFlags {
+        shuffle_spade_games: true,
+        shuffle_toad_houses: true,
+        ..Default::default()
+    })
+}
+
+/// Standard test build flags: toad houses shuffled.
+fn standard_build_flags() -> overworld_build::BuildFlags {
+    overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() }
+}
+
+#[test]
+fn test_pool_assignment_exhaustive() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+
+    let mut rng2 = ChaCha8Rng::seed_from_u64(99);
+    let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, WriteFlags::default());
+
+    // Collect all assigned pool indices.
+    let mut used: Vec<usize> = Vec::new();
+    for wa in &assignments {
+        for a in &wa.fortress {
+            used.push(a.pool_idx);
+        }
+        for a in &wa.level {
+            used.push(a.pool_idx);
+        }
+        for pa in &wa.pipes {
+            used.push(pa.pool_idx_a);
+            used.push(pa.pool_idx_b);
+        }
+        if let Some(a) = &wa.airship {
+            used.push(a.pool_idx);
+        }
+        if let Some(a) = &wa.bowser {
+            used.push(a.pool_idx);
+        }
+        for a in &wa.bonus {
+            used.push(a.pool_idx);
+        }
+        for a in &wa.toad {
+            used.push(a.pool_idx);
+        }
     }
 
-    #[test]
-    fn test_pool_assignment_exhaustive() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-        let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+    // No pool entry assigned more than once.
+    let total_used = used.len();
+    used.sort();
+    used.dedup();
+    assert_eq!(
+        used.len(),
+        total_used,
+        "duplicate pool assignments detected",
+    );
 
-        let mut rng2 = ChaCha8Rng::seed_from_u64(99);
-        let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng2, WriteFlags::default());
-
-        // Collect all assigned pool indices.
-        let mut used: Vec<usize> = Vec::new();
-        for wa in &assignments {
-            for a in &wa.fortress {
-                used.push(a.pool_idx);
-            }
-            for a in &wa.level {
-                used.push(a.pool_idx);
-            }
-            for pa in &wa.pipes {
-                used.push(pa.pool_idx_a);
-                used.push(pa.pool_idx_b);
-            }
-            if let Some(a) = &wa.airship {
-                used.push(a.pool_idx);
-            }
-            if let Some(a) = &wa.bowser {
-                used.push(a.pool_idx);
-            }
-            for a in &wa.bonus {
-                used.push(a.pool_idx);
-            }
-            for a in &wa.toad {
-                used.push(a.pool_idx);
-            }
-        }
-
-        // No pool entry assigned more than once.
-        let total_used = used.len();
-        used.sort();
-        used.dedup();
-        assert_eq!(
-            used.len(),
-            total_used,
-            "duplicate pool assignments detected",
+    // Per-world assignment count must not exceed available pointer table slots.
+    for (wi, wa) in assignments.iter().enumerate() {
+        let level_like = wa.fortress.len() + wa.level.len() + wa.pipes.len() * 2 + wa.bonus.len() + wa.toad.len();
+        let total = level_like + wa.hammer_bro.len();
+        let available = pickup.worlds[wi].pool_indices.len();
+        assert!(
+            total <= available,
+            "W{}: {} assignments exceed {} available pointer table slots",
+            wi + 1, total, available,
         );
+    }
+}
 
-        // Per-world assignment count must not exceed available pointer table slots.
+#[test]
+fn test_troll_pipes_never_assigned_hand_levels() {
+    // Troll pipes don't clear when beaten — a hand level (8-Hnd1/2/3)
+    // behind a troll pipe would be infinitely farmable for items. The
+    // level-assignment pass must skip hand levels for troll-pipe slots.
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+
+    for seed in 0u64..32 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+        troll_pipes::mark_troll_pipes(&mut build, &mut rng);
+
+        let troll_positions: HashSet<(usize, (usize, usize))> = build.worlds.iter()
+            .flat_map(|w| w.slots.iter()
+                .filter(|s| s.is_troll_pipe)
+                .map(move |s| (w.world_idx, s.pos)))
+            .collect();
+
+        let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
+
         for (wi, wa) in assignments.iter().enumerate() {
-            let level_like = wa.fortress.len() + wa.level.len() + wa.pipes.len() * 2 + wa.bonus.len() + wa.toad.len();
-            let total = level_like + wa.hammer_bro.len();
-            let available = pickup.worlds[wi].pool_indices.len();
-            assert!(
-                total <= available,
-                "W{}: {} assignments exceed {} available pointer table slots",
-                wi + 1, total, available,
+            for a in &wa.level {
+                if !troll_positions.contains(&(wi, a.pos)) { continue; }
+                let ce = &catalog.entries[pickup.pool[a.pool_idx].catalog_idx];
+                assert!(
+                    !rom_data::is_hand_level(ce.world_idx, ce.entry_idx),
+                    "seed {seed}: W{} troll pipe at {:?} got hand level (W{} entry {})",
+                    wi + 1, a.pos, ce.world_idx + 1, ce.entry_idx,
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_write_deterministic() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+
+    let mut rom1 = rom.clone();
+    let mut rom2 = rom.clone();
+
+    for pass in 0..2 {
+        let target = if pass == 0 { &mut rom1 } else { &mut rom2 };
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+        write_overworld(target, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
+    }
+
+    assert_eq!(rom1.data, rom2.data, "same seed must produce identical output");
+}
+
+#[test]
+fn test_w8_sprites_moved() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+
+    let mut test_rom = rom.clone();
+    write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
+
+    // Read W8 sprite positions after write.
+    let positions = rom_data::read_map_sprite_positions(&test_rom, 7);
+
+    // The army sprites (slots 2-5) should be at slot positions, not vanilla.
+    // We can't predict exact positions (random), but they should be valid
+    // grid positions within the W8 map.
+    for &(row, col) in &positions {
+        assert!(row < 9, "W8 sprite row {row} out of range");
+        assert!(col < 64, "W8 sprite col {col} out of range");
+    }
+}
+
+#[test]
+fn test_fx_slots_valid() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+
+    let mut test_rom = rom.clone();
+    write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
+
+    // write_fortress_fx hands out FX slots as one running index across
+    // worlds in write order: world wi's table holds slots
+    // [start, start + lock_count) followed by zeroes, where start is the
+    // total lock count of all earlier worlds. Assert the exact bytes.
+    let mut expected_slot = 0usize;
+    for wi in 0..8 {
+        let fx_base = rom_data::FX_WORLD_TABLE + wi * 4;
+        let lock_count = build.worlds[wi].locks.len();
+        assert!(lock_count <= 4, "W{}: {lock_count} locks exceed 4 FX entries", wi + 1);
+        for i in 0..4 {
+            let want = if i < lock_count { (expected_slot + i) as u8 } else { 0 };
+            assert_eq!(
+                test_rom.read_byte(fx_base + i),
+                want,
+                "W{} FX table entry {i}", wi + 1,
             );
         }
+        expected_slot += lock_count;
     }
+}
 
-    #[test]
-    fn test_troll_pipes_never_assigned_hand_levels() {
-        // Troll pipes don't clear when beaten — a hand level (8-Hnd1/2/3)
-        // behind a troll pipe would be infinitely farmable for items. The
-        // level-assignment pass must skip hand levels for troll-pipe slots.
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        for seed in 0u64..32 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let mut build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            super::super::troll_pipes::mark_troll_pipes(&mut build, &mut rng);
-
-            let troll_positions: HashSet<(usize, (usize, usize))> = build.worlds.iter()
-                .flat_map(|w| w.slots.iter()
-                    .filter(|s| s.is_troll_pipe)
-                    .map(move |s| (w.world_idx, s.pos)))
-                .collect();
-
-            let assignments = assign_pool(&rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
-
-            for (wi, wa) in assignments.iter().enumerate() {
-                for a in &wa.level {
-                    if !troll_positions.contains(&(wi, a.pos)) { continue; }
-                    let ce = &catalog.entries[pickup.pool[a.pool_idx].catalog_idx];
-                    assert!(
-                        !(ce.world_idx == 7 && matches!(ce.entry_idx, 14..=16)),
-                        "seed {seed}: W{} troll pipe at {:?} got hand level (W{} entry {})",
-                        wi + 1, a.pos, ce.world_idx + 1, ce.entry_idx,
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_write_deterministic() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        let mut rom1 = rom.clone();
-        let mut rom2 = rom.clone();
-
-        for pass in 0..2 {
-            let target = if pass == 0 { &mut rom1 } else { &mut rom2 };
-            let mut rng = ChaCha8Rng::seed_from_u64(42);
-            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            write_overworld(target, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
-        }
-
-        assert_eq!(rom1.data, rom2.data, "same seed must produce identical output");
-    }
-
-    #[test]
-    fn test_w8_sprites_moved() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-        let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-        let mut test_rom = rom.clone();
-        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
-
-        // Read W8 sprite positions after write.
-        let positions = rom_data::read_map_sprite_positions(&test_rom, 7);
-
-        // The army sprites (slots 2-5) should be at slot positions, not vanilla.
-        // We can't predict exact positions (random), but they should be valid
-        // grid positions within the W8 map.
-        for &(row, col) in &positions {
-            assert!(row < 9, "W8 sprite row {row} out of range");
-            assert!(col < 64, "W8 sprite col {col} out of range");
-        }
-    }
-
-    #[test]
-    fn test_fx_slots_valid() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-        let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-        let mut test_rom = rom.clone();
-        write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
-
-        // Count total locked fortresses across all worlds.
-        let total_locks: usize = build.worlds.iter().map(|b| b.locks.len()).sum();
-
-        // Read FX world tables — count non-zero entries.
-        let mut fx_count = 0;
-        for wi in 0..8 {
-            let fx_base = rom_data::FX_WORLD_TABLE + wi * 4;
-            for i in 0..4 {
-                let slot_idx = test_rom.read_byte(fx_base + i);
-                if slot_idx != 0 || (i == 0 && !build.worlds[wi].locks.is_empty()) {
-                    // Slot 0 is valid (could be index 0), so check lock count.
-                    if i < build.worlds[wi].locks.len() {
-                        fx_count += 1;
-                    }
-                }
-            }
-        }
-
-        assert_eq!(
-            fx_count, total_locks,
-            "FX slot count {fx_count} != total locks {total_locks}",
+#[test]
+fn test_hammer_bro_redistribution_written() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    for seed in 0..16u64 {
+        let catalog = node_catalog::NodeCatalog::build(&rom, false);
+        let pickup = overworld_pickup::pick_up(
+            &rom,
+            &catalog,
+            overworld_pickup::PickupFlags {
+                shuffle_spade_games: true,
+                shuffle_toad_houses: true,
+                shuffle_hammer_bros: true,
+            },
         );
-    }
-
-    #[test]
-    fn test_hammer_bro_redistribution_written() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        for seed in 0..16u64 {
-            let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-            let pickup = super::super::overworld_pickup::pick_up(
-                &rom,
-                &catalog,
-                super::super::overworld_pickup::PickupFlags {
-                    shuffle_spade_games: true,
-                    shuffle_toad_houses: true,
-                    shuffle_hammer_bros: true,
-                },
-            );
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let data = OverworldData { pickup: &pickup, catalog: &catalog };
-            let build = super::super::overworld_build::build(&rom, &data, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, shuffle_hammer_bros: true, ..Default::default() });
-
-            let mut test_rom = rom.clone();
-            write_overworld(&mut test_rom, &build, &data, &mut rng, WriteFlags { shuffle_hammer_bros: true, ..Default::default() });
-
-            // Each world's written HB sprite count matches the build decision,
-            // and every sprite landed on the position the builder chose.
-            for wi in 0..8 {
-                let written: std::collections::HashSet<(usize, usize)> =
-                    rom_data::read_hb_sprite_positions(&test_rom, wi).into_iter().collect();
-                let decided: std::collections::HashSet<(usize, usize)> =
-                    build.worlds[wi].hb_sprites.iter().map(|s| s.grid_pos).collect();
-                assert_eq!(
-                    written, decided,
-                    "seed {seed} W{}: written HB sprite positions != build decision", wi + 1
-                );
-
-                // After writing HBs, at least 2 eligible map-object slots remain
-                // empty for a runtime white-house spawn. eligible_hb_map_slots
-                // counts both placed HBs and still-empty slots, so the empties
-                // are the eligible count minus what we wrote.
-                let eligible = rom_data::eligible_hb_map_slots(&test_rom, wi).len();
-                let empty = eligible - written.len();
-                assert!(
-                    empty >= 2,
-                    "seed {seed} W{}: only {empty} empty map-object slots left", wi + 1
-                );
-            }
-
-            // The 15 encounters' rewards are all present and non-zero (the
-            // vanilla rewards are all real items, just redistributed).
-            let rewards = rom_data::collect_hb_sprite_rewards(&test_rom);
-            assert_eq!(rewards.len(), 15, "seed {seed}: {} HB rewards written != 15", rewards.len());
-            assert!(rewards.iter().all(|&r| r != 0), "seed {seed}: a written HB reward is zero");
-        }
-    }
-
-    #[test]
-    fn test_pointer_table_sorted() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-        let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let data = OverworldData { pickup: &pickup, catalog: &catalog };
+        let build = overworld_build::build(&rom, &data, &mut rng, overworld_build::BuildFlags { shuffle_toad_houses: true, shuffle_hammer_bros: true, ..Default::default() });
 
         let mut test_rom = rom.clone();
+        write_overworld(&mut test_rom, &build, &data, &mut rng, WriteFlags { shuffle_hammer_bros: true, ..Default::default() });
+
+        // Each world's written HB sprite count matches the build decision,
+        // and every sprite landed on the position the builder chose.
+        for wi in 0..8 {
+            let written: std::collections::HashSet<(usize, usize)> =
+                rom_data::read_hb_sprite_positions(&test_rom, wi).into_iter().collect();
+            let decided: std::collections::HashSet<(usize, usize)> =
+                build.worlds[wi].hb_sprites.iter().map(|s| s.grid_pos).collect();
+            assert_eq!(
+                written, decided,
+                "seed {seed} W{}: written HB sprite positions != build decision", wi + 1
+            );
+
+            // After writing HBs, at least 2 eligible map-object slots remain
+            // empty for a runtime white-house spawn. eligible_hb_map_slots
+            // counts both placed HBs and still-empty slots, so the empties
+            // are the eligible count minus what we wrote.
+            let eligible = rom_data::eligible_hb_map_slots(&test_rom, wi).len();
+            let empty = eligible - written.len();
+            assert!(
+                empty >= 2,
+                "seed {seed} W{}: only {empty} empty map-object slots left", wi + 1
+            );
+        }
+
+        // The 15 encounters' rewards are all present and non-zero (the
+        // vanilla rewards are all real items, just redistributed).
+        let rewards = rom_data::collect_hb_sprite_rewards(&test_rom);
+        assert_eq!(rewards.len(), 15, "seed {seed}: {} HB rewards written != 15", rewards.len());
+        assert!(rewards.iter().all(|&r| r != 0), "seed {seed}: a written HB reward is zero");
+    }
+}
+
+#[test]
+fn test_pointer_table_sorted() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+
+    let mut test_rom = rom.clone();
+    write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
+
+    // Verify each world's pointer table is sorted by (screen, row, col).
+    for (wi, world) in WORLDS.iter().enumerate() {
+        let n = world.entry_count;
+        let rt = world.rowtype_offset;
+        let sc = rt + n;
+
+        let mut prev = (0u8, 0u8, 0u8);
+        for i in 0..n {
+            let rowtype = test_rom.read_byte(rt + i);
+            let scrcol = test_rom.read_byte(sc + i);
+            let screen = (scrcol >> 4) & 0x0F;
+            let row_nib = (rowtype >> 4) & 0x0F;
+            let col = scrcol & 0x0F;
+            let key = (screen, row_nib, col);
+
+            assert!(
+                key >= prev,
+                "W{} entry {i} not sorted: ({},{},{}) < ({},{},{})",
+                wi + 1, key.0, key.1, key.2, prev.0, prev.1, prev.2,
+            );
+            prev = key;
+        }
+    }
+}
+
+/// Every BFS-reachable blank tile must have a pointer table entry after
+/// writing. Uncovered blanks crash the game when the player walks onto them.
+#[test]
+fn test_no_uncovered_blank_nodes() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+
+    for seed in [42u64, 123, 999, 7777, 31337] {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+
+        let mut test_rom = rom.clone();
+        qol::fix_w3_drawbridges(&mut test_rom);
+        qol::remove_rocks(&mut test_rom);
+        qol::fix_big_q_block_rooms(&mut test_rom);
         write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
 
-        // Verify each world's pointer table is sorted by (screen, row, col).
+        let pipes_by_world = rom_data::read_pipe_pairs(&test_rom);
+
         for (wi, world) in WORLDS.iter().enumerate() {
-            let n = world.entry_count;
-            let rt = world.rowtype_offset;
-            let sc = rt + n;
+            let grid = rom_data::read_tile_grid(&test_rom, wi);
+            let pipe_pairs = pipes_by_world.get(&wi)
+                .cloned()
+                .unwrap_or_default();
+            let walk = map_walker::walk_map(&grid, &pipe_pairs, None, wi);
 
-            let mut prev = (0u8, 0u8, 0u8);
-            for i in 0..n {
-                let rowtype = test_rom.read_byte(rt + i);
-                let scrcol = test_rom.read_byte(sc + i);
-                let screen = (scrcol >> 4) & 0x0F;
-                let row_nib = (rowtype >> 4) & 0x0F;
-                let col = scrcol & 0x0F;
-                let key = (screen, row_nib, col);
-
-                assert!(
-                    key >= prev,
-                    "W{} entry {i} not sorted: ({},{},{}) < ({},{},{})",
-                    wi + 1, key.0, key.1, key.2, prev.0, prev.1, prev.2,
-                );
-                prev = key;
-            }
-        }
-    }
-
-    /// Every BFS-reachable blank tile must have a pointer table entry after
-    /// writing. Uncovered blanks crash the game when the player walks onto them.
-    #[test]
-    fn test_no_uncovered_blank_nodes() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        for seed in [42u64, 123, 999, 7777, 31337] {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            let mut test_rom = rom.clone();
-            super::super::qol::fix_w3_drawbridges(&mut test_rom);
-            super::super::qol::remove_rocks(&mut test_rom);
-            super::super::qol::fix_big_q_block_rooms(&mut test_rom);
-            write_overworld(&mut test_rom, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
-
-            let pipes_by_world = rom_data::read_pipe_pairs(&test_rom);
-
-            for (wi, world) in WORLDS.iter().enumerate() {
-                let grid = rom_data::read_tile_grid(&test_rom, wi);
-                let pipe_pairs = pipes_by_world.get(&wi)
-                    .cloned()
-                    .unwrap_or_default();
-                let walk = super::super::map_walker::walk_map(&grid, &pipe_pairs, None, wi);
-
-                // Collect positions that have pointer table entries.
-                let mut covered: HashSet<(usize, usize)> = HashSet::new();
-                for i in 0..world.entry_count {
-                    let pos = rom_data::entry_grid_position(&test_rom, world, i);
-                    if pos.0 < grid.rows {
-                        covered.insert(pos);
-                    }
-                }
-
-                // Every reachable blank tile must be covered.
-                for &node in &walk.nodes {
-                    let (r, c) = node;
-                    if r >= grid.rows || c >= grid.cols {
-                        continue;
-                    }
-                    let tile = grid.get(r, c);
-                    if !rom_data::VALID_BLANK_TILES.contains(&tile) {
-                        continue;
-                    }
-                    assert!(
-                        covered.contains(&node),
-                        "seed {seed} W{}: uncovered blank tile ${tile:02X} at ({r},{c})",
-                        wi + 1,
-                    );
+            // Collect positions that have pointer table entries.
+            let mut covered: HashSet<(usize, usize)> = HashSet::new();
+            for i in 0..world.entry_count {
+                let pos = rom_data::entry_grid_position(&test_rom, world, i);
+                if pos.0 < grid.rows {
+                    covered.insert(pos);
                 }
             }
-        }
-    }
 
-    /// Generate a full ROM for manual/emulator testing.
-    #[test]
-    #[ignore]
-    fn test_generate_rom() {
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => {
-                eprintln!("ROM not found, skipping");
-                return;
-            }
-        };
-        let catalog = super::super::node_catalog::NodeCatalog::build(&rom, false);
-        let pickup = super::super::overworld_pickup::pick_up(&rom, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-
-        for seed in [42u64, 123, 999] {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let build = super::super::overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-            let mut out = rom.clone();
-
-            // Apply QoL patches that the builder expects.
-            super::super::qol::fix_w3_drawbridges(&mut out);
-            super::super::qol::remove_rocks(&mut out);
-            super::super::qol::fix_big_q_block_rooms(&mut out);
-
-            write_overworld(&mut out, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
-
-            let filename = format!("writer_test_seed{seed}.nes");
-            std::fs::write(&filename, &out.data).unwrap();
-            eprintln!("Wrote {filename}");
-        }
-    }
-
-    /// Piranha shuffle end-to-end: run the full randomizer in On and Wild
-    /// modes and check the ROM-side invariants — plants written with no
-    /// reward byte, sitting on path-node tiles over real pointer entries,
-    /// and every world keeping enough empty map-object slots for runtime
-    /// bonus spawns. Off mode must keep the vanilla W7 plants.
-    #[test]
-    fn test_piranha_shuffle_plants_written() {
-        use crate::{Options, PiranhaMode};
-
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-
-        let plant_slots = |out: &Rom, wi: usize| -> Vec<(usize, (usize, usize))> {
-            (0..9)
-                .filter(|&slot| {
-                    out.read_byte(rom_data::map_obj_slot_offset(
-                        out, rom_data::MAP_OBJ_IDS_MASTER, wi, slot,
-                    )) == 0x07
-                })
-                .map(|slot| {
-                    let y = out.read_byte(rom_data::map_obj_slot_offset(
-                        out, rom_data::MAP_OBJ_YS_MASTER, wi, slot,
-                    )) as usize;
-                    let xhi = out.read_byte(rom_data::map_obj_slot_offset(
-                        out, rom_data::MAP_OBJ_XHIS_MASTER, wi, slot,
-                    )) as usize;
-                    let xlo = out.read_byte(rom_data::map_obj_slot_offset(
-                        out, rom_data::MAP_OBJ_XLOS_MASTER, wi, slot,
-                    )) as usize;
-                    (slot, (y / 16 - 2, xhi * 16 + xlo / 16))
-                })
-                .collect()
-        };
-
-        for mode in [PiranhaMode::On, PiranhaMode::Wild] {
-            let mut out = rom.clone();
-            let options = Options {
-                piranha_shuffle: mode,
-                palettes: false,
-                ..Default::default()
-            };
-            crate::randomizer::randomize(&mut out, 42, &options);
-
-            let mut total_plants = 0;
-            for wi in 0..8 {
-                let empty = (0..9)
-                    .filter(|&slot| {
-                        out.read_byte(rom_data::map_obj_slot_offset(
-                            &out, rom_data::MAP_OBJ_IDS_MASTER, wi, slot,
-                        )) == 0x00
-                    })
-                    .count();
+            // Every reachable blank tile must be covered.
+            for &node in &walk.nodes {
+                let (r, c) = node;
+                if r >= grid.rows || c >= grid.cols {
+                    continue;
+                }
+                let tile = grid.get(r, c);
+                if !rom_data::VALID_BLANK_TILES.contains(&tile) {
+                    continue;
+                }
                 assert!(
-                    empty >= super::super::overworld_build::RESERVED_DYNAMIC_SLOTS,
-                    "{mode:?}: W{} has only {empty} empty map-object slots",
+                    covered.contains(&node),
+                    "seed {seed} W{}: uncovered blank tile ${tile:02X} at ({r},{c})",
                     wi + 1,
                 );
-
-                for (slot, (row, col)) in plant_slots(&out, wi) {
-                    total_plants += 1;
-                    assert_eq!(
-                        out.read_byte(rom_data::map_obj_reward_offset(wi, slot)),
-                        0,
-                        "{mode:?}: relocated plant carries a reward byte",
-                    );
-                    // Under-tile is a path node, not a numbered level tile.
-                    let tile = out.read_byte(rom_data::map_tile_offset(wi, row, col));
-                    assert!(
-                        !(0x03..=0x15).contains(&tile),
-                        "{mode:?}: W{} plant at ({row},{col}) sits on level tile {tile:#04x}",
-                        wi + 1,
-                    );
-                    // A pointer entry (the level the plant fronts) exists there.
-                    let world = &rom_data::WORLDS[wi];
-                    let found = (0..world.entry_count).any(|i| {
-                        rom_data::entry_grid_position(&out, world, i) == (row, col)
-                    });
-                    assert!(
-                        found,
-                        "{mode:?}: W{} plant at ({row},{col}) has no pointer entry",
-                        wi + 1,
-                    );
-                }
-            }
-            match mode {
-                // Both released levels got sprites at seed 42 (skips are
-                // possible in principle — hand-trap slot, full world — but
-                // zero plants would mean the feature silently no-opped).
-                PiranhaMode::On => assert!(
-                    (1..=2).contains(&total_plants),
-                    "On: expected 1-2 plants, found {total_plants}",
-                ),
-                PiranhaMode::Wild => assert!(
-                    total_plants >= 6,
-                    "Wild: expected ~1 plant per world, found {total_plants}",
-                ),
-                PiranhaMode::Off => unreachable!(),
             }
         }
+    }
+}
 
-        // Off: vanilla plants stay at their linked slots with a reward.
+/// Generate a full ROM for manual/emulator testing.
+#[test]
+#[ignore]
+fn test_generate_rom() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+
+    for seed in [42u64, 123, 999] {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let build = overworld_build::build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+
         let mut out = rom.clone();
-        let options = Options { palettes: false, ..Default::default() };
+
+        // Apply QoL patches that the builder expects.
+        qol::fix_w3_drawbridges(&mut out);
+        qol::remove_rocks(&mut out);
+        qol::fix_big_q_block_rooms(&mut out);
+
+        write_overworld(&mut out, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, WriteFlags::default());
+
+        let filename = format!("writer_test_seed{seed}.nes");
+        std::fs::write(&filename, &out.data).unwrap();
+        eprintln!("Wrote {filename}");
+    }
+}
+
+/// Piranha shuffle end-to-end: run the full randomizer in On and Wild
+/// modes and check the ROM-side invariants — plants written with no
+/// reward byte, sitting on path-node tiles over real pointer entries,
+/// and every world keeping enough empty map-object slots for runtime
+/// bonus spawns. Off mode must keep the vanilla W7 plants.
+#[test]
+fn test_piranha_shuffle_plants_written() {
+    use crate::{Options, PiranhaMode};
+
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+
+    let plant_slots = |out: &Rom, wi: usize| -> Vec<(usize, (usize, usize))> {
+        (0..9)
+            .filter(|&slot| {
+                out.read_byte(rom_data::map_obj_slot_offset(
+                    out, rom_data::MAP_OBJ_IDS_MASTER, wi, slot,
+                )) == 0x07
+            })
+            .map(|slot| {
+                let y = out.read_byte(rom_data::map_obj_slot_offset(
+                    out, rom_data::MAP_OBJ_YS_MASTER, wi, slot,
+                )) as usize;
+                let xhi = out.read_byte(rom_data::map_obj_slot_offset(
+                    out, rom_data::MAP_OBJ_XHIS_MASTER, wi, slot,
+                )) as usize;
+                let xlo = out.read_byte(rom_data::map_obj_slot_offset(
+                    out, rom_data::MAP_OBJ_XLOS_MASTER, wi, slot,
+                )) as usize;
+                (slot, (y / 16 - 2, xhi * 16 + xlo / 16))
+            })
+            .collect()
+    };
+
+    for mode in [PiranhaMode::On, PiranhaMode::Wild] {
+        let mut out = rom.clone();
+        let options = Options {
+            piranha_shuffle: mode,
+            palettes: false,
+            ..Default::default()
+        };
         crate::randomizer::randomize(&mut out, 42, &options);
-        for &(wi, slot, _) in rom_data::MAP_OBJ_ENTRY_LINKS {
-            let id = out.read_byte(rom_data::map_obj_slot_offset(
-                &out, rom_data::MAP_OBJ_IDS_MASTER, wi, slot,
-            ));
-            assert_eq!(id, 0x07, "Off: vanilla plant missing at W{} slot {slot}", wi + 1);
-            assert_ne!(
-                out.read_byte(rom_data::map_obj_reward_offset(wi, slot)),
-                0,
-                "Off: vanilla plant reward cleared",
+
+        let mut total_plants = 0;
+        for wi in 0..8 {
+            let empty = (0..9)
+                .filter(|&slot| {
+                    out.read_byte(rom_data::map_obj_slot_offset(
+                        &out, rom_data::MAP_OBJ_IDS_MASTER, wi, slot,
+                    )) == 0x00
+                })
+                .count();
+            assert!(
+                empty >= overworld_build::RESERVED_DYNAMIC_SLOTS,
+                "{mode:?}: W{} has only {empty} empty map-object slots",
+                wi + 1,
             );
+
+            for (slot, (row, col)) in plant_slots(&out, wi) {
+                total_plants += 1;
+                assert_eq!(
+                    out.read_byte(rom_data::map_obj_reward_offset(wi, slot)),
+                    0,
+                    "{mode:?}: relocated plant carries a reward byte",
+                );
+                // Under-tile is a path node, not a numbered level tile.
+                let tile = out.read_byte(rom_data::map_tile_offset(wi, row, col));
+                assert!(
+                    !(0x03..=0x15).contains(&tile),
+                    "{mode:?}: W{} plant at ({row},{col}) sits on level tile {tile:#04x}",
+                    wi + 1,
+                );
+                // A pointer entry (the level the plant fronts) exists there.
+                let world = &rom_data::WORLDS[wi];
+                let found = (0..world.entry_count).any(|i| {
+                    rom_data::entry_grid_position(&out, world, i) == (row, col)
+                });
+                assert!(
+                    found,
+                    "{mode:?}: W{} plant at ({row},{col}) has no pointer entry",
+                    wi + 1,
+                );
+            }
+        }
+        match mode {
+            // Both released levels got sprites at seed 42 (skips are
+            // possible in principle — hand-trap slot, full world — but
+            // zero plants would mean the feature silently no-opped).
+            PiranhaMode::On => assert!(
+                (1..=2).contains(&total_plants),
+                "On: expected 1-2 plants, found {total_plants}",
+            ),
+            PiranhaMode::Wild => assert!(
+                total_plants >= 6,
+                "Wild: expected ~1 plant per world, found {total_plants}",
+            ),
+            PiranhaMode::Off => unreachable!(),
         }
     }
 
-    /// With piranha shuffle active the two plant levels enter the regular
-    /// level pool — and they end in a treasure chest, so a troll pipe must
-    /// never disguise them (CHEST_LEVELS membership drives the exclusion,
-    /// same as 3-7 / 5-1 / 8-Tank).
-    #[test]
-    fn test_troll_pipes_never_assigned_piranha_levels() {
-        use crate::PiranhaMode;
+    // Off: vanilla plants stay at their linked slots with a reward.
+    let mut out = rom.clone();
+    let options = Options { palettes: false, ..Default::default() };
+    crate::randomizer::randomize(&mut out, 42, &options);
+    for &(wi, slot, _) in rom_data::MAP_OBJ_ENTRY_LINKS {
+        let id = out.read_byte(rom_data::map_obj_slot_offset(
+            &out, rom_data::MAP_OBJ_IDS_MASTER, wi, slot,
+        ));
+        assert_eq!(id, 0x07, "Off: vanilla plant missing at W{} slot {slot}", wi + 1);
+        assert_ne!(
+            out.read_byte(rom_data::map_obj_reward_offset(wi, slot)),
+            0,
+            "Off: vanilla plant reward cleared",
+        );
+    }
+}
 
-        let rom = match load_rom() {
-            Some(r) => r,
-            None => return,
-        };
-        // Piranha-active pipeline: sprites cleared, catalog entries released.
-        let mut prepped = rom.clone();
-        super::super::piranha_rooms::clear_vanilla_plants(&mut prepped);
-        let mut catalog = super::super::node_catalog::NodeCatalog::build(&prepped, false);
-        catalog.release_map_objects();
-        let pickup = super::super::overworld_pickup::pick_up(&prepped, &catalog, super::super::overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
+/// With piranha shuffle active the two plant levels enter the regular
+/// level pool — and they end in a treasure chest, so a troll pipe must
+/// never disguise them (CHEST_LEVELS membership drives the exclusion,
+/// same as 3-7 / 5-1 / 8-Tank).
+#[test]
+fn test_troll_pipes_never_assigned_piranha_levels() {
+    use crate::PiranhaMode;
 
-        // Both released plant levels must be in the pool at all.
-        let pooled_piranhas = pickup.pool.iter()
-            .filter(|pe| rom_data::MAP_OBJ_ENTRY_LINKS.iter()
-                .any(|&(w, _, e)| pe.world_idx == w && pe.entry_idx == e))
-            .count();
-        assert_eq!(pooled_piranhas, 2, "released plant levels missing from pool");
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    // Piranha-active pipeline: sprites cleared, catalog entries released.
+    let mut prepped = rom.clone();
+    piranha_rooms::clear_vanilla_plants(&mut prepped);
+    let mut catalog = node_catalog::NodeCatalog::build(&prepped, false);
+    catalog.release_map_objects();
+    let pickup = standard_pickup(&prepped, &catalog);
 
-        for seed in 0u64..32 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let mut build = super::super::overworld_build::build(&prepped, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, super::super::overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            super::super::troll_pipes::mark_troll_pipes(&mut build, &mut rng);
+    // Both released plant levels must be in the pool at all.
+    let pooled_piranhas = pickup.pool.iter()
+        .filter(|pe| rom_data::MAP_OBJ_ENTRY_LINKS.iter()
+            .any(|&(w, _, e)| pe.world_idx == w && pe.entry_idx == e))
+        .count();
+    assert_eq!(pooled_piranhas, 2, "released plant levels missing from pool");
 
-            let troll_positions: HashSet<(usize, (usize, usize))> = build.worlds.iter()
-                .flat_map(|w| w.slots.iter()
-                    .filter(|s| s.is_troll_pipe)
-                    .map(move |s| (w.world_idx, s.pos)))
-                .collect();
+    for seed in 0u64..32 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut build = overworld_build::build(&prepped, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, standard_build_flags());
+        troll_pipes::mark_troll_pipes(&mut build, &mut rng);
 
-            let flags = WriteFlags { piranha: PiranhaMode::Wild, ..Default::default() };
-            let assignments = assign_pool(&prepped, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, flags);
+        let troll_positions: HashSet<(usize, (usize, usize))> = build.worlds.iter()
+            .flat_map(|w| w.slots.iter()
+                .filter(|s| s.is_troll_pipe)
+                .map(move |s| (w.world_idx, s.pos)))
+            .collect();
 
-            for (wi, wa) in assignments.iter().enumerate() {
-                for a in &wa.level {
-                    if !troll_positions.contains(&(wi, a.pos))
-                        || wa.demoted_troll_pipes.contains(&a.pos)
-                    {
-                        continue;
-                    }
-                    let ce = &catalog.entries[pickup.pool[a.pool_idx].catalog_idx];
-                    assert!(
-                        !rom_data::is_chest_level(ce.world_idx, ce.entry_idx),
-                        "seed {seed}: W{} troll pipe at {:?} got chest level (W{} entry {})",
-                        wi + 1, a.pos, ce.world_idx + 1, ce.entry_idx,
-                    );
+        let flags = WriteFlags { piranha: PiranhaMode::Wild, ..Default::default() };
+        let assignments = assign_pool(&prepped, &build, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, flags);
+
+        for (wi, wa) in assignments.iter().enumerate() {
+            for a in &wa.level {
+                if !troll_positions.contains(&(wi, a.pos))
+                    || wa.demoted_troll_pipes.contains(&a.pos)
+                {
+                    continue;
                 }
+                let ce = &catalog.entries[pickup.pool[a.pool_idx].catalog_idx];
+                assert!(
+                    !rom_data::is_chest_level(ce.world_idx, ce.entry_idx),
+                    "seed {seed}: W{} troll pipe at {:?} got chest level (W{} entry {})",
+                    wi + 1, a.pos, ce.world_idx + 1, ce.entry_idx,
+                );
             }
         }
     }
+}

--- a/src/randomize/overworld_writer/types.rs
+++ b/src/randomize/overworld_writer/types.rs
@@ -2,15 +2,6 @@
 
 use super::*;
 
-/// W8 army sprite definitions: (map_object_slot, is_fortress).
-/// Tank goes on a level slot, the other 3 go on fortress slots.
-pub(super) const W8_ARMY_SPRITES: &[(usize, bool)] = &[
-    (2, false), // Tank sprite (ID $0E) → level slot
-    (3, true),  // Navy/Battleship sprite (ID $0D) → fortress slot
-    (4, true),  // Air Force sprite (ID $0F) → fortress slot
-    (5, true),  // Super Tank sprite (ID $0E) → fortress slot
-];
-
 /// A concrete assignment of a pool entry to a grid position.
 #[derive(Clone, Debug)]
 pub(super) struct Assignment {
@@ -63,7 +54,3 @@ pub(super) struct WorldAssignments {
     /// sees a normal level icon rather than a pipe leading to a hand-trap.
     pub(super) demoted_troll_pipes: HashSet<(usize, usize)>,
 }
-
-/// Hammer Bro map-sprite type ids. Cosmetic on the overworld (the battle is the
-/// node under the sprite); assigned at random per encounter.
-pub(super) const HB_SPRITE_IDS: [u8; 4] = [0x03, 0x04, 0x05, 0x06];

--- a/src/randomize/palettes.rs
+++ b/src/randomize/palettes.rs
@@ -252,7 +252,7 @@ pub fn randomize_themed<R: Rng>(rom: &mut Rom, rng: &mut R) {
     };
 
     for region in THEMED_REGIONS {
-        apply_variant_groups(rom, region, &shift_for, rng);
+        apply_variant_groups(rom, region, shift_for, rng);
     }
 
     // Hue-rotate the kept-vanilla chromatic quartets in place.
@@ -287,7 +287,7 @@ fn rotate_hue(byte: u8, shift: u8) -> u8 {
 fn apply_variant_groups<R: Rng>(
     rom: &mut Rom,
     groups: &[VariantGroup],
-    shift_for: &dyn Fn(usize) -> u8,
+    shift_for: impl Fn(usize) -> u8,
     rng: &mut R,
 ) {
     for group in groups {

--- a/src/randomize/pipe_helpers.rs
+++ b/src/randomize/pipe_helpers.rs
@@ -116,7 +116,7 @@ pub(super) fn resort_pointer_table(rom: &mut Rom, world_idx: usize) {
     // PRG012 is loaded at CPU $A000-$BFFF during the map screen, so the
     // CPU addresses in the master table are in the $A000+ range.
     let init_ptr = rom_data::read_word(rom, INIT_INDEX_MASTER + world_idx * 2);
-    let init_file = 0x18010 + (init_ptr as usize - 0xA000);
+    let init_file = rom_data::PRG012_FILE_BASE + (init_ptr as usize - 0xA000);
 
     // All worlds allocate 4 InitIndex bytes (gap between InitIndex and
     // ByRowType pointers is always 4), regardless of actual screen count.

--- a/src/randomize/podoboo_gauntlet.rs
+++ b/src/randomize/podoboo_gauntlet.rs
@@ -36,17 +36,12 @@ const MIN_X_GAP: u8 = 2;
 /// MIN_X_GAP constraint to surrounding entries.
 const X_JITTER_RADIUS: u8 = 4;
 
-/// ROM file offsets of podoboos pinned to their vanilla (X, Y) — they are
-/// never jittered. These are the first two regular podoboos of the
-/// corridor; players rely on them as a fixed entry landmark. Keyed on
-/// absolute ROM offset to match the enemy-protection convention used
-/// elsewhere (e.g. `powerups::PROTECTED_OFFSETS`). Each segment entry is 3
-/// bytes starting at `SEG_OFFSET + 1`, so `VANILLA[j]` lives at
-/// `SEG_OFFSET + 1 + 3*j`.
-const PROTECTED_OFFSETS: &[usize] = &[
-    0xD2CA, // 5-F2 sub-area 1 podoboo #1 (X=0x06)
-    0xD2CD, // 5-F2 sub-area 1 podoboo #2 (X=0x0B)
-];
+/// Vanilla X positions of podoboos pinned to their vanilla (X, Y) — they
+/// are never jittered. These are the first two regular podoboos of the
+/// corridor (the first two [`VANILLA`] entries, file offsets 0xD2CA and
+/// 0xD2CD); players rely on them as a fixed entry landmark. X is unique
+/// within the segment, so matching by X during the sorted walk is exact.
+const PINNED_X: &[u8] = &[0x06, 0x0B];
 
 /// Vanilla layout of 5-F2 sub-area 1 — hard-coded so the composer
 /// produces a known segment regardless of what bytes the input ROM has at
@@ -93,22 +88,12 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R) {
     // entries 20 (Podoboo 0x63) and 21 (Boo 0x6F) — index 22 (Podoboo
     // 0x6A) follows. We sort by X up-front so the jitter logic sees a
     // canonical order.
-    // Resolve protected offsets to vanilla X values before sorting. VANILLA
-    // is in file order, so entry j sits at SEG_OFFSET + 1 + 3*j; X is unique
-    // within the segment, so matching by X during the sorted walk is exact.
-    let pinned_x: Vec<u8> = VANILLA
-        .iter()
-        .enumerate()
-        .filter(|(j, _)| PROTECTED_OFFSETS.contains(&(SEG_OFFSET + 1 + 3 * j)))
-        .map(|(_, e)| e.x)
-        .collect();
-
     let mut sorted_vanilla: Vec<SegmentEntry> = VANILLA.to_vec();
     sorted_vanilla.sort_by_key(|e| e.x);
 
     let mut out: Vec<SegmentEntry> = Vec::with_capacity(ENTRY_COUNT);
     for (i, entry) in sorted_vanilla.iter().enumerate() {
-        let new_entry = if is_target(entry.obj_id) && !pinned_x.contains(&entry.x) {
+        let new_entry = if is_target(entry.obj_id) && !PINNED_X.contains(&entry.x) {
             let prev_x = out.last().map(|e| e.x).unwrap_or(SEG_X_MIN.saturating_sub(MIN_X_GAP));
             let next_x = sorted_vanilla.get(i + 1).map(|e| e.x).unwrap_or(SEG_X_MAX.saturating_add(MIN_X_GAP));
             let lo = prev_x.saturating_add(MIN_X_GAP)
@@ -189,6 +174,14 @@ mod tests {
                 assert_eq!(e.y & 0xF0, 0x10, "seed {seed}: podoboo crossed page");
             }
         }
+    }
+
+    #[test]
+    fn pinned_x_matches_vanilla_entries() {
+        // PINNED_X is derived from the first two VANILLA podoboos.
+        assert_eq!(PINNED_X, &[VANILLA[0].x, VANILLA[1].x]);
+        assert_eq!(VANILLA[0].obj_id, PODOBOO);
+        assert_eq!(VANILLA[1].obj_id, PODOBOO);
     }
 
     #[test]

--- a/src/randomize/powerups.rs
+++ b/src/randomize/powerups.rs
@@ -113,15 +113,17 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, no_airship_stars: bool) {
                 let shape = b2 & 0x0F;
                 let file_offset = region.start + i + 2;
 
-                if group == GEN_GROUP_POWERBLOCK {
-                    if QBLOCK_SHAPES.contains(&shape) && !PROTECTED_OFFSETS.contains(&file_offset) {
+                // Protected offsets only ever hold group-1 blocks, so the
+                // guard applies to group 1 alone (group 2 is never checked).
+                if group == GEN_GROUP_POWERBLOCK && !PROTECTED_OFFSETS.contains(&file_offset) {
+                    if QBLOCK_SHAPES.contains(&shape) {
                         let pool = if no_airship_stars && AIRSHIP_QBLOCK_OFFSETS.contains(&file_offset) {
                             QBLOCK_SHAPES_NO_STAR
                         } else {
                             QBLOCK_SHAPES
                         };
                         data[i + 2] = *pool.choose(rng).unwrap();
-                    } else if BRICK_SHAPES.contains(&shape) && !PROTECTED_OFFSETS.contains(&file_offset) {
+                    } else if BRICK_SHAPES.contains(&shape) {
                         data[i + 2] = *BRICK_SHAPES.choose(rng).unwrap();
                     }
                 } else if group == GEN_GROUP_EXTENDED && region.randomize_note_wood {

--- a/src/randomize/powerups.rs
+++ b/src/randomize/powerups.rs
@@ -133,17 +133,7 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, no_airship_stars: bool) {
                 }
             }
 
-            // Determine command size: 3 bytes normally, 4 if this is a
-            // variable-size dispatch that reads an extra byte.
-            let mut cmd_size = 3;
-            if !is_fixed {
-                let grp = (b0 >> 5) as usize;
-                let dispatch = grp * 15 + ((b2 >> 4) as usize) - 1;
-                if region.extra_byte_dispatches.contains(&(dispatch as u8)) {
-                    cmd_size = 4;
-                }
-            }
-            i += cmd_size;
+            i += region.command_size(b0, b2);
         }
 
         rom.write_range(region.start, &data);

--- a/src/randomize/qol/canoe.rs
+++ b/src/randomize/qol/canoe.rs
@@ -1,24 +1,39 @@
 //! W3 canoe softlock fixes (respawn + map-data backup/restore).
 
 use crate::rom::Rom;
-use crate::randomize::rom_data::{FS_CANOE_BACKUP, FS_CANOE_RESPAWN};
+use crate::randomize::rom_data::{FS_CANOE_BACKUP, FS_CANOE_RESPAWN, jsr_into_bank};
 
 // Canoe softlock fix — based on "SMB3 - Canoe Softlock Fixes (Open World
-// compatible).ips". Two hooks plus two free-space subroutines.
+// compatible).ips". Two hooks, one JSR retarget, and two free-space
+// subroutines.
 
-// Hook at PRG010 CPU $C6EA → JSR FS_CANOE_RESPAWN (5 bytes incl. NOP NOP).
-const CANOE_RESPAWN_HOOK: usize = 0x146FA;
-// Boundary check adjustment at PRG010 CPU $CF13 (2 bytes).
-const CANOE_BOUNDARY_PATCH: usize = 0x14F23;
-// Hook at PRG011 CPU $A22F → JSR FS_CANOE_BACKUP (5 bytes incl. NOP NOP).
+// Byte offset of Part B (map-data restore) inside CANOE_BACKUP_ROUTINE.
+// Part A (backup) is the first 28 bytes; Part B follows at CPU $BD0C.
+const CANOE_RESTORE_OFFSET: usize = 28;
+
+// Hook at PRG010 CPU $C6EA (5 bytes): replaces the vanilla `LDA #$00 /
+// STA $0500` with `JSR` to Part B of FS_CANOE_BACKUP, which restores the
+// backed-up map data and then re-executes the displaced LDA/STA itself.
+const CANOE_RESTORE_HOOK: usize = 0x146FA;
+
+// Operand bytes of the vanilla `JSR $D1FE` at PRG010 CPU $CF12 (2 bytes),
+// retargeted to FS_CANOE_RESPAWN — which runs the original $D1FE routine
+// first, then saves the death-respawn position for canoe entry.
+const CANOE_RESPAWN_RETARGET: usize = 0x14F23;
+
+// FS_CANOE_RESPAWN's CPU address: PRG010 is mapped at $C000-$DFFF on the
+// world map, so CPU = $C000 + (file - 0x14010) = $DDE0.
+const CANOE_RESPAWN_CPU: u16 = (0xC000 + FS_CANOE_RESPAWN - 0x14010) as u16;
+
+// Hook at PRG011 CPU $A22F → JSR FS_CANOE_BACKUP Part A (5 bytes incl. NOP NOP).
 const CANOE_BACKUP_HOOK: usize = 0x1623F;
 
 // Record 3: subroutine in PRG010 free space (FS_CANOE_RESPAWN).
 // Saves player map position as death respawn point when entering via canoe ($4B).
 #[rustfmt::skip]
 const CANOE_RESPAWN_ROUTINE: [u8; 35] = [
-    0x20, 0xFE, 0xD1, // JSR $D1FE  (original routine)
-    0xC9, 0x4B,       // CMP #$4B   (canoe state?)
+    0x20, 0xFE, 0xD1, // JSR $D1FE  (the displaced original JSR target)
+    0xC9, 0x4B,       // CMP #$4B   (canoe dock tile)
     0xD0, 0x1B,       // BNE +27    (skip if not canoe)
     0xB5, 0x75,       // LDA $75,X  (map obj Y)
     0x9D, 0x7E, 0x79, // STA $797E,X (death respawn Y)
@@ -79,17 +94,22 @@ const CANOE_BACKUP_ROUTINE: [u8; 66] = [
 ///
 /// Based on "SMB3 - Canoe Softlock Fixes (Open World compatible).ips".
 pub fn fix_canoe_softlock(rom: &mut Rom) {
-    // Record 1: Hook at PRG010 CPU $C6EA → JSR $BD0C (canoe cleanup)
-    rom.write_range(CANOE_RESPAWN_HOOK, &[0x20, 0x0C, 0xBD, 0xEA, 0xEA]);
+    // Record 1: hook at PRG010 CPU $C6EA → JSR $BD0C (FS_CANOE_BACKUP Part B,
+    // the map-data restore), NOP-padded over the displaced 5 bytes.
+    let [jsr, lo, hi] = jsr_into_bank(11, FS_CANOE_BACKUP + CANOE_RESTORE_OFFSET);
+    rom.write_range(CANOE_RESTORE_HOOK, &[jsr, lo, hi, 0xEA, 0xEA]);
 
-    // Record 2: Boundary check adjustment at PRG010 CPU $CF13
-    rom.write_range(CANOE_BOUNDARY_PATCH, &[0xE0, 0xDD]);
+    // Record 2: retarget the vanilla `JSR $D1FE` at CPU $CF12 to
+    // FS_CANOE_RESPAWN ($DDE0) — operand bytes only, the JSR opcode stays.
+    rom.write_range(CANOE_RESPAWN_RETARGET, &CANOE_RESPAWN_CPU.to_le_bytes());
 
     // Record 3: respawn-save subroutine
     rom.write_range(FS_CANOE_RESPAWN, &CANOE_RESPAWN_ROUTINE);
 
-    // Record 4: Hook at PRG011 CPU $A22F → JSR $BCF0 (canoe backup)
-    rom.write_range(CANOE_BACKUP_HOOK, &[0x20, 0xF0, 0xBC, 0xEA, 0xEA]);
+    // Record 4: hook at PRG011 CPU $A22F → JSR $BCF0 (FS_CANOE_BACKUP Part A,
+    // the backup).
+    let [jsr, lo, hi] = jsr_into_bank(11, FS_CANOE_BACKUP);
+    rom.write_range(CANOE_BACKUP_HOOK, &[jsr, lo, hi, 0xEA, 0xEA]);
 
     // Record 5: backup/restore subroutines
     rom.write_range(FS_CANOE_BACKUP, &CANOE_BACKUP_ROUTINE);

--- a/src/randomize/qol/cards.rs
+++ b/src/randomize/qol/cards.rs
@@ -44,7 +44,7 @@ pub fn card_speed_clear(rom: &mut Rom) {
         0xEA, 0xEA,        // NOP; NOP (pad to 5 bytes)
     ]);
 
-    // Trampoline at $FFE0 (PRG031, always mapped, 24 bytes):
+    // Trampoline at $FFE0 (PRG031, always mapped, 26 bytes):
     //
     // $FFE0: LDA $7D9E,Y      ; displaced: load 3rd card
     // $FFE3: BNE +3            ; if not empty → check cards
@@ -95,7 +95,7 @@ mod tests {
 
         // Hook: JMP $FFE0; NOP; NOP
         assert_eq!(rom.read_range(CARD_HOOK, 5), &[0x4C, 0xE0, 0xFF, 0xEA, 0xEA]);
-        // Trampoline: 24 bytes at PRG031 dead space
+        // Trampoline: 26 bytes at PRG031 dead space
         assert_eq!(rom.read_byte(CARD_TRAMPOLINE), 0xB9); // LDA $7D9E,Y
         assert_eq!(rom.read_byte(CARD_TRAMPOLINE + 2), 0x7D);
         // One-of-each path: JMP $BD5A

--- a/src/randomize/qol/hammer_breaks.rs
+++ b/src/randomize/qol/hammer_breaks.rs
@@ -1,14 +1,18 @@
 //! Hammer item also breaks fortress locks / water-gap bridges.
 
 use crate::rom::Rom;
-use crate::randomize::rom_data::FS_HAMMER_LOCKS;
+use crate::randomize::rom_data::{FS_HAMMER_LOCKS, prg_bank_file_to_cpu};
 
-// Make the hammer item also break fortress lock tiles on the overworld map.
+// Make the hammer item also break fortress lock tiles and/or water-gap
+// bridge locks on the overworld map.
 //
 // The vanilla hammer routine at PRG026 (file 0x346D5, CPU $A6C5) uses a
 // 7-byte range check: `SEC; SBC #$51; CMP #$02; BCC .found` which only
 // matches rock tiles $51–$52. We replace this with a JSR to a table-driven
-// subroutine in PRG026 free space that checks 5 tile IDs (2 rocks + 3 locks).
+// subroutine in PRG026 free space whose tables are built from the flags:
+// the 2 rock tiles are always present, `locks` adds the 3 fortress lock
+// tiles, and `bridges` adds the water gap lock (0x9D → 0xB3) — so the
+// tables hold 2–6 entries.
 //
 // Patch site 1 — Range check (file 0x346D5, 7 bytes):
 //   `SEC; SBC #$51; CMP #$02; BCC .found` →
@@ -17,19 +21,16 @@ use crate::randomize::rom_data::FS_HAMMER_LOCKS;
 // Patch site 2 — Replacement tile load (file 0x346E9, 3 bytes):
 //   `LDA $A6B1,X` → `LDA $7EB6` (load from scratch RAM set by subroutine)
 //
-// New subroutine at FS_HAMMER_LOCKS (0x3557F, CPU $B56F), 47 bytes:
+// New subroutine at FS_HAMMER_LOCKS (0x3557F, CPU $B56F), up to 50 bytes:
 //   Table-driven check of breakable tiles, stores replacement tile in $7EB6,
 //   saves/restores X via $7EB7, returns carry clear if breakable.
-//
-// Water gap locks (0x9D → 0xB3) are intentionally excluded — bridge tiles
-// need more testing.
 
 /// File offset of the 7-byte range check in the hammer routine ($A6C5).
 const HAMMER_RANGE_CHECK: usize = 0x346D5;
 /// File offset of `LDA $A6B1,X` (replacement tile load) at CPU $A6D8.
 const HAMMER_REPLACE_LOAD: usize = 0x346E8;
-/// CPU address of the subroutine: $A000 + (0x3557F - 0x34010) = $B56F.
-const HAMMER_LOCKS_SUB_CPU: u16 = 0xB56F;
+/// CPU address of the subroutine in PRG026 ($A000 window): $B56F.
+const HAMMER_LOCKS_SUB_CPU: u16 = prg_bank_file_to_cpu(26, FS_HAMMER_LOCKS);
 
 pub fn hammer_breaks_tiles(rom: &mut Rom, locks: bool, bridges: bool) {
     // Build tables dynamically based on which flags are set.

--- a/src/randomize/qol/overworld_map.rs
+++ b/src/randomize/qol/overworld_map.rs
@@ -1,6 +1,7 @@
 //! Overworld map tile edits: rocks, W8 canoe/bridges, drawbridges, N-cards.
 
 use crate::rom::Rom;
+use crate::randomize::rom_data::{FX_MAP_TILE_REPLACE, map_tile_offset, write_map_sprite};
 
 // W3 drawbridge map tile patches: (file offset, replacement tile).
 // Vanilla: 2× $B2 horizontal + 2× $B1 vertical. Replace with $B3
@@ -84,7 +85,7 @@ const W8_BRIDGE_EDITS: &[(usize, usize, u8)] = &[
 /// [`W8_BRIDGE_EDITS`]). Independent of the `8s are Wild` option.
 pub fn apply_w8_bridges(rom: &mut Rom) {
     for &(row, col, tile) in W8_BRIDGE_EDITS {
-        rom.write_byte(crate::randomize::rom_data::map_tile_offset(7, row, col), tile);
+        rom.write_byte(map_tile_offset(7, row, col), tile);
     }
     // Vanilla FX slot 16 sits at W8 (row 5, col 53) — right on our new bridge
     // row — and its replace_tile is 0x45 (plain path). The builder's pickup
@@ -92,20 +93,20 @@ pub fn apply_w8_bridges(rom: &mut Rom) {
     // 0xB3 bridge. Point it at the bridge tile so the slot opens to a bridge,
     // matching the other bridge columns (and gating as a water gap if a
     // fortress lands there).
-    rom.write_byte(crate::randomize::rom_data::FX_MAP_TILE_REPLACE + 16, 0xB3);
+    rom.write_byte(FX_MAP_TILE_REPLACE + 16, 0xB3);
 }
 
 /// Apply the W8 canoe docks + extra paths and place the canoe sprite (see
 /// [`W8_CANOE_PATH_EDITS`]). Gated behind the `8s are Wild` option.
 pub fn apply_w8_canoe_and_paths(rom: &mut Rom) {
     for &(row, col, tile) in W8_CANOE_PATH_EDITS {
-        rom.write_byte(crate::randomize::rom_data::map_tile_offset(7, row, col), tile);
+        rom.write_byte(map_tile_offset(7, row, col), tile);
     }
     // Place the W8 canoe (object ID 0x10) in map-object slot 6, floating at
     // (5,7) beside the mainland dock (5,6). Slot 6 is past the builder's army
     // sprites (slots 2-5), so the overworld writer leaves it intact. This is
     // the boat that makes the screen-0 island docks reachable in-game.
-    crate::randomize::rom_data::write_map_sprite(rom, 7, 6, 5, 7, 0x10);
+    write_map_sprite(rom, 7, 6, 5, 7, 0x10);
 }
 
 /// Add extra hammer-breakable rocks (the `More hammer rocks` option).
@@ -121,7 +122,7 @@ pub fn apply_w8_canoe_and_paths(rom: &mut Rom) {
 ///   independently of the `8s are Wild` option.
 pub fn make_hammer_rocks(rom: &mut Rom) {
     rom.write_byte(W1_HAMMER_ROCK_OFFSET, 0x51);
-    rom.write_byte(crate::randomize::rom_data::map_tile_offset(7, 3, 37), 0x51);
+    rom.write_byte(map_tile_offset(7, 3, 37), 0x51);
 }
 
 /// Remove N-card (N-Spade) panels from the overworld map.
@@ -169,7 +170,7 @@ mod tests {
         assert_eq!(rom.read_byte(W1_HAMMER_ROCK_OFFSET), 0x51);
         // W8 (3,37) screen-2 rock.
         assert_eq!(
-            rom.read_byte(crate::randomize::rom_data::map_tile_offset(7, 3, 37)),
+            rom.read_byte(map_tile_offset(7, 3, 37)),
             0x51
         );
     }

--- a/src/randomize/qol/starting_state.rs
+++ b/src/randomize/qol/starting_state.rs
@@ -18,26 +18,27 @@ pub fn set_starting_lives(rom: &mut Rom, lives: u8) {
 
 /// Write starting items into Mario's inventory via a trampoline in PRG031.
 ///
-/// Replaces the 8-byte lives init at 0x308E0 with `JSR $E250` into a
-/// routine that sets lives, does the intro skip, queues the seeded menu
-/// music, AND writes up to 3 items to inventory ($7D80+). Must run AFTER
-/// title_screen (which hooks the same region for intro skip) — this
-/// trampoline incorporates that behavior.
+/// Replaces the 8-byte lives init at 0x308E0 with `JSR $E250`
+/// (FS_STARTING_ITEMS) into a routine that sets lives, does the intro skip,
+/// queues the seeded menu music, AND writes up to 3 items to inventory
+/// ($7D80+).
+///
+/// Must run AFTER title_screen: both patch the lives-init region, and this
+/// JSR overwrites title_screen's intro-skip hook at 0x308E2. The trampoline
+/// replays the identical intro-skip + menu-music bytes (shared
+/// `title_screen::intro_skip_music_bytes`), so behavior is preserved;
+/// title_screen's FS_INTRO_SKIP routine is left in ROM unreferenced.
 pub fn write_starting_items(rom: &mut Rom, seed: u64, lives: u8, items: &[u8]) {
     let lives = lives.clamp(1, 99);
-    let music = crate::randomize::title_screen::pick_menu_music(seed);
+    let cpu = crate::randomize::rom_data::prg031_file_to_cpu(FS_STARTING_ITEMS); // $E250
     // Build trampoline: lives init + intro skip + menu music + item writes + RTS
-    // CPU $E250 = file FS_STARTING_ITEMS
     let mut buf = Vec::with_capacity(33);
     buf.extend_from_slice(&[
         0xA9, lives,         // LDA #lives
         0x8D, 0x36, 0x07,    // STA $0736
         0x8D, 0x37, 0x07,    // STA $0737
-        0xA9, 0x06,          // LDA #$06       (Title_State = IntroSkip)
-        0x85, 0xDE,          // STA $DE
-        0xA9, music,         // LDA #music
-        0x8D, 0xF5, 0x04,    // STA $04F5      (queue menu music)
     ]);
+    buf.extend_from_slice(&crate::randomize::title_screen::intro_skip_music_bytes(seed));
     for (i, &item) in items.iter().take(3).enumerate() {
         buf.extend_from_slice(&[
             0xA9, item,                      // LDA #item
@@ -47,9 +48,10 @@ pub fn write_starting_items(rom: &mut Rom, seed: u64, lives: u8, items: &[u8]) {
     buf.push(0x60); // RTS
     rom.write_range(FS_STARTING_ITEMS, &buf);
 
-    // Patch lives init: JSR $E250 + NOP×5
+    // Patch lives init: JSR $E250 + NOP×5 (overwrites the title_screen
+    // intro-skip hook at 0x308E2 — see the doc comment above).
     rom.write_range(LIVES_INIT_BASE, &[
-        0x20, 0x50, 0xE2,                    // JSR $E250
+        0x20, cpu as u8, (cpu >> 8) as u8,   // JSR $E250
         0xEA, 0xEA, 0xEA, 0xEA, 0xEA,       // NOP ×5
     ]);
 }

--- a/src/randomize/rom_data/access.rs
+++ b/src/randomize/rom_data/access.rs
@@ -63,8 +63,14 @@ pub(crate) fn prg_bank_cpu_to_file(bank: usize, cpu_addr: u16) -> usize {
 
 /// Inverse of [`prg_bank_cpu_to_file`]: file offset within an $A000-window
 /// bank back to its CPU address.
-pub(crate) fn prg_bank_file_to_cpu(bank: usize, file_offset: usize) -> u16 {
+pub(crate) const fn prg_bank_file_to_cpu(bank: usize, file_offset: usize) -> u16 {
     (0xA000 + (file_offset - bank * 0x2000 - 0x10)) as u16
+}
+
+/// Convert a file offset in PRG031 (the MMC3 fixed bank, always mapped at
+/// $E000-$FFFF, file 0x3E010) to its CPU address.
+pub(crate) const fn prg031_file_to_cpu(file_offset: usize) -> u16 {
+    (0xE000 + (file_offset - 0x3E010)) as u16
 }
 
 /// Build a 3-byte `JSR <target>` where `target` is given as a *file offset*
@@ -293,20 +299,26 @@ pub(crate) fn write_map_sprite(
     rom.write_byte(id_off, id);
 }
 
-/// Read the grid positions of all active floating sprites for a world.
-///
-/// Each world has up to 9 map object slots. A slot with ID $FF is unused.
-/// For active slots, we convert pixel coordinates back to grid positions.
-/// These are the positions where floating sprites sit (hammer bros, piranhas,
-/// W8 hand traps, etc.) and should not have level/fort tiles placed under them.
-pub(crate) fn read_map_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usize, usize)> {
+/// True if a map-object slot id is a Hammer Bro sprite (0x03–0x06).
+pub(crate) fn is_hb_sprite_id(id: u8) -> bool {
+    (0x03..=0x06).contains(&id)
+}
+
+/// Read the grid positions of map-object sprites whose slot id satisfies
+/// `pred`. Pixel coordinates are converted back to grid positions (reverse of
+/// Grid→pixel: Y=(row+2)*16, XHi=col/16, XLo=(col%16)*16); slots whose Y would
+/// put the row below 0 are skipped as invalid.
+fn read_sprite_positions(
+    rom: &Rom,
+    world_idx: usize,
+    pred: impl Fn(u8) -> bool,
+) -> Vec<(usize, usize)> {
     let mut positions = Vec::new();
 
     for slot in 0..9 {
         let id_off = map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot);
-        let id = rom.read_byte(id_off);
-        if id == 0xFF {
-            continue; // unused slot
+        if !pred(rom.read_byte(id_off)) {
+            continue;
         }
 
         let y_off = map_obj_slot_offset(rom, MAP_OBJ_YS_MASTER, world_idx, slot);
@@ -317,7 +329,6 @@ pub(crate) fn read_map_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usi
         let xhi = rom.read_byte(xhi_off) as usize;
         let xlo = rom.read_byte(xlo_off) as usize;
 
-        // Reverse of Grid→pixel: Y=(row+2)*16, XHi=col/16, XLo=(col%16)*16
         if y < 32 {
             continue; // invalid (row would be negative)
         }
@@ -330,38 +341,21 @@ pub(crate) fn read_map_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usi
     positions
 }
 
+/// Read the grid positions of all active floating sprites for a world.
+///
+/// Each world has up to 9 map object slots. A slot with ID $FF is unused.
+/// These are the positions where floating sprites sit (hammer bros, piranhas,
+/// W8 hand traps, etc.) and should not have level/fort tiles placed under them.
+pub(crate) fn read_map_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usize, usize)> {
+    read_sprite_positions(rom, world_idx, |id| id != 0xFF)
+}
+
 /// Read grid positions of hammer bro sprites only (IDs 0x03–0x06).
 ///
 /// These positions need HB level pointer entries even though they are excluded
 /// from level/fort/pipe placement by `fixed_positions`.
 pub(crate) fn read_hb_sprite_positions(rom: &Rom, world_idx: usize) -> Vec<(usize, usize)> {
-    let mut positions = Vec::new();
-
-    for slot in 0..9 {
-        let id_off = map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot);
-        let id = rom.read_byte(id_off);
-        if !(0x03..=0x06).contains(&id) {
-            continue;
-        }
-
-        let y_off = map_obj_slot_offset(rom, MAP_OBJ_YS_MASTER, world_idx, slot);
-        let xhi_off = map_obj_slot_offset(rom, MAP_OBJ_XHIS_MASTER, world_idx, slot);
-        let xlo_off = map_obj_slot_offset(rom, MAP_OBJ_XLOS_MASTER, world_idx, slot);
-
-        let y = rom.read_byte(y_off) as usize;
-        let xhi = rom.read_byte(xhi_off) as usize;
-        let xlo = rom.read_byte(xlo_off) as usize;
-
-        if y < 32 {
-            continue;
-        }
-        let row = (y / 16).saturating_sub(2);
-        let col = xhi * 16 + xlo / 16;
-
-        positions.push((row, col));
-    }
-
-    positions
+    read_sprite_positions(rom, world_idx, is_hb_sprite_id)
 }
 
 /// Map-object reward item table (Global Item IDs). A flat 9-bytes-per-world
@@ -376,19 +370,24 @@ pub(crate) fn map_obj_reward_offset(world_idx: usize, slot: usize) -> usize {
     MAP_OBJ_REWARDS + world_idx * 9 + slot
 }
 
+/// First map-object slot usable for sprite placement in a world. Slot 0
+/// always holds a fixed non-HB marker (`id 0x01`) and is reserved; slot 1
+/// (the airship sprite slot) is reserved in W1-W7 but usable in W8, which has
+/// no airship.
+pub(crate) fn first_usable_map_obj_slot(world_idx: usize) -> usize {
+    if world_idx == W8_IDX { 1 } else { 2 }
+}
+
 /// Map-object slot indices that can host a redistributed Hammer Bro sprite in
-/// this world. Slot 0 always holds a fixed non-HB marker (`id 0x01`) and is
-/// reserved; slot 1 (the airship sprite slot) is reserved in W1-W7 but usable
-/// in W8, which has no airship. A slot qualifies if it is empty (`0x00`) or
-/// currently holds a Hammer Bro (`0x03-0x06`, which redistribution clears) — so
-/// the result is identical before and after [`clear_hb_sprites`].
+/// this world (see [`first_usable_map_obj_slot`] for the reserved low slots).
+/// A slot qualifies if it is empty (`0x00`) or currently holds a Hammer Bro
+/// (`0x03-0x06`, which redistribution clears) — so the result is identical
+/// before and after [`clear_hb_sprites`].
 pub(crate) fn eligible_hb_map_slots(rom: &Rom, world_idx: usize) -> Vec<usize> {
-    const W8: usize = 7;
-    let first = if world_idx == W8 { 1 } else { 2 };
-    (first..9)
+    (first_usable_map_obj_slot(world_idx)..9)
         .filter(|&slot| {
             let id = rom.read_byte(map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot));
-            id == 0x00 || (0x03..=0x06).contains(&id)
+            id == 0x00 || is_hb_sprite_id(id)
         })
         .collect()
 }
@@ -401,7 +400,7 @@ pub(crate) fn collect_hb_sprite_rewards(rom: &Rom) -> Vec<u8> {
     for world_idx in 0..8 {
         for slot in 0..9 {
             let id = rom.read_byte(map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot));
-            if (0x03..=0x06).contains(&id) {
+            if is_hb_sprite_id(id) {
                 rewards.push(rom.read_byte(map_obj_reward_offset(world_idx, slot)));
             }
         }
@@ -415,12 +414,8 @@ pub(crate) fn collect_hb_sprite_rewards(rom: &Rom) -> Vec<u8> {
 pub(crate) fn clear_hb_sprites(rom: &mut Rom, world_idx: usize) {
     for slot in 0..9 {
         let id_off = map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot);
-        if (0x03..=0x06).contains(&rom.read_byte(id_off)) {
-            rom.write_byte(id_off, 0x00);
-            rom.write_byte(map_obj_slot_offset(rom, MAP_OBJ_YS_MASTER, world_idx, slot), 0);
-            rom.write_byte(map_obj_slot_offset(rom, MAP_OBJ_XHIS_MASTER, world_idx, slot), 0);
-            rom.write_byte(map_obj_slot_offset(rom, MAP_OBJ_XLOS_MASTER, world_idx, slot), 0);
-            rom.write_byte(map_obj_reward_offset(world_idx, slot), 0);
+        if is_hb_sprite_id(rom.read_byte(id_off)) {
+            clear_map_sprite(rom, world_idx, slot);
         }
     }
 }
@@ -430,9 +425,7 @@ pub(crate) fn clear_hb_sprites(rom: &mut Rom, world_idx: usize) {
 /// writer (which fills eligible slots from the bottom) and the reserved
 /// dynamic-spawn buffer.
 pub(crate) fn last_empty_map_obj_slot(rom: &Rom, world_idx: usize) -> Option<usize> {
-    const W8: usize = 7;
-    let first = if world_idx == W8 { 1 } else { 2 };
-    (first..9).rev().find(|&slot| {
+    (first_usable_map_obj_slot(world_idx)..9).rev().find(|&slot| {
         rom.read_byte(map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot)) == 0x00
     })
 }

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -11,14 +11,14 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     // PRG031 (always mapped $E000–$FFFF, file 0x3E010)
     (0x3E924, 25, "title_screen: sprite copy routine"),
     (0x3E93D, 40, "title_screen: sprite data table"),
-    (0x35572, 13, "mystery_anchor: item redirect trampoline"),
-    (0x3557F, 50, "hammer_locks: tile check subroutine + tables"),
     (0x3E260, 33, "starting_items: lives + intro skip + menu music + inventory init trampoline"),
     (0x3E281, 69, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + Map_Init seed helper"),
     (0x3E965, 13, "title_screen: intro skip + menu music routine"),
     (0x3FFF0, 26, "card_speed_clear: XOR trampoline"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
     (0x35530, 66, "big_q_block: lookup routine + tables"),
+    (0x35572, 13, "mystery_anchor: item redirect trampoline"),
+    (0x3557F, 50, "hammer_locks: tile check subroutine + tables"),
     (0x355B1, 12, "anchor_visuals: items-vs-cards index guard trampoline"),
     // PRG027 (file 0x36010, CPU $A000–$BFFF)
     (0x379D9, 894, "king_quotes: 7 quotes + hook (7×120 + 54)"),
@@ -67,6 +67,8 @@ pub(crate) const FS_SEED_HASH_DATA: usize    = 0x3E93D; // 40 bytes
 pub(crate) const FS_INTRO_SKIP: usize        = 0x3E965; // 13 bytes
 
 pub(crate) const FS_CARD_CLEAR: usize        = 0x3FFF0; // 26 bytes
+
+pub(crate) const FS_STARTING_ITEMS: usize    = 0x3E260; // 33 bytes
 
 // PRG031 — start_airship_swap engine scaffolding. One ~69-byte block: 4 × 8-byte
 // per-world tables followed by a single assembled seed subroutine. PRG031 is
@@ -140,12 +142,12 @@ pub(crate) const FS_FX_SCREEN_CHECK: usize   = 0x15554; // 80 bytes (Fred's algo
 pub(crate) const FS_CANOE_RESPAWN: usize     = 0x15DF0; // 35 bytes
 
 // PRG011
-pub(crate) const FS_CANOE_BACKUP: usize      = 0x17D00; // 59 bytes
+pub(crate) const FS_CANOE_BACKUP: usize      = 0x17D00; // 66 bytes
 
 // 8-byte hand-trap bypass subroutine for the overworld bro movement gate
-// (MaCobra52's "Bros don't stop on hands"). CPU $BD42. Sits just past the
+// (MaCobra52's "Bros don't stop on hands"). CPU $BD32. Sits just past the
 // 66-byte FS_CANOE_BACKUP reservation; the gate hook at $B425 JSRs here.
-pub(crate) const FS_BROS_NO_HANDS: usize     = 0x17D42; // 8 bytes (CPU $BD42)
+pub(crate) const FS_BROS_NO_HANDS: usize     = 0x17D42; // 8 bytes (CPU $BD32)
 
 // PRG026 (cont.)
 pub(crate) const FS_MYSTERY_ANCHOR: usize    = 0x35572; // 13 bytes
@@ -153,8 +155,6 @@ pub(crate) const FS_MYSTERY_ANCHOR: usize    = 0x35572; // 13 bytes
 pub(crate) const FS_HAMMER_LOCKS: usize      = 0x3557F; // 50 bytes
 
 pub(crate) const FS_ANCHOR_ITEM_GUARD: usize = 0x355B1; // 12 bytes (CPU $B5A1)
-
-pub(crate) const FS_STARTING_ITEMS: usize    = 0x3E260; // 33 bytes
 
 // PRG001 (file 0x02010, CPU $A000–$BFFF)
 // Koopaling stomp handler is ObjHit_Koopaling in prg001.asm (southbird disassembly).
@@ -261,23 +261,63 @@ mod free_space_tests {
     #[test]
     fn test_free_space_constants_match_registry() {
         let offsets: Vec<usize> = FREE_SPACE_ALLOCATIONS.iter().map(|&(o, _, _)| o).collect();
-        assert!(offsets.contains(&FS_WORLD_ORDER));
-        assert!(offsets.contains(&FS_BIG_Q_SAVE));
-        assert!(offsets.contains(&FS_SEED_HASH_ROUTINE));
-        assert!(offsets.contains(&FS_SEED_HASH_DATA));
-        assert!(offsets.contains(&FS_INTRO_SKIP));
-        assert!(offsets.contains(&FS_CARD_CLEAR));
-        assert!(offsets.contains(&FS_BIG_Q_LOOKUP));
-        assert!(offsets.contains(&FS_KING_QUOTES));
-        assert!(offsets.contains(&FS_FX_SCREEN_CHECK));
-        assert!(offsets.contains(&FS_CANOE_RESPAWN));
-        assert!(offsets.contains(&FS_CANOE_BACKUP));
-        assert!(offsets.contains(&FS_KOOPA_HITS_SUB));
-        assert!(offsets.contains(&FS_BOOMBOOM_HITS_TABLE));
-        assert!(offsets.contains(&FS_BOOMBOOM_HITS_SUB));
-        assert!(offsets.contains(&FS_STARTING_ITEMS));
-        assert!(offsets.contains(&FS_MYSTERY_ANCHOR));
-        assert!(offsets.contains(&FS_HAMMER_LOCKS));
+        // Every FS_* constant that names a whole allocation must be a
+        // registry row. This list is exhaustive — add new FS_* consts here.
+        for &(off, name) in &[
+            (FS_WORLD_ORDER, "FS_WORLD_ORDER"),
+            (FS_BIG_Q_SAVE, "FS_BIG_Q_SAVE"),
+            (FS_SEED_HASH_ROUTINE, "FS_SEED_HASH_ROUTINE"),
+            (FS_SEED_HASH_DATA, "FS_SEED_HASH_DATA"),
+            (FS_INTRO_SKIP, "FS_INTRO_SKIP"),
+            (FS_CARD_CLEAR, "FS_CARD_CLEAR"),
+            (FS_STARTING_ITEMS, "FS_STARTING_ITEMS"),
+            (FS_SAS_BLOCK, "FS_SAS_BLOCK"),
+            (FS_SAS_GAMEOVER_FINALIZE, "FS_SAS_GAMEOVER_FINALIZE"),
+            (FS_BIG_Q_LOOKUP, "FS_BIG_Q_LOOKUP"),
+            (FS_MYSTERY_ANCHOR, "FS_MYSTERY_ANCHOR"),
+            (FS_HAMMER_LOCKS, "FS_HAMMER_LOCKS"),
+            (FS_ANCHOR_ITEM_GUARD, "FS_ANCHOR_ITEM_GUARD"),
+            (FS_KING_QUOTES, "FS_KING_QUOTES"),
+            (FS_FX_SCREEN_CHECK, "FS_FX_SCREEN_CHECK"),
+            (FS_CANOE_RESPAWN, "FS_CANOE_RESPAWN"),
+            (FS_CANOE_BACKUP, "FS_CANOE_BACKUP"),
+            (FS_BROS_NO_HANDS, "FS_BROS_NO_HANDS"),
+            (FS_KOOPA_HITS_SUB, "FS_KOOPA_HITS_SUB"),
+            (FS_KOOPA_COLLISION_GUARD, "FS_KOOPA_COLLISION_GUARD"),
+            (FS_KOOPA_VRAM_CLEAR, "FS_KOOPA_VRAM_CLEAR"),
+            (FS_KOOPA_FIRE_PRESET, "FS_KOOPA_FIRE_PRESET"),
+            (FS_KOOPA_Y_CLAMP, "FS_KOOPA_Y_CLAMP"),
+            (FS_FIRE_FLOWER, "FS_FIRE_FLOWER"),
+            (FS_BOOMBOOM_HITS_TABLE, "FS_BOOMBOOM_HITS_TABLE"),
+            (FS_BOOMBOOM_HITS_SUB, "FS_BOOMBOOM_HITS_SUB"),
+            (FS_HAND_ROOMS, "FS_HAND_ROOMS"),
+            (FS_PIRANHA_ROOMS, "FS_PIRANHA_ROOMS"),
+            (FS_FASTER_FROG, "FS_FASTER_FROG"),
+            (FS_HOLD_LEFT_HELPER, "FS_HOLD_LEFT_HELPER"),
+        ] {
+            assert!(
+                offsets.contains(&off),
+                "{name} (0x{off:05X}) missing from FREE_SPACE_ALLOCATIONS"
+            );
+        }
+        // Interior offsets (sub-tables inside a parent allocation) must fall
+        // within some registry row.
+        let covered = |o: usize| {
+            FREE_SPACE_ALLOCATIONS.iter().any(|&(ro, rs, _)| o >= ro && o < ro + rs)
+        };
+        for &(off, name) in &[
+            (FS_SAS_X_TABLE, "FS_SAS_X_TABLE"),
+            (FS_SAS_XHI_TABLE, "FS_SAS_XHI_TABLE"),
+            (FS_SAS_SCRL_TABLE, "FS_SAS_SCRL_TABLE"),
+            (FS_SAS_SCRH_TABLE, "FS_SAS_SCRH_TABLE"),
+            (FS_SAS_SEED_HELPER, "FS_SAS_SEED_HELPER"),
+            (FS_KOOPA_HITS_TABLE, "FS_KOOPA_HITS_TABLE"),
+        ] {
+            assert!(
+                covered(off),
+                "{name} (0x{off:05X}) not covered by any FREE_SPACE_ALLOCATIONS row"
+            );
+        }
     }
 
     // Ground-truth pins for the PRG bank ↔ file-offset mapping. Each pair is a

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -52,6 +52,11 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
 // PRG030
 pub(crate) const FS_WORLD_ORDER: usize       = 0x3DF20; // 28 bytes
 
+/// CPU address of the world-order routine: $8000 + (0x3DF20 - 0x3C010) = $9F10.
+/// PRG030 is the MMC3 fixed bank at $8000-$9FFF (file 0x3C010), so
+/// `prg_bank_file_to_cpu` (which assumes the $A000 window) does not apply.
+pub(crate) const WORLD_ORDER_CPU: u16        = 0x9F10;
+
 pub(crate) const FS_BIG_Q_SAVE: usize        = 0x3DF3C; // 20 bytes
 
 // PRG031

--- a/src/randomize/rom_data/grid.rs
+++ b/src/randomize/rom_data/grid.rs
@@ -6,7 +6,6 @@ use super::*;
 #[derive(Clone, Debug)]
 pub(crate) struct Grid {
     pub tiles: Vec<Vec<u8>>,
-    pub rows: usize,
     pub cols: usize,
     /// Whether `8s are Wild` is active for this run. Rides on the grid so the
     /// map walker and builder can resolve the active canoe edges (via
@@ -26,6 +25,11 @@ impl Grid {
         self.tiles[row][col] = tile;
     }
 
+    /// Row count — every overworld grid has exactly [`ROWS`] rows; only the
+    /// column count varies per world.
+    pub fn rows(&self) -> usize {
+        ROWS
+    }
 }
 
 /// Read a world's tile grid from ROM as a mutable Grid. The grid is born with
@@ -48,12 +52,12 @@ pub(crate) fn read_tile_grid(rom: &Rom, world_idx: usize) -> Grid {
         tiles.push(row);
     }
 
-    Grid { tiles, rows: ROWS, cols, eights_are_wild: false }
+    Grid { tiles, cols, eights_are_wild: false }
 }
 
 /// Find the START tile position in a grid.
 pub(crate) fn find_start(grid: &Grid) -> Option<(usize, usize)> {
-    for r in 0..grid.rows {
+    for r in 0..grid.rows() {
         for c in 0..grid.cols {
             if grid.get(r, c) == TILE_START {
                 return Some((r, c));

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -653,3 +653,53 @@ pub(crate) struct FxSlot {
     pub grid_col: usize,
     pub replace_tile: u8,
 }
+
+#[cfg(test)]
+mod fortress_table_tests {
+    use super::*;
+    use crate::randomize::rom_data::read_entry;
+    use crate::rom::Rom;
+
+    /// FORTRESS_ENTRIES, BOOMBOOM_Y_OFFSETS, and VANILLA_FORTRESS_OBJ_PTRS are
+    /// three parallel arrays held in the same order (per-fortress). This guard
+    /// pins the invariants their consumers rely on.
+    #[test]
+    fn fortress_parallel_tables_stay_in_sync() {
+        assert_eq!(FORTRESS_ENTRIES.len(), BOOMBOOM_Y_OFFSETS.len());
+        assert_eq!(FORTRESS_ENTRIES.len(), VANILLA_FORTRESS_OBJ_PTRS.len());
+
+        // boomboom_y_offset_for_obj keys the pairing on the obj_ptr, so a
+        // duplicate obj_ptr would silently shadow a later fortress.
+        for (i, a) in VANILLA_FORTRESS_OBJ_PTRS.iter().enumerate() {
+            assert!(
+                !VANILLA_FORTRESS_OBJ_PTRS[i + 1..].contains(a),
+                "duplicate fortress obj_ptr {a:#06X}"
+            );
+        }
+
+        // Cross-check the shared ordering against the real ROM: the pointer
+        // table entry at FORTRESS_ENTRIES[i] must hold obj_ptr
+        // VANILLA_FORTRESS_OBJ_PTRS[i], and BOOMBOOM_Y_OFFSETS[i] must point
+        // at the Y byte of a Boom-Boom enemy entry ([id, x, y]).
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            return; // Base ROM not present (e.g. CI) — skip.
+        };
+        let rom = Rom::from_bytes(&bytes).unwrap();
+        for (i, &(w, e)) in FORTRESS_ENTRIES.iter().enumerate() {
+            let entry = read_entry(&rom, &WORLDS[w], e);
+            let obj_ptr = ((entry.obj_hi as u16) << 8) | entry.obj_lo as u16;
+            assert_eq!(
+                obj_ptr, VANILLA_FORTRESS_OBJ_PTRS[i],
+                "fortress {i} (W{}[{e}]): obj_ptr mismatch",
+                w + 1
+            );
+            // Boom-Boom object ids: 0x4A Q-ball, 0x4B jump, 0x4C fly (see tools/rom_map.py BOOMBOOM_IDS).
+            let id = rom.read_byte(BOOMBOOM_Y_OFFSETS[i] - 2);
+            assert!(
+                (0x4A..=0x4C).contains(&id),
+                "fortress {i} (W{}[{e}]): byte at BOOMBOOM_Y_OFFSETS[{i}]-2 is {id:#04X}, not a Boom-Boom id",
+                w + 1
+            );
+        }
+    }
+}

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -99,6 +99,21 @@ pub(crate) struct LevelDataRegion {
     pub randomize_note_wood: bool,
 }
 
+impl LevelDataRegion {
+    /// Size in bytes of the generator command whose first and third stream
+    /// bytes are `b0`/`b2`: 3 normally, 4 when the tileset's variable-size
+    /// dispatch reads an extra byte. Every level-stream walker (powerups,
+    /// enemy entry points) must step with this — a re-derived copy of the
+    /// formula is how parsers drift out of alignment.
+    pub fn command_size(&self, b0: u8, b2: u8) -> usize {
+        if (b2 & 0xF0) == 0 {
+            return 3; // fixed-size generator
+        }
+        let dispatch = (b0 >> 5) as usize * 15 + ((b2 >> 4) as usize) - 1;
+        if self.extra_byte_dispatches.contains(&(dispatch as u8)) { 4 } else { 3 }
+    }
+}
+
 /// Level data regions by tileset (file offset ranges + extra-byte dispatch info).
 pub(crate) const LEVEL_DATA_REGIONS: &[LevelDataRegion] = &[
     LevelDataRegion { // Underground (TS14) — same dispatch table as TS3

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -223,6 +223,11 @@ pub(crate) const TILE_PIPE: u8 = 0xBC;
 #[allow(dead_code)]
 pub(crate) const TILE_FORTRESS: u8 = 0x67;
 
+/// All map tiles the game treats as fortresses ($67, $EB, $6A —
+/// Map_Removable_Tiles + completion-unsafe). $6A's CHR animation is frozen
+/// by `patch_metatile_6a_freeze` so it can serve as a static variant.
+pub(crate) const FORTRESS_TILES: [u8; 3] = [TILE_FORTRESS, 0xEB, 0x6A];
+
 /// Airship dock tile ID.
 pub(crate) const TILE_AIRSHIP: u8 = 0xC9;
 
@@ -245,6 +250,11 @@ pub(crate) const TILE_NODE: u8 = 0x47;
 
 /// Number of rows in every overworld map.
 pub(crate) const ROWS: usize = 9;
+
+/// File offset where PRG012 begins. PRG012 is loaded at CPU $A000-$BFFF
+/// during the map screen; file offset = 0x18010 + (cpu_addr - 0xA000).
+/// Holds the map metatile quadrant tables and the InitIndex master table.
+pub(crate) const PRG012_FILE_BASE: usize = 0x18010;
 
 // Pipe destination tables (PRG002)
 pub(crate) const PIPE_MAP_XHI: usize = 0x046AA;
@@ -309,6 +319,12 @@ pub(crate) fn is_chest_level(world_idx: usize, entry_idx: usize) -> bool {
     CHEST_LEVELS
         .iter()
         .any(|&(w, e, _)| w == world_idx && e == entry_idx)
+}
+
+/// True if the given vanilla `(world_idx, entry_idx)` is a W8 hand level
+/// (8-Hnd1/2/3) — the short item-drop bonus rooms behind the hand traps.
+pub(crate) fn is_hand_level(world_idx: usize, entry_idx: usize) -> bool {
+    world_idx == 7 && (14..=16).contains(&entry_idx)
 }
 
 /// Destination byte → world index (0-based). Only paired pipe destinations.

--- a/src/randomize/segment_writer.rs
+++ b/src/randomize/segment_writer.rs
@@ -193,11 +193,14 @@ pub fn walk_segments(
         let mut count = 0;
         let mut terminated = false;
         while i < end {
-            // Treat entering a skip range mid-segment as if we hit the
-            // segment's terminator. The skip range starts on a boundary
-            // a level loader would also treat as a stop (it covers
-            // bytes a per-level loader would not read), so cutting the
-            // segment there matches loader semantics.
+            // Running into a skip range mid-segment leaves `terminated`
+            // false, so the segment is dropped and the walk ends (the
+            // `!terminated` break below). In practice this never fires:
+            // every SPOILED_SEGMENT_RANGES entry starts at a segment
+            // boundary (leading $FF / page byte — see its doc), so ranges
+            // are consumed whole by the outer-loop skip. This check is a
+            // backstop so a mis-specified range can't yield a segment
+            // built from spoiled bytes.
             if in_skip(i).is_some() {
                 break;
             }

--- a/src/randomize/start_airship_swap.rs
+++ b/src/randomize/start_airship_swap.rs
@@ -32,6 +32,11 @@ use super::rom_data::{
     MAP_INIT_SCROLL_SITE, MAP_TILE_GRIDS, MAP_Y_STARTS_OFF, WORLDS,
 };
 
+/// World index of W5 (Sky), the one world with special-case handling: its
+/// vanilla start is approached from above (no castle-top write) and its map
+/// presents two static screens (page-aligned camera framing).
+const W5_IDX: usize = 4;
+
 // ---------------------------------------------------------------------------
 // Phase 1: catalog mutation
 // ---------------------------------------------------------------------------
@@ -90,9 +95,9 @@ pub(super) fn swap_tiles_above(grid: &mut Grid, world_idx: usize, catalog: &Node
         .world(world_idx)
         .find(|e| matches!(e.kind, NodeKind::Start))
     else { return };
-    let (sr, sc) = airship_entry.grid_pos;
-    let (ar, ac) = start_entry.grid_pos;
-    if sr == 0 || ar == 0 {
+    let (old_start_r, old_start_c) = airship_entry.grid_pos;
+    let (old_airship_r, old_airship_c) = start_entry.grid_pos;
+    if old_start_r == 0 || old_airship_r == 0 {
         return;
     }
     // The tile directly above the vanilla airship (`0xC8`, the castle's top
@@ -107,14 +112,14 @@ pub(super) fn swap_tiles_above(grid: &mut Grid, world_idx: usize, catalog: &Node
     // start position, that water square dangles above the relocated start
     // tile in the middle of land/sky, which looks wrong. Substitute a
     // per-world background tile in those cases.
-    let above_old_airship = grid.get(ar - 1, ac);
+    let above_old_airship = grid.get(old_airship_r - 1, old_airship_c);
     let above_for_new_start = match above_start_override(world_idx) {
         Some(t) => t,
-        None => grid.get(sr - 1, sc),
+        None => grid.get(old_start_r - 1, old_start_c),
     };
-    grid.set(ar - 1, ac, above_for_new_start);
-    if world_idx != 4 {
-        grid.set(sr - 1, sc, above_old_airship);
+    grid.set(old_airship_r - 1, old_airship_c, above_for_new_start);
+    if world_idx != W5_IDX {
+        grid.set(old_start_r - 1, old_start_c, above_old_airship);
     }
 }
 
@@ -123,8 +128,8 @@ pub(super) fn swap_tiles_above(grid: &mut Grid, world_idx: usize, catalog: &Node
 /// water override to a generic land/sky blank.
 fn above_start_override(world_idx: usize) -> Option<u8> {
     match world_idx {
-        3 | 6 => Some(0x42), // W4 / W7 — land path blank
-        4 => Some(0xD7),     // W5 — sky blank
+        3 | 6 => Some(0x42),    // W4 / W7 — land path blank
+        W5_IDX => Some(0xD7),   // W5 — sky blank
         _ => None,
     }
 }
@@ -184,6 +189,16 @@ pub(super) fn write_swapped_world_entries(rom: &mut Rom, world_idx: usize, catal
 ///     the spiral lands on the per-world start instead of vanilla column 2
 ///   * Per-swapped-world `Map_Object` slot-1 sprite position move
 pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
+    build_position_tables(rom, catalog);
+    write_seed_helper(rom);
+    write_gameover_finalize(rom);
+    move_airship_sprites(rom, catalog);
+}
+
+/// Build and write the four per-world position tables (X/XHi/ScrL/ScrH) in
+/// PRG031 free space plus the vanilla `Map_Y_Starts` table, all derived from
+/// the catalog's (possibly swapped) Start positions.
+fn build_position_tables(rom: &mut Rom, catalog: &NodeCatalog) {
     let mut y_tbl = [0u8; 8];
     let mut x_tbl = [0u8; 8];
     let mut xhi_tbl = [0u8; 8];
@@ -209,7 +224,7 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
         // collapses to 0 regardless.) Page-0 / unswapped starts collapse to column 0
         // in either branch (identical to vanilla).
         let cols = MAP_TILE_GRIDS[wi].columns as i32;
-        let col = if wi == 4 {
+        let col = if wi == W5_IDX {
             (sc as i32 / 16) * 16 // W5: page-align to the start's static screen
         } else {
             (((sc as i32 - 8) + 4).max(0) / 8) * 8 // round-to-8, floored at 0
@@ -225,7 +240,11 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
     rom.write_range(FS_SAS_XHI_TABLE, &xhi_tbl);
     rom.write_range(FS_SAS_SCRL_TABLE, &scrl_tbl);
     rom.write_range(FS_SAS_SCRH_TABLE, &scrh_tbl);
+}
 
+/// Write the PRG031 Map_Init seed subroutine and replace the vanilla
+/// `Map_Init` scroll-store with a `JSR` to it.
+fn write_seed_helper(rom: &mut Rom) {
     rom.set_tag("start_airship_swap/helper");
     let x_tbl_cpu = file_to_prg031_cpu(FS_SAS_X_TABLE);
     let xhi_tbl_cpu = file_to_prg031_cpu(FS_SAS_XHI_TABLE);
@@ -269,7 +288,15 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
         MAP_INIT_SCROLL_SITE,
         &[0x20, (seed_helper_cpu & 0xFF) as u8, (seed_helper_cpu >> 8) as u8],
     );
+}
 
+/// Write the PRG011 game-over twirl finalize subroutine and hook it into
+/// `GameOver_TwirlToStart`.
+fn write_gameover_finalize(rom: &mut Rom) {
+    let x_tbl_cpu = file_to_prg031_cpu(FS_SAS_X_TABLE);
+    let xhi_tbl_cpu = file_to_prg031_cpu(FS_SAS_XHI_TABLE);
+    let scrl_tbl_cpu = file_to_prg031_cpu(FS_SAS_SCRL_TABLE);
+    let scrh_tbl_cpu = file_to_prg031_cpu(FS_SAS_SCRH_TABLE);
     // GameOver_TwirlToStart spirals Mario back to the start via a per-frame X/Y
     // delta, then at finalize copies World_Map_X/XHi/Y into Map_Previous_*. The
     // delta is low-byte/within-screen only (and uses a second hardcoded column-2
@@ -328,7 +355,11 @@ pub(crate) fn write_engine_scaffolding(rom: &mut Rom, catalog: &NodeCatalog) {
         GAMEOVER_FINALIZE_SITE,
         &[0x20, (finalize_cpu & 0xFF) as u8, (finalize_cpu >> 8) as u8],
     );
+}
 
+/// Move the `Map_Object` slot-1 airship sprite to the catalog's Airship
+/// position in each swapped world.
+fn move_airship_sprites(rom: &mut Rom, catalog: &NodeCatalog) {
     rom.set_tag("start_airship_swap/slot1");
     for wi in 0..7 {
         if !catalog.start_airship_swapped[wi] {

--- a/src/randomize/title_screen.rs
+++ b/src/randomize/title_screen.rs
@@ -33,17 +33,18 @@ const HOOK_OFFSET: usize = 0x317B1;
 
 /// PRG031 free space for the sprite copy routine — from rom_data::FS_SEED_HASH_ROUTINE.
 const ROUTINE_OFFSET: usize = super::rom_data::FS_SEED_HASH_ROUTINE;
+const ROUTINE_CPU: u16 = super::rom_data::prg031_file_to_cpu(ROUTINE_OFFSET); // $E914
 
 /// Sprite data table immediately after the routine — from rom_data::FS_SEED_HASH_DATA.
 const DATA_OFFSET: usize = super::rom_data::FS_SEED_HASH_DATA;
-const DATA_CPU_LO: u8 = 0x2D;
-const DATA_CPU_HI: u8 = 0xE9;
+const DATA_CPU: u16 = super::rom_data::prg031_file_to_cpu(DATA_OFFSET); // $E92D
 
 /// Skip the title screen intro cutscene by setting Title_State = 6 (IntroSkip)
 /// during init, after the zero-page clear. Title_State is at zero-page $DE.
 /// We hook STA $0736 at file 0x308E2 → JSR $E955 (free space after sprite data).
 const INTRO_SKIP_HOOK_OFFSET: usize = 0x308E2;
 const INTRO_SKIP_ROUTINE_OFFSET: usize = super::rom_data::FS_INTRO_SKIP;
+const INTRO_SKIP_CPU: u16 = super::rom_data::prg031_file_to_cpu(INTRO_SKIP_ROUTINE_OFFSET); // $E955
 
 /// Curated music tracks for the title menu. Values are written to the music
 /// change trigger at $04F5 — each one is a looping theme that fits a static
@@ -77,6 +78,19 @@ const X_RIGHT: u8 = 24;
 const Y_START: u8 = 64;
 const Y_SPACING: u8 = 24;
 
+/// Instruction bytes shared by the intro-skip routine (here) and the
+/// starting-items trampoline (`qol::starting_state`): set Title_State ($DE) =
+/// 6 (IntroSkip) and queue the seeded menu music via $04F5.
+pub(super) fn intro_skip_music_bytes(seed: u64) -> [u8; 9] {
+    let music = pick_menu_music(seed);
+    [
+        0xA9, 0x06,       // LDA #$06
+        0x85, 0xDE,       // STA $DE    (Title_State = IntroSkip)
+        0xA9, music,      // LDA #music
+        0x8D, 0xF5, 0x04, // STA $04F5  (queue menu music)
+    ]
+}
+
 /// Compute 5 icon indices and a palette choice from seed + flag bytes.
 fn compute_hash(seed: u64, options: &Options) -> ([usize; HASH_LENGTH], u8) {
     let flag_bytes = options.to_flag_bytes();
@@ -100,16 +114,14 @@ fn compute_hash(seed: u64, options: &Options) -> ([usize; HASH_LENGTH], u8) {
 /// in the top-left corner. The icons and palette are deterministically
 /// chosen from the seed and options so players can verify they share
 /// the same settings.
-pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
-    let (icons, palette) = compute_hash(seed, options);
-
-    // Build sprite data: 5 icons x 2 sprites x 4 bytes = 40 bytes.
-    // The copy routine iterates X downward in groups of 8, mapping:
-    //   data[32..39] -> OAM[0..7],  data[24..31] -> OAM[32..39],
-    //   data[16..23] -> OAM[64..71], data[8..15] -> OAM[96..103],
-    //   data[0..7]   -> OAM[128..135]
-    // We place icon 0 (topmost) in the highest data group so it lands
-    // in the lowest OAM slot (highest sprite priority).
+/// Build the 40-byte sprite data table: 5 icons x 2 sprites x 4 bytes.
+/// The copy routine iterates X downward in groups of 8, mapping:
+///   data[32..39] -> OAM[0..7],  data[24..31] -> OAM[32..39],
+///   data[16..23] -> OAM[64..71], data[8..15] -> OAM[96..103],
+///   data[0..7]   -> OAM[128..135]
+/// We place icon 0 (topmost) in the highest data group so it lands
+/// in the lowest OAM slot (highest sprite priority).
+fn build_sprite_data(icons: &[usize; HASH_LENGTH], palette: u8) -> [u8; HASH_LENGTH * 8] {
     let mut sprite_data = [0u8; HASH_LENGTH * 8];
     for i in 0..HASH_LENGTH {
         let group = HASH_LENGTH - 1 - i; // icon 0 -> group 4 (bytes 32-39)
@@ -125,6 +137,12 @@ pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
         sprite_data[base + 6] = palette | extra_attr_r;
         sprite_data[base + 7] = X_RIGHT;
     }
+    sprite_data
+}
+
+pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
+    let (icons, palette) = compute_hash(seed, options);
+    let sprite_data = build_sprite_data(&icons, palette);
 
     // ASM routine (25 bytes) at CPU $E914:
     //   LDY #$07
@@ -148,7 +166,7 @@ pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
     let routine: [u8; 25] = [
         0xA0, 0x07,                         // LDY #$07
         0xA2, (HASH_LENGTH * 8 - 1) as u8,  // LDX #$27
-        0xBD, DATA_CPU_LO, DATA_CPU_HI,     // LDA $E92D,X
+        0xBD, DATA_CPU as u8, (DATA_CPU >> 8) as u8, // LDA $E92D,X
         0x99, 0x00, 0x02,                   // STA $0200,Y
         0x8A,                                // TXA
         0x29, 0x07,                          // AND #$07
@@ -167,7 +185,7 @@ pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
     rom.write_range(DATA_OFFSET, &sprite_data);
 
     // Hook: replace JSR $B7D6 with JMP $E914 in the title screen sprite loop.
-    rom.write_range(HOOK_OFFSET, &[0x4C, 0x14, 0xE9]);
+    rom.write_range(HOOK_OFFSET, &[0x4C, ROUTINE_CPU as u8, (ROUTINE_CPU >> 8) as u8]);
 
     // Skip intro cutscene: hook STA $0736 in title screen init to also set
     // Title_State ($DE) = 6 (IntroSkip). This loads all graphics quickly and
@@ -176,17 +194,19 @@ pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
     //
     // Replace: 8D 36 07 (STA $0736) → 20 55 E9 (JSR $E955)
     // At $E955: STA $0736 / LDA #$06 / STA $DE / LDA #music / STA $04F5 / RTS
-    let music = pick_menu_music(seed);
-    rom.write_range(INTRO_SKIP_HOOK_OFFSET, &[0x20, 0x55, 0xE9]);
-    #[rustfmt::skip]
-    rom.write_range(INTRO_SKIP_ROUTINE_OFFSET, &[
-        0x8D, 0x36, 0x07, // STA $0736  (original instruction)
-        0xA9, 0x06,       // LDA #$06
-        0x85, 0xDE,       // STA $DE    (Title_State = IntroSkip)
-        0xA9, music,      // LDA #music
-        0x8D, 0xF5, 0x04, // STA $04F5  (queue menu music)
-        0x60,             // RTS
-    ]);
+    //
+    // NOTE: when starting items are enabled, `qol::write_starting_items` later
+    // overwrites the whole lives-init block at 0x308E0 (including this hook)
+    // with its own trampoline, which replays the same intro-skip + music bytes
+    // (`intro_skip_music_bytes`); the routine below is then dead but harmless.
+    rom.write_range(
+        INTRO_SKIP_HOOK_OFFSET,
+        &[0x20, INTRO_SKIP_CPU as u8, (INTRO_SKIP_CPU >> 8) as u8],
+    );
+    let mut intro_routine = vec![0x8D, 0x36, 0x07]; // STA $0736 (original instruction)
+    intro_routine.extend_from_slice(&intro_skip_music_bytes(seed));
+    intro_routine.push(0x60); // RTS
+    rom.write_range(INTRO_SKIP_ROUTINE_OFFSET, &intro_routine);
 }
 
 #[cfg(test)]
@@ -237,22 +257,7 @@ mod tests {
     fn sprite_data_positions() {
         let opts = Options::default();
         let (icons, palette) = compute_hash(42, &opts);
-
-        let mut sprite_data = [0u8; HASH_LENGTH * 8];
-        for i in 0..HASH_LENGTH {
-            let group = HASH_LENGTH - 1 - i;
-            let y = Y_START + i as u8 * Y_SPACING;
-            let (tile_l, tile_r, extra_attr_r) = ICON_TILES[icons[i]];
-            let base = group * 8;
-            sprite_data[base] = y;
-            sprite_data[base + 1] = tile_l;
-            sprite_data[base + 2] = palette;
-            sprite_data[base + 3] = X_LEFT;
-            sprite_data[base + 4] = y;
-            sprite_data[base + 5] = tile_r;
-            sprite_data[base + 6] = palette | extra_attr_r;
-            sprite_data[base + 7] = X_RIGHT;
-        }
+        let sprite_data = build_sprite_data(&icons, palette);
 
         // Icon 0 is in group 4 (bytes 32-39), should have Y_START
         assert_eq!(sprite_data[32], Y_START);
@@ -261,6 +266,22 @@ mod tests {
 
         // Icon 4 is in group 0 (bytes 0-7), should have Y_START + 4*Y_SPACING
         assert_eq!(sprite_data[0], Y_START + 4 * Y_SPACING);
+    }
+
+    #[test]
+    fn write_seed_hash_writes_sprite_data_to_rom() {
+        let opts = Options::default();
+        let mut rom = crate::randomize::qol::test_support::make_test_rom();
+        write_seed_hash(&mut rom, 42, &opts);
+
+        // The data table in ROM must be exactly what build_sprite_data emits.
+        let (icons, palette) = compute_hash(42, &opts);
+        let expected = build_sprite_data(&icons, palette);
+        assert_eq!(rom.read_range(DATA_OFFSET, expected.len()), &expected[..]);
+
+        // Hook and intro-skip hook target the derived CPU addresses.
+        assert_eq!(rom.read_range(HOOK_OFFSET, 3), &[0x4C, 0x14, 0xE9]);
+        assert_eq!(rom.read_range(INTRO_SKIP_HOOK_OFFSET, 3), &[0x20, 0x55, 0xE9]);
     }
 
     #[test]

--- a/src/randomize/troll_pipes.rs
+++ b/src/randomize/troll_pipes.rs
@@ -18,9 +18,8 @@ const TROLL_PIPE_PERCENT: u32 = 75;
 ///
 /// Each eligible world independently has a [`TROLL_PIPE_PERCENT`]% chance of
 /// actually receiving a pipe; on the miss the world keeps a normal level
-/// tile. The roll is always drawn (even when there is no candidate slot) so
-/// downstream RNG stays aligned across worlds and the output is reproducible
-/// per seed.
+/// tile. The roll is drawn every world regardless of whether a candidate
+/// slot exists, so the outcome is reproducible per seed.
 ///
 /// The writer reads `slot.is_troll_pipe` and stamps `0xBC` (PIPE tile)
 /// instead of a level-number tile. The slot's level pointer entry is
@@ -45,8 +44,8 @@ pub(crate) fn mark_troll_pipes<R: Rng>(build: &mut BuildResult, rng: &mut R) {
             .filter(|(_, s)| s.kind == SlotKind::Level && !s.is_hand_trap)
             .map(|(i, _)| i)
             .collect();
-        // Draw the appearance roll unconditionally so RNG advances by the
-        // same amount per world regardless of whether a candidate exists.
+        // The appearance roll is drawn every world, candidates or not (the
+        // `choose` below still only consumes RNG when candidates exist).
         let appears = rng.random_range(..100u32) < TROLL_PIPE_PERCENT;
         if let Some(&pick) = candidates.choose(rng)
             && appears
@@ -64,6 +63,18 @@ mod tests {
     use crate::randomize::{node_catalog, overworld_build, overworld_pickup, troll_pipes};
     use crate::rom::Rom;
 
+    /// Run the catalog → pickup → build pipeline for `seed` and mark troll
+    /// pipes, returning the finished build.
+    fn build_with_troll_pipes(rom: &Rom, seed: u64) -> overworld_build::BuildResult {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let catalog = node_catalog::NodeCatalog::build(rom, false);
+        let pickup = overworld_pickup::pick_up(rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
+        let data = overworld_build::OverworldData { pickup: &pickup, catalog: &catalog };
+        let mut build = overworld_build::build(rom, &data, &mut rng, overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
+        troll_pipes::mark_troll_pipes(&mut build, &mut rng);
+        build
+    }
+
     #[test]
     fn marks_at_most_one_pipe_per_world_w2_w8() {
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
@@ -74,12 +85,7 @@ mod tests {
         let mut marked = 0usize; // W2-W8 worlds that got a pipe
         let mut eligible = 0usize; // W2-W8 worlds total
         for seed in 0u64..SEEDS {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let catalog = node_catalog::NodeCatalog::build(&rom, false);
-            let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-            let data = overworld_build::OverworldData { pickup: &pickup, catalog: &catalog };
-            let mut build = overworld_build::build(&rom, &data, &mut rng, overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            troll_pipes::mark_troll_pipes(&mut build, &mut rng);
+            let build = build_with_troll_pipes(&rom, seed);
             for w in &build.worlds {
                 let n = w.slots.iter().filter(|s| s.is_troll_pipe).count();
                 if w.world_idx == 0 {
@@ -109,13 +115,7 @@ mod tests {
         };
         let rom = Rom::from_bytes(&bytes).unwrap();
         let run = || {
-            let mut rng = ChaCha8Rng::seed_from_u64(42);
-            let catalog = node_catalog::NodeCatalog::build(&rom, false);
-            let pickup = overworld_pickup::pick_up(&rom, &catalog, overworld_pickup::PickupFlags { shuffle_spade_games: true, shuffle_toad_houses: true, ..Default::default() });
-            let data = overworld_build::OverworldData { pickup: &pickup, catalog: &catalog };
-            let mut build = overworld_build::build(&rom, &data, &mut rng, overworld_build::BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-            troll_pipes::mark_troll_pipes(&mut build, &mut rng);
-            build.worlds.iter()
+            build_with_troll_pipes(&rom, 42).worlds.iter()
                 .map(|w| w.slots.iter().filter(|s| s.is_troll_pipe).count())
                 .collect::<Vec<_>>()
         };

--- a/src/randomize/world_order.rs
+++ b/src/randomize/world_order.rs
@@ -2,6 +2,7 @@ use rand::Rng;
 use rand::seq::SliceRandom;
 
 use crate::rom::Rom;
+use super::rom_data::{FS_WORLD_ORDER, WORLD_ORDER_CPU};
 
 /// File offset of the `INC World_Num; JMP $84A0` instruction (6 bytes).
 /// Original bytes: EE 27 07 4C A0 84
@@ -24,20 +25,13 @@ pub(super) const WORLD_INIT_OPERAND: usize = 0x30CC3;
 /// clears $0160 to zero on power-on, so it's safe to skip this write.
 const DEBUG_FLAG_STA_OFFSET: usize = 0x30CC7;
 
-/// Free space in PRG030 — offset from rom_data::FS_WORLD_ORDER.
-/// Uses 28 bytes: 12 routine + 8 next-world table + 8 display table.
-const ROUTINE_OFFSET: usize = super::rom_data::FS_WORLD_ORDER;
-
-/// CPU address of the routine in free space.
-const ROUTINE_CPU: u16 = 0x9F10;
-
 /// CPU address of the lookup table (routine + 12 bytes).
-const TABLE_CPU: u16 = ROUTINE_CPU + 12;
+const TABLE_CPU: u16 = WORLD_ORDER_CPU + 12;
 
 /// File offset of the display-number table (8 bytes, right after next-world table).
 /// PRG030 is always mapped at $8000–$9FFF (MMC3 fixed bank in mode 1), so CPU $9F24
 /// is accessible from any bank configuration.
-const DISPLAY_TABLE_OFFSET: usize = ROUTINE_OFFSET + 20; // 12 routine + 8 next-world
+const DISPLAY_TABLE_OFFSET: usize = FS_WORLD_ORDER + 20; // 12 routine + 8 next-world
 const DISPLAY_TABLE_CPU: u16 = TABLE_CPU + 8; // $9F24
 
 /// Map screen "WORLD X" display site (PRG010).
@@ -83,8 +77,8 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, world_count: u8) {
     next_world[7] = 7;
 
     // Patch the original INC World_Num site to JMP to our routine
-    let routine_lo = (ROUTINE_CPU & 0xFF) as u8;
-    let routine_hi = ((ROUTINE_CPU >> 8) & 0xFF) as u8;
+    let routine_lo = (WORLD_ORDER_CPU & 0xFF) as u8;
+    let routine_hi = ((WORLD_ORDER_CPU >> 8) & 0xFF) as u8;
     rom.write_range(WORLD_INC_OFFSET, &[
         0x4C, routine_lo, routine_hi, // JMP $9F10
         0xEA, 0xEA, 0xEA,            // NOP NOP NOP (pad)
@@ -99,10 +93,10 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, world_count: u8) {
         0x8D, 0x27, 0x07,             // STA World_Num ($0727)
         0x4C, 0xA0, 0x84,             // JMP $84A0 (map init)
     ];
-    rom.write_range(ROUTINE_OFFSET, &routine);
+    rom.write_range(FS_WORLD_ORDER, &routine);
 
     // Write the lookup table immediately after the routine
-    rom.write_range(ROUTINE_OFFSET + routine.len(), &next_world);
+    rom.write_range(FS_WORLD_ORDER + routine.len(), &next_world);
 
     // Build the display-number table: internal world -> display tile ($F1–$F8).
     // worlds[i] is the internal world at shuffled position i, so position i
@@ -121,7 +115,7 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, world_count: u8) {
     // Original 10 bytes: AC 27 07 C8 98 09 F0 8D 04 03
     rom.write_range(MAP_DISPLAY_OFFSET, &[
         0xAE, 0x27, 0x07,             // LDX $0727  (World_Num)
-        0xBD, disp_lo, disp_hi,       // LDA $DF24,X (display tile)
+        0xBD, disp_lo, disp_hi,       // LDA $9F24,X (display tile)
         0x8D, 0x04, 0x03,             // STA $0304
         0xEA,                         // NOP (pad)
     ]);
@@ -130,7 +124,7 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, world_count: u8) {
     // Original 10 bytes: AE 27 07 E8 8A 09 F0 99 04 03
     rom.write_range(STATUS_DISPLAY_OFFSET, &[
         0xAE, 0x27, 0x07,             // LDX $0727  (World_Num)
-        0xBD, disp_lo, disp_hi,       // LDA $DF24,X (display tile)
+        0xBD, disp_lo, disp_hi,       // LDA $9F24,X (display tile)
         0x99, 0x04, 0x03,             // STA $0304,Y
         0xEA,                         // NOP (pad)
     ]);
@@ -156,7 +150,7 @@ mod tests {
         data[WORLD_INC_OFFSET..WORLD_INC_OFFSET + 6]
             .copy_from_slice(&[0xEE, 0x27, 0x07, 0x4C, 0xA0, 0x84]);
         // Fill free space with FF
-        data[ROUTINE_OFFSET..ROUTINE_OFFSET + 32].fill(0xFF);
+        data[FS_WORLD_ORDER..FS_WORLD_ORDER + 32].fill(0xFF);
         Rom::from_bytes_lax(&data, true).unwrap()
     }
 
@@ -177,17 +171,11 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         randomize(&mut rom, &mut rng, 7);
 
-        // Read the lookup table
-        let table = rom.read_range(ROUTINE_OFFSET + 12, 8);
+        // Read the lookup table and check three things: world 7 maps to
+        // itself, every entry is a valid world number, and following the
+        // next-world chain from any start visits all 8 worlds.
+        let table = rom.read_range(FS_WORLD_ORDER + 12, 8);
 
-        // Every world 0-7 should appear exactly once as a "next" destination
-        // (except world 7 which maps to itself)
-        // More importantly: following the chain from world[0] in shuffled order
-        // should visit all 8 worlds
-        let mut visited = [false; 8];
-        // Find which world is first in the shuffled order (it's the one that
-        // no other world points to, except itself if it's 7)
-        // Actually, let's just verify: table[7] == 7 (world 7 is always last)
         assert_eq!(table[7], 7, "World 7 (Dark Land) should map to itself");
 
         // All table values should be valid world numbers
@@ -195,10 +183,8 @@ mod tests {
             assert!(next <= 7, "Invalid world number in table: {next}");
         }
 
-        // The chain should visit all worlds: starting from any world in position 0,
-        // following next pointers should reach world 7
-        // Find a starting world (one that appears as table[x] for no x,
-        // i.e., it's the first world in the sequence — or just check all worlds reachable)
+        // Following next pointers from every start should cover all 8 worlds.
+        let mut visited = [false; 8];
         for start in 0..8u8 {
             let mut current = start;
             visited[current as usize] = true;
@@ -223,7 +209,7 @@ mod tests {
 
         // The starting world should match the first entry in the chain
         // Follow the chain from start_world and verify we visit all 8 worlds
-        let table = rom.read_range(ROUTINE_OFFSET + 12, 8);
+        let table = rom.read_range(FS_WORLD_ORDER + 12, 8);
         let mut visited = [false; 8];
         let mut current = start_world;
         for _ in 0..8 {
@@ -258,8 +244,8 @@ mod tests {
         randomize(&mut rom2, &mut rng2, 7);
 
         assert_eq!(
-            rom1.read_range(ROUTINE_OFFSET, 20),
-            rom2.read_range(ROUTINE_OFFSET, 20),
+            rom1.read_range(FS_WORLD_ORDER, 20),
+            rom2.read_range(FS_WORLD_ORDER, 20),
         );
     }
 
@@ -269,7 +255,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         randomize(&mut rom, &mut rng, 7);
 
-        let routine = rom.read_range(ROUTINE_OFFSET, 12);
+        let routine = rom.read_range(FS_WORLD_ORDER, 12);
         // LDX $0727
         assert_eq!(&routine[0..3], &[0xAE, 0x27, 0x07]);
         // LDA table,X (BD xx xx)
@@ -319,14 +305,14 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         randomize(&mut rom, &mut rng, 7);
 
-        // Map display: should now use LDX $0727; LDA $DF24,X; STA $0304; NOP
+        // Map display: should now use LDX $0727; LDA $9F24,X; STA $0304; NOP
         let map_patch = rom.read_range(MAP_DISPLAY_OFFSET, 10);
         assert_eq!(&map_patch[0..3], &[0xAE, 0x27, 0x07]); // LDX $0727
         assert_eq!(map_patch[3], 0xBD);                      // LDA abs,X
         assert_eq!(&map_patch[6..9], &[0x8D, 0x04, 0x03]);  // STA $0304
         assert_eq!(map_patch[9], 0xEA);                      // NOP
 
-        // Status bar: should now use LDX $0727; LDA $DF24,X; STA $0304,Y; NOP
+        // Status bar: should now use LDX $0727; LDA $9F24,X; STA $0304,Y; NOP
         let status_patch = rom.read_range(STATUS_DISPLAY_OFFSET, 10);
         assert_eq!(&status_patch[0..3], &[0xAE, 0x27, 0x07]); // LDX $0727
         assert_eq!(status_patch[3], 0xBD);                      // LDA abs,X
@@ -340,7 +326,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         randomize(&mut rom, &mut rng, 3);
 
-        let table = rom.read_range(ROUTINE_OFFSET + 12, 8);
+        let table = rom.read_range(FS_WORLD_ORDER + 12, 8);
 
         // Follow chain from starting world: should visit exactly 4 worlds (3 + Dark Land)
         let start_world = rom.read_byte(WORLD_INIT_OPERAND);

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -114,13 +114,6 @@ impl Options {
             | ((self.swap_start_airship as u8) << 1)
             | (self.more_hammer_rocks.is_on() as u8);
 
-        let b4 = (self.card_speed_clear as u8) << 7
-            | (self.remove_n_cards as u8) << 6
-            | (self.skip_wand_cutscene as u8) << 5
-            | (self.adjust_boss_hitboxes as u8) << 4
-            | (self.shuffle_spade_games as u8) << 3;
-            // bits 2-0 used by hb_encounters and wild_injections below
-
         // Helper to encode EnemyMode as 2 bits
         fn em(m: EnemyMode) -> u8 {
             match m {
@@ -129,6 +122,17 @@ impl Options {
                 EnemyMode::Wild => 2,
             }
         }
+
+        // b4: card_speed_clear(7) remove_n_cards(6) skip_wand_cutscene(5)
+        //     adjust_boss_hitboxes(4) shuffle_spade_games(3)
+        //     hb_encounters(2-1) wild_injections(0)
+        let b4 = (self.card_speed_clear as u8) << 7
+            | (self.remove_n_cards as u8) << 6
+            | (self.skip_wand_cutscene as u8) << 5
+            | (self.adjust_boss_hitboxes as u8) << 4
+            | (self.shuffle_spade_games as u8) << 3
+            | em(self.hb_encounters) << 1
+            | (self.wild_injections as u8);
 
         // b5: ground(7-6) shell(5-4) flying(3-2) hammer_vulnerable_koopalings(1) early_sun(0)
         let b5 = em(self.ground) << 6
@@ -148,20 +152,10 @@ impl Options {
             | em(self.thwomps);
 
         // b7: rotodiscs(7-6) cannons(5-4) water(3-2) bros(1-0)
-        // But we also need hb_encounters(2 bits) and wild_injections(1 bit)
-        // = 5 tri-states (10 bits) + 1 bool = 11 bits. We have 16 bits (b7+overflow).
-        // Rearrange: put last 5 tri-states + injection across b7 and steal bits from b4.
-        //
-        // b7: rotodiscs(7-6) cannons(5-4) water(3-2) bros(1-0)
         let b7 = em(self.rotodiscs) << 6
             | em(self.cannons) << 4
             | em(self.water) << 2
             | em(self.bros);
-
-        // Use b4 bits 2-0 for hb_encounters(2 bits) + wild_injections(1 bit)
-        let b4 = b4
-            | (em(self.hb_encounters) << 1)
-            | (self.wild_injections as u8);
 
         // b8-b9: starting items (3 nibbles, 0 = none)
         // For sentinel values (>=14), store 0 in the nibble and encode
@@ -242,9 +236,16 @@ impl Options {
 
     /// Decode a Crockford Base-32 flag key string into Options.
     pub fn from_flag_key(key: &str) -> Result<Options, String> {
-        let encoded = key.strip_prefix(FLAG_KEY_PREFIX)
-            .or_else(|| key.strip_prefix("smb3r-"))
-            .unwrap_or(key);
+        // Strip the "SMB3R-" prefix case-insensitively if present. Compare as
+        // bytes so a non-ASCII key can't panic on a char-boundary slice.
+        let prefix_len = FLAG_KEY_PREFIX.len();
+        let encoded = if key.len() >= prefix_len
+            && key.as_bytes()[..prefix_len].eq_ignore_ascii_case(FLAG_KEY_PREFIX.as_bytes())
+        {
+            &key[prefix_len..]
+        } else {
+            key
+        };
 
         let bytes = base32_decode(encoded, 13)?;
 

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -475,16 +475,16 @@ fn randomize_inner(
         randomize::fire_flower::apply(rom, options.fire_flower);
     }
 
-    // Stamp flag key + seed into free space at STAMP_OFFSET (PRG012). 25 bytes:
-    //   [0..4]   "S3R\xNN" magic + version
-    //   [4..17]  flag key bytes (13 bytes in v23)
-    //   [17..25] seed (little-endian u64)
+    // Stamp flag key + seed into free space at STAMP_OFFSET (PRG012):
+    //   "S3R" magic + version byte, the flag key bytes (13 in v23), then the
+    //   seed (little-endian u64). Sizes derive from to_flag_bytes() so the
+    //   stamp grows with the flag key.
     rom.set_tag("stamp");
     let flag_bytes = options.to_flag_bytes();
-    let mut stamp = [0u8; 25];
-    stamp[0..3].copy_from_slice(b"S3R");
-    stamp[3] = FLAG_KEY_VERSION;
-    stamp[4..17].copy_from_slice(&flag_bytes);
-    stamp[17..25].copy_from_slice(&seed.to_le_bytes());
+    let mut stamp = Vec::with_capacity(4 + flag_bytes.len() + 8);
+    stamp.extend_from_slice(b"S3R");
+    stamp.push(FLAG_KEY_VERSION);
+    stamp.extend_from_slice(&flag_bytes);
+    stamp.extend_from_slice(&seed.to_le_bytes());
     rom.write_range(STAMP_OFFSET, &stamp);
 }

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -448,8 +448,11 @@ fn randomize_inner(
     }
 
     // Starting items trampoline — must run AFTER title_screen because both
-    // write to the lives init region at 0x308E0. The trampoline incorporates
-    // the intro skip (LDA #$06; STA $DE) so the title_screen hook is preserved.
+    // write to the lives init region at 0x308E0: this one wins, overwriting
+    // title_screen's intro-skip hook at 0x308E2. The trampoline replays the
+    // identical intro-skip + menu-music bytes (shared
+    // `title_screen::intro_skip_music_bytes`), so behavior is unchanged;
+    // title_screen's FS_INTRO_SKIP routine is left in ROM unreferenced.
     if !options.starting_items.is_empty() {
         rom.set_tag("qol/starting_items");
         randomize::qol::write_starting_items(rom, seed, options.starting_lives, &resolved_items);

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -139,7 +139,7 @@ pub struct Options {
     /// Number of worlds before Dark Land (1–7, default 7).
     #[serde(default = "default_world_count")]
     pub world_count: u8,
-    #[serde(default = "default_false")]
+    #[serde(default)]
     pub big_q_blocks: bool,
     /// Shuffle pipe endpoint positions during the overworld rebuild.
     #[serde(default = "default_true")]
@@ -359,10 +359,6 @@ pub struct Options {
     /// randomization seed.
     #[serde(default)]
     pub skip_rom_validation: bool,
-}
-
-pub(super) fn default_false() -> bool {
-    false
 }
 
 pub(super) fn default_true() -> bool {

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1,967 +1,880 @@
-    use super::*;
-    use crate::rom::Rom;
+use super::*;
+use crate::rom::Rom;
 
-    const ANCHOR: u8 = 0x0A;
+const ANCHOR: u8 = 0x0A;
 
-    // Item table offsets (must match items.rs)
-    const HAMMER_BROS_ITEMS_OFFSET: usize = 0x16190;
-    const TOAD_HOUSE_ITEMS_OFFSET: usize = 0x3B14B;
+// Item table offsets (must match items.rs)
+const HAMMER_BROS_ITEMS_OFFSET: usize = 0x16190;
+const TOAD_HOUSE_ITEMS_OFFSET: usize = 0x3B14B;
 
-    /// Options safe for zeroed test ROMs.
-    /// Palettes disabled because they use OS entropy (cosmetic, decoupled from seed).
-    fn test_options() -> Options {
-        Options {
-            shuffle_airships: false,
-            palettes: false,
-            ..Default::default()
-        }
+/// Options safe for zeroed test ROMs.
+/// Palettes disabled because they use OS entropy (cosmetic, decoupled from seed).
+fn test_options() -> Options {
+    Options {
+        shuffle_airships: false,
+        palettes: false,
+        ..Default::default()
     }
+}
 
-    /// Load the real SMB3 ROM. Tests that drive the full `randomize()`
-    /// pipeline need it — the overworld builder reads real pointer
-    /// tables and panics on synthetic data. Returns `None` (caller
-    /// silently skips) when the ROM isn't in the project root, mirroring
-    /// `map_walker::tests::test_render_randomized_seed`.
-    fn make_test_rom() -> Option<Rom> {
-        let bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
-        Rom::from_bytes(&bytes).ok()
+/// Load the real SMB3 ROM. Tests that drive the full `randomize()`
+/// pipeline need it — the overworld builder reads real pointer
+/// tables and panics on synthetic data. Returns `None` (caller
+/// silently skips) when the ROM isn't in the project root, mirroring
+/// `map_walker::tests::test_render_randomized_seed`.
+fn make_test_rom() -> Option<Rom> {
+    let bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+    Rom::from_bytes(&bytes).ok()
+}
+
+/// What the flag-key decoder should return for `o`: cosmetic fields are not
+/// encoded, so decoding always yields palettes=true and palette_themed=false.
+fn normalized(mut o: Options) -> Options {
+    o.palettes = true;
+    o.palette_themed = false;
+    o
+}
+
+#[test]
+fn mystery_anchor_trampoline_written() {
+    let Some(mut rom) = make_test_rom() else { return };
+    // Place anchors in item tables — they should stay as 0x0A
+    rom.write_byte(HAMMER_BROS_ITEMS_OFFSET + 2, ANCHOR);
+    rom.write_byte(TOAD_HOUSE_ITEMS_OFFSET + 1, ANCHOR);
+
+    let mut options = test_options();
+    options.chest_items = false;
+    options.remove_whistles = false;
+    // Pin Hammer Bro redistribution off so the planted anchor in the HB
+    // reward table isn't relocated — this test is about the mystery-anchor
+    // trampoline, not sprite shuffling.
+    options.shuffle_hammer_bros = false;
+    randomize(&mut rom, 0x12345678, &options);
+
+    // Anchor items should remain in data tables (mystery behavior)
+    assert_eq!(rom.read_byte(HAMMER_BROS_ITEMS_OFFSET + 2), ANCHOR,
+        "Anchor should stay in item table (mystery item)");
+    assert_eq!(rom.read_byte(TOAD_HOUSE_ITEMS_OFFSET + 1), ANCHOR,
+        "Anchor should stay in item table (mystery item)");
+
+    // Trampoline should be written at PRG026 free space
+    use crate::randomize::rom_data::FS_MYSTERY_ANCHOR as FS;
+    // Trampoline starts with LDX $7D80,Y (0xBE)
+    assert_eq!(rom.read_byte(FS), 0xBE, "Trampoline LDX abs,Y opcode");
+    // Target powerup is at offset +8 (LDX #imm operand)
+    let target = rom.read_byte(FS + 8);
+    assert!((0x01..=0x08).contains(&target),
+        "Trampoline target 0x{target:02X} should be a valid mystery pool item (1-8)");
+
+    // DynJump table entry at 0x34564: $A5B6 (Inv_UseItem_Powerup)
+    assert_eq!(rom.read_range(0x34564, 2), &[0xB6, 0xA5]);
+    // Hook at 0x345D8: JSR $B562
+    assert_eq!(rom.read_range(0x345D8, 3), &[0x20, 0x62, 0xB5]);
+}
+
+#[test]
+fn write_log_populated_after_randomize() {
+    let Some(mut rom) = make_test_rom() else { return };
+    let options = test_options();
+    randomize(&mut rom, 0x12345678, &options);
+
+    let log = rom.write_log();
+    assert!(!log.is_empty(), "Write log should be non-empty after randomize");
+
+    // Every write should have a proper tag (not "untagged")
+    for record in log {
+        assert_ne!(
+            record.tag, "untagged",
+            "Write at offset 0x{:05X} has no tag",
+            record.offset
+        );
     }
+}
 
-    #[test]
-    fn mystery_anchor_trampoline_written() {
-        let Some(mut rom) = make_test_rom() else { return };
-        // Place anchors in item tables — they should stay as 0x0A
-        rom.write_byte(HAMMER_BROS_ITEMS_OFFSET + 2, ANCHOR);
-        rom.write_byte(TOAD_HOUSE_ITEMS_OFFSET + 1, ANCHOR);
+#[test]
+fn default_matches_serde_empty_object() {
+    // Guard against drift between the manual Default impl and the
+    // #[serde(default = ...)] attributes. Adding a field to Options
+    // requires both to agree, or this test fails. Critical because
+    // the WASM `default_options_json()` export ships these defaults
+    // to the JS layer for parity-checking the schema.
+    let from_default = Options::default();
+    let from_empty: Options = serde_json::from_str("{}").unwrap();
+    assert_eq!(from_default, from_empty);
+}
 
-        let mut options = test_options();
-        options.chest_items = false;
-        options.remove_whistles = false;
-        // Pin Hammer Bro redistribution off so the planted anchor in the HB
-        // reward table isn't relocated — this test is about the mystery-anchor
-        // trampoline, not sprite shuffling.
-        options.shuffle_hammer_bros = false;
-        randomize(&mut rom, 0x12345678, &options);
+#[test]
+fn flag_key_round_trip_defaults() {
+    let opts = Options::default();
+    let key = opts.to_flag_key();
+    assert!(key.starts_with("SMB3R-"));
+    assert_eq!(key.len(), 27); // "SMB3R-" + 21 base32
+    let decoded = Options::from_flag_key(&key).unwrap();
+    assert_eq!(decoded, normalized(opts));
+}
 
-        // Anchor items should remain in data tables (mystery behavior)
-        assert_eq!(rom.read_byte(HAMMER_BROS_ITEMS_OFFSET + 2), ANCHOR,
-            "Anchor should stay in item table (mystery item)");
-        assert_eq!(rom.read_byte(TOAD_HOUSE_ITEMS_OFFSET + 1), ANCHOR,
-            "Anchor should stay in item table (mystery item)");
+#[test]
+fn flag_key_round_trip_all_wild() {
+    // Everything flipped away from the all-off baseline.
+    let opts = Options {
+        fire_flower: FireFlowerMode::Wild,
+        piranha_shuffle: PiranhaMode::Wild,
+        powerups: true,
+        palettes: true,
+        world_order: true,
+        big_q_blocks: true,
+        shuffle_pipes: true,
+        shuffle_airships: true,
+        shuffle_hammer_bros: true,
+        disable_autoscroll: true,
+        chest_items: true,
+        remove_whistles: true,
+        more_hammer_rocks: Tri::On,
+        eights_are_wild: Tri::On,
+        starting_lives: 99,
+        card_speed_clear: true,
+        remove_n_cards: true,
+        skip_wand_cutscene: true,
+        adjust_boss_hitboxes: true,
+        koopaling_hits: true,
+        boomboom_hits: true,
+        hammer_vulnerable_koopalings: true,
+        random_koopalings: true,
+        include_beta_stages: true,
+        hammer_breaks_locks: Tri::On,
+        hammer_breaks_bridges: Tri::On,
+        early_sun: true,
+        limit_bro_movement: true,
+        japanese_damage: true,
+        infinite_mushroom_houses: true,
+        fast_mushroom_house: true,
+        faster_tail_speed: true,
+        no_game_over_penalty: true,
+        faster_frog: true,
+        shuffle_spade_games: true,
+        shuffle_toad_houses: true,
+        hands_levels: true,
+        troll_pipes: Tri::On,
+        ground: EnemyMode::Wild,
+        shell: EnemyMode::Wild,
+        flying: EnemyMode::Wild,
+        piranhas: EnemyMode::Wild,
+        ghosts: EnemyMode::Wild,
+        thwomps: EnemyMode::Wild,
+        rotodiscs: EnemyMode::Wild,
+        cannons: EnemyMode::Wild,
+        water: EnemyMode::Wild,
+        bros: EnemyMode::Wild,
+        hb_encounters: EnemyMode::Wild,
+        wild_injections: true,
+        starting_items: vec![0x05, 0x09, 0x03],
+        ..all_off_options()
+    };
+    let key = opts.to_flag_key();
+    let decoded = Options::from_flag_key(&key).unwrap();
+    assert_eq!(opts.random_koopalings, decoded.random_koopalings);
+    assert_eq!(opts.include_beta_stages, decoded.include_beta_stages);
+    assert_eq!(opts.starting_items, decoded.starting_items);
+    assert_eq!(opts.hammer_breaks_locks, decoded.hammer_breaks_locks);
+    assert_eq!(opts.hammer_breaks_bridges, decoded.hammer_breaks_bridges);
+    assert_eq!(opts.world_order, decoded.world_order);
+    assert_eq!(opts.world_count, decoded.world_count);
+    assert_eq!(opts.starting_lives, decoded.starting_lives);
+    assert_eq!(opts.ground, decoded.ground);
+    assert_eq!(opts.shell, decoded.shell);
+    assert_eq!(opts.thwomps, decoded.thwomps);
+    assert_eq!(opts.rotodiscs, decoded.rotodiscs);
+    assert_eq!(opts.cannons, decoded.cannons);
+    assert_eq!(opts.hb_encounters, decoded.hb_encounters);
+    assert_eq!(opts.wild_injections, decoded.wild_injections);
+}
 
-        // Trampoline should be written at PRG026 free space
-        use crate::randomize::rom_data::FS_MYSTERY_ANCHOR as FS;
-        // Trampoline starts with LDX $7D80,Y (0xBE)
-        assert_eq!(rom.read_byte(FS), 0xBE, "Trampoline LDX abs,Y opcode");
-        // Target powerup is at offset +8 (LDX #imm operand)
-        let target = rom.read_byte(FS + 8);
-        assert!((0x01..=0x08).contains(&target),
-            "Trampoline target 0x{target:02X} should be a valid mystery pool item (1-8)");
+#[test]
+fn flag_key_round_trip_all_off() {
+    let opts = all_off_options();
+    let key = opts.to_flag_key();
+    let decoded = Options::from_flag_key(&key).unwrap();
+    assert!(decoded.starting_items.is_empty());
+    assert!(!decoded.powerups);
+    assert_eq!(decoded.hammer_breaks_locks, Tri::Off);
+    assert_eq!(decoded.hammer_breaks_bridges, Tri::Off);
+    assert!(decoded.palettes); // palettes always true from flag key (cosmetic, not encoded)
+    assert!(!decoded.disable_autoscroll);
+    assert!(!decoded.shuffle_airships);
+    assert!(!decoded.shuffle_spade_games);
+    assert_eq!(decoded.ground, EnemyMode::Off);
+    assert_eq!(decoded.thwomps, EnemyMode::Off);
+    assert_eq!(decoded.hb_encounters, EnemyMode::Off);
+    assert!(!decoded.wild_injections);
+    assert_eq!(decoded.starting_lives, 1);
+}
 
-        // DynJump table entry at 0x34564: $A5B6 (Inv_UseItem_Powerup)
-        assert_eq!(rom.read_range(0x34564, 2), &[0xB6, 0xA5]);
-        // Hook at 0x345D8: JSR $B562
-        assert_eq!(rom.read_range(0x345D8, 3), &[0x20, 0x62, 0xB5]);
-    }
+#[test]
+fn flag_key_case_insensitive_prefix() {
+    let opts = Options::default();
+    let key = opts.to_flag_key();
+    let lower = key.to_lowercase();
+    let decoded = Options::from_flag_key(&lower).unwrap();
+    assert_eq!(opts.powerups, decoded.powerups);
+}
 
-    #[test]
-    fn write_log_populated_after_randomize() {
-        let Some(mut rom) = make_test_rom() else { return };
-        let options = test_options();
-        randomize(&mut rom, 0x12345678, &options);
+#[test]
+fn flag_key_mixed_case_prefix() {
+    let opts = Options::default();
+    let key = opts.to_flag_key();
+    let mixed = format!("Smb3r-{}", key.strip_prefix("SMB3R-").unwrap());
+    let decoded = Options::from_flag_key(&mixed).unwrap();
+    assert_eq!(decoded, normalized(opts));
+}
 
-        let log = rom.write_log();
-        assert!(!log.is_empty(), "Write log should be non-empty after randomize");
+#[test]
+fn flag_key_without_prefix() {
+    let opts = Options::default();
+    let key = opts.to_flag_key();
+    let b32 = key.strip_prefix("SMB3R-").unwrap();
+    let decoded = Options::from_flag_key(b32).unwrap();
+    assert_eq!(opts.powerups, decoded.powerups);
+}
 
-        // Every write should have a proper tag (not "untagged")
-        for record in log {
+#[test]
+fn flag_key_invalid_version() {
+    // Encode version 0xFF into base32 (first byte = 0xFF, rest zeros)
+    let mut bad_bytes = [0u8; 13];
+    bad_bytes[0] = 0xFF;
+    let key = format!("SMB3R-{}", base32_encode(&bad_bytes));
+    let result = Options::from_flag_key(&key);
+    assert!(result.is_err());
+}
+
+#[test]
+fn flag_key_invalid_chars() {
+    let result = Options::from_flag_key("SMB3R-!!!!!!!!!!!!!!!!!!!");
+    assert!(result.is_err());
+}
+
+/// Holistic flag-key check: every encoded option must (a) change the flag
+/// key when toggled away from defaults, and (b) round-trip exactly through
+/// encode→decode. Catches bit-collision bugs where two fields share a bit.
+///
+/// `palettes` and `palette_themed` are cosmetic — they intentionally do not
+/// change the flag key, so they're tested in the `cosmetic` table.
+#[test]
+fn flag_key_per_option_round_trip() {
+    // Helper: clone defaults, apply mutator, encode/decode, return both.
+    fn check_round_trip(
+        label: &str,
+        mutate: impl Fn(&mut Options),
+        change_key: bool,
+    ) {
+        let default_opts = Options::default();
+        let default_key = default_opts.to_flag_key();
+
+        let mut mutated = default_opts.clone();
+        mutate(&mut mutated);
+
+        let mutated_key = mutated.to_flag_key();
+        if change_key {
             assert_ne!(
-                record.tag, "untagged",
-                "Write at offset 0x{:05X} has no tag",
-                record.offset
+                default_key, mutated_key,
+                "{label}: mutating did not change the flag key (bit collision?)",
             );
-        }
-    }
-
-    #[test]
-    fn default_matches_serde_empty_object() {
-        // Guard against drift between the manual Default impl and the
-        // #[serde(default = ...)] attributes. Adding a field to Options
-        // requires both to agree, or this test fails. Critical because
-        // the WASM `default_options_json()` export ships these defaults
-        // to the JS layer for parity-checking the schema.
-        let from_default = Options::default();
-        let from_empty: Options = serde_json::from_str("{}").unwrap();
-        assert_eq!(from_default, from_empty);
-    }
-
-    #[test]
-    fn flag_key_round_trip_defaults() {
-        let opts = Options::default();
-        let key = opts.to_flag_key();
-        assert!(key.starts_with("SMB3R-"));
-        assert_eq!(key.len(), 27); // "SMB3R-" + 21 base32
-        let decoded = Options::from_flag_key(&key).unwrap();
-        assert_eq!(opts.powerups, decoded.powerups);
-        assert_eq!(opts.palettes, decoded.palettes);
-        assert_eq!(opts.world_order, decoded.world_order);
-        assert_eq!(opts.world_count, decoded.world_count);
-        assert_eq!(opts.big_q_blocks, decoded.big_q_blocks);
-        assert_eq!(opts.disable_autoscroll, decoded.disable_autoscroll);
-        assert_eq!(opts.chest_items, decoded.chest_items);
-        assert_eq!(opts.remove_whistles, decoded.remove_whistles);
-        assert_eq!(opts.shuffle_pipes, decoded.shuffle_pipes);
-        assert_eq!(opts.shuffle_airships, decoded.shuffle_airships);
-        assert_eq!(opts.shuffle_hammer_bros, decoded.shuffle_hammer_bros);
-        assert_eq!(opts.more_hammer_rocks, decoded.more_hammer_rocks);
-        assert_eq!(opts.starting_lives, decoded.starting_lives);
-        assert_eq!(opts.card_speed_clear, decoded.card_speed_clear);
-        assert_eq!(opts.remove_n_cards, decoded.remove_n_cards);
-        assert_eq!(opts.skip_wand_cutscene, decoded.skip_wand_cutscene);
-        assert_eq!(opts.adjust_boss_hitboxes, decoded.adjust_boss_hitboxes);
-        assert_eq!(opts.ground, decoded.ground);
-        assert_eq!(opts.shell, decoded.shell);
-        assert_eq!(opts.flying, decoded.flying);
-        assert_eq!(opts.piranhas, decoded.piranhas);
-        assert_eq!(opts.ghosts, decoded.ghosts);
-        assert_eq!(opts.thwomps, decoded.thwomps);
-        assert_eq!(opts.rotodiscs, decoded.rotodiscs);
-        assert_eq!(opts.cannons, decoded.cannons);
-        assert_eq!(opts.water, decoded.water);
-        assert_eq!(opts.bros, decoded.bros);
-        assert_eq!(opts.hb_encounters, decoded.hb_encounters);
-        assert_eq!(opts.wild_injections, decoded.wild_injections);
-        assert_eq!(opts.starting_items, decoded.starting_items);
-        assert_eq!(opts.hammer_breaks_locks, decoded.hammer_breaks_locks);
-        assert_eq!(opts.hammer_breaks_bridges, decoded.hammer_breaks_bridges);
-    }
-
-    #[test]
-    fn flag_key_round_trip_all_wild() {
-        let opts = Options {
-            fire_flower: FireFlowerMode::Wild,
-            piranha_shuffle: PiranhaMode::Wild,
-            powerups: true,
-            palettes: true,
-            palette_themed: false,
-            player_color: None,
-            world_order: true,
-            world_count: 7,
-            big_q_blocks: true,
-            shuffle_pipes: true,
-            shuffle_airships: true,
-            shuffle_hammer_bros: true,
-            disable_autoscroll: true,
-            chest_items: true,
-            remove_whistles: true,
-            more_hammer_rocks: Tri::On,
-            eights_are_wild: Tri::On,
-            starting_lives: 99,
-            card_speed_clear: true,
-            remove_n_cards: true,
-            skip_wand_cutscene: true,
-            adjust_boss_hitboxes: true,
-            koopaling_hits: true,
-            boomboom_hits: true,
-            hammer_vulnerable_koopalings: true,
-            random_koopalings: true,
-            include_beta_stages: true,
-            hammer_breaks_locks: Tri::On,
-            hammer_breaks_bridges: Tri::On,
-            early_sun: true,
-            limit_bro_movement: true,
-            japanese_damage: true,
-            infinite_mushroom_houses: true,
-            fast_mushroom_house: true,
-            faster_tail_speed: true,
-            no_game_over_penalty: true,
-            faster_frog: true,
-            shuffle_spade_games: true,
-            shuffle_toad_houses: true,
-            hands_levels: true,
-            troll_pipes: Tri::On,
-            swap_start_airship: false,
-            ground: EnemyMode::Wild,
-            shell: EnemyMode::Wild,
-            flying: EnemyMode::Wild,
-            piranhas: EnemyMode::Wild,
-            ghosts: EnemyMode::Wild,
-            thwomps: EnemyMode::Wild,
-            rotodiscs: EnemyMode::Wild,
-            cannons: EnemyMode::Wild,
-            water: EnemyMode::Wild,
-            bros: EnemyMode::Wild,
-            hb_encounters: EnemyMode::Wild,
-            wild_injections: true,
-            starting_items: vec![0x05, 0x09, 0x03],
-            skip_rom_validation: false,
-            anchor_visuals: false,
-        };
-        let key = opts.to_flag_key();
-        let decoded = Options::from_flag_key(&key).unwrap();
-        assert_eq!(opts.random_koopalings, decoded.random_koopalings);
-        assert_eq!(opts.include_beta_stages, decoded.include_beta_stages);
-        assert_eq!(opts.starting_items, decoded.starting_items);
-        assert_eq!(opts.hammer_breaks_locks, decoded.hammer_breaks_locks);
-        assert_eq!(opts.hammer_breaks_bridges, decoded.hammer_breaks_bridges);
-        assert_eq!(opts.world_order, decoded.world_order);
-        assert_eq!(opts.world_count, decoded.world_count);
-        assert_eq!(opts.starting_lives, decoded.starting_lives);
-        assert_eq!(opts.ground, decoded.ground);
-        assert_eq!(opts.shell, decoded.shell);
-        assert_eq!(opts.thwomps, decoded.thwomps);
-        assert_eq!(opts.rotodiscs, decoded.rotodiscs);
-        assert_eq!(opts.cannons, decoded.cannons);
-        assert_eq!(opts.hb_encounters, decoded.hb_encounters);
-        assert_eq!(opts.wild_injections, decoded.wild_injections);
-    }
-
-    #[test]
-    fn flag_key_round_trip_all_off() {
-        let opts = Options {
-            fire_flower: FireFlowerMode::Off,
-            piranha_shuffle: PiranhaMode::Off,
-            powerups: false,
-            palettes: false,
-            palette_themed: false,
-            player_color: None,
-            world_order: false,
-            world_count: 7,
-            big_q_blocks: false,
-            shuffle_pipes: false,
-            shuffle_airships: false,
-            shuffle_hammer_bros: false,
-            disable_autoscroll: false,
-            chest_items: false,
-            remove_whistles: false,
-            more_hammer_rocks: Tri::Off,
-            eights_are_wild: Tri::Off,
-            starting_lives: 1,
-            card_speed_clear: false,
-            remove_n_cards: false,
-            skip_wand_cutscene: false,
-            adjust_boss_hitboxes: false,
-            koopaling_hits: false,
-            boomboom_hits: false,
-            hammer_vulnerable_koopalings: false,
-            random_koopalings: false,
-            include_beta_stages: false,
-            hammer_breaks_locks: Tri::Off,
-            hammer_breaks_bridges: Tri::Off,
-            early_sun: false,
-            limit_bro_movement: false,
-            japanese_damage: false,
-            infinite_mushroom_houses: false,
-            fast_mushroom_house: false,
-            faster_tail_speed: false,
-            no_game_over_penalty: false,
-            faster_frog: false,
-            shuffle_spade_games: false,
-            shuffle_toad_houses: false,
-            hands_levels: false,
-            troll_pipes: Tri::Off,
-            swap_start_airship: false,
-            ground: EnemyMode::Off,
-            shell: EnemyMode::Off,
-            flying: EnemyMode::Off,
-            piranhas: EnemyMode::Off,
-            ghosts: EnemyMode::Off,
-            thwomps: EnemyMode::Off,
-            rotodiscs: EnemyMode::Off,
-            cannons: EnemyMode::Off,
-            water: EnemyMode::Off,
-            bros: EnemyMode::Off,
-            hb_encounters: EnemyMode::Off,
-            wild_injections: false,
-            starting_items: vec![],
-            skip_rom_validation: false,
-            anchor_visuals: false,
-        };
-        let key = opts.to_flag_key();
-        let decoded = Options::from_flag_key(&key).unwrap();
-        assert!(decoded.starting_items.is_empty());
-        assert!(!decoded.powerups);
-        assert_eq!(decoded.hammer_breaks_locks, Tri::Off);
-        assert_eq!(decoded.hammer_breaks_bridges, Tri::Off);
-        assert!(decoded.palettes); // palettes always true from flag key (cosmetic, not encoded)
-        assert!(!decoded.disable_autoscroll);
-        assert!(!decoded.shuffle_airships);
-        assert!(!decoded.shuffle_spade_games);
-        assert_eq!(decoded.ground, EnemyMode::Off);
-        assert_eq!(decoded.thwomps, EnemyMode::Off);
-        assert_eq!(decoded.hb_encounters, EnemyMode::Off);
-        assert!(!decoded.wild_injections);
-        assert_eq!(decoded.starting_lives, 1);
-    }
-
-    #[test]
-    fn flag_key_case_insensitive_prefix() {
-        let opts = Options::default();
-        let key = opts.to_flag_key();
-        let lower = key.to_lowercase();
-        let decoded = Options::from_flag_key(&lower).unwrap();
-        assert_eq!(opts.powerups, decoded.powerups);
-    }
-
-    #[test]
-    fn flag_key_without_prefix() {
-        let opts = Options::default();
-        let key = opts.to_flag_key();
-        let b32 = key.strip_prefix("SMB3R-").unwrap();
-        let decoded = Options::from_flag_key(b32).unwrap();
-        assert_eq!(opts.powerups, decoded.powerups);
-    }
-
-    #[test]
-    fn flag_key_invalid_version() {
-        // Encode version 0xFF into base32 (first byte = 0xFF, rest zeros)
-        let mut bad_bytes = [0u8; 13];
-        bad_bytes[0] = 0xFF;
-        let key = format!("SMB3R-{}", base32_encode(&bad_bytes));
-        let result = Options::from_flag_key(&key);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn flag_key_invalid_chars() {
-        let result = Options::from_flag_key("SMB3R-!!!!!!!!!!!!!!!!!!!");
-        assert!(result.is_err());
-    }
-
-    /// Holistic flag-key check: every encoded option must (a) change the flag
-    /// key when toggled away from defaults, and (b) round-trip exactly through
-    /// encode→decode. Catches bit-collision bugs where two fields share a bit.
-    ///
-    /// `palettes` and `palette_themed` are cosmetic — they intentionally do not
-    /// change the flag key, so they're tested in the `cosmetic` table.
-    #[test]
-    fn flag_key_per_option_round_trip() {
-        // Helper: clone defaults, apply mutator, encode/decode, return both.
-        fn check_round_trip(
-            label: &str,
-            mutate: impl Fn(&mut Options),
-            change_key: bool,
-        ) {
-            let default_opts = Options::default();
-            let default_key = default_opts.to_flag_key();
-
-            let mut mutated = default_opts.clone();
-            mutate(&mut mutated);
-
-            let mutated_key = mutated.to_flag_key();
-            if change_key {
-                assert_ne!(
-                    default_key, mutated_key,
-                    "{label}: mutating did not change the flag key (bit collision?)",
-                );
-            } else {
-                assert_eq!(
-                    default_key, mutated_key,
-                    "{label}: cosmetic field unexpectedly changed the flag key",
-                );
-            }
-
-            // Decode round-trip. Cosmetic fields are not encoded, so the
-            // decoder always returns palettes=true, palette_themed=false;
-            // normalize the expected value to match before comparing.
-            let mut expected = mutated.clone();
-            expected.palettes = true;
-            expected.palette_themed = false;
-
-            let recovered = Options::from_flag_key(&mutated_key)
-                .unwrap_or_else(|e| panic!("{label}: failed to decode key '{mutated_key}': {e}"));
+        } else {
             assert_eq!(
-                recovered, expected,
-                "{label}: round-trip mismatch\n  encoded: {mutated:?}\n  decoded: {recovered:?}",
+                default_key, mutated_key,
+                "{label}: cosmetic field unexpectedly changed the flag key",
             );
         }
 
-        /// A label + a closure that flips one Options field.
-        type OptionTweak = (&'static str, Box<dyn Fn(&mut Options)>);
+        // Decode round-trip, normalizing cosmetic fields on the expected side.
+        let expected = normalized(mutated.clone());
 
-        // Cosmetic: must NOT change the flag key.
-        let cosmetic: Vec<OptionTweak> = vec![
-            ("palettes",       Box::new(|o| o.palettes = !o.palettes)),
-            ("palette_themed", Box::new(|o| o.palette_themed = !o.palette_themed)),
-        ];
-        for (label, mutate) in cosmetic {
-            check_round_trip(label, mutate, false);
-        }
-
-        // Encoded booleans: toggling must change the flag key.
-        let bools: Vec<OptionTweak> = vec![
-            ("powerups",                     Box::new(|o| o.powerups = !o.powerups)),
-            ("world_order",                  Box::new(|o| o.world_order = !o.world_order)),
-            ("big_q_blocks",                 Box::new(|o| o.big_q_blocks = !o.big_q_blocks)),
-            ("shuffle_pipes",                Box::new(|o| o.shuffle_pipes = !o.shuffle_pipes)),
-            ("shuffle_airships",             Box::new(|o| o.shuffle_airships = !o.shuffle_airships)),
-            ("shuffle_hammer_bros",          Box::new(|o| o.shuffle_hammer_bros = !o.shuffle_hammer_bros)),
-            ("disable_autoscroll",           Box::new(|o| o.disable_autoscroll = !o.disable_autoscroll)),
-            ("chest_items",                  Box::new(|o| o.chest_items = !o.chest_items)),
-            ("remove_whistles",              Box::new(|o| o.remove_whistles = !o.remove_whistles)),
-            ("card_speed_clear",             Box::new(|o| o.card_speed_clear = !o.card_speed_clear)),
-            ("remove_n_cards",               Box::new(|o| o.remove_n_cards = !o.remove_n_cards)),
-            ("skip_wand_cutscene",           Box::new(|o| o.skip_wand_cutscene = !o.skip_wand_cutscene)),
-            ("adjust_boss_hitboxes",         Box::new(|o| o.adjust_boss_hitboxes = !o.adjust_boss_hitboxes)),
-            ("koopaling_hits",               Box::new(|o| o.koopaling_hits = !o.koopaling_hits)),
-            ("boomboom_hits",                Box::new(|o| o.boomboom_hits = !o.boomboom_hits)),
-            ("hammer_vulnerable_koopalings", Box::new(|o| o.hammer_vulnerable_koopalings = !o.hammer_vulnerable_koopalings)),
-            ("random_koopalings",            Box::new(|o| o.random_koopalings = !o.random_koopalings)),
-            ("include_beta_stages",          Box::new(|o| o.include_beta_stages = !o.include_beta_stages)),
-            ("shuffle_spade_games",           Box::new(|o| o.shuffle_spade_games = !o.shuffle_spade_games)),
-            ("shuffle_toad_houses",          Box::new(|o| o.shuffle_toad_houses = !o.shuffle_toad_houses)),
-            ("wild_injections",              Box::new(|o| o.wild_injections = !o.wild_injections)),
-        ];
-        for (label, mutate) in bools {
-            check_round_trip(label, mutate, true);
-        }
-
-        // Tri-state enemy modes: cycle through every value so each non-default
-        // mode is exercised. Defaults differ per class, so test all three modes.
-        type TriSetter = Box<dyn Fn(&mut Options, EnemyMode)>;
-        let tristates: Vec<(&str, TriSetter)> = vec![
-            ("ground",        Box::new(|o, m| o.ground = m)),
-            ("shell",         Box::new(|o, m| o.shell = m)),
-            ("flying",        Box::new(|o, m| o.flying = m)),
-            ("piranhas",      Box::new(|o, m| o.piranhas = m)),
-            ("ghosts",        Box::new(|o, m| o.ghosts = m)),
-            ("thwomps",       Box::new(|o, m| o.thwomps = m)),
-            ("rotodiscs",     Box::new(|o, m| o.rotodiscs = m)),
-            ("cannons",       Box::new(|o, m| o.cannons = m)),
-            ("water",         Box::new(|o, m| o.water = m)),
-            ("bros",          Box::new(|o, m| o.bros = m)),
-            ("hb_encounters", Box::new(|o, m| o.hb_encounters = m)),
-        ];
-        for (label, set) in tristates {
-            for &mode in &[EnemyMode::Off, EnemyMode::Shuffle, EnemyMode::Wild] {
-                let default_opts = Options::default();
-                let mut mutated = default_opts.clone();
-                set(&mut mutated, mode);
-                let mut expected = mutated.clone();
-                expected.palettes = true;
-                expected.palette_themed = false;
-                let recovered = Options::from_flag_key(&mutated.to_flag_key()).unwrap();
-                assert_eq!(
-                    recovered, expected,
-                    "{label}={mode:?}: round-trip mismatch",
-                );
-            }
-        }
-
-        // Player-hidden tri flags (Off/On/Maybe): every state must round-trip,
-        // and every non-default state must change the flag key.
-        type TriFlagSetter = Box<dyn Fn(&mut Options, Tri)>;
-        let tri_flags: Vec<(&str, TriFlagSetter)> = vec![
-            ("hammer_breaks_locks",   Box::new(|o, t| o.hammer_breaks_locks = t)),
-            ("hammer_breaks_bridges", Box::new(|o, t| o.hammer_breaks_bridges = t)),
-            ("troll_pipes",           Box::new(|o, t| o.troll_pipes = t)),
-            ("more_hammer_rocks",        Box::new(|o, t| o.more_hammer_rocks = t)),
-            ("eights_are_wild",       Box::new(|o, t| o.eights_are_wild = t)),
-        ];
-        for (label, set) in tri_flags {
-            let default_opts = Options::default();
-            let default_key = default_opts.to_flag_key();
-            for &state in &[Tri::Off, Tri::On, Tri::Maybe] {
-                let mut mutated = default_opts.clone();
-                set(&mut mutated, state);
-                let mutated_key = mutated.to_flag_key();
-                let mut expected = mutated.clone();
-                expected.palettes = true;
-                expected.palette_themed = false;
-                let recovered = Options::from_flag_key(&mutated_key).unwrap();
-                assert_eq!(recovered, expected, "{label}={state:?}: round-trip mismatch");
-                // Default state shares its key with default; non-default must differ.
-                let is_default_state = recovered == {
-                    let mut d = default_opts.clone();
-                    d.palettes = true;
-                    d.palette_themed = false;
-                    d
-                };
-                if !is_default_state {
-                    assert_ne!(default_key, mutated_key, "{label}={state:?}: key must change");
-                }
-            }
-        }
-
-        // Piranha shuffle (Off/On/Wild): every state must round-trip, and the
-        // non-default states must change the flag key.
-        {
-            let default_key = Options::default().to_flag_key();
-            for &mode in &[PiranhaMode::Off, PiranhaMode::On, PiranhaMode::Wild] {
-                let mutated = Options { piranha_shuffle: mode, ..Default::default() };
-                let mutated_key = mutated.to_flag_key();
-                let expected = Options { palettes: true, palette_themed: false, ..mutated.clone() };
-                let recovered = Options::from_flag_key(&mutated_key).unwrap();
-                assert_eq!(recovered, expected, "piranha_shuffle={mode:?}: round-trip mismatch");
-                if mode != PiranhaMode::Off {
-                    assert_ne!(default_key, mutated_key, "piranha_shuffle={mode:?}: key must change");
-                }
-            }
-        }
-
-        // starting_lives is 2 bits indexing {1, 5, 20, 99} — only the four
-        // canonical values round-trip exactly.
-        for lives in STARTING_LIVES_VALUES {
-            let opts = Options { starting_lives: lives, ..Default::default() };
-            let expected = Options { palettes: true, palette_themed: false, ..opts.clone() };
-            let recovered = Options::from_flag_key(&opts.to_flag_key()).unwrap();
-            assert_eq!(recovered.starting_lives, lives, "starting_lives={lives}: round-trip mismatch");
-            assert_eq!(recovered, expected, "starting_lives={lives}: full struct mismatch");
-        }
-        for wc in 1u8..=7 {
-            let opts = Options { world_count: wc, ..Default::default() };
-            let expected = Options { palettes: true, palette_themed: false, ..opts.clone() };
-            let recovered = Options::from_flag_key(&opts.to_flag_key()).unwrap();
-            assert_eq!(recovered.world_count, wc, "world_count={wc}: round-trip mismatch");
-            assert_eq!(recovered, expected, "world_count={wc}: full struct mismatch");
-        }
-
-        // starting_items: empty, singles, multi, sentinels (random modes).
-        for items in [
-            vec![],
-            vec![3u8],
-            vec![3, 6, 9],
-            vec![ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY],
-        ] {
-            let opts = Options { starting_items: items.clone(), ..Default::default() };
-            let expected = Options { palettes: true, palette_themed: false, ..opts.clone() };
-            let recovered = Options::from_flag_key(&opts.to_flag_key()).unwrap();
-            assert_eq!(recovered.starting_items, items, "starting_items={items:?}: round-trip mismatch");
-            assert_eq!(recovered, expected, "starting_items={items:?}: full struct mismatch");
-        }
-
-        // Combination: every encoded boolean flipped from default, all
-        // tri-states set to Wild, level shuffle on, beta stages, items.
-        // Catches bit-collision bugs that only manifest when many fields
-        // share their non-default values.
-        let mut everything = Options::default();
-        everything.powerups = !everything.powerups;
-        everything.world_order = !everything.world_order;
-        everything.big_q_blocks = !everything.big_q_blocks;
-        everything.shuffle_pipes = !everything.shuffle_pipes;
-        everything.shuffle_airships = !everything.shuffle_airships;
-        everything.shuffle_hammer_bros = !everything.shuffle_hammer_bros;
-        everything.disable_autoscroll = !everything.disable_autoscroll;
-        everything.chest_items = !everything.chest_items;
-        everything.remove_whistles = !everything.remove_whistles;
-        everything.more_hammer_rocks = Tri::Maybe;
-        everything.eights_are_wild = Tri::Maybe;
-        everything.card_speed_clear = !everything.card_speed_clear;
-        everything.remove_n_cards = !everything.remove_n_cards;
-        everything.skip_wand_cutscene = !everything.skip_wand_cutscene;
-        everything.adjust_boss_hitboxes = !everything.adjust_boss_hitboxes;
-        everything.koopaling_hits = !everything.koopaling_hits;
-        everything.boomboom_hits = !everything.boomboom_hits;
-        everything.hammer_vulnerable_koopalings = true;
-        everything.random_koopalings = true;
-        everything.include_beta_stages = true;
-        everything.hammer_breaks_locks = Tri::Maybe;
-        everything.hammer_breaks_bridges = Tri::On;
-        everything.troll_pipes = Tri::Maybe;
-        everything.shuffle_spade_games = !everything.shuffle_spade_games;
-        everything.shuffle_toad_houses = !everything.shuffle_toad_houses;
-        everything.wild_injections = true;
-        everything.ground = EnemyMode::Wild;
-        everything.shell = EnemyMode::Wild;
-        everything.flying = EnemyMode::Wild;
-        everything.piranhas = EnemyMode::Wild;
-        everything.ghosts = EnemyMode::Wild;
-        everything.thwomps = EnemyMode::Wild;
-        everything.rotodiscs = EnemyMode::Wild;
-        everything.cannons = EnemyMode::Wild;
-        everything.water = EnemyMode::Wild;
-        everything.bros = EnemyMode::Wild;
-        everything.hb_encounters = EnemyMode::Wild;
-        everything.starting_lives = 99;
-        everything.world_count = 1;
-        everything.starting_items = vec![ITEM_RANDOM, 5, ITEM_RANDOM_SUIT_ONLY];
-        let mut expected = everything.clone();
-        expected.palettes = true;
-        expected.palette_themed = false;
-        let recovered = Options::from_flag_key(&everything.to_flag_key()).unwrap();
-        assert_eq!(recovered, expected, "all-fields-flipped: round-trip mismatch");
-    }
-
-    #[test]
-    fn flag_key_hammer_vuln_koopalings_distinct_from_hb_encounters() {
-        // Regression: hammer_vulnerable_koopalings used to share bit 2 of b4
-        // with the high bit of hb_encounters (a tri-state at bits 2-1).
-        // When hb_encounters=Wild (em=2), bit 2 was already set, so toggling
-        // hammer_vulnerable_koopalings produced no change in the flag key.
-        let a = Options {
-            hb_encounters: EnemyMode::Wild,
-            hammer_vulnerable_koopalings: false,
-            ..Default::default()
-        };
-
-        let b = Options { hammer_vulnerable_koopalings: true, ..a.clone() };
-
-        assert_ne!(a.to_flag_key(), b.to_flag_key(),
-            "toggling hammer_vulnerable_koopalings must change the flag key");
-
-        let dec_a = Options::from_flag_key(&a.to_flag_key()).unwrap();
-        let dec_b = Options::from_flag_key(&b.to_flag_key()).unwrap();
-        assert!(!dec_a.hammer_vulnerable_koopalings);
-        assert!(dec_b.hammer_vulnerable_koopalings);
-        assert_eq!(dec_a.hb_encounters, EnemyMode::Wild);
-        assert_eq!(dec_b.hb_encounters, EnemyMode::Wild);
-    }
-
-    #[test]
-    fn base32_round_trip() {
-        // Test with various byte patterns
-        for data in [
-            vec![0u8; 11],
-            vec![0xFF; 11],
-            vec![0x0E, 0xFF, 0xFE, 0x63, 0xFC, 0xAA, 0xAA, 0xAA, 0x59, 0x37, 0xC0],
-            (0..11).collect::<Vec<u8>>(),
-        ] {
-            let encoded = base32_encode(&data);
-            let decoded = base32_decode(&encoded, data.len()).unwrap();
-            assert_eq!(data, decoded, "round-trip failed for {data:?} (encoded: {encoded})");
-        }
-    }
-
-    /// Inline FNV-1a hash — no external dependency needed.
-    fn fnv1a(data: &[u8]) -> u64 {
-        let mut h: u64 = 0xcbf29ce484222325;
-        for &b in data {
-            h ^= b as u64;
-            h = h.wrapping_mul(0x100000001b3);
-        }
-        h
-    }
-
-    /// Build an Options with everything disabled (exercises "skip everything" branches).
-    fn all_off_options() -> Options {
-        Options {
-            fire_flower: FireFlowerMode::Off,
-            piranha_shuffle: PiranhaMode::Off,
-            powerups: false,
-            palettes: false,
-            palette_themed: false,
-            player_color: None,
-            world_order: false,
-            world_count: 7,
-            big_q_blocks: false,
-            shuffle_pipes: false,
-            shuffle_airships: false,
-            shuffle_hammer_bros: false,
-            disable_autoscroll: false,
-            chest_items: false,
-            remove_whistles: false,
-            more_hammer_rocks: Tri::Off,
-            eights_are_wild: Tri::Off,
-            starting_lives: 1,
-            card_speed_clear: false,
-            remove_n_cards: false,
-            skip_wand_cutscene: false,
-            adjust_boss_hitboxes: false,
-            koopaling_hits: false,
-            boomboom_hits: false,
-            hammer_vulnerable_koopalings: false,
-            random_koopalings: false,
-            include_beta_stages: false,
-            hammer_breaks_locks: Tri::Off,
-            hammer_breaks_bridges: Tri::Off,
-            early_sun: false,
-            limit_bro_movement: false,
-            japanese_damage: false,
-            infinite_mushroom_houses: false,
-            fast_mushroom_house: false,
-            faster_tail_speed: false,
-            no_game_over_penalty: false,
-            faster_frog: false,
-            shuffle_spade_games: false,
-            shuffle_toad_houses: false,
-            hands_levels: false,
-            troll_pipes: Tri::Off,
-            swap_start_airship: false,
-            ground: EnemyMode::Off,
-            shell: EnemyMode::Off,
-            flying: EnemyMode::Off,
-            piranhas: EnemyMode::Off,
-            ghosts: EnemyMode::Off,
-            thwomps: EnemyMode::Off,
-            rotodiscs: EnemyMode::Off,
-            cannons: EnemyMode::Off,
-            water: EnemyMode::Off,
-            bros: EnemyMode::Off,
-            hb_encounters: EnemyMode::Off,
-            wild_injections: false,
-            starting_items: vec![],
-            skip_rom_validation: false,
-            anchor_visuals: false,
-        }
-    }
-
-    /// Build an Options with all features cranked to max.
-    /// Palettes disabled because they use OS entropy (cosmetic, decoupled from seed).
-    fn all_on_options() -> Options {
-        Options {
-            fire_flower: FireFlowerMode::On,
-            piranha_shuffle: PiranhaMode::On,
-            powerups: true,
-            palettes: false,
-            palette_themed: false,
-            player_color: None,
-            world_order: true,
-            world_count: 3,
-            big_q_blocks: true,
-            shuffle_pipes: false,
-            shuffle_airships: true,
-            shuffle_hammer_bros: true,
-            disable_autoscroll: true,
-            chest_items: true,
-            remove_whistles: true,
-            more_hammer_rocks: Tri::On,
-            eights_are_wild: Tri::On,
-            starting_lives: 99,
-            card_speed_clear: true,
-            remove_n_cards: true,
-            skip_wand_cutscene: true,
-            adjust_boss_hitboxes: true,
-            koopaling_hits: true,
-            boomboom_hits: true,
-            hammer_vulnerable_koopalings: true,
-            random_koopalings: true,
-            include_beta_stages: false,
-            hammer_breaks_locks: Tri::On,
-            hammer_breaks_bridges: Tri::On,
-            early_sun: true,
-            limit_bro_movement: true,
-            japanese_damage: true,
-            infinite_mushroom_houses: true,
-            fast_mushroom_house: true,
-            faster_tail_speed: true,
-            no_game_over_penalty: true,
-            faster_frog: true,
-            shuffle_spade_games: true,
-            shuffle_toad_houses: true,
-            hands_levels: true,
-            troll_pipes: Tri::On,
-            swap_start_airship: false,
-            ground: EnemyMode::Wild,
-            shell: EnemyMode::Wild,
-            flying: EnemyMode::Wild,
-            piranhas: EnemyMode::Wild,
-            ghosts: EnemyMode::Wild,
-            thwomps: EnemyMode::Wild,
-            rotodiscs: EnemyMode::Wild,
-            cannons: EnemyMode::Wild,
-            water: EnemyMode::Wild,
-            bros: EnemyMode::Wild,
-            hb_encounters: EnemyMode::Wild,
-            wild_injections: true,
-            starting_items: vec![0x05, 0x09, 0x03],
-            skip_rom_validation: false,
-            anchor_visuals: true,
-        }
-    }
-
-    /// Build an Options testing world_order in isolation (no enemy RNG consumption).
-    fn world_order_only_options() -> Options {
-        let mut opts = all_off_options();
-        opts.world_order = true;
-        opts.world_count = 5;
-        opts
-    }
-
-    #[test]
-    fn test_full_determinism() {
-        let configs: Vec<(&str, Options)> = vec![
-            ("defaults", test_options()),
-            ("all_on", all_on_options()),
-            ("all_off", all_off_options()),
-            ("world_order_only", world_order_only_options()),
-        ];
-
-        let seed = 42u64;
-        for (name, options) in &configs {
-            // Run 1
-            let Some(mut rom1) = make_test_rom() else { return };
-            randomize(&mut rom1, seed, options);
-
-            // Run 2 (same seed, same options)
-            let Some(mut rom2) = make_test_rom() else { return };
-            randomize(&mut rom2, seed, options);
-
-            // Same-run determinism — find first differing byte for diagnostics
-            let b1 = rom1.output_bytes();
-            let b2 = rom2.output_bytes();
-            if b1 != b2 {
-                for i in 0..b1.len() {
-                    if b1[i] != b2[i] {
-                        panic!(
-                            "{name}: non-determinism at offset 0x{i:05X}: \
-                             run1=0x{:02X} run2=0x{:02X}",
-                            b1[i], b2[i]
-                        );
-                    }
-                }
-            }
-
-            // Verify hashes match (determinism, not pinned to a specific value)
-            let hash1 = fnv1a(b1);
-            let hash2 = fnv1a(b2);
-            assert_eq!(
-                hash1, hash2,
-                "{name}: hash mismatch between runs (0x{hash1:016X} vs 0x{hash2:016X})"
-            );
-        }
-    }
-
-    #[test]
-    fn maybe_flags_are_deterministic_and_hidden() {
-        // A `Maybe` flag must (1) round-trip through the flag key as `Maybe`,
-        // (2) produce a flag key indistinguishable from the seed-resolved
-        // concrete states (the value bit is forced to 0, like Off), and
-        // (3) generate byte-identical ROMs across runs with the same seed.
-        let mut opts = test_options();
-        opts.troll_pipes = Tri::Maybe;
-        opts.hammer_breaks_locks = Tri::Maybe;
-
-        // (1) round-trip
-        let decoded = Options::from_flag_key(&opts.to_flag_key()).unwrap();
-        assert_eq!(decoded.troll_pipes, Tri::Maybe);
-        assert_eq!(decoded.hammer_breaks_locks, Tri::Maybe);
-
-        // (2) hidden: a Maybe key differs from both On and Off keys, so the
-        // player can't read the resolved state off it.
-        let on = Options { troll_pipes: Tri::On, hammer_breaks_locks: Tri::On, ..test_options() };
-        let off = Options { troll_pipes: Tri::Off, hammer_breaks_locks: Tri::Off, ..test_options() };
-        assert_ne!(opts.to_flag_key(), on.to_flag_key());
-        assert_ne!(opts.to_flag_key(), off.to_flag_key());
-
-        // (3) determinism across runs (needs the real ROM).
-        let seed = 0xC0FFEEu64;
-        let Some(mut rom1) = make_test_rom() else { return };
-        let Some(mut rom2) = make_test_rom() else { return };
-        randomize(&mut rom1, seed, &opts);
-        randomize(&mut rom2, seed, &opts);
+        let recovered = Options::from_flag_key(&mutated_key)
+            .unwrap_or_else(|e| panic!("{label}: failed to decode key '{mutated_key}': {e}"));
         assert_eq!(
-            fnv1a(rom1.output_bytes()),
-            fnv1a(rom2.output_bytes()),
-            "Maybe flags must resolve identically for the same seed",
+            recovered, expected,
+            "{label}: round-trip mismatch\n  encoded: {mutated:?}\n  decoded: {recovered:?}",
         );
     }
 
-    #[test]
-    fn maybe_resolves_both_ways_across_seeds() {
-        // The more_hammer_rocks=Maybe coin flip must actually flip: across many
-        // seeds it should land On for some and Off for others. We isolate the
-        // *gameplay* effect (the make_hammer_rocks tile write) by comparing
-        // each Maybe run's tile bytes to the explicit-On run's bytes, so the
-        // flag-key stamp / title hash (which always differ for Maybe) don't
-        // confound the comparison.
-        let Some(_) = make_test_rom() else { return };
-        let on = Options { more_hammer_rocks: Tri::On, ..test_options() };
-        let maybe = Options { more_hammer_rocks: Tri::Maybe, ..test_options() };
+    /// A label + a closure that flips one Options field.
+    type OptionTweak = (&'static str, Box<dyn Fn(&mut Options)>);
 
-        // Capture the byte ranges make_hammer_rocks touches from a known-On run.
-        let on_touched: Vec<(usize, Vec<u8>)> = {
-            let mut rom = make_test_rom().unwrap();
-            randomize(&mut rom, 0, &on);
-            rom.write_log().iter()
-                .filter(|r| r.tag == "qol/more_hammer_rocks")
-                .map(|r| (r.offset, rom.read_range(r.offset, r.len).to_vec()))
-                .collect()
-        };
-        assert!(!on_touched.is_empty(), "expected more_hammer_rocks to write bytes when On");
-
-        let mut saw_on = false;
-        let mut saw_off = false;
-        for seed in 0u64..24 {
-            let mut rom = make_test_rom().unwrap();
-            randomize(&mut rom, seed, &maybe);
-            let matches_on = on_touched.iter()
-                .all(|(off, bytes)| rom.read_range(*off, bytes.len()) == bytes.as_slice());
-            if matches_on { saw_on = true; } else { saw_off = true; }
-        }
-        assert!(saw_on && saw_off,
-            "more_hammer_rocks=Maybe never exercised both outcomes across 24 seeds \
-             (saw_on={saw_on}, saw_off={saw_off})");
+    // Cosmetic: must NOT change the flag key.
+    let cosmetic: Vec<OptionTweak> = vec![
+        ("palettes",       Box::new(|o| o.palettes = !o.palettes)),
+        ("palette_themed", Box::new(|o| o.palette_themed = !o.palette_themed)),
+    ];
+    for (label, mutate) in cosmetic {
+        check_round_trip(label, mutate, false);
     }
 
-    #[test]
-    fn write_log_tags_match_enabled_modules() {
-        let Some(mut rom) = make_test_rom() else { return };
-        let mut options = test_options();
-        // Disable optional modules we can check for absence
-        options.ground = EnemyMode::Off;
-        options.shell = EnemyMode::Off;
-        options.flying = EnemyMode::Off;
-        options.piranhas = EnemyMode::Off;
-        options.ghosts = EnemyMode::Off;
-        options.water = EnemyMode::Off;
-        options.bros = EnemyMode::Off;
-        options.world_order = false;
-        // Keep this on — it writes to known offsets even on a zeroed ROM.
-        options.disable_autoscroll = true;
-        randomize(&mut rom, 42, &options);
-
-        let tags: Vec<&str> = rom.write_log().iter().map(|r| r.tag.as_str()).collect();
-        // These modules write to fixed offsets that differ from zero
-        assert!(tags.iter().any(|t| t.starts_with("autoscroll")));
-        // Disabled modules should not appear
-        assert!(!tags.iter().any(|t| t.starts_with("enemies")));
-        assert!(!tags.iter().any(|t| t.starts_with("world_order")));
+    // Encoded booleans: toggling must change the flag key.
+    let bools: Vec<OptionTweak> = vec![
+        ("powerups",                     Box::new(|o| o.powerups = !o.powerups)),
+        ("world_order",                  Box::new(|o| o.world_order = !o.world_order)),
+        ("big_q_blocks",                 Box::new(|o| o.big_q_blocks = !o.big_q_blocks)),
+        ("shuffle_pipes",                Box::new(|o| o.shuffle_pipes = !o.shuffle_pipes)),
+        ("shuffle_airships",             Box::new(|o| o.shuffle_airships = !o.shuffle_airships)),
+        ("shuffle_hammer_bros",          Box::new(|o| o.shuffle_hammer_bros = !o.shuffle_hammer_bros)),
+        ("disable_autoscroll",           Box::new(|o| o.disable_autoscroll = !o.disable_autoscroll)),
+        ("chest_items",                  Box::new(|o| o.chest_items = !o.chest_items)),
+        ("remove_whistles",              Box::new(|o| o.remove_whistles = !o.remove_whistles)),
+        ("card_speed_clear",             Box::new(|o| o.card_speed_clear = !o.card_speed_clear)),
+        ("remove_n_cards",               Box::new(|o| o.remove_n_cards = !o.remove_n_cards)),
+        ("skip_wand_cutscene",           Box::new(|o| o.skip_wand_cutscene = !o.skip_wand_cutscene)),
+        ("adjust_boss_hitboxes",         Box::new(|o| o.adjust_boss_hitboxes = !o.adjust_boss_hitboxes)),
+        ("koopaling_hits",               Box::new(|o| o.koopaling_hits = !o.koopaling_hits)),
+        ("boomboom_hits",                Box::new(|o| o.boomboom_hits = !o.boomboom_hits)),
+        ("hammer_vulnerable_koopalings", Box::new(|o| o.hammer_vulnerable_koopalings = !o.hammer_vulnerable_koopalings)),
+        ("random_koopalings",            Box::new(|o| o.random_koopalings = !o.random_koopalings)),
+        ("include_beta_stages",          Box::new(|o| o.include_beta_stages = !o.include_beta_stages)),
+        ("shuffle_spade_games",           Box::new(|o| o.shuffle_spade_games = !o.shuffle_spade_games)),
+        ("shuffle_toad_houses",          Box::new(|o| o.shuffle_toad_houses = !o.shuffle_toad_houses)),
+        ("wild_injections",              Box::new(|o| o.wild_injections = !o.wild_injections)),
+    ];
+    for (label, mutate) in bools {
+        check_round_trip(label, mutate, true);
     }
 
-    #[test]
-    fn flag_key_round_trip_all_random_items() {
-        let opts = Options {
-            starting_items: vec![ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY],
-            ..Default::default()
-        };
-        let key = opts.to_flag_key();
-        let decoded = Options::from_flag_key(&key).unwrap();
-        assert_eq!(decoded.starting_items, vec![ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY]);
-    }
-
-    #[test]
-    fn flag_key_round_trip_mixed_random_and_concrete() {
-        let opts = Options {
-            starting_items: vec![ITEM_RANDOM, 3],
-            ..Default::default()
-        };
-        let key = opts.to_flag_key();
-        let decoded = Options::from_flag_key(&key).unwrap();
-        assert_eq!(decoded.starting_items, vec![ITEM_RANDOM, 3]);
-    }
-
-    #[test]
-    fn resolve_starting_item_deterministic() {
-        let mut rng1 = ChaCha8Rng::seed_from_u64(42);
-        let mut rng2 = ChaCha8Rng::seed_from_u64(42);
-        let a = resolve_starting_item(ITEM_RANDOM, &mut rng1);
-        let b = resolve_starting_item(ITEM_RANDOM, &mut rng2);
-        assert_eq!(a, b, "same seed must produce same item");
-    }
-
-    #[test]
-    fn resolve_suit_only_in_range() {
-        for seed in 0..100u64 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let item = resolve_starting_item(ITEM_RANDOM_SUIT_ONLY, &mut rng);
-            assert!((1..=6).contains(&item), "suit-only produced {item}, expected 1-6");
+    // Tri-state enemy modes: cycle through every value so each non-default
+    // mode is exercised. Defaults differ per class, so test all three modes.
+    type TriSetter = Box<dyn Fn(&mut Options, EnemyMode)>;
+    let tristates: Vec<(&str, TriSetter)> = vec![
+        ("ground",        Box::new(|o, m| o.ground = m)),
+        ("shell",         Box::new(|o, m| o.shell = m)),
+        ("flying",        Box::new(|o, m| o.flying = m)),
+        ("piranhas",      Box::new(|o, m| o.piranhas = m)),
+        ("ghosts",        Box::new(|o, m| o.ghosts = m)),
+        ("thwomps",       Box::new(|o, m| o.thwomps = m)),
+        ("rotodiscs",     Box::new(|o, m| o.rotodiscs = m)),
+        ("cannons",       Box::new(|o, m| o.cannons = m)),
+        ("water",         Box::new(|o, m| o.water = m)),
+        ("bros",          Box::new(|o, m| o.bros = m)),
+        ("hb_encounters", Box::new(|o, m| o.hb_encounters = m)),
+    ];
+    for (label, set) in tristates {
+        for &mode in &[EnemyMode::Off, EnemyMode::Shuffle, EnemyMode::Wild] {
+            let default_opts = Options::default();
+            let mut mutated = default_opts.clone();
+            set(&mut mutated, mode);
+            let expected = normalized(mutated.clone());
+            let recovered = Options::from_flag_key(&mutated.to_flag_key()).unwrap();
+            assert_eq!(
+                recovered, expected,
+                "{label}={mode:?}: round-trip mismatch",
+            );
         }
     }
 
-    #[test]
-    fn resolve_no_whistle_never_whistle() {
-        for seed in 0..100u64 {
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let item = resolve_starting_item(ITEM_RANDOM_NO_WHISTLE, &mut rng);
-            assert_ne!(item, 0x0C, "no-whistle produced a whistle on seed {seed}");
-            assert!((1..=13).contains(&item), "no-whistle produced {item}, expected 1-13 (not 12)");
+    // Player-hidden tri flags (Off/On/Maybe): every state must round-trip,
+    // and every non-default state must change the flag key.
+    type TriFlagSetter = Box<dyn Fn(&mut Options, Tri)>;
+    let tri_flags: Vec<(&str, TriFlagSetter)> = vec![
+        ("hammer_breaks_locks",   Box::new(|o, t| o.hammer_breaks_locks = t)),
+        ("hammer_breaks_bridges", Box::new(|o, t| o.hammer_breaks_bridges = t)),
+        ("troll_pipes",           Box::new(|o, t| o.troll_pipes = t)),
+        ("more_hammer_rocks",        Box::new(|o, t| o.more_hammer_rocks = t)),
+        ("eights_are_wild",       Box::new(|o, t| o.eights_are_wild = t)),
+    ];
+    for (label, set) in tri_flags {
+        let default_opts = Options::default();
+        let default_key = default_opts.to_flag_key();
+        for &state in &[Tri::Off, Tri::On, Tri::Maybe] {
+            let mut mutated = default_opts.clone();
+            set(&mut mutated, state);
+            let mutated_key = mutated.to_flag_key();
+            let expected = normalized(mutated.clone());
+            let recovered = Options::from_flag_key(&mutated_key).unwrap();
+            assert_eq!(recovered, expected, "{label}={state:?}: round-trip mismatch");
+            // Default state shares its key with default; non-default must differ.
+            let is_default_state = recovered == normalized(default_opts.clone());
+            if !is_default_state {
+                assert_ne!(default_key, mutated_key, "{label}={state:?}: key must change");
+            }
         }
     }
 
-    #[test]
-    fn resolve_concrete_passthrough() {
-        let mut rng = ChaCha8Rng::seed_from_u64(0);
-        assert_eq!(resolve_starting_item(0, &mut rng), 0);
-        assert_eq!(resolve_starting_item(5, &mut rng), 5);
-        assert_eq!(resolve_starting_item(13, &mut rng), 13);
+    // Piranha shuffle (Off/On/Wild): every state must round-trip, and the
+    // non-default states must change the flag key.
+    {
+        let default_key = Options::default().to_flag_key();
+        for &mode in &[PiranhaMode::Off, PiranhaMode::On, PiranhaMode::Wild] {
+            let mutated = Options { piranha_shuffle: mode, ..Default::default() };
+            let mutated_key = mutated.to_flag_key();
+            let expected = normalized(mutated.clone());
+            let recovered = Options::from_flag_key(&mutated_key).unwrap();
+            assert_eq!(recovered, expected, "piranha_shuffle={mode:?}: round-trip mismatch");
+            if mode != PiranhaMode::Off {
+                assert_ne!(default_key, mutated_key, "piranha_shuffle={mode:?}: key must change");
+            }
+        }
     }
+
+    // starting_lives is 2 bits indexing {1, 5, 20, 99} — only the four
+    // canonical values round-trip exactly.
+    for lives in STARTING_LIVES_VALUES {
+        let opts = Options { starting_lives: lives, ..Default::default() };
+        let expected = normalized(opts.clone());
+        let recovered = Options::from_flag_key(&opts.to_flag_key()).unwrap();
+        assert_eq!(recovered.starting_lives, lives, "starting_lives={lives}: round-trip mismatch");
+        assert_eq!(recovered, expected, "starting_lives={lives}: full struct mismatch");
+    }
+    for wc in 1u8..=7 {
+        let opts = Options { world_count: wc, ..Default::default() };
+        let expected = normalized(opts.clone());
+        let recovered = Options::from_flag_key(&opts.to_flag_key()).unwrap();
+        assert_eq!(recovered.world_count, wc, "world_count={wc}: round-trip mismatch");
+        assert_eq!(recovered, expected, "world_count={wc}: full struct mismatch");
+    }
+
+    // starting_items: empty, singles, multi, sentinels (random modes).
+    for items in [
+        vec![],
+        vec![3u8],
+        vec![3, 6, 9],
+        vec![ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY],
+    ] {
+        let opts = Options { starting_items: items.clone(), ..Default::default() };
+        let expected = normalized(opts.clone());
+        let recovered = Options::from_flag_key(&opts.to_flag_key()).unwrap();
+        assert_eq!(recovered.starting_items, items, "starting_items={items:?}: round-trip mismatch");
+        assert_eq!(recovered, expected, "starting_items={items:?}: full struct mismatch");
+    }
+
+    // Combination: every encoded boolean flipped from default, all
+    // tri-states set to Wild, level shuffle on, beta stages, items.
+    // Catches bit-collision bugs that only manifest when many fields
+    // share their non-default values.
+    let mut everything = Options::default();
+    everything.powerups = !everything.powerups;
+    everything.world_order = !everything.world_order;
+    everything.big_q_blocks = !everything.big_q_blocks;
+    everything.shuffle_pipes = !everything.shuffle_pipes;
+    everything.shuffle_airships = !everything.shuffle_airships;
+    everything.shuffle_hammer_bros = !everything.shuffle_hammer_bros;
+    everything.disable_autoscroll = !everything.disable_autoscroll;
+    everything.chest_items = !everything.chest_items;
+    everything.remove_whistles = !everything.remove_whistles;
+    everything.more_hammer_rocks = Tri::Maybe;
+    everything.eights_are_wild = Tri::Maybe;
+    everything.card_speed_clear = !everything.card_speed_clear;
+    everything.remove_n_cards = !everything.remove_n_cards;
+    everything.skip_wand_cutscene = !everything.skip_wand_cutscene;
+    everything.adjust_boss_hitboxes = !everything.adjust_boss_hitboxes;
+    everything.koopaling_hits = !everything.koopaling_hits;
+    everything.boomboom_hits = !everything.boomboom_hits;
+    everything.hammer_vulnerable_koopalings = true;
+    everything.random_koopalings = true;
+    everything.include_beta_stages = true;
+    everything.hammer_breaks_locks = Tri::Maybe;
+    everything.hammer_breaks_bridges = Tri::On;
+    everything.troll_pipes = Tri::Maybe;
+    everything.shuffle_spade_games = !everything.shuffle_spade_games;
+    everything.shuffle_toad_houses = !everything.shuffle_toad_houses;
+    everything.wild_injections = true;
+    everything.ground = EnemyMode::Wild;
+    everything.shell = EnemyMode::Wild;
+    everything.flying = EnemyMode::Wild;
+    everything.piranhas = EnemyMode::Wild;
+    everything.ghosts = EnemyMode::Wild;
+    everything.thwomps = EnemyMode::Wild;
+    everything.rotodiscs = EnemyMode::Wild;
+    everything.cannons = EnemyMode::Wild;
+    everything.water = EnemyMode::Wild;
+    everything.bros = EnemyMode::Wild;
+    everything.hb_encounters = EnemyMode::Wild;
+    everything.starting_lives = 99;
+    everything.world_count = 1;
+    everything.starting_items = vec![ITEM_RANDOM, 5, ITEM_RANDOM_SUIT_ONLY];
+    let expected = normalized(everything.clone());
+    let recovered = Options::from_flag_key(&everything.to_flag_key()).unwrap();
+    assert_eq!(recovered, expected, "all-fields-flipped: round-trip mismatch");
+}
+
+#[test]
+fn flag_key_hammer_vuln_koopalings_distinct_from_hb_encounters() {
+    // Regression: hammer_vulnerable_koopalings used to share bit 2 of b4
+    // with the high bit of hb_encounters (a tri-state at bits 2-1).
+    // When hb_encounters=Wild (em=2), bit 2 was already set, so toggling
+    // hammer_vulnerable_koopalings produced no change in the flag key.
+    let a = Options {
+        hb_encounters: EnemyMode::Wild,
+        hammer_vulnerable_koopalings: false,
+        ..Default::default()
+    };
+
+    let b = Options { hammer_vulnerable_koopalings: true, ..a.clone() };
+
+    assert_ne!(a.to_flag_key(), b.to_flag_key(),
+        "toggling hammer_vulnerable_koopalings must change the flag key");
+
+    let dec_a = Options::from_flag_key(&a.to_flag_key()).unwrap();
+    let dec_b = Options::from_flag_key(&b.to_flag_key()).unwrap();
+    assert!(!dec_a.hammer_vulnerable_koopalings);
+    assert!(dec_b.hammer_vulnerable_koopalings);
+    assert_eq!(dec_a.hb_encounters, EnemyMode::Wild);
+    assert_eq!(dec_b.hb_encounters, EnemyMode::Wild);
+}
+
+#[test]
+fn base32_round_trip() {
+    // Test with various byte patterns
+    for data in [
+        vec![0u8; 11],
+        vec![0xFF; 11],
+        vec![0x0E, 0xFF, 0xFE, 0x63, 0xFC, 0xAA, 0xAA, 0xAA, 0x59, 0x37, 0xC0],
+        (0..11).collect::<Vec<u8>>(),
+    ] {
+        let encoded = base32_encode(&data);
+        let decoded = base32_decode(&encoded, data.len()).unwrap();
+        assert_eq!(data, decoded, "round-trip failed for {data:?} (encoded: {encoded})");
+    }
+}
+
+/// Inline FNV-1a hash — no external dependency needed.
+fn fnv1a(data: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+/// Build an Options with everything disabled (exercises "skip everything" branches).
+///
+/// Deliberately an exhaustive field-by-field literal (no `..Default::default()`):
+/// adding a field to Options must fail to compile here, forcing the flag-key
+/// tests to be updated alongside the struct.
+fn all_off_options() -> Options {
+    Options {
+        fire_flower: FireFlowerMode::Off,
+        piranha_shuffle: PiranhaMode::Off,
+        powerups: false,
+        palettes: false,
+        palette_themed: false,
+        player_color: None,
+        world_order: false,
+        world_count: 7,
+        big_q_blocks: false,
+        shuffle_pipes: false,
+        shuffle_airships: false,
+        shuffle_hammer_bros: false,
+        disable_autoscroll: false,
+        chest_items: false,
+        remove_whistles: false,
+        more_hammer_rocks: Tri::Off,
+        eights_are_wild: Tri::Off,
+        starting_lives: 1,
+        card_speed_clear: false,
+        remove_n_cards: false,
+        skip_wand_cutscene: false,
+        adjust_boss_hitboxes: false,
+        koopaling_hits: false,
+        boomboom_hits: false,
+        hammer_vulnerable_koopalings: false,
+        random_koopalings: false,
+        include_beta_stages: false,
+        hammer_breaks_locks: Tri::Off,
+        hammer_breaks_bridges: Tri::Off,
+        early_sun: false,
+        limit_bro_movement: false,
+        japanese_damage: false,
+        infinite_mushroom_houses: false,
+        fast_mushroom_house: false,
+        faster_tail_speed: false,
+        no_game_over_penalty: false,
+        faster_frog: false,
+        shuffle_spade_games: false,
+        shuffle_toad_houses: false,
+        hands_levels: false,
+        troll_pipes: Tri::Off,
+        swap_start_airship: false,
+        ground: EnemyMode::Off,
+        shell: EnemyMode::Off,
+        flying: EnemyMode::Off,
+        piranhas: EnemyMode::Off,
+        ghosts: EnemyMode::Off,
+        thwomps: EnemyMode::Off,
+        rotodiscs: EnemyMode::Off,
+        cannons: EnemyMode::Off,
+        water: EnemyMode::Off,
+        bros: EnemyMode::Off,
+        hb_encounters: EnemyMode::Off,
+        wild_injections: false,
+        starting_items: vec![],
+        skip_rom_validation: false,
+        anchor_visuals: false,
+    }
+}
+
+/// Build an Options with all features cranked to max.
+/// Palettes disabled because they use OS entropy (cosmetic, decoupled from seed).
+fn all_on_options() -> Options {
+    Options {
+        fire_flower: FireFlowerMode::On,
+        piranha_shuffle: PiranhaMode::On,
+        powerups: true,
+        palettes: false,
+        palette_themed: false,
+        player_color: None,
+        world_order: true,
+        world_count: 3,
+        big_q_blocks: true,
+        shuffle_pipes: false,
+        shuffle_airships: true,
+        shuffle_hammer_bros: true,
+        disable_autoscroll: true,
+        chest_items: true,
+        remove_whistles: true,
+        more_hammer_rocks: Tri::On,
+        eights_are_wild: Tri::On,
+        starting_lives: 99,
+        card_speed_clear: true,
+        remove_n_cards: true,
+        skip_wand_cutscene: true,
+        adjust_boss_hitboxes: true,
+        koopaling_hits: true,
+        boomboom_hits: true,
+        hammer_vulnerable_koopalings: true,
+        random_koopalings: true,
+        include_beta_stages: false,
+        hammer_breaks_locks: Tri::On,
+        hammer_breaks_bridges: Tri::On,
+        early_sun: true,
+        limit_bro_movement: true,
+        japanese_damage: true,
+        infinite_mushroom_houses: true,
+        fast_mushroom_house: true,
+        faster_tail_speed: true,
+        no_game_over_penalty: true,
+        faster_frog: true,
+        shuffle_spade_games: true,
+        shuffle_toad_houses: true,
+        hands_levels: true,
+        troll_pipes: Tri::On,
+        swap_start_airship: false,
+        ground: EnemyMode::Wild,
+        shell: EnemyMode::Wild,
+        flying: EnemyMode::Wild,
+        piranhas: EnemyMode::Wild,
+        ghosts: EnemyMode::Wild,
+        thwomps: EnemyMode::Wild,
+        rotodiscs: EnemyMode::Wild,
+        cannons: EnemyMode::Wild,
+        water: EnemyMode::Wild,
+        bros: EnemyMode::Wild,
+        hb_encounters: EnemyMode::Wild,
+        wild_injections: true,
+        starting_items: vec![0x05, 0x09, 0x03],
+        skip_rom_validation: false,
+        anchor_visuals: true,
+    }
+}
+
+/// Build an Options testing world_order in isolation (no enemy RNG consumption).
+fn world_order_only_options() -> Options {
+    let mut opts = all_off_options();
+    opts.world_order = true;
+    opts.world_count = 5;
+    opts
+}
+
+#[test]
+fn test_full_determinism() {
+    let configs: Vec<(&str, Options)> = vec![
+        ("defaults", test_options()),
+        ("all_on", all_on_options()),
+        ("all_off", all_off_options()),
+        ("world_order_only", world_order_only_options()),
+    ];
+
+    let seed = 42u64;
+    for (name, options) in &configs {
+        // Run 1
+        let Some(mut rom1) = make_test_rom() else { return };
+        randomize(&mut rom1, seed, options);
+
+        // Run 2 (same seed, same options)
+        let Some(mut rom2) = make_test_rom() else { return };
+        randomize(&mut rom2, seed, options);
+
+        // Same-run determinism — find first differing byte for diagnostics
+        let b1 = rom1.output_bytes();
+        let b2 = rom2.output_bytes();
+        if b1 != b2 {
+            for i in 0..b1.len() {
+                if b1[i] != b2[i] {
+                    panic!(
+                        "{name}: non-determinism at offset 0x{i:05X}: \
+                         run1=0x{:02X} run2=0x{:02X}",
+                        b1[i], b2[i]
+                    );
+                }
+            }
+        }
+
+        // Verify hashes match (determinism, not pinned to a specific value)
+        let hash1 = fnv1a(b1);
+        let hash2 = fnv1a(b2);
+        assert_eq!(
+            hash1, hash2,
+            "{name}: hash mismatch between runs (0x{hash1:016X} vs 0x{hash2:016X})"
+        );
+    }
+}
+
+#[test]
+fn maybe_flags_are_deterministic_and_hidden() {
+    // A `Maybe` flag must (1) round-trip through the flag key as `Maybe`,
+    // (2) produce a flag key indistinguishable from the seed-resolved
+    // concrete states (the value bit is forced to 0, like Off), and
+    // (3) generate byte-identical ROMs across runs with the same seed.
+    let mut opts = test_options();
+    opts.troll_pipes = Tri::Maybe;
+    opts.hammer_breaks_locks = Tri::Maybe;
+
+    // (1) round-trip
+    let decoded = Options::from_flag_key(&opts.to_flag_key()).unwrap();
+    assert_eq!(decoded.troll_pipes, Tri::Maybe);
+    assert_eq!(decoded.hammer_breaks_locks, Tri::Maybe);
+
+    // (2) hidden: a Maybe key differs from both On and Off keys, so the
+    // player can't read the resolved state off it.
+    let on = Options { troll_pipes: Tri::On, hammer_breaks_locks: Tri::On, ..test_options() };
+    let off = Options { troll_pipes: Tri::Off, hammer_breaks_locks: Tri::Off, ..test_options() };
+    assert_ne!(opts.to_flag_key(), on.to_flag_key());
+    assert_ne!(opts.to_flag_key(), off.to_flag_key());
+
+    // (3) determinism across runs (needs the real ROM).
+    let seed = 0xC0FFEEu64;
+    let Some(mut rom1) = make_test_rom() else { return };
+    let Some(mut rom2) = make_test_rom() else { return };
+    randomize(&mut rom1, seed, &opts);
+    randomize(&mut rom2, seed, &opts);
+    assert_eq!(
+        fnv1a(rom1.output_bytes()),
+        fnv1a(rom2.output_bytes()),
+        "Maybe flags must resolve identically for the same seed",
+    );
+}
+
+#[test]
+fn maybe_resolves_both_ways_across_seeds() {
+    // The more_hammer_rocks=Maybe coin flip must actually flip: across many
+    // seeds it should land On for some and Off for others. We isolate the
+    // *gameplay* effect (the make_hammer_rocks tile write) by comparing
+    // each Maybe run's tile bytes to the explicit-On run's bytes, so the
+    // flag-key stamp / title hash (which always differ for Maybe) don't
+    // confound the comparison.
+    let Some(_) = make_test_rom() else { return };
+    let on = Options { more_hammer_rocks: Tri::On, ..test_options() };
+    let maybe = Options { more_hammer_rocks: Tri::Maybe, ..test_options() };
+
+    // Capture the byte ranges make_hammer_rocks touches from a known-On run.
+    let on_touched: Vec<(usize, Vec<u8>)> = {
+        let mut rom = make_test_rom().unwrap();
+        randomize(&mut rom, 0, &on);
+        rom.write_log().iter()
+            .filter(|r| r.tag == "qol/more_hammer_rocks")
+            .map(|r| (r.offset, rom.read_range(r.offset, r.len).to_vec()))
+            .collect()
+    };
+    assert!(!on_touched.is_empty(), "expected more_hammer_rocks to write bytes when On");
+
+    let mut saw_on = false;
+    let mut saw_off = false;
+    for seed in 0u64..24 {
+        let mut rom = make_test_rom().unwrap();
+        randomize(&mut rom, seed, &maybe);
+        let matches_on = on_touched.iter()
+            .all(|(off, bytes)| rom.read_range(*off, bytes.len()) == bytes.as_slice());
+        if matches_on { saw_on = true; } else { saw_off = true; }
+    }
+    assert!(saw_on && saw_off,
+        "more_hammer_rocks=Maybe never exercised both outcomes across 24 seeds \
+         (saw_on={saw_on}, saw_off={saw_off})");
+}
+
+#[test]
+fn write_log_tags_match_enabled_modules() {
+    let Some(mut rom) = make_test_rom() else { return };
+    let mut options = test_options();
+    // Disable optional modules we can check for absence
+    options.ground = EnemyMode::Off;
+    options.shell = EnemyMode::Off;
+    options.flying = EnemyMode::Off;
+    options.piranhas = EnemyMode::Off;
+    options.ghosts = EnemyMode::Off;
+    options.water = EnemyMode::Off;
+    options.bros = EnemyMode::Off;
+    options.world_order = false;
+    // Keep this on — it writes to known offsets even on a zeroed ROM.
+    options.disable_autoscroll = true;
+    randomize(&mut rom, 42, &options);
+
+    let tags: Vec<&str> = rom.write_log().iter().map(|r| r.tag.as_str()).collect();
+    // These modules write to fixed offsets that differ from zero
+    assert!(tags.iter().any(|t| t.starts_with("autoscroll")));
+    // Disabled modules should not appear
+    assert!(!tags.iter().any(|t| t.starts_with("enemies")));
+    assert!(!tags.iter().any(|t| t.starts_with("world_order")));
+}
+
+#[test]
+fn flag_key_round_trip_all_random_items() {
+    let opts = Options {
+        starting_items: vec![ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY],
+        ..Default::default()
+    };
+    let key = opts.to_flag_key();
+    let decoded = Options::from_flag_key(&key).unwrap();
+    assert_eq!(decoded.starting_items, vec![ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY]);
+}
+
+#[test]
+fn flag_key_round_trip_mixed_random_and_concrete() {
+    let opts = Options {
+        starting_items: vec![ITEM_RANDOM, 3],
+        ..Default::default()
+    };
+    let key = opts.to_flag_key();
+    let decoded = Options::from_flag_key(&key).unwrap();
+    assert_eq!(decoded.starting_items, vec![ITEM_RANDOM, 3]);
+}
+
+#[test]
+fn resolve_starting_item_deterministic() {
+    let mut rng1 = ChaCha8Rng::seed_from_u64(42);
+    let mut rng2 = ChaCha8Rng::seed_from_u64(42);
+    let a = resolve_starting_item(ITEM_RANDOM, &mut rng1);
+    let b = resolve_starting_item(ITEM_RANDOM, &mut rng2);
+    assert_eq!(a, b, "same seed must produce same item");
+}
+
+#[test]
+fn resolve_suit_only_in_range() {
+    for seed in 0..100u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let item = resolve_starting_item(ITEM_RANDOM_SUIT_ONLY, &mut rng);
+        assert!((1..=6).contains(&item), "suit-only produced {item}, expected 1-6");
+    }
+}
+
+#[test]
+fn resolve_no_whistle_never_whistle() {
+    for seed in 0..100u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let item = resolve_starting_item(ITEM_RANDOM_NO_WHISTLE, &mut rng);
+        assert_ne!(item, 0x0C, "no-whistle produced a whistle on seed {seed}");
+        assert!((1..=13).contains(&item), "no-whistle produced {item}, expected 1-13 (not 12)");
+    }
+}
+
+#[test]
+fn resolve_concrete_passthrough() {
+    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    assert_eq!(resolve_starting_item(0, &mut rng), 0);
+    assert_eq!(resolve_starting_item(5, &mut rng), 5);
+    assert_eq!(resolve_starting_item(13, &mut rng), 13);
+}


### PR DESCRIPTION
## Summary

Full-codebase simplicity review (all `.rs` files, ~28k lines) followed by six cleanup commits working through every finding. No functionality changes; ROM output verified **byte-identical** to `main` at every phase across seeds and heavy option mixes, with two accepted per-seed deltas noted below.

### Per-commit highlights

- **enemies** (`ab655b9`): delete `PageBuckets` — since the uniform-pick fix its `pick()` was identical to `pick_compatible` over the wild pool, and `build()` carried a latent K× over-weighting bug for no-bank enemies. `find_class_pool` returns an explicit `ClassPool` enum instead of encoding pool kind in pointer identity (`ptr::eq`), which also makes the piranha pools `const` again. Shared `LevelDataRegion::command_size()` ends the level-stream parser fork between powerups and enemy entry points. `pick_replacement()` extracted from the 285-line walker loop.
- **core infra** (`d1661a2`): remove the dead `--shuffle-pipes`/`--shuffle-airships` flags (parsed, never read); flatten the ips.rs gap-absorption scan (behavior pinned by a new record-layout test — the real gap limit is 4 bytes, not the 3 the old comment implied); build flag-key `b4` in one expression; case-insensitive `SMB3R-` prefix; de-duplicate the ~50-field Options literal in tests.
- **overworld builder** (`fd57932`): named sibling imports replace the six `use *` globs; `ScoredLock` struct replaces positional 6-tuples in `place_locks`; `stamp_slots()` unifies two production copies and four *drifted* test copies of slot stamping; scoring weights defined once.
- **writer + map_walker** (`d602588`): delete a 27-line stale doc block describing a different patch; `canoes_reachable` reuses the real BFS core instead of a ~60-line hand-synced copy (dock-gating semantics unchanged); `take_level_slot`/`write_entry_pos`/`shuffled_obj_groups` dedups with exact RNG/take order preserved; `test_fx_slots_valid` asserts exact FX slot bytes instead of a near-tautological count.
- **feature modules** (`edd9554`): fix four comments claiming `LDA $DF24,X` (address is `$9F24`); split SAS `write_engine_scaffolding` along its tag seams; podoboo landmark pinning is direct (`PINNED_X`) instead of offset→index→X; `map_table()` removes six read-map-write copies in items.rs; koopalings entry points generic over `R: Rng`.
- **qol / rom_data** (`6288389`): canoe.rs hook constants renamed to what they actually do — verified byte-for-byte that the old `CANOE_RESPAWN_HOOK` calls the *restore* half of `FS_CANOE_BACKUP` and the old "boundary patch" is the real respawn retarget (`$DDE0` = `FS_CANOE_RESPAWN`); JSR operands now derived via `jsr_into_bank`. Free-space registry factual fixes (66-byte backup routine, `$BD32` not `$BD42`) and its test now covers every `FS_*` constant. Title-screen CPU addresses derived from FS constants via new `prg031_file_to_cpu`. Shared intro-skip helper replaces the byte-duplicated trampoline between title_screen and starting_state, with the overwrite relationship stated where it happens.

### Verification

- `cargo clippy --all-targets -- -D warnings`: clean at every commit.
- `cargo test`: 252 lib + integration suites green; `enemy_invariant_baseline` oracle ran 500 seeds on the real ROM with zero violations.
- Determinism: patched-ROM output byte-compared against the pre-change build per phase (seeds 1/7/42/107; option mixes covering world order, SAS, wild injections, piranha wild, koopalings, big-Q, starting items, hammer-breaks, 8s-are-wild, beta stages) — identical except the two accepted deltas below.

### Accepted per-seed deltas (unreleased project; distribution unchanged)

1. Enemy wild picks can differ per seed — candidate ordering changed when PageBuckets' grouping was removed; uniform distribution and all invariants unchanged.
2. King-quote selection differs per seed — `choose_multiple` replaces the manual pick-7 loop; diff confined to the quote text block.

### Open question (not changed)

`swap_enemy`'s tall-enemy Y−1 keys off the new id only, so tall→tall swaps (bro↔bro) also rise one row while the fire-jet shift is delta-based. The comment now states this plainly; whether it should become delta-based is a playtest call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)