### PR TITLE
fix: pin chaser CHR pages level-wide to stop sprite mangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Fixed
+
+- Garbled enemy sprites in levels with player-chasing enemies: Lakitu, the
+  Angry Sun, and the Big Berthas (vanilla, wild-picked, or wild-injected)
+  now pin their graphics page across the whole level instead of just their
+  own screen, wild injections check the entire enemy segment (including
+  levels that share its data), and Boom-Boom's page is respected by nearby
+  enemy picks.
+
 ## [0.11.2] - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,8 @@ into a versioned section when a release is cut.
 - Garbled enemy sprites in levels with player-chasing enemies: Lakitu, the
   Angry Sun, and the Big Berthas (vanilla, wild-picked, or wild-injected)
   now pin their graphics page across the whole level instead of just their
-  own screen, wild injections check the entire enemy segment (including
-  levels that share its data), and Boom-Boom's page is respected by nearby
-  enemy picks.
+  own screen, and wild injections check the entire enemy segment (including
+  levels that share its data).
 
 ## [0.11.2] - 2026-07-10
 

--- a/src/randomize/enemies/class_modes.rs
+++ b/src/randomize/enemies/class_modes.rs
@@ -117,18 +117,29 @@ impl ClassPool {
 }
 
 /// Whether the walker's Pass 1 should pre-commit this object's CHR page
-/// before replacements are picked: non-swappable objects (except Boom-Booms,
-/// which are swapped separately via `BOOMBOOM_SWAP`) and uniform-CHR classes
-/// (every member shares the page/slot, so a swap can't change it). Wild
-/// entries never pre-commit — their page is decided by the pick itself.
+/// before replacements are picked: non-swappable objects and uniform-CHR
+/// classes (every member shares the page/slot, so a swap can't change it).
+/// Boom-Booms pre-commit too — their separate `BOOMBOOM_SWAP` is CHR-neutral
+/// (0x4B↔0x4C share one page/slot; 0x4A never swaps), so the original id's
+/// page is exact. Wild entries never pre-commit — their page is decided by
+/// the pick itself.
 pub(super) fn should_precommit(obj_id: u8, modes: &ClassModes) -> bool {
     match find_class_pool(obj_id, modes) {
-        None => !BOOMBOOM_IDS.contains(&obj_id),
+        None => true,
         Some(ClassPool::Wild) => false,
         Some(ClassPool::PiranhaStd) => is_uniform_chr_class(PIRANHAS_WILD),
         Some(ClassPool::PiranhaCeil) => is_uniform_chr_class(PIRANHASC_WILD),
         Some(ClassPool::Class(class)) => is_uniform_chr_class(class),
     }
+}
+
+/// Whether this entry's CHR page is fixed before any pick is made: either the
+/// enemy can't change (no class pool / class off / curated SkipSwap), or any
+/// swap it can undergo keeps the same page (uniform-CHR class, Boom-Boom
+/// self-swap). Pinned pages are pre-committed so picks route around them.
+pub(super) fn is_pinned(obj_id: u8, file_offset: usize, modes: &ClassModes) -> bool {
+    should_precommit(obj_id, modes)
+        || entry_protection_at(file_offset) == Some(EntryProtection::SkipSwap)
 }
 
 /// Identify which class an enemy ID belongs to, and return the swap pool

