### PR TITLE
fix: bring the cannon fire family into the CHR page model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ into a versioned section when a release is cut.
   now pin their graphics page across the whole level instead of just their
   own screen, and wild injections check the entire enemy segment (including
   levels that share its data).
+- Garbled enemy sprites in levels with cannons and spawner pipes: the cannon
+  fire family now counts toward graphics-page compatibility — cannonball and
+  bob-omb cannons force their page level-wide (matching how the game engine
+  reloads it every frame), goomba pipes and Bill cannons account for the
+  page their spawned enemies need, and cannon shuffle picks respect the
+  pages already committed around them.
 
 ## [0.11.2] - 2026-07-10
 

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -3025,6 +3025,39 @@ partial tables in the sections above are subsets of this data.
 All 180 entries verified byte-for-byte against ROM (2025-04-13). Matches
 `sprite_bank()` in `enemies.rs` with zero discrepancies.
 
+#### Cannon Fire Family CHR Behavior (PRG007, verified 2026-07-12)
+
+The cannon fire objects (`OBJ_CFIRE_*`, IDs 0xBC–0xD0) are special objects
+with **no `PatTableSel` dispatch entry**, but they have real CHR effects
+(southbird prg007.asm, CFire jump table at the `CannonFire_DrawAndUpdate`
+DynJump):
+
+- **`CFire_Cannonball`** — handles ALL cannonball cannons, BIG cannonball
+  cannons, and the Bob-omb launchers (0xC2–0xCF). Its first instructions are
+  `LDA #$36 / STA PatTable_BankSel+4`, executed **unconditionally every frame
+  the cfire slot is loaded** — *before* its own fire-timer and off-screen
+  early-outs. **`CFire_4Way`** (0xBF) does the same.
+- CannonFire slots live in a dedicated 8-entry FIFO (`CannonFire_ID` etc.),
+  spawned by scroll (PRG005 `Level_ObjectsSpawnByScroll` shifts all slots up
+  and drops the oldest). Slots are **never freed by scrolling away** — once
+  spawned, a cannon keeps re-asserting slot +4 = $36 until eight newer
+  cfires push it out or the level ends. Effectively a level-wide slot-4 pin.
+- **`CFire_GoombaPipe`** (0xC0/0xC1) — no PatTable write; spawns `OBJ_GOOMBA`
+  (0x72), whose own PatTableSel demands $4F/+5.
+- **`CFire_BulletBill`** (0xBC/0xBD) — no PatTable write; spawns the bullet /
+  missile bill objects 0x78/0x79 ($4F/+5). Placing 0x78/0x79 directly in
+  level data leaves them uninitialized — only the cannon sets their state.
+- **`CFire_RockyWrench`** (0xBE) — spawns `OBJ_ROCKYWRENCH` (0xAD), which
+  needs $36/+4 (same page as the cannonballs).
+- **`CFire_Laser`** (0xD0) — no PatTable write, no spawned bank need.
+
+Vanilla level data respects the pin: **no vanilla enemy segment mixes a
+cannonball-family cfire with a non-$36 slot-4 enemy** (checked across all
+240 segments via rom_map.json), and the two segments mixing pipes/bills
+with $37/+5 fire jets keep them >16 tiles apart. The randomizer mirrors
+this in `sprite_bank()` (cfire arm) and `CHASER_IDS` (cannonball family =
+level-wide pin).
+
 ---
 
 ## Gameplay Mechanics (ROM Offsets)

