### PR TITLE
fix: veto wandering-bro landings on beaten piranha/W8-army nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ into a versioned section when a release is cut.
 - 34 new king rescue quotes: 26 suit-specific (9 frog, 8 raccoon, 9 hammer)
   plus eight standard quotes.
 
+### Changed
+
+- Wandering map bros now avoid stepping onto hand-trap tiles entirely
+  (previously they stepped on and immediately marched off again).
+
+### Fixed
+
+- Wandering Hammer Bros can no longer land on beaten piranha-plant or W8
+  army map nodes, which let the player replay the beaten level by touching
+  the bro.
+
 ### Removed
 
 - The no-op `--shuffle-pipes` and `--shuffle-airships` CLI flags — both

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1812,6 +1812,77 @@ dock tile (`0x4B`) so the player can board it. See the randomizer's
 `write_map_sprite` and W8 `CANOE_EDGES` (mainland `(5,6)` → islands
 `(3,8)/(5,10)/(5,12)`).
 
+### World-Map Object March Validation (PRG011)
+
+How wandering map objects (Hammer Bros, N-Spade, white toad house, coin ship)
+decide where they may move after each level completion. All addresses verified
+against the southbird disassembly (prg011.asm) and ROM bytes. PRG011 file =
+CPU − $A000 + 0x16010.
+
+**Routines** (marchers use `Map_Object_March`; the W7 plant and W8 artillery
+use `Map_Object_Stationary` and never move):
+
+| Routine | CPU | File | Role |
+|---------|-----|------|------|
+| `Map_MarchValidateTravel` | `$B39D` (entry) | `0x173AD` | Validates a candidate travel direction; called with A = random 0–3 |
+| — retry-pick loop | `$B3A3` | `0x173B3` | Re-pick target: rejects `JMP` here (does NOT reset the give-up counter) |
+| — landing-zone PickTravel `JSR $B43B` | `$B3FD` | `0x1740D` | Second PickTravel call (2-tiles-ahead landing zone) — randomizer hook site |
+| — blacklist scan | `$B406` | `0x17416` | `CMP Map_Object_Forbid_LandingTiles-1,Y` loop |
+| — threshold check | `$B425` | `0x17435` | `CMP $7E98,Y` (Tile_AttrTable+4, shared level-gate thresholds) |
+| `Map_Object_March_PickTravel` | `$B43B` | `0x1744B` | Computes the target tile's SRAM address + row/col nibbles |
+
+**Movement model:** each march hop is **2 tiles**. The pass-through tile
+(1 ahead) must be in `Map_Object_Valid_Left/Right/Down/Up` (PRG010, the same
+9-byte path-tile registries at file 0x15258/0x15261/0x1526A/0x15273 the player
+walk uses) — so marchers only travel along the path network and can never
+cross water; they CAN cross screens (the travel offset tables carry X-Hi
+deltas). The landing tile (2 ahead) is then checked against:
+
+1. `Map_Object_Forbid_LandingTiles` — 17-byte blacklist at `$B388` / file
+   `0x17398`: completed-level checkmark panels (`TILE_MARIOCOMP_*` /
+   `LUIGICOMP_*`), pipe, spade, spirals, fort rubble, Start, dancing
+   palm/bush. Match → `JMP $B3A3` (reject, re-pick). This is why bros never
+   park on beaten *regular* levels. The opt-in `limit_bro_movement` patch
+   (macobra.rs) rewrites this table into a 12-entry whitelist of node tiles
+   and inverts the scan branch at `$B409` / file `0x17419`.
+2. `Map_MarchXtraForbidTiles` — 4 bytes right after: toad houses,
+   castle-bottom, path-and-nub. Match → extend march (`Map_March_Count` $20
+   → $40) so the object keeps moving.
+3. `Tile_AttrTable+4,Y` (`$7E98`, per-palette-page level-gate thresholds, the
+   same RAM the player gate uses) — an "enterable" landing (tile ≥ its page
+   threshold) also extends the march instead of resting.
+
+**Give-up path:** after 4 failed direction attempts (`Temp_Var2`), the routine
+does `PLA/PLA/RTS` — returning to its caller's *caller*, so the object stays
+put for this turn. Any injected reject must preserve this stack contract.
+
+**PickTravel state** (decoded from ROM bytes; zero-page temp numbering per
+southbird): after `Map_Object_March_PickTravel` returns,
+`Map_Tile_Addr` (`$63/$64`) = `Tile_Mem_Addr[screen] + $F0` and `Temp_Var3`
+(`$02`) = Y-coordinate byte OR'd with the column-within-screen, so
+**`($63) + $02` is the landing tile's absolute SRAM address** — unique per
+(screen, row, col) in the loaded world (`World_Num` `$0727` disambiguates).
+`Tile_Mem_Addr` is a word table in PRG030 (fixed bank) at CPU `$8000` / file
+`0x3C010`, base `$6000`, stride `$1B0` per screen. Grid coords encode as
+`addr = $6000 + (col/16)*$1B0 + $F0 + (row+2)*16 + col%16` (hi byte always
+≥ `$61`). `Temp_Var15/16` (`$0E/$0F`) plus A/X/Y/flags are dead scratch at
+the hook site. Relevant object RAM: `Map_Object_ActY` `$0500`, `ActX` `$050F`,
+`ActXH` `$051E`, `Map_Object_Data` (march direction) `$052D`,
+`Map_March_Count` `$053C`.
+
+**Randomizer hook (march veto,** `overworld_writer/march_veto.rs`**):** the
+`JSR $B43B` at `$B3FD` is replaced with a JSR to a trampoline in PRG011 free
+space (`FS_MARCH_VETO`, file `0x17D70` / CPU `$BD60`; 59-byte routine +
+8-byte per-world offset table + 40-byte address list). It computes the
+landing SRAM address as above and rejects the hop (`PLA/PLA` +
+`JMP $B3A3`) when the address matches the current world's registry — the
+plant/army auto-enter nodes, which the engine never converts to checkmark
+tiles (winning only poofs the sprite), plus any landing on the hand-trap
+tile `$E6` (subsuming MaCobra's former `bros_no_hands` `$B425` hook; `$E6`
+stays in the pass-through registries so bros still walk *through* hands).
+Composes with `limit_bro_movement` in either order — disjoint byte ranges,
+and the veto fires before either table-scan regime.
+
 ### Map_Unused7EEA — Dead Code LUT (PRG011: 0x16018)
 
 An 8-byte LUT at PRG011 CPU `$A008` (file `0x16018`), labeled `Map_Unused7EEA_Vals` in