--- a/src/randomize/enemies/class_modes.rs
+++ b/src/randomize/enemies/class_modes.rs
@@ -119,13 +119,16 @@ impl ClassPool {
 /// Whether the walker's Pass 1 should pre-commit this object's CHR page
 /// before replacements are picked: non-swappable objects and uniform-CHR
 /// classes (every member shares the page/slot, so a swap can't change it).
-/// Boom-Booms pre-commit too — their separate `BOOMBOOM_SWAP` is CHR-neutral
-/// (0x4B↔0x4C share one page/slot; 0x4A never swaps), so the original id's
-/// page is exact. Wild entries never pre-commit — their page is decided by
-/// the pick itself.
+/// Wild entries never pre-commit — their page is decided by the pick itself.
+///
+/// Boom-Booms are DELIBERATELY not pinned, even though their self-swap is
+/// CHR-neutral: pinning $33/+5 (or $13/+4 for 0x4A) would exclude shell
+/// enemies (koopas are $4F/+5) from Boom-Boom rooms, and the shell-vs-boss
+/// interaction is wanted gameplay. Boom-Booms sit alone in their arenas in
+/// almost every level, so the CHR risk is accepted.
 pub(super) fn should_precommit(obj_id: u8, modes: &ClassModes) -> bool {
     match find_class_pool(obj_id, modes) {
-        None => true,
+        None => !BOOMBOOM_IDS.contains(&obj_id),
         Some(ClassPool::Wild) => false,
         Some(ClassPool::PiranhaStd) => is_uniform_chr_class(PIRANHAS_WILD),
         Some(ClassPool::PiranhaCeil) => is_uniform_chr_class(PIRANHASC_WILD),

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -57,6 +57,7 @@ pub fn enemy_entry_points(rom: &Rom) -> Vec<u16> {
 pub(super) fn inject_at_entry_points<R: Rng>(
     data: &mut [u8],
     entry_ptrs: &[u16],
+    bounds: &[segment_writer::SegmentBounds],
     opts: &Options,
     rng: &mut R,
 ) {
@@ -124,13 +125,30 @@ pub(super) fn inject_at_entry_points<R: Rng>(
             continue;
         }
 
-        // Pre-commit CHR pages for the rest of the run so the injected
-        // enemy is chosen compatible with what stays.
+        // Pre-commit pinned CHR pages from the WHOLE $FF-bounded segment
+        // containing this ep — not just the ep's own run. Level enemy runs
+        // nest inside segments: an outer level's run starts earlier and
+        // reads straight through this ep, so the injected enemy (which
+        // chases the player level-wide — every WILD_INJECTION_ID is a
+        // chaser) is also on screen with entries *before* the ep when that
+        // level is played.
+        let Some(seg) = bounds.iter().find(|b| {
+            let entries_start = b.file_offset + 1;
+            let entries_end = entries_start + b.entry_count * 3;
+            (entries_start..entries_end).contains(&first_entry_idx)
+        }) else {
+            continue; // ep not inside any walkable segment — don't inject
+        };
         let mut s4 = ChrSlot::Free;
         let mut s5 = ChrSlot::Free;
-        for e in &entries[1..] {
-            if should_precommit(e.obj_id, &normal_modes) {
-                commit_chr_page(e.obj_id, &mut s4, &mut s5);
+        for k in 0..seg.entry_count {
+            let off = seg.file_offset + 1 + k * 3;
+            if off == entries[0].data_index {
+                continue; // the slot being replaced — its enemy goes away
+            }
+            let fo = ENEMY_DATA_START + off;
+            if is_pinned(data[off], fo, &normal_modes) {
+                commit_chr_page(data[off], &mut s4, &mut s5);
             }
         }
 

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -97,10 +97,14 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
     // Wild injection runs in its own pass driven by *level entry points*
     // (header-pointed enemy_ptr values), not by walker-segments. This
     // guarantees every injection lands on a byte the SMB3 level loader
-    // actually reads. See inject_at_entry_points doc for details.
+    // actually reads. See inject_at_entry_points doc for details. Segment
+    // bounds are passed so the injection's CHR pin-scan can cover the whole
+    // $FF-bounded segment, not just the ep's own run (runs nest, and outer
+    // levels see the injected enemy too).
     if opts.wild_injections && !big_q_only {
         let entry_ptrs = enemy_entry_points(rom);
-        inject_at_entry_points(&mut data, &entry_ptrs, opts, rng);
+        let bounds = segment_writer::walk_segments(&data, 0, data.len(), &skip_ranges);
+        inject_at_entry_points(&mut data, &entry_ptrs, &bounds, opts, rng);
     }
 
     let mut i = 0;
@@ -169,17 +173,46 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         // CHR pages.
         let groups = chr_groups(&entries);
 
+        // Level-wide chaser bookkeeping (see CHASER_IDS): Lakitu, the Angry
+        // Sun, and the Big Berthas follow the player across proximity groups,
+        // so the one-screen assumption behind chr_groups doesn't hold for them.
+        //  - seg_all accumulates every commitment in the segment: pinned pages
+        //    from all groups up front, then every pick as it's made. A chaser
+        //    candidate must be compatible with all of it (checked in
+        //    pick_replacement via ChrCtx::segment).
+        //  - seg_chaser holds the pages of chasers present in the segment
+        //    (pinned now, or picked as we go); it seeds every group's local
+        //    slots so ordinary picks stay compatible with a chaser that will
+        //    follow the player to them.
+        let mut seg_all4 = ChrSlot::Free;
+        let mut seg_all5 = ChrSlot::Free;
+        let mut seg_chaser4 = ChrSlot::Free;
+        let mut seg_chaser5 = ChrSlot::Free;
+        if !big_q_only {
+            for entry in &entries {
+                let fo = ENEMY_DATA_START + entry.data_index;
+                if is_pinned(entry.obj_id, fo, modes) {
+                    commit_chr_page(entry.obj_id, &mut seg_all4, &mut seg_all5);
+                    if CHASER_IDS.contains(&entry.obj_id) {
+                        commit_chr_page(entry.obj_id, &mut seg_chaser4, &mut seg_chaser5);
+                    }
+                }
+            }
+        }
+
         for group in &groups {
             // Two-pass approach per CHR group:
-            // Pass 1: pre-commit CHR pages from non-swappable objects AND uniform-CHR
-            // classes (all members share the same page/slot, so swapping can't change it).
-            let mut committed_slot4 = ChrSlot::Free;
-            let mut committed_slot5 = ChrSlot::Free;
+            // Pass 1: pre-commit CHR pages from pinned entries (non-swappable
+            // objects, uniform-CHR classes, SkipSwap protections), seeded with
+            // the pages of any level-wide chasers in the segment.
+            let mut committed_slot4 = seg_chaser4;
+            let mut committed_slot5 = seg_chaser5;
 
             if !big_q_only {
                 for &idx in group {
                     let entry = &entries[idx];
-                    if should_precommit(entry.obj_id, modes) {
+                    let fo = ENEMY_DATA_START + entry.data_index;
+                    if is_pinned(entry.obj_id, fo, modes) {
                         commit_chr_page(entry.obj_id, &mut committed_slot4, &mut committed_slot5);
                     }
                 }
@@ -206,20 +239,33 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                     data[entry.data_index] = *BOOMBOOM_SWAP.choose(rng).unwrap();
                     continue;
                 }
-                // SkipSwap keeps its enemy but still pins the CHR slot.
+                // SkipSwap keeps its enemy; its CHR page was already pinned
+                // in Pass 1 (is_pinned covers SkipSwap protections).
                 if protection == Some(EntryProtection::SkipSwap) {
-                    commit_chr_page(entry.obj_id, &mut committed_slot4, &mut committed_slot5);
                     continue;
                 }
 
                 let was_bertha = BERTHA_IDS.contains(&data[entry.data_index]);
                 let cap_full = bertha_count.saturating_sub(was_bertha as u8)
                     >= MAX_BERTHA_PER_SEGMENT;
+                let chr = ChrCtx {
+                    local: (committed_slot4, committed_slot5),
+                    segment: (seg_all4, seg_all5),
+                };
                 let Some(chosen) = pick_replacement(
-                    entry, protection, modes, wild_pool,
-                    (committed_slot4, committed_slot5), cap_full, rng,
+                    entry, protection, modes, wild_pool, chr, cap_full, rng,
                 ) else {
-                    continue; // protection mode off, or not a known class: no swap
+                    // No swap (protection mode off, unknown class, or no
+                    // compatible candidate) — the vanilla enemy stays, so its
+                    // page is a real on-screen commitment like any pick.
+                    // (Redundant for pass-1-pinned entries; it matters when a
+                    // swappable entry found no compatible replacement.)
+                    commit_chr_page(entry.obj_id, &mut committed_slot4, &mut committed_slot5);
+                    commit_chr_page(entry.obj_id, &mut seg_all4, &mut seg_all5);
+                    if CHASER_IDS.contains(&entry.obj_id) {
+                        commit_chr_page(entry.obj_id, &mut seg_chaser4, &mut seg_chaser5);
+                    }
+                    continue;
                 };
 
                 let chosen_is_bertha = BERTHA_IDS.contains(&chosen);
@@ -230,6 +276,10 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                 }
                 swap_enemy(&mut data, entry.data_index, chosen);
                 commit_chr_page(chosen, &mut committed_slot4, &mut committed_slot5);
+                commit_chr_page(chosen, &mut seg_all4, &mut seg_all5);
+                if CHASER_IDS.contains(&chosen) {
+                    commit_chr_page(chosen, &mut seg_chaser4, &mut seg_chaser5);
+                }
             }
 
         }

--- a/src/randomize/enemies/picking.rs
+++ b/src/randomize/enemies/picking.rs
@@ -82,10 +82,12 @@ pub(super) fn pick_replacement<R: Rng>(
     protection: Option<EntryProtection>,
     modes: &ClassModes,
     wild_pool: &[u8],
-    (slot4, slot5): (ChrSlot, ChrSlot),
+    chr: ChrCtx,
     cap_full: bool,
     rng: &mut R,
 ) -> Option<u8> {
+    let (slot4, slot5) = chr.local;
+    let (seg4, seg5) = chr.segment;
     // Base pool + primary pick. A pool-replacing protection
     // (ForceShell/TankBro/Stompable/ExcludeHazards) chooses the pool;
     // otherwise it's the normal class pool, picked via the
@@ -150,7 +152,11 @@ pub(super) fn pick_replacement<R: Rng>(
         let over_cap = cap_full && BERTHA_IDS.contains(&id);
         // Giant red piranha (off-center hitbox) only where one was.
         let bad_giant = id == GIANT_RED_PIRANHA && entry.obj_id != GIANT_RED_PIRANHA;
-        !(over_cap || bad_giant)
+        // A level-wide chaser must be CHR-compatible with every page
+        // committed anywhere in the segment, not just this group — it
+        // follows the player into all of them (see CHASER_IDS).
+        let chaser_clash = CHASER_IDS.contains(&id) && !is_chr_compatible(id, seg4, seg5);
+        !(over_cap || bad_giant || chaser_clash)
     };
     // (A piranha slot can't become a hazard: the piranha pools are
     // self-contained and contain none — verified by the harness's

--- a/src/randomize/enemies/sprite_bank.rs
+++ b/src/randomize/enemies/sprite_bank.rs
@@ -177,6 +177,17 @@ pub(super) fn is_uniform_chr_class(class: &[u8]) -> bool {
     page4.is_some() || page5.is_some()
 }
 
+/// CHR commitments a pick consults. `local` is the proximity group's slots —
+/// what can share the screen with the entry under the one-screen model.
+/// `segment` is every commitment anywhere in the segment (pinned pages from
+/// all groups, plus every pick made so far): the bar a level-wide chaser must
+/// clear, since it follows the player into every group (see `CHASER_IDS`).
+#[derive(Clone, Copy)]
+pub(super) struct ChrCtx {
+    pub(super) local: (ChrSlot, ChrSlot),
+    pub(super) segment: (ChrSlot, ChrSlot),
+}
+
 /// Check whether an enemy is compatible with the current CHR page commitments.
 pub(super) fn is_chr_compatible(id: u8, slot4: ChrSlot, slot5: ChrSlot) -> bool {
     match sprite_bank(id) {

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -1,10 +1,10 @@
 //! Enemy / hazard class tables and the hazard-category predicates.
 //! Pure data + small pure helpers shared across the enemies submodules.
 
-pub(super) const BOOMBOOM_IDS: &[u8] = &[0x4A, 0x4B, 0x4C];
-
-/// Boom-Boom variants that can be swapped with each other.
-/// 0x4A is excluded — it's the stationary variant used in specific contexts.
+/// Boom-Boom variants that can be swapped with each other (0x4B jump, 0x4C
+/// fly — both CHR page $33/slot 5, so the swap is CHR-neutral).
+/// 0x4A (Q-ball) is excluded — it's the stationary variant used in specific
+/// contexts. All three pre-commit their vanilla page (see should_precommit).
 pub(super) const BOOMBOOM_SWAP: &[u8] = &[0x4B, 0x4C];
 
 // Object IDs from the Southbird SMB3 disassembly (smb3.asm).
@@ -366,6 +366,20 @@ pub(super) const MAX_BERTHA_PER_SEGMENT: u8 = 2;
 /// are split into separate CHR groups. Enemies more than one screen apart
 /// can never be visible simultaneously, so they don't need compatible CHR pages.
 pub(super) const CHR_GROUP_GAP: u8 = 16;
+
+/// Enemies that follow the player across the whole level: Lakitu hovers
+/// overhead indefinitely, the Angry Sun swoops for the rest of the level once
+/// triggered, and the two Big Bertha fish shadow the player along connected
+/// water. The one-screen assumption behind [`CHR_GROUP_GAP`] does not hold
+/// for these — their CHR page constrains *every* proximity group in the
+/// segment, and placing one anywhere requires compatibility with every page
+/// committed anywhere in the segment.
+pub(super) const CHASER_IDS: &[u8] = &[
+    0x83, // Lakitu (enemy-spawning variant)
+    0xAF, // Angry Sun
+    0x2D, // OBJ_BIGBERTHA (leaping eater — the "Boss Bass")
+    0x63, // OBJ_BIGBERTHABIRTHER
+];
 
 /// All cannon-fire IDs merged for Wild mode — every cfire ID can become every
 /// other cfire ID (incl. cross-direction and cross-type swaps). Excludes

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -1,10 +1,12 @@
 //! Enemy / hazard class tables and the hazard-category predicates.
 //! Pure data + small pure helpers shared across the enemies submodules.
 
-/// Boom-Boom variants that can be swapped with each other (0x4B jump, 0x4C
-/// fly — both CHR page $33/slot 5, so the swap is CHR-neutral).
-/// 0x4A (Q-ball) is excluded — it's the stationary variant used in specific
-/// contexts. All three pre-commit their vanilla page (see should_precommit).
+/// All Boom-Boom variants — exempt from CHR pinning (see should_precommit:
+/// shell enemies must stay pickable in Boom-Boom rooms).
+pub(super) const BOOMBOOM_IDS: &[u8] = &[0x4A, 0x4B, 0x4C];
+
+/// Boom-Boom variants that can be swapped with each other.
+/// 0x4A is excluded — it's the stationary variant used in specific contexts.
 pub(super) const BOOMBOOM_SWAP: &[u8] = &[0x4B, 0x4C];
 
 // Object IDs from the Southbird SMB3 disassembly (smb3.asm).

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -921,12 +921,14 @@
         }
     }
 
-    /// Boom-Boom's CHR page is pinned in Pass 1 (its self-swap is CHR-neutral:
-    /// 0x4B↔0x4C share $33/+5), so nearby picks can't garble the boss.
+    /// Boom-Booms are deliberately NOT CHR-pinned (see should_precommit):
+    /// shell enemies (koopas, $4F/+5) must stay pickable next to a Boom-Boom
+    /// ($33/+5) because the shell-vs-boss interaction is wanted gameplay.
     #[test]
-    fn test_boomboom_page_precommitted() {
+    fn test_boomboom_does_not_block_shell_picks() {
         let flags = Options {
-            ground: EnemyMode::Wild,
+            ground: EnemyMode::Wild, // goomba slot draws from the wild pool…
+            shell: EnemyMode::Wild,  // …which includes the koopas
             ..Options::default()
         };
         let rom = rom_with_segment(&[
@@ -935,6 +937,7 @@
             0x4B, 0x10, 0x10, // Boom-Boom (jump, $33/+5)
             0xFF,
         ]);
+        let mut saw_koopa = false;
         for seed in 0..200u64 {
             let mut rom_copy = rom.clone();
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -944,16 +947,19 @@
                 BOOMBOOM_SWAP.contains(&boom),
                 "seed {seed}: Boom-Boom became 0x{boom:02X}"
             );
-            let id = rom_copy.read_byte(ENEMY_DATA_START + 2);
-            if let Some(bank) = sprite_bank(id) {
-                assert!(
-                    bank.slot != 5 || bank.chr_page == 0x33,
-                    "seed {seed}: pick 0x{id:02X} (page ${:02X}/+5) garbles the \
-                     Boom-Boom ($33/+5)",
-                    bank.chr_page
-                );
+            // Green/Red Troopa are $4F/+5 — CHR-conflicting with the
+            // Boom-Boom, but allowed on purpose.
+            if matches!(rom_copy.read_byte(ENEMY_DATA_START + 2), 0x6C | 0x6D) {
+                saw_koopa = true;
+                break;
             }
         }
+        assert!(
+            saw_koopa,
+            "no koopa ever picked next to a Boom-Boom in 200 seeds — \
+             Boom-Boom's CHR page is being pinned, but it must stay unpinned \
+             so shells remain available in boss rooms"
+        );
     }
 
     /// Install two fake level headers so both eps are entry points: the outer

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -850,6 +850,207 @@
         }
     }
 
+    /// A vanilla Lakitu (out-of-pool chaser) must pin its CHR page for the
+    /// WHOLE level, not just its own proximity group — it follows the player
+    /// across every group (see CHASER_IDS).
+    #[test]
+    fn test_chaser_pins_distant_groups() {
+        let flags = Options {
+            ground: EnemyMode::Wild,
+            shell: EnemyMode::Wild,
+            flying: EnemyMode::Wild,
+            water: EnemyMode::Wild,
+            bros: EnemyMode::Wild,
+            ..Options::default()
+        };
+        let rom = rom_with_segment(&[
+            0xFF, 0x01,
+            0x83, 0x05, 0x10, // Lakitu ($0B/+4, chaser) — screen 0
+            0x72, 0x80, 0x19, // Goomba — 7 screens away, own CHR group
+            0x6C, 0x84, 0x19, // Green Troopa — same distant group
+            0xFF,
+        ]);
+        for seed in 0..200u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            assert_eq!(
+                rom_copy.read_byte(ENEMY_DATA_START + 2), 0x83,
+                "seed {seed}: Lakitu must not be swapped"
+            );
+            for off in [5usize, 8] {
+                let id = rom_copy.read_byte(ENEMY_DATA_START + off);
+                if let Some(bank) = sprite_bank(id) {
+                    assert!(
+                        bank.slot != 4 || bank.chr_page == 0x0B,
+                        "seed {seed}: pick 0x{id:02X} (page ${:02X}/+4) in a distant \
+                         group conflicts with the level-wide Lakitu ($0B/+4)",
+                        bank.chr_page
+                    );
+                }
+            }
+        }
+    }
+
+    /// A chaser pick (Big Bertha) must be CHR-compatible with pages pinned
+    /// anywhere in the segment, not just its own group — it will follow the
+    /// player to them. Non-chaser picks in the distant group stay free.
+    #[test]
+    fn test_chaser_pick_respects_distant_pins() {
+        let flags = Options {
+            water: EnemyMode::Wild,
+            ..Options::default()
+        };
+        let rom = rom_with_segment(&[
+            0xFF, 0x01,
+            0x8A, 0x05, 0x10, // Thwomp ($12/+4), class off by default → pinned
+            0x62, 0x80, 0x19, // Blooper — 7 screens away, own CHR group
+            0xFF,
+        ]);
+        for seed in 0..300u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            assert_eq!(rom_copy.read_byte(ENEMY_DATA_START + 2), 0x8A);
+            let id = rom_copy.read_byte(ENEMY_DATA_START + 5);
+            assert!(
+                !BERTHA_IDS.contains(&id),
+                "seed {seed}: Bertha 0x{id:02X} ($1A/+4) picked despite the Thwomp \
+                 ($12/+4) pinned elsewhere in the level"
+            );
+        }
+    }
+
+    /// Boom-Boom's CHR page is pinned in Pass 1 (its self-swap is CHR-neutral:
+    /// 0x4B↔0x4C share $33/+5), so nearby picks can't garble the boss.
+    #[test]
+    fn test_boomboom_page_precommitted() {
+        let flags = Options {
+            ground: EnemyMode::Wild,
+            ..Options::default()
+        };
+        let rom = rom_with_segment(&[
+            0xFF, 0x01,
+            0x72, 0x0E, 0x19, // Goomba — same screen as the Boom-Boom
+            0x4B, 0x10, 0x10, // Boom-Boom (jump, $33/+5)
+            0xFF,
+        ]);
+        for seed in 0..200u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            let boom = rom_copy.read_byte(ENEMY_DATA_START + 5);
+            assert!(
+                BOOMBOOM_SWAP.contains(&boom),
+                "seed {seed}: Boom-Boom became 0x{boom:02X}"
+            );
+            let id = rom_copy.read_byte(ENEMY_DATA_START + 2);
+            if let Some(bank) = sprite_bank(id) {
+                assert!(
+                    bank.slot != 5 || bank.chr_page == 0x33,
+                    "seed {seed}: pick 0x{id:02X} (page ${:02X}/+5) garbles the \
+                     Boom-Boom ($33/+5)",
+                    bank.chr_page
+                );
+            }
+        }
+    }
+
+    /// Install two fake level headers so both eps are entry points: the outer
+    /// level's run starts at the segment head and reads straight through the
+    /// inner ep.
+    fn install_two_entry_headers(data: &mut [u8], ep_a: u16, ep_b: u16) {
+        let region_start = 0x1E512usize; // Plains (TS1) region start
+        let mut pos = region_start;
+        for ep in [ep_a, ep_b] {
+            data[pos] = 0;
+            data[pos + 1] = 0;
+            data[pos + 2] = (ep & 0xFF) as u8;
+            data[pos + 3] = ((ep >> 8) & 0xFF) as u8;
+            for k in 4..9 {
+                data[pos + k] = 0;
+            }
+            data[pos + 9] = 0xFF; // empty command stream
+            pos += 10;
+        }
+    }
+
+    /// The injection pin-scan must cover the whole $FF-bounded segment, not
+    /// just the ep's own run: an outer level reads straight through the inner
+    /// ep, so its pinned pages constrain the injected chaser too.
+    #[test]
+    fn test_injection_pin_scan_covers_outer_prefix() {
+        let flags = Options {
+            wild_injections: true,
+            ..Options::default()
+        };
+        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
+
+        // Outer ep → page byte at +1; inner ep → the Goomba entry at +5
+        // (entries-only form). The Thwomp sits BEFORE the inner ep — only the
+        // outer level sees it — and pins slot 4 to $12, which conflicts with
+        // every injection id (all slot 4: $0B / $32 / $1A).
+        let mut data = blank_rom_image();
+        let seg = &[
+            0xFF, 0x01,
+            0x8A, 0x05, 0x10, // Thwomp ($12/+4), class off by default → pinned
+            0x72, 0x10, 0x19, // Goomba (inner level's first entry)
+            0xFF,
+        ];
+        data[ENEMY_DATA_START..ENEMY_DATA_START + seg.len()].copy_from_slice(seg);
+        install_two_entry_headers(
+            &mut data,
+            (ENEMY_DATA_START + 1) as u16,
+            (ENEMY_DATA_START + 5) as u16,
+        );
+        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+        for seed in 0..500u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            let id = rom_copy.read_byte(ENEMY_DATA_START + 5);
+            assert!(
+                !injection_ids.contains(&id),
+                "seed {seed}: chaser 0x{id:02X} injected at the inner ep despite \
+                 the Thwomp ($12/+4) in the outer level's prefix"
+            );
+        }
+
+        // Positive control: swap the Thwomp for a slot-5 pin (wood block,
+        // $13/+5). All injection ids are slot 4, so injections must still
+        // land at the inner ep in some seeds — the wider pin-scan must not
+        // over-block.
+        let mut data2 = blank_rom_image();
+        let seg2 = &[
+            0xFF, 0x01,
+            0x2E, 0x05, 0x10, // Wood block ($13/+5), out-of-pool → pinned
+            0x72, 0x10, 0x19, // Goomba (inner level's first entry)
+            0xFF,
+        ];
+        data2[ENEMY_DATA_START..ENEMY_DATA_START + seg2.len()].copy_from_slice(seg2);
+        install_two_entry_headers(
+            &mut data2,
+            (ENEMY_DATA_START + 1) as u16,
+            (ENEMY_DATA_START + 5) as u16,
+        );
+        let rom2 = Rom::from_bytes_lax(&data2, true).unwrap();
+        let mut saw = false;
+        for seed in 0..500u64 {
+            let mut rom_copy = rom2.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            if injection_ids.contains(&rom_copy.read_byte(ENEMY_DATA_START + 5)) {
+                saw = true;
+                break;
+            }
+        }
+        assert!(
+            saw,
+            "pin-scan over-blocks: no injection at the inner ep in 500 seeds \
+             with only a slot-5 pin present"
+        );
+    }
+
     #[test]
     fn test_chr_groups_split_distant_enemies() {
         // Two enemies far apart (screen 0 vs screen 5) should get independent


### PR DESCRIPTION
## Problem

Levels still frequently showed garbled (wrong-CHR-page) sprites, concentrated in levels containing enemies outside the swap pools — Lakitu, the Angry Sun — and in levels receiving wild injections.

## Root cause

The CHR-compatibility model splits each enemy segment into X-proximity groups (`chr_groups`, gap > 16 tiles) on the assumption that distant enemies never share the screen. That assumption is false for **chasers** — Lakitu, the Angry Sun, and the two Big Berthas follow the player across the entire level. A chaser (vanilla, injected, or wild-picked) only pinned its CHR page in its own group; every other group picked pages freely, and when the chaser followed the player there, one of them garbled.

## Fixes

1. **Walker — level-wide chaser tracking.** New `CHASER_IDS` table (`0x83` Lakitu, `0xAF` Angry Sun, `0x2D`/`0x63` Big Berthas). Chaser pages seed every proximity group's slots, and picking a chaser anywhere requires compatibility with every page committed anywhere in the segment (threaded through a new `ChrCtx` into `pick_replacement`'s `keep` filter).
2. **Injection — full-segment pin-scan.** The pre-commit scan now covers the whole `$FF`-bounded segment (via `walk_segments` bounds) instead of just `ep..$FF`: enemy runs nest, so an outer level reads straight through an inner ep and sees the injected chaser next to its own pinned enemies.
3. **Pass-1 pinning gaps.** `SkipSwap` entries pin in pass 1 instead of mid-loop (picks earlier in the group couldn't see them); a swappable entry that finds no compatible replacement now commits its vanilla page.

**Deliberately unchanged:** Boom-Booms remain exempt from CHR pinning — pinning `$33`/+5 would exclude shell enemies (koopas, `$4F`/+5) from Boom-Boom rooms, and the shell-vs-boss interaction is wanted gameplay; Boom-Booms sit alone in their arenas in almost every level. The rationale is now documented at `should_precommit`, with a regression test asserting koopas stay pickable next to a Boom-Boom.

## Verification

- Three new chaser/injection regression tests; all **fail on the pre-fix code** (verified by stashing the src changes) and pass now, plus the Boom-Boom shells-stay-available test.
- `enemy_invariant_baseline` (500-seed oracle vs the real ROM) passes.
- `chr_stats`: wild-injection rate stays healthy — 3.9 Lakitu/Sun injections per seed, 100% at visible entry points.
- `cargo clippy --all-targets -- -D warnings` clean; full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)