--- a/src/randomize/enemies/sprite_bank.rs
+++ b/src/randomize/enemies/sprite_bank.rs
@@ -10,7 +10,9 @@ pub struct SpriteBank {
 /// Returns `None` for objects that use NOCHANGE (no bank switch).
 /// Covers ALL object IDs 0x00–0xB3 (from ROM PatTableSel tables) so that
 /// the two-pass pre-scan can correctly pre-commit CHR pages from non-swappable
-/// objects (platforms, rotodiscs, bosses, fire jets, etc.).
+/// objects (platforms, rotodiscs, bosses, fire jets, etc.), plus the cannon
+/// fire family 0xBC–0xD0 whose requirements come from in-routine bank writes
+/// and spawned children rather than a PatTableSel entry (see the cfire arm).
 pub fn sprite_bank(id: u8) -> Option<SpriteBank> {
     match id {
         // === Group 1: PRG001 (IDs 0x00–0x23) ===
@@ -125,8 +127,26 @@ pub fn sprite_bank(id: u8) -> Option<SpriteBank> {
         0xAF => Some(SpriteBank { chr_page: 0x32, slot: 4 }),
         0xB3 => Some(SpriteBank { chr_page: 0x0B, slot: 4 }),
 
-        // IDs 0xB4+ (cannons, autoscroll, etc.) — handled by PRG007,
-        // typically NOCHANGE or no visible sprites requiring bank switch
+        // === Cannon fire family (IDs 0xBC–0xD0, CFire handlers in PRG007) ===
+        // These spawners have no PatTableSel dispatch entry, but they have
+        // real CHR needs (verified in southbird prg007.asm):
+        // - Bullet/Missile Bill cannons spawn 0x78/0x79 and Goomba pipes
+        //   spawn OBJ_GOOMBA (0x72) — the children's own PatTableSel demands
+        //   $4F on slot +5.
+        0xBC | 0xBD | 0xC0 | 0xC1 => Some(SpriteBank { chr_page: 0x4F, slot: 5 }),
+        // - `CFire_Cannonball` (all cannonballs, BIG cannonballs, and the
+        //   bob-omb launchers) and `CFire_4Way` write PatTable_BankSel+4=$36
+        //   UNCONDITIONALLY every frame they're loaded — before their own
+        //   timer/off-screen early-outs — and a spawned cfire slot survives
+        //   until 8 newer cfires push it out of the FIFO, i.e. usually the
+        //   rest of the level. Level-wide slot-4 pin (they're in CHASER_IDS
+        //   for exactly that reason).
+        // - The Rocky Wrench cfire (0xBE) spawns OBJ_ROCKYWRENCH (0xAD),
+        //   which needs the same $36/+4 via its own PatTableSel.
+        0xBE | 0xBF | 0xC2..=0xCF => Some(SpriteBank { chr_page: 0x36, slot: 4 }),
+
+        // Everything else 0xB4+ (laser cfire 0xD0, autoscroll controllers,
+        // etc.) — no bank switch and no spawned sprite bank need.
         _ => None,
     }
 }

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -369,18 +369,41 @@ pub(super) const MAX_BERTHA_PER_SEGMENT: u8 = 2;
 /// can never be visible simultaneously, so they don't need compatible CHR pages.
 pub(super) const CHR_GROUP_GAP: u8 = 16;
 
-/// Enemies that follow the player across the whole level: Lakitu hovers
-/// overhead indefinitely, the Angry Sun swoops for the rest of the level once
-/// triggered, and the two Big Bertha fish shadow the player along connected
-/// water. The one-screen assumption behind [`CHR_GROUP_GAP`] does not hold
-/// for these — their CHR page constrains *every* proximity group in the
-/// segment, and placing one anywhere requires compatibility with every page
-/// committed anywhere in the segment.
+/// Enemies whose CHR page constrains *every* proximity group in the segment,
+/// so the one-screen assumption behind [`CHR_GROUP_GAP`] does not hold and
+/// placing one anywhere requires compatibility with every page committed
+/// anywhere in the segment. Two ways to earn membership:
+/// - True chasers that follow the player across the whole level: Lakitu
+///   hovers overhead indefinitely, the Angry Sun swoops for the rest of the
+///   level once triggered, and the two Big Bertha fish shadow the player
+///   along connected water.
+/// - Cannonball-family cannon fires: `CFire_Cannonball` / `CFire_4Way` write
+///   `PatTable_BankSel+4 = $36` unconditionally every frame they're loaded
+///   (before their own on-screen checks), and a spawned cfire slot survives
+///   until 8 newer cfires push it out of the FIFO — usually the rest of the
+///   level. They don't move, but their slot-4 pin follows the player anyway.
+///   (Vanilla respects this: no vanilla segment mixes a cannonball cfire
+///   with a non-$36 slot-4 enemy.)
 pub(super) const CHASER_IDS: &[u8] = &[
     0x83, // Lakitu (enemy-spawning variant)
     0xAF, // Angry Sun
     0x2D, // OBJ_BIGBERTHA (leaping eater — the "Boss Bass")
     0x63, // OBJ_BIGBERTHABIRTHER
+    0xBF, // OBJ_CFIRE_4WAY (unconditional +4=$36 every frame)
+    0xC2, // OBJ_CFIRE_HLCANNON     — all 0xC2–0xCF run CFire_Cannonball:
+    0xC3, // OBJ_CFIRE_HLBIGCANNON    unconditional +4=$36 every frame
+    0xC4, // OBJ_CFIRE_ULCANNON
+    0xC5, // OBJ_CFIRE_URCANNON
+    0xC6, // OBJ_CFIRE_LLCANNON
+    0xC7, // OBJ_CFIRE_LRCANNON
+    0xC8, // OBJ_CFIRE_HLCANNON2
+    0xC9, // OBJ_CFIRE_ULCANNON2
+    0xCA, // OBJ_CFIRE_URCANNON2
+    0xCB, // OBJ_CFIRE_LLCANNON2
+    0xCC, // OBJ_CFIRE_HRCANNON
+    0xCD, // OBJ_CFIRE_HRBIGCANNON
+    0xCE, // OBJ_CFIRE_LBOBOMBS
+    0xCF, // OBJ_CFIRE_RBOBOMBS
 ];
 
 /// All cannon-fire IDs merged for Wild mode — every cfire ID can become every

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1579,3 +1579,100 @@
             violations.iter().take(40).cloned().collect::<Vec<_>>().join("\n"),
         );
     }