--- a/src/randomize/overworld_writer/march_veto.rs
+++ b/src/randomize/overworld_writer/march_veto.rs
@@ -1,0 +1,180 @@
+//! Per-coordinate landing veto for wandering map objects (Hammer Bros et al).
+//!
+//! Piranha-plant and W8 army levels are map-object sprites over plain
+//! path-node tiles. Beating one poofs the sprite (RAM only), leaving a node
+//! tile that is a legal landing spot for the engine's wandering-object march
+//! — in the vanilla blacklist regime AND under the opt-in
+//! `limit_bro_movement` whitelist (which whitelists exactly the node tiles).
+//! A Hammer Bro parking there re-enters the beaten level when touched.
+//!
+//! Fix: hook `Map_MarchValidateTravel` (PRG011 CPU $B3A3) at its second
+//! `JSR Map_Object_March_PickTravel` call ($B3FD, the landing-zone pick) and
+//! run a trampoline that rejects the hop when the candidate landing tile's
+//! SRAM address matches a per-world registry of plant/army coordinates the
+//! randomizer writes. HB encounter nodes are intentionally NOT vetoed —
+//! replaying a Hammer Bro fight is acceptable.
+//!
+//! The trampoline also rejects landings on the hand-trap tile ($E6),
+//! subsuming MaCobra52's former `bros_no_hands` patch (issue #14) with
+//! stronger semantics: the bro re-picks its direction instead of stepping
+//! onto the hand and marching off again. $E6 stays in the pass-through
+//! whitelist (`VALID_HORZ`), so bros still walk THROUGH hands, matching
+//! vanilla movement.
+//!
+//! Engine facts (verified in the southbird disassembly + ROM bytes):
+//! - Each march hop is 2 tiles; `Map_Object_March_PickTravel` ($B43B) leaves
+//!   `Map_Tile_Addr` ($63/$64) = `Tile_Mem_Addr[screen] + $F0` and
+//!   `Temp_Var3` ($02) = (row-nibble << 4) | column-in-screen, so
+//!   `($63) + $02` is the landing tile's absolute SRAM address — unique per
+//!   (screen, row, col) within the loaded world. `World_Num` ($0727)
+//!   disambiguates worlds.
+//! - `Tile_Mem_Addr` word table lives in PRG030 (fixed bank) at CPU $8000 /
+//!   file 0x3C010, base $6000, stride $1B0 per screen.
+//! - A/X/Y/flags and Temp_Var15/16 ($0E/$0F) are dead at the hook point: the
+//!   code right after the displaced JSR reloads all of them, and $0E/$0F are
+//!   re-stored on every direction re-pick.
+//! - Reject = `JMP $B3A3` (re-pick direction). The routine's give-up path
+//!   does `PLA/PLA/RTS` to return to the caller's caller, so the trampoline
+//!   must pop its own return address before the reject JMP to keep that
+//!   stack contract exact. Worst case the object stays put (safe).
+//! - The hook does not overlap `limit_bro_movement` (writes 0x17398-0x173AC
+//!   and 0x17419-0x17420) and fires before either table-scan regime, so the
+//!   two compose in both orders.
+
+use super::*;
+use super::rom_data::FS_MARCH_VETO;
+
+/// Hook site: file offset of `JSR Map_Object_March_PickTravel` at CPU $B3FD
+/// (the second, landing-zone call inside `Map_MarchValidateTravel`).
+pub(super) const MARCH_VETO_HOOK: usize = 0x1740D;
+
+/// The vanilla bytes at the hook site (`JSR $B43B`), displaced to become the
+/// trampoline's first instruction.
+pub(super) const DISPLACED_JSR: [u8; 3] = [0x20, 0x3B, 0xB4];
+
+/// Hand-trap map tile. Landing on it is vetoed (bros still pass through).
+const HAND_TRAP_TILE: u8 = 0xE6;
+
+/// The direction re-pick loop inside `Map_MarchValidateTravel` (CPU) — the
+/// vanilla landing-reject `JMP $B3A3` target. Jumping here retries with a new
+/// direction WITHOUT resetting the 4-attempt give-up counter (Temp_Var2).
+const RETRY_PICK_CPU: u16 = 0xB3A3;
+
+/// Trampoline layout within the FS_MARCH_VETO block (all offsets in bytes).
+const LOOP_OFF: usize = 30;
+const ACCEPT_OFF: usize = 53;
+const REJECT_OFF: usize = 54;
+pub(super) const ROUTINE_LEN: usize = 59;
+pub(super) const OFFSETS_LEN: usize = 8;
+pub(super) const LIST_LEN: usize = 40; // 16 two-byte entries + 8 per-world terminators
+
+/// SRAM address of the map tile at grid (row, col), as the engine computes it
+/// in `Map_Object_March_PickTravel`: `Tile_Mem_Addr[col/16] + $F0 + Temp_Var3`
+/// where the Y-coordinate byte is `(row + 2) * 16` (same convention as
+/// `write_map_sprite_position`). The hi byte is always >= 0x61, so 0x00 is a
+/// safe list terminator.
+pub(super) fn veto_addr(row: usize, col: usize) -> u16 {
+    (0x6000 + (col / 16) * 0x1B0 + 0xF0 + (row + 2) * 16 + (col % 16)) as u16
+}
+
+/// Write the march-veto hook, trampoline, and per-world coordinate registry.
+///
+/// `w8_positions` are the army sprite placements (world 7 implied);
+/// `plant_positions` carry their own world index. Always applied — the
+/// hand-trap veto replaces the always-on `bros_no_hands` patch even when no
+/// plants are placed.
+pub(super) fn write_march_veto(
+    rom: &mut Rom,
+    w8_positions: &[(usize, (usize, usize))],
+    plant_positions: &[(usize, (usize, usize))],
+) {
+    // Per-world landing addresses, sorted + deduped for stable output.
+    let mut per_world: [Vec<u16>; 8] = Default::default();
+    for &(_, (row, col)) in w8_positions {
+        per_world[7].push(veto_addr(row, col));
+    }
+    for &(wi, (row, col)) in plant_positions {
+        per_world[wi].push(veto_addr(row, col));
+    }
+    for list in &mut per_world {
+        list.sort_unstable();
+        list.dedup();
+    }
+
+    // Registry: per-world byte offset into the list, then (hi, lo) pairs with
+    // a 0x00-hi terminator per world.
+    let mut offsets = [0u8; OFFSETS_LEN];
+    let mut list: Vec<u8> = Vec::new();
+    for (wi, addrs) in per_world.iter().enumerate() {
+        offsets[wi] = list.len() as u8;
+        for &addr in addrs {
+            list.extend_from_slice(&[(addr >> 8) as u8, (addr & 0xFF) as u8]);
+        }
+        list.push(0x00);
+    }
+    assert!(
+        list.len() <= LIST_LEN,
+        "march veto list overflow: {} > {LIST_LEN} bytes",
+        list.len()
+    );
+    list.resize(LIST_LEN, 0x00);
+
+    // Assemble the trampoline. All absolute operands are derived from
+    // FS_MARCH_VETO so they can't drift from where the bytes land (issue #14
+    // convention).
+    let base_cpu = rom_data::prg_bank_file_to_cpu(11, FS_MARCH_VETO);
+    let loop_cpu = base_cpu + LOOP_OFF as u16;
+    let offsets_cpu = base_cpu + ROUTINE_LEN as u16;
+    let list_cpu = offsets_cpu + OFFSETS_LEN as u16;
+    let lo = |a: u16| (a & 0xFF) as u8;
+    let hi = |a: u16| (a >> 8) as u8;
+
+    #[rustfmt::skip]
+    let routine: [u8; ROUTINE_LEN] = [
+        // +0: displaced PickTravel (landing zone)
+        DISPLACED_JSR[0], DISPLACED_JSR[1], DISPLACED_JSR[2],
+        0xA4, 0x02,                               // +3:  LDY Temp_Var3
+        0xB1, 0x63,                               // +5:  LDA (Map_Tile_Addr),Y — landing tile byte
+        0xC9, HAND_TRAP_TILE,                     // +7:  CMP #$E6
+        0xF0, (REJECT_OFF - 11) as u8,            // +9:  BEQ Reject
+        0xA5, 0x63,                               // +11: LDA Map_Tile_AddrL
+        0x18,                                     // +13: CLC
+        0x65, 0x02,                               // +14: ADC Temp_Var3
+        0x85, 0x0E,                               // +16: STA Temp_Var15 = landing addr lo
+        0xA5, 0x64,                               // +18: LDA Map_Tile_AddrH
+        0x69, 0x00,                               // +20: ADC #$00
+        0x85, 0x0F,                               // +22: STA Temp_Var16 = landing addr hi
+        0xAE, 0x27, 0x07,                         // +24: LDX World_Num
+        0xBC, lo(offsets_cpu), hi(offsets_cpu),   // +27: LDY VETO_OFFSETS,X
+        // Loop (+30):
+        0xB9, lo(list_cpu), hi(list_cpu),         // +30: LDA VETO_LIST,Y — entry hi; 0 = end
+        0xF0, (ACCEPT_OFF - 35) as u8,            // +33: BEQ Accept
+        0xC5, 0x0F,                               // +35: CMP Temp_Var16
+        0xD0, 0x09,                               // +37: BNE Next
+        0xB9, lo(list_cpu + 1), hi(list_cpu + 1), // +39: LDA VETO_LIST+1,Y — entry lo
+        0xC5, 0x0E,                               // +42: CMP Temp_Var15
+        0xD0, 0x02,                               // +44: BNE Next
+        0xF0, (REJECT_OFF - 48) as u8,            // +46: BEQ Reject (always taken)
+        // Next (+48):
+        0xC8,                                     // +48: INY
+        0xC8,                                     // +49: INY
+        0x4C, lo(loop_cpu), hi(loop_cpu),         // +50: JMP Loop
+        // Accept (+53): resume at $B400 (vanilla reloads A/X/Y right after)
+        0x60,                                     // +53: RTS
+        // Reject (+54): drop the trampoline frame, then the vanilla reject
+        // path — keeps the give-up path's PLA/PLA/RTS stack contract exact.
+        0x68,                                     // +54: PLA
+        0x68,                                     // +55: PLA
+        0x4C, lo(RETRY_PICK_CPU), hi(RETRY_PICK_CPU), // +56: JMP $B3A3
+    ];
+
+    debug_assert_eq!(
+        rom.read_range(MARCH_VETO_HOOK, 3),
+        DISPLACED_JSR,
+        "march veto hook site changed — displaced instruction mismatch"
+    );
+    rom.write_range(FS_MARCH_VETO, &routine);
+    rom.write_range(FS_MARCH_VETO + ROUTINE_LEN, &offsets);
+    rom.write_range(FS_MARCH_VETO + ROUTINE_LEN + OFFSETS_LEN, &list);
+    rom.write_range(MARCH_VETO_HOOK, &rom_data::jsr_into_bank(11, FS_MARCH_VETO));
+}