+
+    /// Every cannon-fire family member carries the CHR bank its engine
+    /// behavior demands (see the cfire arm in `sprite_bank`): bills and
+    /// goomba pipes spawn $4F/+5 children; the cannonball family (plus the
+    /// 4-way and Rocky Wrench cfires) needs $36/+4. The laser needs nothing.
+    /// The cannonball family is chaser-class (its handler rewrites slot 4
+    /// every frame it stays loaded); bills/pipes are proximity-scoped.
+    #[test]
+    fn test_cfire_sprite_banks() {
+        for &id in &[0xBCu8, 0xBD, 0xC0, 0xC1] {
+            let b = sprite_bank(id).expect("bill/pipe cfire must have a bank");
+            assert_eq!((b.chr_page, b.slot), (0x4F, 5), "id 0x{id:02X}");
+            assert!(!CHASER_IDS.contains(&id), "0x{id:02X} is proximity-scoped");
+        }
+        for id in [0xBEu8, 0xBF].into_iter().chain(0xC2..=0xCF) {
+            let b = sprite_bank(id).expect("cannonball-family cfire must have a bank");
+            assert_eq!((b.chr_page, b.slot), (0x36, 4), "id 0x{id:02X}");
+        }
+        for id in 0xC2u8..=0xCF {
+            assert!(CHASER_IDS.contains(&id), "0x{id:02X} must be chaser-class");
+        }
+        assert!(CHASER_IDS.contains(&0xBF), "4-way pins slot 4 every frame");
+        assert!(sprite_bank(0xD0).is_none(), "laser has no CHR need");
+    }
+
+    /// A cannonball cfire pins slot 4 = $36 for the whole level — its
+    /// handler re-writes the bank every frame it stays loaded, and a spawned
+    /// cfire slot survives until pushed out of the 8-slot FIFO. Picks in
+    /// distant proximity groups must therefore stay $36-compatible on
+    /// slot 4, exactly like the true chasers.
+    #[test]
+    fn test_cannon_pins_distant_groups() {
+        let flags = Options {
+            ground: EnemyMode::Wild,
+            shell: EnemyMode::Wild,
+            flying: EnemyMode::Wild,
+            water: EnemyMode::Wild,
+            bros: EnemyMode::Wild,
+            ..Options::default() // cannons Off → the cfire itself is pinned
+        };
+        let rom = rom_with_segment(&[
+            0xFF, 0x01,
+            0xC8, 0x05, 0x10, // HLCANNON2 ($36/+4 frame-pin) — screen 0
+            0x72, 0x80, 0x19, // Goomba — 7 screens away, own CHR group
+            0x6C, 0x84, 0x19, // Green Troopa — same distant group
+            0xFF,
+        ]);
+        for seed in 0..200u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            assert_eq!(
+                rom_copy.read_byte(ENEMY_DATA_START + 2), 0xC8,
+                "seed {seed}: pinned cannon must not be swapped"
+            );
+            for off in [5usize, 8] {
+                let id = rom_copy.read_byte(ENEMY_DATA_START + off);
+                if let Some(bank) = sprite_bank(id) {
+                    assert!(
+                        bank.slot != 4 || bank.chr_page == 0x36,
+                        "seed {seed}: pick 0x{id:02X} (page ${:02X}/+4) in a distant \
+                         group conflicts with the level-wide cannon pin ($36/+4)",
+                        bank.chr_page
+                    );
+                }
+            }
+        }
+    }
+
+    /// Cannons-wild picks are CHR-gated like any other class: next to a
+    /// pinned fire jet ($37/+5), a Bill cannon can only become a
+    /// cannonball-family member — bills and goomba pipes are filtered out
+    /// because their spawned children need $4F on the jet's slot.
+    #[test]
+    fn test_cannons_wild_respects_slot5_pin() {
+        let flags = Options {
+            cannons: EnemyMode::Wild,
+            ..Options::default()
+        };
+        let rom = rom_with_segment(&[
+            0xFF, 0x01,
+            0xBC, 0x05, 0x0C, // Bullet Bill cannon ($4F/+5 via spawned bills)
+            0xAC, 0x07, 0x11, // upward fire jet ($37/+5), no class → pinned
+            0xFF,
+        ]);
+        for seed in 0..300u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            let id = rom_copy.read_byte(ENEMY_DATA_START + 2);
+            assert!(
+                (0xC2..=0xCF).contains(&id),
+                "seed {seed}: bill slot became 0x{id:02X}; only the $36/+4 \
+                 cannonball family fits beside a $37/+5 fire jet"
+            );
+        }
+    }


### PR DESCRIPTION
Stacked on #80 (merge that first; this PR's base is `feature/chaser-chr-pinning`).

## Problem

The cannon fire spawners (0xBC–0xD0) had no `sprite_bank()` entries — the entire family was invisible to CHR compatibility checks, the two-pass pre-commit, and injection pre-scans, while `ALL_CANNONS` wild merged 17 of them with no CHR consultation. But they have real CHR effects (verified in southbird prg007):

- **`CFire_Cannonball`** (all cannonballs, BIG cannonballs, and bob-omb launchers) and **`CFire_4Way`** write `PatTable_BankSel+4 = $36` **unconditionally every frame they're loaded** — before their own fire-timer/off-screen early-outs. CannonFire slots live in an 8-entry FIFO that is never freed by scrolling away, so one spawned cannon pins slot 4 for essentially the rest of the level.
- **Goomba pipes** spawn `OBJ_GOOMBA` (0x72) and **Bill cannons** spawn 0x78/0x79 — the children's own PatTableSel demands $4F/+5.
- **Rocky Wrench cfire** spawns the mole (0xAD), needing the same $36/+4 as the cannons.

Result: cannons-wild swaps changed slot/page requirements invisibly, and picks near vanilla cfires could commit conflicting pages — both producing the flickering garbled sprites that survive #80.

## Fix

- `sprite_bank()` cfire arm: pipes/bills → $4F/+5; cannonball family + 4-way + wrench cfire → $36/+4; laser → none. Everything downstream (pre-commit, injection pre-scan, class-pick CHR gating) composes automatically.
- Cannonball family (0xBF, 0xC2–0xCF) added to `CHASER_IDS`: they don't chase, but their every-frame slot-4 pin has exactly the level-wide semantics the chaser machinery models.

## Vanilla validates the model

Checked all 240 enemy segments via rom_map.json: **no vanilla segment mixes a cannonball cfire with a non-$36 slot-4 enemy**, and the two segments mixing pipes/bills with $37/+5 fire jets keep them >16 tiles apart (separate proximity groups). So the pin introduces zero conflicts on vanilla data — it only constrains randomized picks to what the engine actually requires.

## Tests / docs

3 new tests (bank-mapping guard, cannon pins distant groups, cannons-wild respects a $37/+5 pin); full suite + `enemy_invariant_baseline` green; clippy clean. New ROM reference subsection "Cannon Fire Family CHR Behavior" documents the engine research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)