--- a/src/randomize/overworld_writer/mod.rs
+++ b/src/randomize/overworld_writer/mod.rs
@@ -24,6 +24,7 @@ mod assign;
 mod grid;
 mod pointers;
 mod fortress_fx;
+mod march_veto;
 mod metatiles;
 mod sprites;
 
@@ -101,6 +102,10 @@ pub(crate) fn write_overworld<R: Rng>(
     // Plants claim their map-object slots before the HB writer so its slot
     // eligibility scan sees them as occupied.
     write_plant_sprites(rom, &plant_positions);
+    // Keep wandering map objects (Hammer Bros) off plant/army nodes — a bro
+    // parked on one would replay the level after it's beaten. Also vetoes
+    // hand-trap landings (subsumes the former bros_no_hands patch).
+    march_veto::write_march_veto(rom, &w8_sprite_positions, &plant_positions);
     if flags.shuffle_hammer_bros {
         write_hb_sprites(rom, build, rng);
     }

--- a/src/randomize/overworld_writer/tests.rs
+++ b/src/randomize/overworld_writer/tests.rs
@@ -577,3 +577,199 @@ fn test_troll_pipes_never_assigned_piranha_levels() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// March veto (keep wandering bros off plant/army nodes + hand traps)
+// ---------------------------------------------------------------------------
+
+/// Parse the written registry back out of the ROM: per-world address lists.
+fn read_veto_registry(rom: &Rom) -> Vec<Vec<u16>> {
+    let offs = rom
+        .read_range(rom_data::FS_MARCH_VETO + march_veto::ROUTINE_LEN, march_veto::OFFSETS_LEN)
+        .to_vec();
+    let list = rom
+        .read_range(
+            rom_data::FS_MARCH_VETO + march_veto::ROUTINE_LEN + march_veto::OFFSETS_LEN,
+            march_veto::LIST_LEN,
+        )
+        .to_vec();
+    offs.iter()
+        .map(|&o| {
+            let mut v = Vec::new();
+            let mut i = o as usize;
+            while list[i] != 0 {
+                v.push(u16::from_be_bytes([list[i], list[i + 1]]));
+                i += 2;
+            }
+            v
+        })
+        .collect()
+}
+
+/// Semantic hook check: the bytes at the hook site must be a JSR whose
+/// operand resolves (via the bank mapping, not recomputed arithmetic) to the
+/// FS_MARCH_VETO block, and the block must start with the displaced vanilla
+/// instruction.
+fn assert_veto_hook_installed(rom: &Rom) {
+    let hook = rom.read_range(march_veto::MARCH_VETO_HOOK, 3);
+    assert_eq!(hook[0], 0x20, "hook must be a JSR");
+    let cpu = u16::from_le_bytes([hook[1], hook[2]]);
+    assert_eq!(
+        rom_data::prg_bank_cpu_to_file(11, cpu),
+        rom_data::FS_MARCH_VETO,
+        "hook JSR must land on the veto trampoline"
+    );
+    assert_eq!(
+        rom.read_range(rom_data::FS_MARCH_VETO, 3),
+        march_veto::DISPLACED_JSR,
+        "trampoline must start with the displaced PickTravel JSR"
+    );
+}
+
+#[test]
+fn test_march_veto_registry_roundtrip() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let mut test_rom = rom.clone();
+    // W8 armies (world 7 implied) + plants; (7, (4, 6)) duplicates an army.
+    let w8 = vec![(2usize, (4usize, 6usize)), (3, (2, 20))];
+    let plants = vec![(0usize, (2usize, 3usize)), (7, (4, 6))];
+    march_veto::write_march_veto(&mut test_rom, &w8, &plants);
+
+    assert_veto_hook_installed(&test_rom);
+
+    let registry = read_veto_registry(&test_rom);
+    assert_eq!(registry[0], vec![march_veto::veto_addr(2, 3)]);
+    let w7 = &registry[7];
+    assert!(w7.contains(&march_veto::veto_addr(4, 6)));
+    assert!(w7.contains(&march_veto::veto_addr(2, 20)));
+    assert_eq!(w7.len(), 2, "duplicate army/plant coordinate must dedup");
+    for (wi, list) in registry.iter().enumerate().take(7).skip(1) {
+        assert!(list.is_empty(), "world {} should have no entries", wi + 1);
+    }
+    for addr in registry.iter().flatten() {
+        assert!(
+            (0x6110..=0x66AF).contains(addr),
+            "veto address {addr:#06X} outside the map tile SRAM window"
+        );
+    }
+}
+
+/// veto_addr must reproduce the engine's own address computation: the real
+/// Tile_Mem_Addr word table (PRG030, file 0x3C010) + $F0 + Temp_Var3.
+#[test]
+fn test_march_veto_addr_matches_engine_tile_mem_table() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    for &(row, col) in &[(0usize, 0usize), (2, 3), (4, 19), (7, 35), (8, 63)] {
+        let word_off = 0x3C010 + 2 * (col / 16);
+        let screen_base =
+            u16::from_le_bytes([rom.read_byte(word_off), rom.read_byte(word_off + 1)]);
+        let expected = screen_base + 0xF0 + ((((row as u16) + 2) * 16) | (col as u16 % 16));
+        assert_eq!(
+            march_veto::veto_addr(row, col),
+            expected,
+            "veto_addr({row}, {col}) diverges from the engine formula"
+        );
+    }
+}
+
+/// Full pipeline: piranha Wild + HB shuffle -> the hook is installed and the
+/// registry is well-formed with W8's army nodes present.
+#[test]
+fn test_march_veto_pipeline_writes_registry() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let mut prepped = rom.clone();
+    piranha_rooms::clear_vanilla_plants(&mut prepped);
+    let mut catalog = node_catalog::NodeCatalog::build(&prepped, false);
+    catalog.release_map_objects();
+    let pickup = overworld_pickup::pick_up(
+        &prepped,
+        &catalog,
+        overworld_pickup::PickupFlags {
+            shuffle_spade_games: true,
+            shuffle_toad_houses: true,
+            shuffle_hammer_bros: true,
+        },
+    );
+    let data = OverworldData { pickup: &pickup, catalog: &catalog };
+    let mut rng = ChaCha8Rng::seed_from_u64(7);
+    let build = overworld_build::build(
+        &prepped,
+        &data,
+        &mut rng,
+        overworld_build::BuildFlags {
+            shuffle_toad_houses: true,
+            shuffle_hammer_bros: true,
+            ..Default::default()
+        },
+    );
+    let mut out = prepped.clone();
+    write_overworld(&mut out, &build, &data, &mut rng, WriteFlags {
+        piranha: PiranhaMode::Wild,
+        shuffle_hammer_bros: true,
+        ..Default::default()
+    });
+
+    assert_veto_hook_installed(&out);
+    let registry = read_veto_registry(&out);
+    let total: usize = registry.iter().map(Vec::len).sum();
+    assert!(total <= 16, "registry overflow: {total} entries");
+    assert!(
+        !registry[7].is_empty(),
+        "W8 army nodes must always be vetoed (tank sprite at minimum)"
+    );
+    for addr in registry.iter().flatten() {
+        assert!(
+            (0x6110..=0x66AF).contains(addr),
+            "veto address {addr:#06X} outside the map tile SRAM window"
+        );
+    }
+}
+
+/// The veto must compose with MaCobra's opt-in limit_bro_movement rewrite in
+/// either application order — the two touch disjoint byte ranges.
+#[test]
+fn test_march_veto_composes_with_limit_bro_movement() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let w8 = vec![(2usize, (4usize, 6usize))];
+    let plants = vec![(3usize, (2usize, 9usize))];
+
+    let mut veto_first = rom.clone();
+    march_veto::write_march_veto(&mut veto_first, &w8, &plants);
+    qol::apply_limit_bro_movement(&mut veto_first);
+
+    let mut limit_first = rom.clone();
+    qol::apply_limit_bro_movement(&mut limit_first);
+    march_veto::write_march_veto(&mut limit_first, &w8, &plants);
+
+    // Identical output either way: no overlap between the two patches.
+    for (range_start, range_len, what) in [
+        (0x17398usize, 0x15usize, "limit-bro whitelist table + fill"),
+        (0x17419, 8, "limit-bro rewritten scan code"),
+        (march_veto::MARCH_VETO_HOOK, 3, "veto hook"),
+        (rom_data::FS_MARCH_VETO, 107, "veto trampoline + registry"),
+    ] {
+        assert_eq!(
+            veto_first.read_range(range_start, range_len),
+            limit_first.read_range(range_start, range_len),
+            "{what} differs between application orders"
+        );
+    }
+    assert_veto_hook_installed(&veto_first);
+    assert_veto_hook_installed(&limit_first);
+
+    // Fold-in regression: the old bros_no_hands hook site ($B425) must stay
+    // vanilla — hand-trap avoidance now lives in the veto trampoline.
+    assert_eq!(veto_first.read_range(0x17435, 3), &[0xD9, 0x98, 0x7E]);
+}

--- a/src/randomize/qol/macobra.rs
+++ b/src/randomize/qol/macobra.rs
@@ -1,7 +1,7 @@
 //! MaCobra52 patch bundle: always-on bugfixes plus opt-in feature patches.
 
 use crate::rom::Rom;
-use crate::randomize::rom_data::{FS_BROS_NO_HANDS, FS_FASTER_FROG, FS_HOLD_LEFT_HELPER, jsr_into_bank};
+use crate::randomize::rom_data::{FS_FASTER_FROG, FS_HOLD_LEFT_HELPER};
 
 // ---------------------------------------------------------------------------
 // MaCobra patches — always-on bundle
@@ -80,38 +80,6 @@ const TAIL_SWIM_ROUTINE: [u8; 285] = [
 const HOTFOOT_TAIL_A: usize = 0x0413C;
 const HOTFOOT_TAIL_B: usize = 0x04151;
 const HOTFOOT_TAIL_C: usize = 0x0814D;
-
-// Bros don't stop on hands (by MaCobra52) — fixes issue #14. Roaming
-// overworld bros decide where they may rest via the object-movement level
-// gate at PRG011 $B425 (`CMP $7E98,Y`), the sprite-side twin of the player
-// level gate. It reuses the shared per-palette-page threshold table
-// ($7E98,Y); a tile at-or-above its page threshold is a level slot the bro
-// won't rest on, below-threshold tiles are plain path it can settle on.
-// HANDTRAP tile 0xE6 sits just *below* the page-3 threshold (0xE9), so a
-// wandering bro treats it as plain path and can come to rest on a hand-trap
-// slot — colliding the two encounters (one clears the other).
-//
-// The fix replaces the inline `CMP $7E98,Y` at the gate with a JSR to an
-// 8-byte helper in PRG011 free space (FS_BROS_NO_HANDS, CPU $BD32) that
-// forces 0xE6 to read as gated and otherwise performs the identical compare:
-//
-//   CMP #$E6     ; hand-trap tile?
-//   BEQ +3       ; yes -> return with carry SET (gated), skipping the compare
-//   CMP $7E98,Y  ; no  -> vanilla threshold compare (flags identical)
-//   RTS          ; RTS preserves flags; A/X/Y untouched
-//
-// So 0xE6 now behaves like a normal uncompleted level tile to roaming bros:
-// they may walk *over* it but never rest on it. Completed hand-traps are
-// rewritten to a checkmark tile (already above-threshold), so they act as a
-// barrier with no extra work — matching issue #14's desired behavior.
-//
-// MaCobra's standalone IPS placed the helper at CPU $BC80 (file 0x17C90),
-// which collides with our FS_SAS_GAMEOVER_FINALIZE allocation (0x17C87); it
-// is relocated here to FS_BROS_NO_HANDS. The JSR operand is derived from the
-// helper's file offset via `jsr_into_bank` (never hand-written) so it can't
-// drift from where the helper bytes actually land — see issue #14.
-const BROS_NO_HANDS_HOOK: usize = 0x17435; // CPU $B425, vanilla `CMP $7E98,Y`
-const BROS_NO_HANDS_SUB: [u8; 8] = [0xC9, 0xE6, 0xF0, 0x03, 0xD9, 0x98, 0x7E, 0x60];
 
 // Hold-left airship-entry fix (by MaCobra52) — "SMB3 - Hold left fix.ips".
 // Bug: holding Left while entering an airship spawns Mario out over the pit and
@@ -420,11 +388,10 @@ pub fn apply_macobra_patches(rom: &mut Rom) {
     rom.write_byte(HOTFOOT_TAIL_B, 0x00);
     rom.write_byte(HOTFOOT_TAIL_C, 0x25);
 
-    // Roaming bros don't rest on hand-trap tiles (0xE6). Fixes issue #14.
-    // FS_BROS_NO_HANDS lives in PRG011 (bank 11); derive the JSR operand from
-    // its file offset so the hook can never point past the helper.
-    rom.write_range(BROS_NO_HANDS_HOOK, &jsr_into_bank(11, FS_BROS_NO_HANDS));
-    rom.write_range(FS_BROS_NO_HANDS, &BROS_NO_HANDS_SUB);
+    // NOTE: MaCobra's "Bros don't stop on hands" (issue #14) used to live
+    // here; it is subsumed by the overworld writer's march-veto trampoline
+    // (overworld_writer/march_veto.rs), which rejects hand-trap landings
+    // outright at Map_MarchValidateTravel's landing-zone check.
 
     // Hold-left airship-entry pit-death fix (MaCobra52). See notes above the
     // HOLD_LEFT_* constants. Nine verbatim writes: helper + tail + exit retargets.
@@ -520,44 +487,15 @@ mod tests {
         assert_eq!(target_cpu, 0xC918);
     }
 
+    // The former bros-don't-stop-on-hands hook ($B425) is gone: hand-trap
+    // avoidance moved into the march-veto trampoline. Prove macobra no longer
+    // touches the site (the writer's own tests cover the veto behavior).
     #[test]
-    fn test_macobra_bros_no_hands_writes() {
+    fn test_macobra_leaves_bro_gate_vanilla() {
         let mut rom = make_test_rom();
+        let before = rom.read_range(0x17435, 3).to_vec();
         apply_macobra_patches(&mut rom);
-
-        // Helper landed in PRG011 free space.
-        assert_eq!(
-            rom.read_range(FS_BROS_NO_HANDS, BROS_NO_HANDS_SUB.len()),
-            &BROS_NO_HANDS_SUB
-        );
-        // Follow the JSR operand actually written into the ROM and prove it
-        // resolves to the helper bytes. This is deliberately *semantic*: it
-        // does not recompute the expected operand (the previous version did,
-        // with the same off-by-header arithmetic the production const used, so
-        // it confirmed the bug instead of catching it — see issue #14). A
-        // mis-aimed JSR lands somewhere other than FS_BROS_NO_HANDS, and the
-        // bytes there won't match, regardless of *how* the operand was wrong.
-        let hook = rom.read_range(BROS_NO_HANDS_HOOK, 3);
-        assert_eq!(hook[0], 0x20, "hook must be a JSR");
-        let target_cpu = u16::from_le_bytes([hook[1], hook[2]]) as usize;
-        assert!(
-            (0xA000..0xC000).contains(&target_cpu),
-            "JSR target must stay in the PRG011 $A000-$BFFF window, got {target_cpu:#06X}"
-        );
-        // PRG011 is bank 11: file = 11 * 0x2000 + 0x10 (iNES header) + (cpu - $A000).
-        let target_file = 11 * 0x2000 + 0x10 + (target_cpu - 0xA000);
-        assert_eq!(
-            target_file, FS_BROS_NO_HANDS,
-            "JSR must point at the registered helper allocation, not arbitrary free space"
-        );
-        assert_eq!(
-            rom.read_range(target_file, BROS_NO_HANDS_SUB.len()),
-            &BROS_NO_HANDS_SUB,
-            "JSR operand must land on the helper bytes, not past them"
-        );
-        // Helper preserves vanilla behavior for non-hand tiles: its tail is the
-        // original `CMP $7E98,Y` (D9 98 7E) the hook replaced.
-        assert_eq!(&BROS_NO_HANDS_SUB[4..7], &[0xD9, 0x98, 0x7E]);
+        assert_eq!(rom.read_range(0x17435, 3), &before[..]);
     }
 
     #[test]

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -28,7 +28,8 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
     (0x17C87, 36, "start_airship_swap: game-over twirl finalize helper"),
     (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
-    (0x17D42, 8, "bros_no_hands: hand-trap tile bypass for overworld bro movement gate"),
+    (0x17D50, 26, "no_game_over_penalty: MaCobra NGO routine (macobra.rs NGO_ROUTINE_OFFSET)"),
+    (0x17D70, 107, "march_veto: landing-veto trampoline + per-world coord registry"),
     // PRG001 (file 0x02010, CPU $A000–$BFFF)
     (0x0382A, 23, "koopa_hits: subroutine + defeat JMP + threshold table"),
     (0x03841, 13, "koopa_collision_guard: skip collision bitmap during invuln"),
@@ -144,10 +145,12 @@ pub(crate) const FS_CANOE_RESPAWN: usize     = 0x15DF0; // 35 bytes
 // PRG011
 pub(crate) const FS_CANOE_BACKUP: usize      = 0x17D00; // 66 bytes
 
-// 8-byte hand-trap bypass subroutine for the overworld bro movement gate
-// (MaCobra52's "Bros don't stop on hands"). CPU $BD32. Sits just past the
-// 66-byte FS_CANOE_BACKUP reservation; the gate hook at $B425 JSRs here.
-pub(crate) const FS_BROS_NO_HANDS: usize     = 0x17D42; // 8 bytes (CPU $BD32)
+// March landing-veto trampoline + per-world coordinate registry (CPU $BD60).
+// 59-byte routine + 8-byte per-world offset table + 40-byte address list.
+// Hooked from Map_MarchValidateTravel's landing-zone PickTravel call at
+// $B3FD; keeps wandering map objects off plant/army nodes and hand traps.
+// Sits just past the 26-byte NGO routine (macobra.rs NGO_ROUTINE_OFFSET).
+pub(crate) const FS_MARCH_VETO: usize        = 0x17D70; // 107 bytes (CPU $BD60)
 
 // PRG026 (cont.)
 pub(crate) const FS_MYSTERY_ANCHOR: usize    = 0x35572; // 13 bytes
@@ -281,7 +284,7 @@ mod free_space_tests {
             (FS_FX_SCREEN_CHECK, "FS_FX_SCREEN_CHECK"),
             (FS_CANOE_RESPAWN, "FS_CANOE_RESPAWN"),
             (FS_CANOE_BACKUP, "FS_CANOE_BACKUP"),
-            (FS_BROS_NO_HANDS, "FS_BROS_NO_HANDS"),
+            (FS_MARCH_VETO, "FS_MARCH_VETO"),
             (FS_KOOPA_HITS_SUB, "FS_KOOPA_HITS_SUB"),
             (FS_KOOPA_COLLISION_GUARD, "FS_KOOPA_COLLISION_GUARD"),
             (FS_KOOPA_VRAM_CLEAR, "FS_KOOPA_VRAM_CLEAR"),
@@ -347,9 +350,9 @@ mod free_space_tests {
         // `JSR <file 0x17D00 in bank 11>` must encode as 20 F0 BC (JSR $BCF0).
         assert_eq!(jsr_into_bank(11, 0x17D00), [0x20, 0xF0, 0xBC]);
         // Opcode is always JSR; operand is little-endian CPU address.
-        let j = jsr_into_bank(11, FS_BROS_NO_HANDS);
+        let j = jsr_into_bank(11, FS_MARCH_VETO);
         assert_eq!(j[0], 0x20);
         let cpu = u16::from_le_bytes([j[1], j[2]]);
-        assert_eq!(prg_bank_cpu_to_file(11, cpu), FS_BROS_NO_HANDS);
+        assert_eq!(prg_bank_cpu_to_file(11, cpu), FS_MARCH_VETO);
     }
 }


### PR DESCRIPTION
## Problem

Beaten piranha-plant and W8 army levels are map-object sprites over plain path-node tiles. Winning poofs the sprite (RAM only) — the engine never converts the tile to a checkmark, so the node stays a legal landing spot for wandering Hammer Bros in **both** regimes: the vanilla `Map_Object_Forbid_LandingTiles` blacklist, and the opt-in `limit_bro_movement` whitelist (which whitelists exactly the 12 node tiles). A bro parked on the node replays the beaten level when touched.

## Fix: per-coordinate landing veto

- Hook `Map_MarchValidateTravel`'s landing-zone `JSR Map_Object_March_PickTravel` (file `0x1740D`, CPU `$B3FD`) with a trampoline in PRG011 free space (`FS_MARCH_VETO`, `0x17D70`, 107 B: routine + per-world offset table + address list).
- The trampoline computes the candidate landing tile's SRAM address (`Map_Tile_Addr + Temp_Var3`, exactly as the engine does) and rejects the hop — `PLA/PLA` + `JMP $B3A3`, the vanilla re-pick path — when it matches the current world's registry.
- The overworld writer emits the registry every seed from that seed's plant/army placements. HB battle nodes are intentionally **not** vetoed (replaying a bro fight is fine).
- All JSR/table operands derived via `jsr_into_bank` / `prg_bank_file_to_cpu`, never hand-transcribed (issue #14 convention).

## bros_no_hands folded in

The trampoline also rejects hand-trap (`$E6`) landings, subsuming MaCobra's `bros_no_hands` patch — removed from `macobra.rs`, its `$B425` hook site stays vanilla (regression-tested). Semantics get slightly stronger: bros re-pick their direction instead of stepping onto the hand and marching off; `$E6` stays in the pass-through registries so bros still walk *through* hands. The opt-in `limit_bro_movement` stays separate — verified byte-disjoint and composing in either application order.

## Drive-by

- Registered macobra's NGO routine (`0x17D50`, 26 B) in `FREE_SPACE_ALLOCATIONS` — it was missing, so the overlap test now guards that neighborhood.
- New ROM reference section "World-Map Object March Validation (PRG011)": march routines, forbid tables, the 2-tile hop model, PickTravel state, landing-address formula, give-up stack contract.

## Tests

5 new tests: registry round-trip + semantic hook check, `veto_addr` pinned against the real `Tile_Mem_Addr` table in the ROM, full pipeline (piranha Wild + HB shuffle), `limit_bro_movement` composition in both orders, and `$B425`-stays-vanilla fold regression. Full suite passes; clippy clean under `-D warnings`.

Independent of #79/#80 — branched from main tip, disjoint code areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)