### PR TITLE
Overworld pipe & linearity overhaul (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-12
+
 ### Fixed
 
 - Lobby Shuffle no longer crashes when a level whose interior is a vertical
@@ -31,6 +33,12 @@ into a versioned section when a release is cut.
   intended rather than collapsing the journey into one jump; connectivity is
   still guaranteed (a direct link to the goal is used only as a last-pipe
   fallback).
+- Overworld "spare" pipes (those beyond what island connectivity requires) are
+  now placed after levels are laid out, so each one is aimed to skip a run of
+  forced levels instead of being scored on spatial spread alone. Fewer pointless
+  pipe loops, more genuine shortcuts (pipes now skip ~60% more levels), and a
+  shorter average forced-level run (~1.8 → ~1.4). Every world keeps its vanilla
+  pipe count; connectivity pipes are unchanged.
 - Lobby Shuffle pool grows to 11 with the 2-Pyramid bonus rejoining (its
   pipe-exit crash is fixed above).
 - Garbled enemy sprites in levels with player-chasing enemies: Lakitu, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ into a versioned section when a release is cut.
   pipe loops, more genuine shortcuts (pipes now skip ~60% more levels), and a
   shorter average forced-level run (~1.8 → ~1.4). Every world keeps its vanilla
   pipe count; connectivity pipes are unchanged.
+- World 8's showcase bridges are gated out (as a fortress lock) more often: at
+  least one bridge is out in ~99% of seeds (was ~80%) and two in ~30% (was ~6%),
+  with a rare ~0.08% chance all four are out at once. Pure lock-placement bias;
+  connectivity and beatability are unaffected.
 - Lobby Shuffle pool grows to 11 with the 2-Pyramid bonus rejoining (its
   pipe-exit crash is fixed above).
 - Garbled enemy sprites in levels with player-chasing enemies: Lakitu, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ into a versioned section when a release is cut.
 
 ### Changed
 
+- Overworld level placement is less linear: the weight biasing levels onto the
+  main start→airship route was halved (1.5 → 0.75), so fewer forced levels get
+  glued back-to-back along the critical path. Average run of consecutive
+  must-play levels drops from ~2.1 to ~1.8 (in line with the reference SMB3
+  randomizer) while levels still favor the route over dead-end spurs.
 - Overworld pipe routing in multi-island worlds now grows a chain outward from
   the start, bridging the nearest unreached island each step, instead of always
   piping the start island straight to the goal island. Worlds like 7 and 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ into a versioned section when a release is cut.
 
 ### Changed
 
+- Overworld pipe routing in multi-island worlds now grows a chain outward from
+  the start, bridging the nearest unreached island each step, instead of always
+  piping the start island straight to the goal island. Worlds like 7 and 8
+  (5-7 islands) now route the player through the intermediate islands as
+  intended rather than collapsing the journey into one jump; connectivity is
+  still guaranteed (a direct link to the goal is used only as a last-pipe
+  fallback).
 - Lobby Shuffle pool grows to 11 with the 2-Pyramid bonus rejoining (its
   pipe-exit crash is fixed above).
 - Garbled enemy sprites in levels with player-chasing enemies: Lakitu, the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2024"
 
 [lib]

--- a/src/randomize/overworld_build/locks.rs
+++ b/src/randomize/overworld_build/locks.rs
@@ -4,6 +4,18 @@ use super::*;
 
 use super::types::{BuildResult, LockAssignment, SlotAssignment, SlotKind, stamp_slots};
 
+/// The five always-on W8 screen-3 bridges (see `qol::overworld_map`'s
+/// `W8_BRIDGE_EDITS`). Locking one gaps it out as water until its fortress is
+/// beaten — a deliberate showcase, so the lock scorer nudges toward them.
+const W8_BRIDGE_LOCK_POSITIONS: &[(usize, usize)] = &[(5, 51), (5, 53), (5, 55), (5, 57), (5, 59)];
+
+/// Score bonus for locking a W8 showcase bridge. Sized to noticeably raise how
+/// often a bridge is chosen without overriding the `blocks_later_fort` (+100)
+/// progression signal or the hard reachability rules. Tuned via a 200k-seed
+/// sweep: +8 puts ≥1 bridge out in ~99.6% of seeds, two out in ~30%, and all
+/// four (the ceiling — W8 has 4 forts = 4 locks) out in ~0.08% (a rare treat).
+const W8_BRIDGE_LOCK_BONUS: i32 = 8;
+
 /// A scored lock candidate tracked during selection.
 #[derive(Clone, Copy)]
 struct ScoredLock {
@@ -210,6 +222,13 @@ pub(super) fn place_locks<R: Rng>(
             // than locks on regular path tiles.
             if tile == 0xB3 {
                 score += 1;
+            }
+
+            // W8-specific: bias harder toward the screen-3 showcase bridges so
+            // they're gated out more often than raw chokepoint value alone
+            // would pick them.
+            if world_idx == 7 && W8_BRIDGE_LOCK_POSITIONS.contains(&cand_pos) {
+                score += W8_BRIDGE_LOCK_BONUS;
             }
 
             // Track best overall and best safe separately. (A safe lock

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -45,7 +45,10 @@ pub(crate) use types::{BuildFlags, BuildResult, BuiltWorld, OverworldData};
 // Progression analysis is exercised only by the test suite today (reserved for a
 // future WASM single-seed dump), so surface it just for `tests`.
 #[cfg(test)]
-pub(crate) use progression::{analyze_required_progression, dump_required_progression, PathNodeKind};
+pub(crate) use progression::{
+    analyze_required_progression, classify_pipes, dump_required_progression, hammer_skip,
+    island_count, level_adjacency_pairs, start_goal_express_pipe, PipeClass,
+};
 
 #[cfg(test)]
 mod tests;

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -2,8 +2,9 @@
 
 use super::*;
 
-use super::scoring::{PIPE_SOFTMAX_T, TARGET_MAX_DIST, pick_softmax_by_score, score_pipe_pair};
+use super::scoring::{PIPE_SOFTMAX_T, TARGET_MAX_DIST, pick_softmax_by_score};
 use super::sections::split_blanks_by_reachability;
+use super::types::{SlotAssignment, SlotKind};
 
 /// Number of pipe pairs (not endpoints) per world in the vanilla ROM.
 pub(super) const VANILLA_PIPE_PAIRS: [usize; 8] = [
@@ -247,39 +248,129 @@ pub(super) fn place_pipes<R: Rng>(
             }
             break;
         } else {
-            // No more islands — score candidate pairs and pick from top N
-            let available: Vec<(usize, usize)> = active
-                .iter()
-                .copied()
-                .filter(|p| !used_positions.contains(p))
-                .collect();
-
-            if available.len() < 2 {
-                break; // not enough slots
-            }
-
-            // Enumerate all candidate pairs and score them
-            let mut candidates: Vec<(TeleportEdge, f64)> = Vec::new();
-            for i in 0..available.len() {
-                for j in (i + 1)..available.len() {
-                    let a = available[i];
-                    let b = available[j];
-                    let score = score_pipe_pair(
-                        grid, a, b, &used_positions, &walk.distances, target_pos,
-                    );
-                    candidates.push(((a, b), score));
-                }
-            }
-
-            let (a, b) = pick_softmax_by_score(candidates, PIPE_SOFTMAX_T, rng).unwrap();
-
-            grid.set(a.0, a.1, TILE_PIPE);
-            grid.set(b.0, b.1, TILE_PIPE);
-            used_positions.insert(a);
-            used_positions.insert(b);
-            placed_pairs.push((a, b));
+            // All islands are connected and the target is reachable. The
+            // remaining pipe budget is placed later by `place_spare_pipes`,
+            // after levels exist, so each spare pipe can be aimed to skip a
+            // level instead of being scored on spatial spread alone. Stop the
+            // connectivity phase here.
+            break;
         }
     }
 
     placed_pairs
+}
+
+/// Place `spare_needed` spare pipe pairs after `populate_sections`, converting
+/// the lowest-value filler (HammerBro) slots into pipe endpoints. Unlike the
+/// connectivity phase this runs with levels already placed, so each pair is
+/// scored by how many level slots it lets the player skip: a pipe from a
+/// near-start node to a far node teleports past every level on the stretch
+/// between them (approximated by route-distance band). Endpoints are drawn
+/// only from HammerBro slots — never levels or forts — and both are already
+/// reachable, so a spare pipe can never strand content; it only shortcuts.
+/// Pairs that skip nothing are still placed (a fall-back keeps the world at
+/// its fixed vanilla pipe count).
+// Reason: each argument is a distinct placement input (grid, slots to convert,
+// the pipe list to extend, budget, reserved sprite tiles, start anchor, world,
+// RNG). They don't form a cohesive concept, so bundling adds indirection
+// without clarity — same call shape as `place_pipes`.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn place_spare_pipes<R: Rng>(
+    grid: &mut Grid,
+    slots: &mut [SlotAssignment],
+    pipe_pairs: &mut Vec<TeleportEdge>,
+    spare_needed: usize,
+    reserved: &HashSet<(usize, usize)>,
+    start_pos: Option<(usize, usize)>,
+    world_idx: usize,
+    rng: &mut R,
+) {
+    if spare_needed == 0 {
+        return;
+    }
+
+    // Convertible endpoints: HammerBro filler slots, minus any reserved
+    // (mandatory HB sprite) positions that must keep their sprite. Kept as an
+    // ordered Vec (slot order) — candidate order feeds softmax sampling, so it
+    // must be deterministic across runs, unlike HashSet iteration.
+    let mut available: Vec<(usize, usize)> = slots
+        .iter()
+        .filter(|s| s.kind == SlotKind::HammerBro && !reserved.contains(&s.pos))
+        .map(|s| s.pos)
+        .collect();
+
+    let level_positions: Vec<(usize, usize)> = slots
+        .iter()
+        .filter(|s| s.kind == SlotKind::Level)
+        .map(|s| s.pos)
+        .collect();
+
+    for _ in 0..spare_needed {
+        if available.len() < 2 {
+            break;
+        }
+        // Recompute distances each round — a placed spare pipe (a teleport)
+        // changes the route, so later pairs score against the updated map.
+        let dist = walk_map(grid, pipe_pairs, start_pos, world_idx).distances;
+        let level_d: Vec<usize> = level_positions
+            .iter()
+            .filter_map(|p| dist.get(p).copied())
+            .collect();
+
+        let avail = &available;
+        let mut candidates: Vec<(TeleportEdge, f64)> = Vec::new();
+        for i in 0..avail.len() {
+            for j in (i + 1)..avail.len() {
+                let a = avail[i];
+                let b = avail[j];
+                let (da, db) = match (dist.get(&a), dist.get(&b)) {
+                    (Some(&da), Some(&db)) => (da, db),
+                    _ => continue,
+                };
+                let (lo, hi) = (da.min(db), da.max(db));
+                if hi - lo < 2 {
+                    continue; // too small a jump to be a real shortcut
+                }
+                // Levels whose route distance sits strictly between the two
+                // endpoints are the ones the teleport lets the player skip.
+                let skipped = level_d.iter().filter(|&&d| d > lo && d < hi).count();
+                let score = skipped as f64 * 10.0 + (hi - lo) as f64;
+                candidates.push(((a, b), score));
+            }
+        }
+
+        // Prefer a level-skipping pair; if none qualifies, fall back to the
+        // most distance-separated pair so the world still reaches its vanilla
+        // pipe count.
+        let chosen = pick_softmax_by_score(candidates, PIPE_SOFTMAX_T, rng).or_else(|| {
+            let mut best: Option<(TeleportEdge, usize)> = None;
+            for i in 0..avail.len() {
+                for j in (i + 1)..avail.len() {
+                    let (a, b) = (avail[i], avail[j]);
+                    if let (Some(&da), Some(&db)) = (dist.get(&a), dist.get(&b)) {
+                        let jump = da.abs_diff(db);
+                        if best.is_none_or(|(_, bj)| jump > bj) {
+                            best = Some(((a, b), jump));
+                        }
+                    }
+                }
+            }
+            best.map(|(pair, _)| pair)
+        });
+
+        let (a, b) = match chosen {
+            Some(pair) => pair,
+            None => break,
+        };
+
+        grid.set(a.0, a.1, TILE_PIPE);
+        grid.set(b.0, b.1, TILE_PIPE);
+        available.retain(|&p| p != a && p != b);
+        pipe_pairs.push((a, b));
+        for s in slots.iter_mut() {
+            if s.pos == a || s.pos == b {
+                s.kind = SlotKind::Pipe;
+            }
+        }
+    }
 }

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -2,10 +2,7 @@
 
 use super::*;
 
-use super::scoring::{
-    PIPE_SOFTMAX_T, TARGET_MAX_DIST, pick_softmax_by_score, score_pipe_endpoint,
-    score_pipe_pair, target_proximity_penalty,
-};
+use super::scoring::{PIPE_SOFTMAX_T, TARGET_MAX_DIST, pick_softmax_by_score, score_pipe_pair};
 use super::sections::split_blanks_by_reachability;
 
 /// Number of pipe pairs (not endpoints) per world in the vanilla ROM.
@@ -173,13 +170,21 @@ pub(super) fn place_pipes<R: Rng>(
         let (reachable_blanks, mut unreachable_blanks) =
             split_blanks_by_reachability(active, &walk.nodes, &used_positions);
 
-        // While we still must reach the target, prefer bridging to an island
-        // that actually leads there: keep only unreachable blanks that share a
-        // walk-component with the target. This generalizes the W3 fixed-endpoint
-        // `preferred` filter to every island connection, so RNG can't squander a
-        // pipe on a dead tile that connects nothing (e.g. W4's stranded (6,24)).
-        // Falls back to the unfiltered set when no candidate reaches the target.
-        if must_connect_target && let Some(t) = target_pos {
+        // Guarantee fallback: on the LAST connectivity pipe with the objective
+        // still stranded, restrict the island side to the objective's own
+        // walk-component so this pipe definitely reaches it. Pipes are
+        // teleports (no distance limit), so one pipe always suffices — hence
+        // reserving just the final pipe is enough to guarantee reachability.
+        // On every earlier pipe we instead grow outward (below), so the goal
+        // is reached through intermediate islands, not a direct start→goal
+        // jump. (The old code applied this filter on EVERY connectivity pipe,
+        // which forced the first pipe straight to the goal island — a 100%
+        // start→goal express rate that collapsed multi-island worlds.)
+        let pipes_left = pair_count - placed_pairs.len();
+        if must_connect_target
+            && pipes_left <= 1
+            && let Some(t) = target_pos
+        {
             let target_comp = walk_map(grid, &placed_pairs, Some(t), world_idx).nodes;
             let toward_target: Vec<(usize, usize)> = unreachable_blanks
                 .iter()
@@ -192,31 +197,34 @@ pub(super) fn place_pipes<R: Rng>(
         }
 
         if !unreachable_blanks.is_empty() && !reachable_blanks.is_empty() {
-            // Connect an island: scored selection for both endpoints.
-            // Unreachable side: prefer nearer islands (manhattan from start)
-            // to create progressive chains rather than jumping to the end.
-            let start = start_pos.unwrap_or((0, 0));
+            // Build outward: bridge the reachable frontier to the NEAREST
+            // unreachable island, connecting its closest two blanks. This
+            // grows the pipe network as a chain from start (start → i1 → i2 →
+            // … → goal) instead of teleporting straight to the goal island.
+            // Island side: prefer the blank nearest to the current frontier.
             let b_scored: Vec<((usize, usize), f64)> = unreachable_blanks
                 .iter()
-                .map(|&pos| {
-                    let start_dist = (pos.0.abs_diff(start.0) + pos.1.abs_diff(start.1)) as f64;
-                    // Nearer to start = higher score (invert distance)
-                    let proximity_score = (TARGET_MAX_DIST - start_dist.min(TARGET_MAX_DIST)) / TARGET_MAX_DIST * 5.0;
-                    let target_pen = target_proximity_penalty(pos, target_pos);
-                    (pos, proximity_score - target_pen)
+                .map(|&b| {
+                    let frontier_dist = reachable_blanks
+                        .iter()
+                        .map(|&a| (a.0.abs_diff(b.0) + a.1.abs_diff(b.1)) as f64)
+                        .fold(f64::INFINITY, f64::min);
+                    // Nearer to the reachable frontier = higher score.
+                    let proximity =
+                        (TARGET_MAX_DIST - frontier_dist.min(TARGET_MAX_DIST)) / TARGET_MAX_DIST * 5.0;
+                    (b, proximity)
                 })
                 .collect();
             let b = pick_softmax_by_score(b_scored, PIPE_SOFTMAX_T, rng).unwrap();
 
-            // Reachable side: prefer positions far from start (BFS distance),
-            // spread from existing pipes, and away from target.
+            // Reachable side: the frontier blank nearest to b (shortest bridge),
+            // so the pipe extends the frontier to that island rather than
+            // reaching back across the map.
             let a_scored: Vec<((usize, usize), f64)> = reachable_blanks
                 .iter()
-                .map(|&pos| {
-                    let score = score_pipe_endpoint(
-                        grid, pos, &used_positions, &walk.distances, target_pos,
-                    );
-                    (pos, score)
+                .map(|&a| {
+                    let d = (a.0.abs_diff(b.0) + a.1.abs_diff(b.1)) as f64;
+                    (a, -d) // nearer to b = higher
                 })
                 .collect();
             let a = pick_softmax_by_score(a_scored, PIPE_SOFTMAX_T, rng).unwrap();

--- a/src/randomize/overworld_build/progression.rs
+++ b/src/randomize/overworld_build/progression.rs
@@ -41,6 +41,18 @@ pub(crate) struct RequiredProgression {
     /// Which section's lock the hammer pre-opened, if any. `None` means the
     /// hammer was not used (or the analysis was no-hammer).
     pub hammer_broke_section: Option<usize>,
+    /// Longest run of back-to-back forced *level* plays along the required
+    /// route with no other activity between them. A fortress, pipe transit,
+    /// hammer-bro fight, or lock-poof resets the run; plain walking and
+    /// toad-house/spade panels (rarely entered) do not. This is the "levels
+    /// stacked with nothing to do between them" linearity signal.
+    pub level_streak: usize,
+    /// Trailing level run reaching the objective — how many forced levels sit
+    /// right in front of the airship/Bowser with no fort/pipe/HB/lock between
+    /// the run and the goal. `0` means an action (or lock) gates the final
+    /// approach. A high value is the "clear path, just 2+ levels on the goal"
+    /// complaint.
+    pub goal_stack: usize,
 }
 
 /// Compute the minimum number of fortress/level entries the player must clear
@@ -279,6 +291,13 @@ pub(super) fn analyze_with_pre_opened_mask(
     let mut forts: HashSet<(usize, usize)> = HashSet::new();
     let mut levels: HashSet<(usize, usize)> = HashSet::new();
 
+    // Streak accounting: `run` = current back-to-back forced-level count.
+    // An "activity" (fort / pipe / hammer-bro / crossed lock) resets it;
+    // toad-house/spade/walk tiles pass through without resetting.
+    let mut level_streak = 0usize;
+    let mut goal_stack = 0usize;
+    let mut run = 0usize;
+
     for (i, state) in chain.iter().enumerate() {
         let pos = state.0;
         path.push((pos, kind_for(pos)));
@@ -290,18 +309,41 @@ pub(super) fn analyze_with_pre_opened_mask(
                 && let Some(&section) = lock_section.get(&path_pos)
             {
                 locks_crossed.push((path_pos, section));
+                // A lock crossed on the way into this node is an activity
+                // between the previous node and this one.
+                run = 0;
             }
         }
-        if pos == start || pos == target {
+        if pos == target {
+            // Whatever level run reached the objective uninterrupted.
+            goal_stack = run;
+            continue;
+        }
+        if pos == start {
             continue;
         }
         match kind_at.get(&pos) {
             Some(SlotKind::Fortress) => {
                 forts.insert(pos);
+                run = 0;
             }
             Some(SlotKind::Level) => {
                 levels.insert(pos);
+                run += 1;
+                level_streak = level_streak.max(run);
             }
+            // A pipe ride is a deterministic activity, so it breaks a run.
+            Some(SlotKind::Pipe) => {
+                run = 0;
+            }
+            // Everything else passes through without breaking the run:
+            //   - HammerBro: a hammer-bro *node* is not entered by standing
+            //     on it. The fight is triggered by the wandering sprite,
+            //     whose position is dynamic and unmodeled here, so a node
+            //     with no sprite on it is just empty path. Do NOT credit it
+            //     as an activity between levels.
+            //   - ToadHouse / BonusGame: rarely entered by players.
+            //   - Unclassified / stray transit tiles.
             _ => {}
         }
     }
@@ -313,7 +355,183 @@ pub(super) fn analyze_with_pre_opened_mask(
         path,
         locks_crossed,
         hammer_broke_section: None,
+        level_streak,
+        goal_stack,
     }
+}
+
+/// Count of graph-adjacent Level–Level node pairs, independent of the
+/// required route: two level slots joined by a single walk edge (not a
+/// pipe/canoe teleport). A high count means the map physically stacks
+/// levels side by side — the "level physically next to level" signal,
+/// distinct from the route-based `level_streak`.
+pub(crate) fn level_adjacency_pairs(built: &BuiltWorld) -> usize {
+    let mut grid = built.grid.clone();
+    stamp_slots(&mut grid, &built.slots);
+    let Some(start) = rom_data::find_start(&grid) else {
+        return 0;
+    };
+    let walk = walk_map(&grid, &built.pipe_pairs, Some(start), built.world_idx);
+    let level_pos: HashSet<(usize, usize)> = built
+        .slots
+        .iter()
+        .filter(|s| s.kind == SlotKind::Level)
+        .map(|s| s.pos)
+        .collect();
+    let mut pairs: HashSet<((usize, usize), (usize, usize))> = HashSet::new();
+    for (&a, edges) in &walk.edges {
+        if !level_pos.contains(&a) {
+            continue;
+        }
+        for edge in edges {
+            // path_pos.is_some() ⇒ a walk edge (physical adjacency), not a
+            // pipe/canoe teleport.
+            if edge.path_pos.is_some() && level_pos.contains(&edge.dest) {
+                let key = if a <= edge.dest {
+                    (a, edge.dest)
+                } else {
+                    (edge.dest, a)
+                };
+                pairs.insert(key);
+            }
+        }
+    }
+    pairs.len()
+}
+
+/// What role a single pipe pair plays on the required route.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PipeClass {
+    /// Removing this pipe strands the objective — it's mandatory access to an
+    /// island / rock-sectioned area (function 1: connectivity).
+    Connectivity,
+    /// Removing it keeps the objective reachable and doesn't change min-clears,
+    /// but at least one endpoint is an island (not walk-reachable without
+    /// pipes). This is a *redundant island route* — it gives the player an
+    /// alternate path through the island network, so it's variety, not waste.
+    IslandRouting,
+    /// Removing it keeps the objective reachable, doesn't change min-clears,
+    /// AND both endpoints are walk-reachable mainland. A loop over ground the
+    /// player could already walk, skipping nothing — the true waste to minimize.
+    DeadLoop,
+    /// Removing it RAISES min-clears by `n` — a real shortcut that skips `n`
+    /// forced clears (function 2), regardless of mainland/island.
+    Shortcut(usize),
+}
+
+/// Classify every pipe pair by leave-one-out: remove it (leaving the others
+/// and all canoes intact) and re-run the required-progression analysis. The
+/// mainland/island split uses walk-only reachability from start (no pipes) so
+/// intentional island-hopping routes aren't miscounted as dead-loop waste.
+///
+/// Caveat: leave-one-out reads a lateral loop offering an equal-length
+/// alternative as delta-0 (it doesn't lower the MINIMUM clears). For a
+/// mainland loop that's exactly the waste we're after; the island case is
+/// separated out as `IslandRouting`.
+pub(crate) fn classify_pipes(built: &BuiltWorld) -> Vec<PipeClass> {
+    let base = analyze_required_progression(built, false);
+    let base_clears = base.forts_required + base.levels_required;
+
+    // Mainland = nodes walk-reachable from start with NO pipes. An endpoint
+    // outside this set is only reachable by pipe (an island).
+    let mut grid = built.grid.clone();
+    stamp_slots(&mut grid, &built.slots);
+    let mainland: HashSet<(usize, usize)> = rom_data::find_start(&grid)
+        .map(|s| walk_map(&grid, &[], Some(s), built.world_idx).nodes)
+        .unwrap_or_default();
+
+    let mut out = Vec::with_capacity(built.pipe_pairs.len());
+    for i in 0..built.pipe_pairs.len() {
+        let (a, b) = built.pipe_pairs[i];
+        let mut without = built.clone();
+        without.pipe_pairs.remove(i);
+        let r = analyze_required_progression(&without, false);
+        out.push(if !r.reachable {
+            PipeClass::Connectivity
+        } else {
+            let delta = (r.forts_required + r.levels_required).saturating_sub(base_clears);
+            if delta > 0 {
+                PipeClass::Shortcut(delta)
+            } else if mainland.contains(&a) && mainland.contains(&b) {
+                PipeClass::DeadLoop
+            } else {
+                PipeClass::IslandRouting
+            }
+        });
+    }
+    out
+}
+
+/// Whether a single pipe directly bridges the start walk-component to the
+/// goal walk-component — a start→goal "express" pipe that short-circuits any
+/// intermediate island hops.
+///
+/// `None` when start and goal already share a walk component (no bridging
+/// pipe needed, e.g. W1/W2) or the target is missing. Otherwise `Some(true)`
+/// if such a direct pipe exists.
+///
+/// Interpretation is world-dependent: for few-island worlds (W3/W4/W5) a
+/// direct link is natural or required (~100%). For many-island worlds
+/// (W7/W8) it collapses the intended island-hopping journey into one jump
+/// and should be rare.
+pub(crate) fn start_goal_express_pipe(built: &BuiltWorld) -> Option<bool> {
+    let mut grid = built.grid.clone();
+    stamp_slots(&mut grid, &built.slots);
+    let start = rom_data::find_start(&grid)?;
+    let target = find_target(&grid, built.world_idx)?;
+    let start_comp = walk_map(&grid, &[], Some(start), built.world_idx).nodes;
+    if start_comp.contains(&target) {
+        return None; // start and goal already on the same island
+    }
+    let goal_comp = walk_map(&grid, &[], Some(target), built.world_idx).nodes;
+    let direct = built.pipe_pairs.iter().any(|&(a, b)| {
+        (start_comp.contains(&a) && goal_comp.contains(&b))
+            || (goal_comp.contains(&a) && start_comp.contains(&b))
+    });
+    Some(direct)
+}
+
+/// Rough island count: the number of distinct walk-only components (no pipes)
+/// spanned by the world's start, target, and pipe endpoints. Context for the
+/// express-pipe rate — a world with 2 islands "should" bridge start↔goal
+/// directly; a world with 5 should route through the middle ones.
+pub(crate) fn island_count(built: &BuiltWorld) -> usize {
+    let mut grid = built.grid.clone();
+    stamp_slots(&mut grid, &built.slots);
+    let mut key: Vec<(usize, usize)> = built
+        .pipe_pairs
+        .iter()
+        .flat_map(|&(a, b)| [a, b])
+        .collect();
+    if let Some(s) = rom_data::find_start(&grid) {
+        key.push(s);
+    }
+    if let Some(t) = find_target(&grid, built.world_idx) {
+        key.push(t);
+    }
+    let mut seen: HashSet<(usize, usize)> = HashSet::new();
+    let mut comps = 0;
+    for n in key {
+        if seen.contains(&n) {
+            continue;
+        }
+        let comp = walk_map(&grid, &[], Some(n), built.world_idx).nodes;
+        comps += 1;
+        seen.extend(comp);
+    }
+    comps
+}
+
+/// How many forced clears a lock-breaking hammer lets the player skip:
+/// (no-hammer clears) − (one-hammer clears). This is the "breaking a
+/// rock/lock opens a shortcut past levels" value, assuming the
+/// hammer-breaks-locks mechanic is in play.
+pub(crate) fn hammer_skip(built: &BuiltWorld) -> usize {
+    let nh = analyze_required_progression(built, false);
+    let wh = analyze_required_progression(built, true);
+    let nh_c = nh.forts_required + nh.levels_required;
+    let wh_c = wh.forts_required + wh.levels_required;
+    nh_c.saturating_sub(wh_c)
 }
 
 /// Pretty-print a `RequiredProgression` result for one world. Use for
@@ -424,6 +642,10 @@ pub(super) fn print_progression(
         eprintln!("    TARGET UNREACHABLE");
         return;
     }
+    eprintln!(
+        "    level streak: {}  |  goal stack: {}",
+        p.level_streak, p.goal_stack,
+    );
     let mut lock_iter = p.locks_crossed.iter().peekable();
     for (i, (pos, kind)) in p.path.iter().enumerate() {
         let tag = match kind {

--- a/src/randomize/overworld_build/progression.rs
+++ b/src/randomize/overworld_build/progression.rs
@@ -416,28 +416,35 @@ pub(crate) enum PipeClass {
     /// strands OTHER content: some level/fortress becomes unreachable. Sole
     /// route to optional content the player can choose to play.
     ContentAccess,
+    /// Removing it strands nodes but NO level/fort content — a pipe to a
+    /// content-less spot (e.g. a lone island that just lets the player glimpse
+    /// the final island). Purposefully redundant / scenic, not gameplay waste.
+    Scenic,
     /// Removing it changes NOTHING — target still reachable, min-clears
-    /// unchanged, and the reachable level/fort set is identical. Pure waste.
+    /// unchanged, and the reachable node set is identical. Pure waste.
     Redundant,
 }
 
-/// Level/fortress slot positions reachable from start with the given pipe set
-/// (locks treated as open — this is topological "can the player ever get here",
-/// which they can by clearing the gating fortress). Canoes handled by walk_map.
-fn reachable_content(built: &BuiltWorld) -> HashSet<(usize, usize)> {
+/// Nodes reachable from start with the given pipe set (locks treated as open —
+/// topological "can the player ever get here", which they can by clearing the
+/// gating fortress). Canoes handled by walk_map.
+fn reachable_nodes(built: &BuiltWorld) -> HashSet<(usize, usize)> {
     let mut grid = built.grid.clone();
     stamp_slots(&mut grid, &built.slots);
-    let Some(start) = rom_data::find_start(&grid) else {
-        return HashSet::new();
-    };
-    let reachable = walk_map(&grid, &built.pipe_pairs, Some(start), built.world_idx).nodes;
+    match rom_data::find_start(&grid) {
+        Some(start) => walk_map(&grid, &built.pipe_pairs, Some(start), built.world_idx).nodes,
+        None => HashSet::new(),
+    }
+}
+
+/// How many Level/Fortress slots fall inside a reachable-node set.
+fn content_in(built: &BuiltWorld, reachable: &HashSet<(usize, usize)>) -> usize {
     built
         .slots
         .iter()
         .filter(|s| matches!(s.kind, SlotKind::Level | SlotKind::Fortress))
-        .map(|s| s.pos)
-        .filter(|p| reachable.contains(p))
-        .collect()
+        .filter(|s| reachable.contains(&s.pos))
+        .count()
 }
 
 /// Classify every pipe pair by leave-one-out: remove it (leaving the others
@@ -451,7 +458,8 @@ fn reachable_content(built: &BuiltWorld) -> HashSet<(usize, usize)> {
 pub(crate) fn classify_pipes(built: &BuiltWorld) -> Vec<PipeClass> {
     let base = analyze_required_progression(built, false);
     let base_clears = base.forts_required + base.levels_required;
-    let base_content = reachable_content(built);
+    let base_nodes = reachable_nodes(built);
+    let base_content = content_in(built, &base_nodes);
 
     let mut out = Vec::with_capacity(built.pipe_pairs.len());
     for i in 0..built.pipe_pairs.len() {
@@ -464,12 +472,17 @@ pub(crate) fn classify_pipes(built: &BuiltWorld) -> Vec<PipeClass> {
             let delta = (r.forts_required + r.levels_required).saturating_sub(base_clears);
             if delta > 0 {
                 PipeClass::Shortcut(delta)
-            } else if reachable_content(&without).len() < base_content.len() {
-                // Removing it left the target reachable and clears unchanged,
-                // but a level/fort dropped out of reach — sole content access.
-                PipeClass::ContentAccess
             } else {
-                PipeClass::Redundant
+                // Target still reachable, clears unchanged. Split by what
+                // removing the pipe strands from the reachable set.
+                let nodes = reachable_nodes(&without);
+                if content_in(&without, &nodes) < base_content {
+                    PipeClass::ContentAccess // stranded a level/fort
+                } else if nodes.len() < base_nodes.len() {
+                    PipeClass::Scenic // stranded content-less nodes (a view)
+                } else {
+                    PipeClass::Redundant // stranded nothing — pure waste
+                }
             }
         });
     }

--- a/src/randomize/overworld_build/progression.rs
+++ b/src/randomize/overworld_build/progression.rs
@@ -399,50 +399,62 @@ pub(crate) fn level_adjacency_pairs(built: &BuiltWorld) -> usize {
     pairs.len()
 }
 
-/// What role a single pipe pair plays on the required route.
+/// What a single pipe pair earns its keep by — decided by leave-one-out:
+/// remove it and see what the player loses. The distinction is functional
+/// ("does removing it take anything away"), not geometric (mainland vs
+/// island): an island pipe whose island is reachable another way is just as
+/// redundant as a mainland loop.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PipeClass {
-    /// Removing this pipe strands the objective — it's mandatory access to an
-    /// island / rock-sectioned area (function 1: connectivity).
+    /// Removing it strands the objective — mandatory access (blocks target
+    /// progress).
     Connectivity,
-    /// Removing it keeps the objective reachable and doesn't change min-clears,
-    /// but at least one endpoint is an island (not walk-reachable without
-    /// pipes). This is a *redundant island route* — it gives the player an
-    /// alternate path through the island network, so it's variety, not waste.
-    IslandRouting,
-    /// Removing it keeps the objective reachable, doesn't change min-clears,
-    /// AND both endpoints are walk-reachable mainland. A loop over ground the
-    /// player could already walk, skipping nothing — the true waste to minimize.
-    DeadLoop,
-    /// Removing it RAISES min-clears by `n` — a real shortcut that skips `n`
-    /// forced clears (function 2), regardless of mainland/island.
+    /// Removing it RAISES min-clears by `n` — a shortcut that skips `n` forced
+    /// clears.
     Shortcut(usize),
+    /// Removing it keeps the target reachable and min-clears unchanged, but
+    /// strands OTHER content: some level/fortress becomes unreachable. Sole
+    /// route to optional content the player can choose to play.
+    ContentAccess,
+    /// Removing it changes NOTHING — target still reachable, min-clears
+    /// unchanged, and the reachable level/fort set is identical. Pure waste.
+    Redundant,
+}
+
+/// Level/fortress slot positions reachable from start with the given pipe set
+/// (locks treated as open — this is topological "can the player ever get here",
+/// which they can by clearing the gating fortress). Canoes handled by walk_map.
+fn reachable_content(built: &BuiltWorld) -> HashSet<(usize, usize)> {
+    let mut grid = built.grid.clone();
+    stamp_slots(&mut grid, &built.slots);
+    let Some(start) = rom_data::find_start(&grid) else {
+        return HashSet::new();
+    };
+    let reachable = walk_map(&grid, &built.pipe_pairs, Some(start), built.world_idx).nodes;
+    built
+        .slots
+        .iter()
+        .filter(|s| matches!(s.kind, SlotKind::Level | SlotKind::Fortress))
+        .map(|s| s.pos)
+        .filter(|p| reachable.contains(p))
+        .collect()
 }
 
 /// Classify every pipe pair by leave-one-out: remove it (leaving the others
-/// and all canoes intact) and re-run the required-progression analysis. The
-/// mainland/island split uses walk-only reachability from start (no pipes) so
-/// intentional island-hopping routes aren't miscounted as dead-loop waste.
+/// and all canoes intact) and re-run the required-progression analysis plus a
+/// reachable-content check.
 ///
-/// Caveat: leave-one-out reads a lateral loop offering an equal-length
-/// alternative as delta-0 (it doesn't lower the MINIMUM clears). For a
-/// mainland loop that's exactly the waste we're after; the island case is
-/// separated out as `IslandRouting`.
+/// Caveat: leave-one-out reads a pipe as `Redundant` whenever an equally-good
+/// alternative route AND alternative content-access both exist — i.e. it
+/// measures "does removing this pipe take anything away from the MINIMUM
+/// route or the reachable content", not "could a player ever use it".
 pub(crate) fn classify_pipes(built: &BuiltWorld) -> Vec<PipeClass> {
     let base = analyze_required_progression(built, false);
     let base_clears = base.forts_required + base.levels_required;
-
-    // Mainland = nodes walk-reachable from start with NO pipes. An endpoint
-    // outside this set is only reachable by pipe (an island).
-    let mut grid = built.grid.clone();
-    stamp_slots(&mut grid, &built.slots);
-    let mainland: HashSet<(usize, usize)> = rom_data::find_start(&grid)
-        .map(|s| walk_map(&grid, &[], Some(s), built.world_idx).nodes)
-        .unwrap_or_default();
+    let base_content = reachable_content(built);
 
     let mut out = Vec::with_capacity(built.pipe_pairs.len());
     for i in 0..built.pipe_pairs.len() {
-        let (a, b) = built.pipe_pairs[i];
         let mut without = built.clone();
         without.pipe_pairs.remove(i);
         let r = analyze_required_progression(&without, false);
@@ -452,10 +464,12 @@ pub(crate) fn classify_pipes(built: &BuiltWorld) -> Vec<PipeClass> {
             let delta = (r.forts_required + r.levels_required).saturating_sub(base_clears);
             if delta > 0 {
                 PipeClass::Shortcut(delta)
-            } else if mainland.contains(&a) && mainland.contains(&b) {
-                PipeClass::DeadLoop
+            } else if reachable_content(&without).len() < base_content.len() {
+                // Removing it left the target reachable and clears unchanged,
+                // but a level/fort dropped out of reach — sole content access.
+                PipeClass::ContentAccess
             } else {
-                PipeClass::IslandRouting
+                PipeClass::Redundant
             }
         });
     }

--- a/src/randomize/overworld_build/progression.rs
+++ b/src/randomize/overworld_build/progression.rs
@@ -455,7 +455,30 @@ fn content_in(built: &BuiltWorld, reachable: &HashSet<(usize, usize)>) -> usize 
 /// alternative route AND alternative content-access both exist — i.e. it
 /// measures "does removing this pipe take anything away from the MINIMUM
 /// route or the reachable content", not "could a player ever use it".
+/// Copy of `built` with breakable rocks turned to path ($51→$45 horizontal,
+/// $52→$46 vertical, matching the game's `RockBreak_Replace`). Unbreakable
+/// rocks ($53) stay. Used only by the pipe classifier so a pipe whose sole
+/// value is bypassing a hammer-breakable rock counts as redundant — the player
+/// could break the rock instead. Does NOT affect the build or the streak /
+/// goal-stack metrics, which keep the true rock-as-wall topology.
+fn hammer_open_rocks(built: &BuiltWorld) -> BuiltWorld {
+    let mut b = built.clone();
+    for r in 0..b.grid.rows() {
+        for c in 0..b.grid.cols {
+            match b.grid.get(r, c) {
+                0x51 => b.grid.set(r, c, 0x45),
+                0x52 => b.grid.set(r, c, 0x46),
+                _ => {}
+            }
+        }
+    }
+    b
+}
+
 pub(crate) fn classify_pipes(built: &BuiltWorld) -> Vec<PipeClass> {
+    // Pipe value is judged with hammer-breakable rocks treated as passable, so
+    // a pipe that only bypasses a rock a hammer could break reads as redundant.
+    let built = &hammer_open_rocks(built);
     let base = analyze_required_progression(built, false);
     let base_clears = base.forts_required + base.levels_required;
     let base_nodes = reachable_nodes(built);

--- a/src/randomize/overworld_build/scoring.rs
+++ b/src/randomize/overworld_build/scoring.rs
@@ -157,12 +157,17 @@ pub(super) fn score_with_weights(
 /// Path relevance: max detour (in BFS hops) that still earns a bonus.
 pub(super) const PATH_DETOUR_CAP: f64 = 6.0;
 
-/// Path relevance weight. Max bonus = PATH_DETOUR_CAP * W_PATH = 9.0.
-/// Tuned via test_level_placement_quality: 0.5 was decorative (no bias);
-/// 3.0 dominated and clumped levels on the route at the expense of spread
-/// and dead-ends. 1.5 produces a meaningful route bias without breaking
-/// the spread or density terms.
-pub(super) const W_PATH: f64 = 1.5;
+/// Path relevance weight. Max bonus = PATH_DETOUR_CAP * W_PATH = 4.5.
+/// Lowered from 1.5 → 0.75 to cut back-to-back forced-level streaks: the route
+/// bias was gluing levels onto the start→target trunk, which was the dominant
+/// driver of overworld linearity (mean forced-level streak ~2.1, well above
+/// the reference SMB3 randomizer's ~1.8). A W_PATH sweep via
+/// test_required_progression's linearity block: 1.5→streak 2.12, 1.0→1.89,
+/// 0.75→1.79 (≈ reference), 0.5→1.70, 0.0→1.34 (overshoots and thins the
+/// required route too much). 0.75 keeps a meaningful route bias while landing
+/// streak at the reference level. (History: 3.0 dominated and clumped hard;
+/// 0.5 was once considered "decorative" at the old weightings.)
+pub(super) const W_PATH: f64 = 0.75;
 
 /// Score a candidate position for level placement. Higher = better.
 /// Includes a path relevance bonus: positions on the main start→target

--- a/src/randomize/overworld_build/scoring.rs
+++ b/src/randomize/overworld_build/scoring.rs
@@ -215,18 +215,9 @@ pub(super) fn score_fortress_candidate(
     base + island_bonus
 }
 
-/// Target proximity penalty weight. Higher = more aggressively avoids placing
-/// pipes near the airship/Bowser. Tweakable for tuning.
-pub(super) const W_TARGET_PROXIMITY: f64 = 4.0;
-
-/// Max manhattan distance for target penalty normalization.
+/// Max manhattan distance for pipe frontier-proximity normalization (used by
+/// the connectivity build-outward scoring in `place_pipes`).
 pub(super) const TARGET_MAX_DIST: f64 = 20.0;
-
-/// Cap on the manhattan + BFS spread reward for pipe scoring. Positions
-/// beyond this effective spread all score the same, preventing very-far
-/// positions from always dominating. Applied to the spread term only —
-/// dead-end bonus and density penalty bypass the cap so they always count.
-pub(super) const PIPE_SPREAD_CAP: f64 = 7.0;
 
 /// Softmax temperature for pipe placement. Higher = more random, lower =
 /// more concentrated on top-scoring candidates. Tuned for typical pipe
@@ -236,67 +227,3 @@ pub(super) const PIPE_SOFTMAX_T: f64 = 4.0;
 /// Softmax temperature for fortress placement. Score range is similar to
 /// pipes (~[-12, +15] including the +5 dead-end bonus).
 pub(super) const FORTRESS_SOFTMAX_T: f64 = 4.0;
-
-/// Compute target proximity penalty for a position. Positions near the
-/// airship/Bowser get penalized; positions far away get no penalty.
-pub(super) fn target_proximity_penalty(pos: (usize, usize), target_pos: Option<(usize, usize)>) -> f64 {
-    if let Some(tp) = target_pos {
-        let dist = (pos.0.abs_diff(tp.0) + pos.1.abs_diff(tp.1)) as f64;
-        W_TARGET_PROXIMITY * (TARGET_MAX_DIST - dist.min(TARGET_MAX_DIST)) / TARGET_MAX_DIST
-    } else {
-        0.0
-    }
-}
-
-/// Score a single pipe endpoint. Higher = better.
-///
-/// Spread reward (distance from nearest existing pipe) is capped at
-/// PIPE_SPREAD_CAP. Dead-end bonus, density penalty, and target penalty
-/// are applied outside the cap so they always influence the score.
-///
-/// When `pipe_positions` is empty (first pair) the spread term is 0 — every
-/// candidate ties on spread, so picking is driven by dead-end + target only.
-pub(super) fn score_pipe_endpoint(
-    grid: &Grid,
-    pos: (usize, usize),
-    pipe_positions: &HashSet<(usize, usize)>,
-    bfs_distances: &HashMap<(usize, usize), usize>,
-    target_pos: Option<(usize, usize)>,
-) -> f64 {
-    const DEAD_END_BONUS: f64 = 1.0;
-
-    let (min_manhattan, min_bfs_diff, nearby) =
-        spread_and_density(pos, pipe_positions, bfs_distances);
-
-    let spread = if pipe_positions.is_empty() {
-        0.0
-    } else {
-        let min_bfs_diff = min_bfs_diff.unwrap_or(min_manhattan);
-        let m = (min_manhattan as f64).min(SEP_CAP) * W_MANHATTAN;
-        let b = (min_bfs_diff as f64).min(SEP_CAP) * W_BFS;
-        (m + b).min(PIPE_SPREAD_CAP)
-    };
-
-    let density_penalty = nearby as f64 * W_DENSITY;
-
-    let dead_end_bonus = if is_dead_end(grid, pos) { DEAD_END_BONUS } else { 0.0 };
-
-    spread + dead_end_bonus - density_penalty - target_proximity_penalty(pos, target_pos)
-}
-
-/// Score a candidate pipe pair. Higher = better.
-/// Rewards spread from already-placed pipes, separation between endpoints,
-/// and penalizes proximity to the airship/Bowser target.
-pub(super) fn score_pipe_pair(
-    grid: &Grid,
-    a: (usize, usize),
-    b: (usize, usize),
-    pipe_positions: &HashSet<(usize, usize)>,
-    bfs_distances: &HashMap<(usize, usize), usize>,
-    target_pos: Option<(usize, usize)>,
-) -> f64 {
-    let spread_a = score_pipe_endpoint(grid, a, pipe_positions, bfs_distances, target_pos);
-    let spread_b = score_pipe_endpoint(grid, b, pipe_positions, bfs_distances, target_pos);
-    let separation = ((a.0.abs_diff(b.0) + a.1.abs_diff(b.1)) as f64 * 0.5).min(10.0);
-    spread_a + spread_b + separation
-}

--- a/src/randomize/overworld_build/sections.rs
+++ b/src/randomize/overworld_build/sections.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 use super::locks::place_locks;
-use super::pipes::{FIXED_PIPE_ENDPOINTS, PIPE_EXCLUDED_POSITIONS, place_pipes};
+use super::pipes::{FIXED_PIPE_ENDPOINTS, PIPE_EXCLUDED_POSITIONS, place_pipes, place_spare_pipes};
 use super::scoring::{
     FORTRESS_SOFTMAX_T, is_row78_conflict, pick_softmax_by_score, score_candidate,
     score_fortress_candidate,
@@ -49,8 +49,9 @@ pub(super) fn build_world<R: Rng>(
         .filter(|p| !pipe_excluded.contains(p))
         .collect();
 
-    // Step 1: Place pipes
-    let pipe_pairs = place_pipes(
+    // Step 1: Place connectivity pipes only (island access + target
+    // reachability). Spare pipes are deferred to Step 3.5, after levels exist.
+    let mut pipe_pairs = place_pipes(
         &mut grid,
         &pipe_blanks,
         start_pos,
@@ -61,7 +62,10 @@ pub(super) fn build_world<R: Rng>(
         rng,
     );
 
-    // Collect positions used by pipes
+    // Collect positions used by the connectivity pipes. Spare pipe positions
+    // don't exist yet, so sectioning and level scoring see only these — which
+    // is intended: levels are placed as if there were no shortcuts, then the
+    // spare pipes are added to skip some of them.
     let pipe_positions: HashSet<(usize, usize)> = pipe_pairs
         .iter()
         .flat_map(|&(a, b)| vec![a, b])
@@ -141,6 +145,22 @@ pub(super) fn build_world<R: Rng>(
         kept.extend(hb_slots.into_iter().take(hb_budget));
         slots = kept;
     }
+
+    // Step 3.5: Spare pipes. Now that levels are placed, fill the remaining
+    // pipe budget by converting HammerBro filler slots into pipe endpoints
+    // aimed to skip levels. Runs before locks so `place_locks` accounts for
+    // every pipe (a post-lock pipe could otherwise teleport across a lock).
+    let spare_needed = pipe_pair_count.saturating_sub(pipe_pairs.len());
+    place_spare_pipes(
+        &mut grid,
+        &mut slots,
+        &mut pipe_pairs,
+        spare_needed,
+        &hb_sprite_positions,
+        start_pos,
+        world_idx,
+        rng,
+    );
 
     // Step 4: Lock placement
     let locks = place_locks(

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1727,6 +1727,7 @@ struct ProgLinWorld {
     sum_conn: u64,
     sum_shortcut: u64,
     sum_access: u64,
+    sum_scenic: u64,
     sum_redundant: u64,
     sum_pipe_skip: u64,
     // Start→goal express pipe: how often a single pipe bridges start-island
@@ -1784,6 +1785,7 @@ fn prog_measure_pass(rom_bytes: &[u8], options: &crate::Options, seeds: u64) -> 
                         w.sum_pipe_skip += n as u64;
                     }
                     PipeClass::ContentAccess => w.sum_access += 1,
+                    PipeClass::Scenic => w.sum_scenic += 1,
                     PipeClass::Redundant => w.sum_redundant += 1,
                 }
             }
@@ -1849,11 +1851,11 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
     // (lvls-skipped = how many); access = strands other level/fort content;
     // redundant = nothing changes (pure waste).
     eprintln!(
-        "    pipes/world:   {:>5} {:>9} {:>12} {:>7} {:>10} {:>7} {:>9}",
-        "conn", "shortcut", "lvls-skipped", "access", "redundant", "islands", "express%",
+        "    pipes/world:   {:>5} {:>9} {:>8} {:>7} {:>7} {:>10} {:>9}",
+        "conn", "shortcut", "skipped", "access", "scenic", "redundant", "express%",
     );
-    let (mut g_conn, mut g_short, mut g_skip, mut g_access, mut g_redundant) =
-        (0u64, 0u64, 0u64, 0u64, 0u64);
+    let (mut g_conn, mut g_short, mut g_skip, mut g_access, mut g_scenic, mut g_redundant) =
+        (0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
     for (wi, w) in worlds.iter().enumerate() {
         if w.reachable == 0 {
             continue;
@@ -1865,31 +1867,33 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
             "n/a".to_string()
         };
         eprintln!(
-            "      W{}         {:>5.2} {:>9.2} {:>12.2} {:>7.2} {:>10.2} {:>7.2} {:>9}",
+            "      W{}         {:>5.2} {:>9.2} {:>8.2} {:>7.2} {:>7.2} {:>10.2} {:>9}",
             wi + 1,
             w.sum_conn as f64 / r,
             w.sum_shortcut as f64 / r,
             w.sum_pipe_skip as f64 / r,
             w.sum_access as f64 / r,
+            w.sum_scenic as f64 / r,
             w.sum_redundant as f64 / r,
-            w.sum_islands as f64 / r,
             express,
         );
         g_conn += w.sum_conn;
         g_short += w.sum_shortcut;
         g_skip += w.sum_pipe_skip;
         g_access += w.sum_access;
+        g_scenic += w.sum_scenic;
         g_redundant += w.sum_redundant;
     }
     if t_reach > 0 {
         let tr = t_reach as f64;
-        let all_pipes = g_conn + g_short + g_access + g_redundant;
+        let all_pipes = g_conn + g_short + g_access + g_scenic + g_redundant;
         eprintln!(
-            "      overall:   {:>5.2} {:>9.2} {:>12.2} {:>7.2} {:>10.2}  (redundant {:.0}% of all pipes)",
+            "      overall:   {:>5.2} {:>9.2} {:>8.2} {:>7.2} {:>7.2} {:>10.2}  (redundant {:.0}% of all pipes)",
             g_conn as f64 / tr,
             g_short as f64 / tr,
             g_skip as f64 / tr,
             g_access as f64 / tr,
+            g_scenic as f64 / tr,
             g_redundant as f64 / tr,
             if all_pipes > 0 {
                 g_redundant as f64 / all_pipes as f64 * 100.0

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1856,6 +1856,10 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
     );
     let (mut g_conn, mut g_short, mut g_skip, mut g_access, mut g_scenic, mut g_redundant) =
         (0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+    // Same aggregate but excluding W7, whose 8-pair pipe mesh dominates the
+    // redundancy total and hides the picture for the rest of the map.
+    let (mut x_conn, mut x_short, mut x_access, mut x_scenic, mut x_redundant, mut x_reach) =
+        (0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
     for (wi, w) in worlds.iter().enumerate() {
         if w.reachable == 0 {
             continue;
@@ -1883,6 +1887,14 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
         g_access += w.sum_access;
         g_scenic += w.sum_scenic;
         g_redundant += w.sum_redundant;
+        if wi != 6 {
+            x_conn += w.sum_conn;
+            x_short += w.sum_shortcut;
+            x_access += w.sum_access;
+            x_scenic += w.sum_scenic;
+            x_redundant += w.sum_redundant;
+            x_reach += w.reachable as u64;
+        }
     }
     if t_reach > 0 {
         let tr = t_reach as f64;
@@ -1897,6 +1909,24 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
             g_redundant as f64 / tr,
             if all_pipes > 0 {
                 g_redundant as f64 / all_pipes as f64 * 100.0
+            } else {
+                0.0
+            },
+        );
+    }
+    if x_reach > 0 {
+        let xr = x_reach as f64;
+        let x_pipes = x_conn + x_short + x_access + x_scenic + x_redundant;
+        eprintln!(
+            "      ex-W7:     {:>5.2} {:>9.2} {:>8} {:>7.2} {:>7.2} {:>10.2}  (redundant {:.0}% of all pipes)",
+            x_conn as f64 / xr,
+            x_short as f64 / xr,
+            "",
+            x_access as f64 / xr,
+            x_scenic as f64 / xr,
+            x_redundant as f64 / xr,
+            if x_pipes > 0 {
+                x_redundant as f64 / x_pipes as f64 * 100.0
             } else {
                 0.0
             },

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1709,207 +1709,276 @@ fn test_sas_w3_fixed_pipe_keeps_target_reachable() {
     }
 }
 
-/// Required-progression analyzer.
+/// Per-world linearity accumulators for one measurement pass.
+#[derive(Clone, Default)]
+struct ProgLinWorld {
+    reachable: u32,
+    unreachable: u32,
+    sum_clears: u64,
+    sum_streak: u64,
+    max_streak: usize,
+    streak_ge2: u32,
+    streak_ge3: u32,
+    sum_goal: u64,
+    goal_ge2: u32,
+    sum_adj: u64,
+    // Pipe classification (summed over seeds): counts per class + total
+    // forced clears skipped by shortcut pipes.
+    sum_conn: u64,
+    sum_island: u64,
+    sum_dead: u64,
+    sum_shortcut: u64,
+    sum_pipe_skip: u64,
+    // Start→goal express pipe: how often a single pipe bridges start-island
+    // straight to goal-island. express_total = seeds where it's applicable
+    // (start and goal on different islands).
+    sum_express: u64,
+    sum_express_total: u64,
+    sum_islands: u64,
+    sum_rock_skip: u64,
+}
+
+/// Run `seeds` full-pipeline builds under `options` and accumulate per-world
+/// linearity stats. Uses `randomize_rom_with_overworld_capture` so the maps
+/// are exactly what the CLI/web ships (not a direct `build()`, whose RNG
+/// state differs from a real run).
+fn prog_measure_pass(rom_bytes: &[u8], options: &crate::Options, seeds: u64) -> [ProgLinWorld; 8] {
+    let mut worlds: [ProgLinWorld; 8] = std::array::from_fn(|_| ProgLinWorld::default());
+    for seed in 0..seeds {
+        let (_rom, result) =
+            match crate::randomize_rom_with_overworld_capture(rom_bytes, seed, options, None) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    eprintln!("seed {seed}: randomize failed: {e}");
+                    continue;
+                }
+            };
+        for built in &result.worlds {
+            let w = &mut worlds[built.world_idx];
+            let nh = analyze_required_progression(built, false);
+            if !nh.reachable {
+                w.unreachable += 1;
+                continue;
+            }
+            w.reachable += 1;
+            w.sum_clears += (nh.forts_required + nh.levels_required) as u64;
+            w.sum_streak += nh.level_streak as u64;
+            w.max_streak = w.max_streak.max(nh.level_streak);
+            if nh.level_streak >= 2 {
+                w.streak_ge2 += 1;
+            }
+            if nh.level_streak >= 3 {
+                w.streak_ge3 += 1;
+            }
+            w.sum_goal += nh.goal_stack as u64;
+            if nh.goal_stack >= 2 {
+                w.goal_ge2 += 1;
+            }
+            w.sum_adj += level_adjacency_pairs(built) as u64;
+            w.sum_rock_skip += hammer_skip(built) as u64;
+            for class in classify_pipes(built) {
+                match class {
+                    PipeClass::Connectivity => w.sum_conn += 1,
+                    PipeClass::IslandRouting => w.sum_island += 1,
+                    PipeClass::DeadLoop => w.sum_dead += 1,
+                    PipeClass::Shortcut(n) => {
+                        w.sum_shortcut += 1;
+                        w.sum_pipe_skip += n as u64;
+                    }
+                }
+            }
+            w.sum_islands += island_count(built) as u64;
+            if let Some(direct) = start_goal_express_pipe(built) {
+                w.sum_express_total += 1;
+                if direct {
+                    w.sum_express += 1;
+                }
+            }
+        }
+    }
+    worlds
+}
+
+/// Print one pass's per-world linearity + pipe-role tables.
+fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
+    eprintln!("\n  [{label}]");
+    eprintln!(
+        "    {:<4} {:>7} {:>7} {:>5} {:>5} {:>8} {:>6} {:>10}",
+        "", "clears", "streak", "≥2", "≥3", "goalstk", "adj", "rock-skip",
+    );
+    let (mut t_reach, mut t_streak, mut t_ge2, mut t_ge3, mut t_goal2, mut t_rock) =
+        (0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+    for (wi, w) in worlds.iter().enumerate() {
+        if w.reachable == 0 {
+            eprintln!("    W{}: (no reachable seeds)", wi + 1);
+            continue;
+        }
+        let r = w.reachable as f64;
+        eprintln!(
+            "    W{}  {:>7.2} {:>7.2} {:>4.0}% {:>4.0}% {:>8.2} {:>6.2} {:>10.2}",
+            wi + 1,
+            w.sum_clears as f64 / r,
+            w.sum_streak as f64 / r,
+            w.streak_ge2 as f64 / r * 100.0,
+            w.streak_ge3 as f64 / r * 100.0,
+            w.sum_goal as f64 / r,
+            w.sum_adj as f64 / r,
+            w.sum_rock_skip as f64 / r,
+        );
+        t_reach += w.reachable as u64;
+        t_streak += w.sum_streak;
+        t_ge2 += w.streak_ge2 as u64;
+        t_ge3 += w.streak_ge3 as u64;
+        t_goal2 += w.goal_ge2 as u64;
+        t_rock += w.sum_rock_skip;
+    }
+    if t_reach > 0 {
+        let tr = t_reach as f64;
+        eprintln!(
+            "    overall: streak {:.2} | ≥2 {:.0}% ≥3 {:.0}% | goal-stack≥2 {:.0}% | rock-skip {:.2}",
+            t_streak as f64 / tr,
+            t_ge2 as f64 / tr * 100.0,
+            t_ge3 as f64 / tr * 100.0,
+            t_goal2 as f64 / tr * 100.0,
+            t_rock as f64 / tr,
+        );
+    }
+
+    // Pipe-role breakdown: mean pipes per class per world. dead-loop (mainland
+    // loop skipping nothing) is the true waste; island-routing is intentional
+    // alternate island paths (variety, not waste).
+    eprintln!(
+        "    pipes/world:   {:>5} {:>8} {:>10} {:>10} {:>11} {:>7} {:>9}",
+        "conn", "island", "dead-loop", "shortcut", "lvls-skipped", "islands", "express%",
+    );
+    let (mut g_conn, mut g_island, mut g_dead, mut g_short, mut g_skip) =
+        (0u64, 0u64, 0u64, 0u64, 0u64);
+    for (wi, w) in worlds.iter().enumerate() {
+        if w.reachable == 0 {
+            continue;
+        }
+        let r = w.reachable as f64;
+        let express = if w.sum_express_total > 0 {
+            format!("{:.1}%", w.sum_express as f64 / w.sum_express_total as f64 * 100.0)
+        } else {
+            "n/a".to_string()
+        };
+        eprintln!(
+            "      W{}         {:>5.2} {:>8.2} {:>10.2} {:>10.2} {:>11.2} {:>7.2} {:>9}",
+            wi + 1,
+            w.sum_conn as f64 / r,
+            w.sum_island as f64 / r,
+            w.sum_dead as f64 / r,
+            w.sum_shortcut as f64 / r,
+            w.sum_pipe_skip as f64 / r,
+            w.sum_islands as f64 / r,
+            express,
+        );
+        g_conn += w.sum_conn;
+        g_island += w.sum_island;
+        g_dead += w.sum_dead;
+        g_short += w.sum_shortcut;
+        g_skip += w.sum_pipe_skip;
+    }
+    if t_reach > 0 {
+        let tr = t_reach as f64;
+        let all_pipes = g_conn + g_island + g_dead + g_short;
+        eprintln!(
+            "      overall:   {:>5.2} {:>8.2} {:>10.2} {:>10.2} {:>11.2}  (mainland dead-loop {:.0}% of all pipes)",
+            g_conn as f64 / tr,
+            g_island as f64 / tr,
+            g_dead as f64 / tr,
+            g_short as f64 / tr,
+            g_skip as f64 / tr,
+            if all_pipes > 0 {
+                g_dead as f64 / all_pipes as f64 * 100.0
+            } else {
+                0.0
+            },
+        );
+    }
+    let unreach: u32 = worlds.iter().map(|w| w.unreachable).sum();
+    if unreach > 0 {
+        eprintln!("    WARNING: {unreach} unreachable-target case(s) — possible builder bug");
+    }
+}
+
+/// Required-progression / linearity analyzer.
 ///
-/// Per world, computes the minimum number of fortress + level entries
-/// the player must clear to reach the airship/Bowser. Locks block path
-/// tiles until the fortress whose section opens them is cleared; pipes
-/// are taken whenever they shorten the route. Also reports a "hammer
-/// mode" where all locks start open, isolating fortresses that were
-/// only required because of lock gating.
+/// Per world, computes the minimum fortress + level entries the player must
+/// clear to reach the airship/Bowser (locks gate path tiles until their
+/// fortress is cleared; pipes/canoes taken when they shorten the route),
+/// then derives linearity metrics: back-to-back forced-level streaks, levels
+/// stacked on the goal approach, physical level-adjacency, and how many
+/// forced clears pipes / a lock-breaking hammer let the player skip.
+///
+/// Reports BOTH start↔airship modes (SAS off and on) in one run, since SAS
+/// redistributes which worlds stack levels.
 ///
 /// Run with: cargo test --release test_required_progression -- --ignored --nocapture
-/// Override seed count with PROG_SEEDS=N.
-/// Toggle start↔airship swap with SAS=1.
+/// Override seed count with PROG_SEEDS=N (runs that many PER mode).
+/// FLAGS=SMB3R-… measures a specific flag set (e.g. hammer-breaks-locks on).
 #[test]
 #[ignore]
 fn test_required_progression() {
-    let rom = match load_rom() {
-        Some(r) => r,
-        None => {
+    let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        Ok(b) => b,
+        Err(_) => {
             eprintln!("ROM not found, skipping");
             return;
         }
     };
-    let rom = apply_qol_for_overworld(&rom);
 
     let seeds: u64 = std::env::var("PROG_SEEDS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1000);
 
-    // Per-world tallies: sums for mean, plus min/max.
-    let mut sum_forts = [0u64; 8];
-    let mut sum_levels = [0u64; 8];
-    let mut sum_h_forts = [0u64; 8];
-    let mut sum_h_levels = [0u64; 8];
-    let mut min_forts = [usize::MAX; 8];
-    let mut max_forts = [0usize; 8];
-    let mut min_levels = [usize::MAX; 8];
-    let mut max_levels = [0usize; 8];
-    let mut min_h_forts = [usize::MAX; 8];
-    let mut max_h_forts = [0usize; 8];
-    let mut unreachable = [0u32; 8];
-    let mut unreachable_seeds: [Vec<u64>; 8] = Default::default();
-    // "Trivial bypass" = hammerless playthrough requires 0 forts AND 0
-    // levels (player walks/pipes straight to the airship). Tracked per
-    // world plus classified by whether the path uses a pipe right after
-    // start (pipe_start), right before target (pipe_target), both, or
-    // neither — diagnostic that pinpoints the failure mode.
-    let mut zero_zero = [0u32; 8];
-    let mut zero_zero_seeds: [Vec<u64>; 8] = Default::default();
-    let mut bypass_both = [0u32; 8];
-    let mut bypass_start = [0u32; 8];
-    let mut bypass_target = [0u32; 8];
-    let mut bypass_other = [0u32; 8];
-
-    for seed in 0..seeds {
-        let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
-        let result = build(&rom, &OverworldData { pickup: &pickup, catalog: &catalog }, &mut rng, BuildFlags { shuffle_toad_houses: true, ..Default::default() });
-
-        for built in &result.worlds {
-            let wi = built.world_idx;
-            let no_hammer = analyze_required_progression(built, false);
-            let with_hammer = analyze_required_progression(built, true);
-
-            if !no_hammer.reachable {
-                unreachable[wi] += 1;
-                if unreachable_seeds[wi].len() < 5 {
-                    unreachable_seeds[wi].push(seed);
-                }
-                continue;
+    // Base options = the shipped map. Options::default() is hand-tuned to the
+    // CLI/web defaults; the full pipeline (randomize_rom_with_overworld_capture)
+    // consumes RNG exactly as a real run, so the built maps match real ROMs.
+    // FLAGS=SMB3R-… overrides the flag set (e.g. hammer-breaks-locks).
+    // Palettes off only for run-to-run determinism (cosmetic; no topology).
+    let mut base = match std::env::var("FLAGS") {
+        Ok(key) => match crate::Options::from_flag_key(&key) {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("Invalid FLAGS key: {e}");
+                return;
             }
-            if no_hammer.forts_required == 0 && no_hammer.levels_required == 0 {
-                zero_zero[wi] += 1;
-                if zero_zero_seeds[wi].len() < 5 {
-                    zero_zero_seeds[wi].push(seed);
-                }
-                let path = &no_hammer.path;
-                let pipe_after_start = path.get(1).is_some_and(|(_, k)| matches!(k, PathNodeKind::Pipe));
-                let pipe_before_target = path.len() >= 2
-                    && matches!(path[path.len() - 2].1, PathNodeKind::Pipe);
-                match (pipe_after_start, pipe_before_target) {
-                    (true, true)  => bypass_both[wi]  += 1,
-                    (true, false) => bypass_start[wi] += 1,
-                    (false, true) => bypass_target[wi] += 1,
-                    (false, false)=> bypass_other[wi] += 1,
-                }
-            }
-            sum_forts[wi] += no_hammer.forts_required as u64;
-            sum_levels[wi] += no_hammer.levels_required as u64;
-            sum_h_forts[wi] += with_hammer.forts_required as u64;
-            sum_h_levels[wi] += with_hammer.levels_required as u64;
+        },
+        Err(_) => crate::Options::default(),
+    };
+    base.palettes = false;
+    base.palette_themed = false;
 
-            min_forts[wi] = min_forts[wi].min(no_hammer.forts_required);
-            max_forts[wi] = max_forts[wi].max(no_hammer.forts_required);
-            min_levels[wi] = min_levels[wi].min(no_hammer.levels_required);
-            max_levels[wi] = max_levels[wi].max(no_hammer.levels_required);
-            min_h_forts[wi] = min_h_forts[wi].min(with_hammer.forts_required);
-            max_h_forts[wi] = max_h_forts[wi].max(with_hammer.forts_required);
+    // Combined report: measure BOTH start↔airship modes, since SAS
+    // redistributes which worlds stack levels.
+    let mut sas_off = base.clone();
+    sas_off.swap_start_airship = false;
+    let mut sas_on = base.clone();
+    sas_on.swap_start_airship = true;
+
+    let off = prog_measure_pass(&rom_bytes, &sas_off, seeds);
+    prog_print_pass("SAS off", &off);
+    let on = prog_measure_pass(&rom_bytes, &sas_on, seeds);
+    prog_print_pass("SAS on", &on);
+
+    // Combined one-line comparison of the two modes.
+    let overall = |w: &[ProgLinWorld; 8]| -> (f64, f64) {
+        let reach: u64 = w.iter().map(|x| x.reachable as u64).sum();
+        if reach == 0 {
+            return (0.0, 0.0);
         }
-    }
-
-    let sas_label = if std::env::var("SAS").is_ok() { " [SAS=1]" } else { "" };
-    eprintln!("\n=== Required Progression to Airship ({seeds} seeds{sas_label}) ===");
-    eprintln!();
+        let s: u64 = w.iter().map(|x| x.sum_streak).sum();
+        let g2: u64 = w.iter().map(|x| x.goal_ge2 as u64).sum();
+        (s as f64 / reach as f64, g2 as f64 / reach as f64 * 100.0)
+    };
+    let (so, go) = overall(&off);
+    let (sn, gn) = overall(&on);
     eprintln!(
-        "{:<4} {:>8} {:>8}  {:>8} {:>8}   {:>8} {:>8}  {:>8}",
-        "", "forts", "(range)", "levels", "(range)", "h-forts", "(range)", "saves",
+        "\n  Combined: SAS-off streak {so:.2} / goal-stack≥2 {go:.0}%   vs   SAS-on streak {sn:.2} / goal-stack≥2 {gn:.0}%",
     );
-
-    let mut grand_forts = 0u64;
-    let mut grand_levels = 0u64;
-    let mut grand_h_forts = 0u64;
-    let mut grand_h_levels = 0u64;
-
-    for wi in 0..8 {
-        let seeds_ok = (seeds as u32 - unreachable[wi]) as f64;
-        if seeds_ok == 0.0 {
-            eprintln!("  W{}: (no reachable seeds)", wi + 1);
-            continue;
-        }
-        let avg_f = sum_forts[wi] as f64 / seeds_ok;
-        let avg_l = sum_levels[wi] as f64 / seeds_ok;
-        let avg_hf = sum_h_forts[wi] as f64 / seeds_ok;
-        let saves = avg_f - avg_hf;
-
-        grand_forts += sum_forts[wi];
-        grand_levels += sum_levels[wi];
-        grand_h_forts += sum_h_forts[wi];
-        grand_h_levels += sum_h_levels[wi];
-
-        eprintln!(
-            "  W{}  {:>6.2}   {}-{:<3}  {:>6.2}   {}-{:<3}    {:>6.2}   {}-{:<3}   {:>5.2}",
-            wi + 1,
-            avg_f, min_forts[wi], max_forts[wi],
-            avg_l, min_levels[wi], max_levels[wi],
-            avg_hf, min_h_forts[wi], max_h_forts[wi],
-            saves,
-        );
-    }
-
-    let avg_total_forts = grand_forts as f64 / seeds as f64;
-    let avg_total_levels = grand_levels as f64 / seeds as f64;
-    let avg_total_h_forts = grand_h_forts as f64 / seeds as f64;
-    let avg_total_h_levels = grand_h_levels as f64 / seeds as f64;
-    eprintln!();
-    eprintln!("  Per-seed totals (excludes the 8 objectives):");
-    eprintln!(
-        "    Without hammer: {:.2} forts + {:.2} levels  =  {:.2} clears",
-        avg_total_forts, avg_total_levels, avg_total_forts + avg_total_levels,
-    );
-    eprintln!(
-        "    With hammer:    {:.2} forts + {:.2} levels  =  {:.2} clears  (saves {:.2})",
-        avg_total_h_forts, avg_total_h_levels,
-        avg_total_h_forts + avg_total_h_levels,
-        (avg_total_forts + avg_total_levels) - (avg_total_h_forts + avg_total_h_levels),
-    );
-
-    let total_unreach: u32 = unreachable.iter().sum();
-    if total_unreach > 0 {
-        eprintln!("\n  WARNING: {total_unreach} unreachable-target case(s) — builder bug?");
-        for (wi, &count) in unreachable.iter().enumerate() {
-            if count > 0 {
-                let pct = count as f64 / seeds as f64 * 100.0;
-                let seed_examples: Vec<String> = unreachable_seeds[wi]
-                    .iter()
-                    .map(u64::to_string)
-                    .collect();
-                eprintln!(
-                    "    W{}: {count}/{seeds} ({pct:.1}%)  example seeds: {}",
-                    wi + 1,
-                    seed_examples.join(", "),
-                );
-            }
-        }
-    }
-
-    let total_zero_zero: u32 = zero_zero.iter().sum();
-    let total_world_seeds = seeds as u32 * 8;
-    let overall_pct = total_zero_zero as f64 / total_world_seeds as f64 * 100.0;
-    eprintln!(
-        "\n  Trivial-bypass (0 forts + 0 levels) — overall {total_zero_zero}/{total_world_seeds} ({overall_pct:.2}%):"
-    );
-    for (wi, &count) in zero_zero.iter().enumerate() {
-        let pct = count as f64 / seeds as f64 * 100.0;
-        let examples = if zero_zero_seeds[wi].is_empty() {
-            String::new()
-        } else {
-            let s: Vec<String> = zero_zero_seeds[wi].iter().map(u64::to_string).collect();
-            format!("  example seeds: {}", s.join(", "))
-        };
-        eprintln!("    W{}: {count}/{seeds} ({pct:.1}%){examples}", wi + 1);
-    }
-    let tb = bypass_both.iter().sum::<u32>();
-    let ts = bypass_start.iter().sum::<u32>();
-    let tt = bypass_target.iter().sum::<u32>();
-    let to_ = bypass_other.iter().sum::<u32>();
-    if total_zero_zero > 0 {
-        eprintln!(
-            "  Bypass classification — pipe-both: {tb}, pipe-start-only: {ts}, pipe-target-only: {tt}, neither: {to_}",
-        );
-    }
 }
 
 /// Single-seed dump of the required-progression analysis. Intended for

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1938,6 +1938,98 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
     }
 }
 
+/// How often each of the five always-on W8 screen-3 bridges is chosen as a
+/// lock (i.e. gated "out" as a water gap until its fortress is beaten). Runs
+/// the shipped pipeline so the bridges (`apply_w8_bridges`) are present, and
+/// reports per-bridge frequency plus the distribution of how many are out per
+/// seed, for both start↔airship modes.
+///
+/// Run with: cargo test --release report_w8_bridge_locks -- --ignored --nocapture
+/// Override seed count with BRIDGE_SEEDS=N (default 2000, per mode).
+#[test]
+#[ignore]
+fn report_w8_bridge_locks() {
+    let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let seeds: u64 = std::env::var("BRIDGE_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2000);
+
+    // The 5 always-on W8 screen-3 bridges (row 5). A lock on a bridge tile
+    // gaps it out as water (`gap_tile_for`: 0xB3 -> 0x9D) until its fort falls.
+    const W8_BRIDGES: [(usize, usize); 5] = [(5, 51), (5, 53), (5, 55), (5, 57), (5, 59)];
+
+    let base = crate::Options {
+        palettes: false,
+        palette_themed: false,
+        ..Default::default()
+    };
+
+    for (label, sas) in [("SAS off", false), ("SAS on", true)] {
+        let mut opts = base.clone();
+        opts.swap_start_airship = sas;
+
+        let mut per_bridge = [0u32; 5];
+        let mut count_dist = [0u32; 6]; // index = # bridges out this seed (0..=5)
+        let mut seeds_with_any = 0u32;
+        let mut measured = 0u32;
+
+        for seed in 0..seeds {
+            let (_rom, result) =
+                match crate::randomize_rom_with_overworld_capture(&rom_bytes, seed, &opts, None) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("seed {seed}: {e}");
+                        continue;
+                    }
+                };
+            let w8 = match result.worlds.iter().find(|b| b.world_idx == 7) {
+                Some(b) => b,
+                None => continue,
+            };
+            measured += 1;
+            let mut out_this_seed = 0;
+            for (i, &pos) in W8_BRIDGES.iter().enumerate() {
+                if w8.locks.iter().any(|l| l.pos == pos) {
+                    per_bridge[i] += 1;
+                    out_this_seed += 1;
+                }
+            }
+            count_dist[out_this_seed] += 1;
+            if out_this_seed > 0 {
+                seeds_with_any += 1;
+            }
+        }
+
+        let m = measured.max(1) as f64;
+        eprintln!("\n=== W8 bridges chosen as locks [{label}] — {measured} seeds ===");
+        eprintln!("Per-bridge (locked => bridge is out):");
+        for (i, &pos) in W8_BRIDGES.iter().enumerate() {
+            eprintln!(
+                "  bridge {} {:?}:  {:>5}  ({:>4.1}%)",
+                i + 1,
+                pos,
+                per_bridge[i],
+                per_bridge[i] as f64 / m * 100.0,
+            );
+        }
+        eprintln!("Bridges out per seed:");
+        for (n, &c) in count_dist.iter().enumerate() {
+            eprintln!("  {n}:  {:>5}  ({:>4.1}%)", c, c as f64 / m * 100.0);
+        }
+        eprintln!(
+            "Seeds with >=1 bridge out:  {seeds_with_any}/{measured}  ({:.1}%)",
+            seeds_with_any as f64 / m * 100.0,
+        );
+    }
+}
+
 /// Required-progression / linearity analyzer.
 ///
 /// Per world, computes the minimum fortress + level entries the player must

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1725,9 +1725,9 @@ struct ProgLinWorld {
     // Pipe classification (summed over seeds): counts per class + total
     // forced clears skipped by shortcut pipes.
     sum_conn: u64,
-    sum_island: u64,
-    sum_dead: u64,
     sum_shortcut: u64,
+    sum_access: u64,
+    sum_redundant: u64,
     sum_pipe_skip: u64,
     // Start→goal express pipe: how often a single pipe bridges start-island
     // straight to goal-island. express_total = seeds where it's applicable
@@ -1779,12 +1779,12 @@ fn prog_measure_pass(rom_bytes: &[u8], options: &crate::Options, seeds: u64) -> 
             for class in classify_pipes(built) {
                 match class {
                     PipeClass::Connectivity => w.sum_conn += 1,
-                    PipeClass::IslandRouting => w.sum_island += 1,
-                    PipeClass::DeadLoop => w.sum_dead += 1,
                     PipeClass::Shortcut(n) => {
                         w.sum_shortcut += 1;
                         w.sum_pipe_skip += n as u64;
                     }
+                    PipeClass::ContentAccess => w.sum_access += 1,
+                    PipeClass::Redundant => w.sum_redundant += 1,
                 }
             }
             w.sum_islands += island_count(built) as u64;
@@ -1844,14 +1844,15 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
         );
     }
 
-    // Pipe-role breakdown: mean pipes per class per world. dead-loop (mainland
-    // loop skipping nothing) is the true waste; island-routing is intentional
-    // alternate island paths (variety, not waste).
+    // Pipe-role breakdown (mean pipes/world), by what removing the pipe would
+    // cost the player: conn = strands the target; shortcut = raises min-clears
+    // (lvls-skipped = how many); access = strands other level/fort content;
+    // redundant = nothing changes (pure waste).
     eprintln!(
-        "    pipes/world:   {:>5} {:>8} {:>10} {:>10} {:>11} {:>7} {:>9}",
-        "conn", "island", "dead-loop", "shortcut", "lvls-skipped", "islands", "express%",
+        "    pipes/world:   {:>5} {:>9} {:>12} {:>7} {:>10} {:>7} {:>9}",
+        "conn", "shortcut", "lvls-skipped", "access", "redundant", "islands", "express%",
     );
-    let (mut g_conn, mut g_island, mut g_dead, mut g_short, mut g_skip) =
+    let (mut g_conn, mut g_short, mut g_skip, mut g_access, mut g_redundant) =
         (0u64, 0u64, 0u64, 0u64, 0u64);
     for (wi, w) in worlds.iter().enumerate() {
         if w.reachable == 0 {
@@ -1864,34 +1865,34 @@ fn prog_print_pass(label: &str, worlds: &[ProgLinWorld; 8]) {
             "n/a".to_string()
         };
         eprintln!(
-            "      W{}         {:>5.2} {:>8.2} {:>10.2} {:>10.2} {:>11.2} {:>7.2} {:>9}",
+            "      W{}         {:>5.2} {:>9.2} {:>12.2} {:>7.2} {:>10.2} {:>7.2} {:>9}",
             wi + 1,
             w.sum_conn as f64 / r,
-            w.sum_island as f64 / r,
-            w.sum_dead as f64 / r,
             w.sum_shortcut as f64 / r,
             w.sum_pipe_skip as f64 / r,
+            w.sum_access as f64 / r,
+            w.sum_redundant as f64 / r,
             w.sum_islands as f64 / r,
             express,
         );
         g_conn += w.sum_conn;
-        g_island += w.sum_island;
-        g_dead += w.sum_dead;
         g_short += w.sum_shortcut;
         g_skip += w.sum_pipe_skip;
+        g_access += w.sum_access;
+        g_redundant += w.sum_redundant;
     }
     if t_reach > 0 {
         let tr = t_reach as f64;
-        let all_pipes = g_conn + g_island + g_dead + g_short;
+        let all_pipes = g_conn + g_short + g_access + g_redundant;
         eprintln!(
-            "      overall:   {:>5.2} {:>8.2} {:>10.2} {:>10.2} {:>11.2}  (mainland dead-loop {:.0}% of all pipes)",
+            "      overall:   {:>5.2} {:>9.2} {:>12.2} {:>7.2} {:>10.2}  (redundant {:.0}% of all pipes)",
             g_conn as f64 / tr,
-            g_island as f64 / tr,
-            g_dead as f64 / tr,
             g_short as f64 / tr,
             g_skip as f64 / tr,
+            g_access as f64 / tr,
+            g_redundant as f64 / tr,
             if all_pipes > 0 {
-                g_dead as f64 / all_pipes as f64 * 100.0
+                g_redundant as f64 / all_pipes as f64 * 100.0
             } else {
                 0.0
             },

--- a/tools/required_progression.py
+++ b/tools/required_progression.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Required-progression analysis for arbitrary (randomized) SMB3 ROMs.
+
+ROM-driven port of the Rust analyzer in
+src/randomize/overworld_build/progression.rs (test_required_progression),
+usable on ROMs we didn't build — e.g. the Fred (fcoughlin) reference ROMs
+in /fred. Per world it reports:
+
+  - how many enterable levels / fortresses exist on the map
+  - minimum fortress/level clears to reach the airship (W8: Bowser castle)
+    without a hammer and with one hammer
+
+Engine model (vanilla semantics, which Fred ROMs keep):
+  - level gate: a node tile blocks through-movement until completed iff
+    tile >= threshold[palette page] (thresholds 03/67/BF/E9, universal —
+    see docs/smb3_rom_reference.md "World-Map Level Gating")
+  - fortress FX: beating the k-th fortress in a world (any fortress) fires
+    the k-th FX slot of that world's FX list, replacing one map tile
+    (lock -> path, water gap -> bridge, ...)
+  - hammer: breaks one rock ($51/$52). Fred ROMs (and our
+    hammer_breaks_locks flag) extend this to locks ($54/$56/$E4);
+    auto-detected from the Inv_UseItem_Hammer byte signature.
+  - W3 canoe: stateful boat — a canoe edge is usable only when the boat
+    sits at the player's dock, and riding moves the boat with the player.
+
+Usage:
+  python3 tools/required_progression.py ROM [ROM ...]
+  python3 tools/required_progression.py fred/*.nes
+
+ACCURACY LIMITATION — read before comparing our ROMs to others:
+  This tool classifies nodes from the FINAL ROM's map tiles. Two of our
+  default-on features disguise forced levels as non-levels on the map, so
+  this tool UNDER-COUNTS them on our own output:
+    - hand traps  (tile 0xE6): a forced level shown as a hazard hand.
+    - troll pipes (tile 0xBC, not in the pipe tables): a level shown as a
+      pipe; this tool wrongly treats it as a streak-breaking transit.
+  The Rust analyzer (progression.rs / test_required_progression) measures
+  the pre-writer BuiltWorld, where these are still Level slots, so it is
+  the source of truth for OUR ROMs. This Python tool is accurate for ROMs
+  WITHOUT those disguises (vanilla, Fred/fcoughlin), which is what it's for
+  (measuring external ROMs the Rust builder never produced).
+"""
+
+import heapq
+import os
+import sys
+from collections import Counter
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rom_map as rm
+
+# Per-palette-page level-gate thresholds (file 0x18410, universal).
+THRESHOLDS = [0x03, 0x67, 0xBF, 0xE9]
+
+TILE_FORT = 0x67
+TILE_AIRSHIP = 0xC9
+TILE_BOWSER = 0xCC
+ROCK_TILES = {0x51, 0x52}
+LOCK_TILES = {0x54, 0x56, 0xE4}
+# Enterable level-like tiles that do NOT gate movement (special-entry):
+# spiral castles ($5F/$DF), dark-land unnumbered level ($E6).
+SPECIAL_LEVEL_TILES = {0x5F, 0xDF, 0xE6}
+
+# Blocking path tile -> its opened/broken form (Map_Removable_Tiles /
+# Map_RemoveTo_Tiles at 0x18447/0x1844F).
+REMOVE_TO = {0x51: 0x45, 0x52: 0x46, 0x54: 0x46, 0x67: 0x60,
+             0xEB: 0xE3, 0xE4: 0xDA, 0x56: 0x45, 0x9D: 0xB3}
+
+# W3 canoe docks (boat starts at the first mainland dock).
+CANOE_EDGES_BY_WORLD = {
+    2: [((6, 20), (5, 24)), ((6, 20), (0, 32))],
+}
+
+# Map-object IDs that force level entry when the player lands on them
+# (Map_Object_Stationary): piranha plant, W8 navy/tank/air force.
+AUTO_ENTER_OBJ_IDS = {0x07, 0x0D, 0x0E, 0x0F}
+
+# Vanilla fortress enemy-data pointers and the file offset of each
+# fortress's Boom-Boom Y byte (rom_data/tables.rs). The Y upper nibble is
+# the fortress's 1-based FX ordinal: beating the fortress fires FX slot
+# FX_WORLD_TABLE[world*4 + ordinal-1]. Level shuffles move pointer-table
+# entries, not the enemy data, so the obj_ptr identifies the fortress in
+# any shuffled ROM (ours and Fred's alike).
+FORTRESS_OBJ_PTRS = [
+    0xD32B, 0xD222, 0xD393, 0xD362, 0xD508, 0xD528, 0xD3D0, 0xD2B4,
+    0xD4B0, 0xCAAB, 0xD470, 0xD4E4, 0xD41B, 0xD8CC, 0xD867, 0xD551,
+    0xD91C,
+]
+BOOMBOOM_Y_OFFSETS = [
+    0x0D35F, 0x0D262, 0x0D3D3, 0x0D3A1, 0x0D536, 0x0D55F, 0x0D40F,
+    0x0D2C7, 0x0D4E1, 0x0CAE1, 0x0D4B0, 0x0D4FA, 0x0D47E, 0x0DA32,
+    0x0DA37, 0x0D597, 0x0DA2D,
+]
+BOOMBOOM_Y_BY_OBJ = dict(zip(FORTRESS_OBJ_PTRS, BOOMBOOM_Y_OFFSETS))
+
+
+def entry_obj_ptr(rom, world_idx, entry_idx):
+    w = rm.WORLDS[world_idx]
+    n = w["entry_count"]
+    objsets = w["rowtype_offset"] + 2 * n
+    return rom[objsets + entry_idx * 2] | (rom[objsets + entry_idx * 2 + 1] << 8)
+
+
+def fort_ordinals(rom, world_idx):
+    """{grid_pos: fx_ordinal} for every fortress-entry in the world.
+    Ordinal k >= 1 means beating this fort fires the world's k-th FX slot.
+    Covers both 0x67 fortress tiles and the W8 armies (navy/tank/air
+    force), which are fortress entries too."""
+    out = {}
+    for i in range(rm.WORLDS[world_idx]["entry_count"]):
+        obj = entry_obj_ptr(rom, world_idx, i)
+        y_off = BOOMBOOM_Y_BY_OBJ.get(obj)
+        if y_off is not None:
+            out[rm.entry_grid_position(rom, world_idx, i)] = rom[y_off] >> 4
+    return out
+
+# Map-object master pointer tables (PRG011).
+MAP_OBJ_YS, MAP_OBJ_XHIS, MAP_OBJ_XLOS, MAP_OBJ_IDS = (
+    0x16020, 0x16030, 0x16040, 0x16050)
+
+
+def forced_object_positions(rom, world_idx):
+    """Grid positions of stationary auto-enter map objects (plants/armies)."""
+    def ptr(master):
+        off = master + world_idx * 2
+        return 0x16010 + (rom[off] | (rom[off + 1] << 8)) - 0xA000
+    ys, xhis, xlos, ids = (ptr(MAP_OBJ_YS), ptr(MAP_OBJ_XHIS),
+                           ptr(MAP_OBJ_XLOS), ptr(MAP_OBJ_IDS))
+    out = set()
+    for s in range(9):
+        if rom[ids + s] in AUTO_ENTER_OBJ_IDS:
+            row = (rom[ys + s] >> 4) - 2
+            col = rom[xhis + s] * 16 + (rom[xlos + s] >> 4)
+            if row >= 0:
+                out.add((row, col))
+    return out
+
+
+def node_kinds(rom, world_idx):
+    """{grid_pos: entry_type} via rom_map's classifier — 'level', 'fortress',
+    'pipe', 'hammer_bro', 'toad_house', 'bonus_game', etc. Used to decide
+    which route nodes are streak-breaking activities."""
+    _, lookup = rm.build_entry_lookup(rom, world_idx)
+    return {pos: e["type"] for pos, e in lookup.items()}
+
+
+def spiral_transit_pairs(rom, world_idx):
+    """Spiral-castle transit teleports (e.g. W5 tower). Riding one means
+    clearing the tower level, so these edges cost 1. Returns
+    {(a, b), (b, a), ...} plus a map pos -> spiral tile pos to tally."""
+    pairs = set()
+    tally = {}
+    for wi, from_idx, to_idx in rm.SPECIAL_TRANSITIONS:
+        if wi != world_idx:
+            continue
+        a = rm.entry_grid_position(rom, world_idx, from_idx)
+        b = rm.entry_grid_position(rom, world_idx, to_idx)
+        pairs.update([(a, b), (b, a)])
+        tally[(a, b)] = a
+        tally[(b, a)] = a
+    return pairs, tally
+
+
+def gated(tile):
+    return tile >= THRESHOLDS[tile >> 6]
+
+
+def detect_hammer_breaks_locks(rom):
+    """Vanilla Inv_UseItem_Hammer checks `tile - $51 < 2` (rocks only).
+    Fred ROMs replace the compare with a JSR to a routine that also
+    accepts $54/$56/$E4. Any deviation from the vanilla bytes is treated
+    as 'hammers break locks too'."""
+    return bytes(rom[0x346D5:0x346D8]) != b"\xE9\x51\xC9"
+
+
+def entry_positions(rom, world_idx):
+    w = rm.WORLDS[world_idx]
+    return {rm.entry_grid_position(rom, world_idx, i)
+            for i in range(w["entry_count"])}
+
+
+def fx_requirements(rom, world_idx, ordinals):
+    """{fx_target_pos: (fx_index, replace_tile)} for this world's FX slots.
+
+    Only FX indices some fortress actually fires (its ordinal) are
+    included — trailing world-table bytes are zero-filled and would
+    otherwise alias FX slot 0."""
+    slots = rm.read_fx_slots(rom)
+    base = rm.FX_WORLD_TABLE + world_idx * 4
+    fired = {k - 1 for k in ordinals if k >= 1}
+    out = {}
+    for j in range(4):
+        if j not in fired:
+            continue
+        s = slots[rom[base + j]]
+        out[(s["grid_row"], s["grid_col"])] = (j, s["replace_tile"])
+    return out
+
+
+def build_edges(grid, fx_req):
+    """Edge list over the fully-open grid.
+
+    Returns dict pos -> [(dest, path_pos, orig_path_tile)].  path_pos is
+    None for teleport edges added later (pipes/canoes are handled by the
+    caller).  Edges through blocked tiles (rocks/locks/FX targets) are
+    included; the Dijkstra decides whether they are usable in a state.
+    """
+    rows, cols = len(grid), len(grid[0])
+
+    def open_tile(r, c):
+        t = grid[r][c]
+        if (r, c) in fx_req:
+            return fx_req[(r, c)][1]
+        return REMOVE_TO.get(t, t)
+
+    edges = {}
+    for r in range(rows):
+        for c in range(cols):
+            t = grid[r][c]
+            if t in rm.BACKGROUND_TILES:
+                continue
+            for dr, dc, valid in ((0, 1, rm.VALID_HORZ), (0, -1, rm.VALID_HORZ),
+                                  (1, 0, rm.VALID_VERT), (-1, 0, rm.VALID_VERT)):
+                pr, pc = r + dr, c + dc
+                nr, nc = r + 2 * dr, c + 2 * dc
+                if not (0 <= nr < rows and 0 <= nc < cols):
+                    continue
+                if open_tile(pr, pc) not in valid:
+                    continue
+                if grid[nr][nc] in rm.BACKGROUND_TILES:
+                    continue
+                edges.setdefault((r, c), []).append(
+                    ((nr, nc), (pr, pc), grid[pr][pc]))
+    return edges
+
+
+def analyze_world(rom, world_idx, hammer_locks, hammer_target=None):
+    """Min-clears Dijkstra. Returns dict or None if target unreachable."""
+    grid = rm.read_tile_grid(rom, world_idx)
+    rows, cols = len(grid), len(grid[0])
+    start = rm.find_start(grid)
+    target_tile = TILE_BOWSER if world_idx == 7 else TILE_AIRSHIP
+    target = next(((r, c) for r in range(rows) for c in range(cols)
+                   if grid[r][c] == target_tile), None)
+    if start is None or target is None:
+        return None
+
+    ford = fort_ordinals(rom, world_idx)  # pos -> FX ordinal (0 = no FX)
+    forts = sorted(ford)
+    fort_bit = {pos: 1 << i for i, pos in enumerate(forts)}
+    # For each FX index, the fort bits that fire it when beaten.
+    fx_firers = {}
+    for pos, k in ford.items():
+        if k >= 1:
+            fx_firers.setdefault(k - 1, 0)
+            fx_firers[k - 1] |= fort_bit[pos]
+    fx_req = fx_requirements(rom, world_idx, ford.values())
+    entries = entry_positions(rom, world_idx)
+    edges = build_edges(grid, fx_req)
+    forced = forced_object_positions(rom, world_idx)
+    spiral_pairs, spiral_tally = spiral_transit_pairs(rom, world_idx)
+    kinds = node_kinds(rom, world_idx)
+
+    pipe_lookup = {}
+    for a, b in rm.read_pipe_pairs(rom)[world_idx]:
+        pipe_lookup.setdefault(a, []).append(b)
+        pipe_lookup.setdefault(b, []).append(a)
+
+    canoe_edges = CANOE_EDGES_BY_WORLD.get(world_idx, [])
+    boat0 = canoe_edges[0][0] if canoe_edges else None
+
+    def usable(path_pos, orig, mask):
+        if path_pos == hammer_target:
+            return True
+        if orig in ROCK_TILES:
+            return False  # only the hammer opens rocks
+        if path_pos in fx_req:
+            j = fx_req[path_pos][0]
+            return bool(mask & fx_firers.get(j, 0))
+        return True  # plain path tile
+
+    def node_cost(pos, mask):
+        """(cost, new_mask, passable). Charges 1 for gated/enterable nodes."""
+        t = grid[pos[0]][pos[1]]
+        if pos == target:
+            return 1, mask, True
+        if pos in ford:
+            bit = fort_bit[pos]
+            if mask & bit:
+                return 0, mask, True
+            return 1, mask | bit, True
+        if pos in forced:
+            return 1, mask, True  # stationary plant/army: landing = playing
+        if gated(t):
+            if pos in entries:
+                return 1, mask, True
+            return 0, mask, False  # gated scenery with no entry: wall
+        return 0, mask, True
+
+    dist = {}
+    prev = {}
+    initial = (start, 0, boat0)
+    dist[initial] = 0
+    heap = [(0, initial)]
+    goal = None
+    while heap:
+        cost, state = heapq.heappop(heap)
+        if cost > dist.get(state, 1 << 30):
+            continue
+        pos, mask, boat = state
+        if pos == target:
+            goal = state
+            break
+
+        def relax(dest, boat_after, extra=0):
+            c, new_mask, ok = node_cost(dest, mask)
+            if not ok:
+                return
+            key = (dest, new_mask, boat_after)
+            if cost + c + extra < dist.get(key, 1 << 30):
+                dist[key] = cost + c + extra
+                prev[key] = state
+                heapq.heappush(heap, (cost + c + extra, key))
+
+        for dest, path_pos, orig in edges.get(pos, ()):
+            if usable(path_pos, orig, mask):
+                relax(dest, boat)
+        for dest in pipe_lookup.get(pos, ()):
+            # Spiral-castle transits are levels: riding costs a clear.
+            relax(dest, boat, extra=1 if (pos, dest) in spiral_pairs else 0)
+        if boat == pos:
+            for a, b in canoe_edges:
+                if pos in (a, b):
+                    dest = b if pos == a else a
+                    relax(dest, dest)
+
+    if goal is None:
+        return None
+
+    # Reconstruct; tally distinct fort/level positions (target excluded).
+    chain = [goal]
+    while chain[-1] in prev:
+        chain.append(prev[chain[-1]])
+    chain.reverse()
+    fseen, lseen = set(), set()
+    # Streak = longest run of back-to-back forced *level* plays with no other
+    # activity between them. A fortress, pipe (ride or node), hammer-bro, or
+    # crossed lock resets the run; toad-house/spade/walk pass through. Mirrors
+    # the Rust analyzer in progression.rs.
+    streak = max_streak = goal_stack = 0
+    for i, (pos, _, _) in enumerate(chain):
+        reset = added_level = False
+        if i > 0:
+            prev = chain[i - 1][0]
+            hop = (prev, pos)
+            if hop in spiral_tally:                 # riding a spiral tower level
+                lseen.add(spiral_tally[hop])
+                added_level = True
+            elif pos in pipe_lookup.get(prev, ()):  # pipe ride
+                reset = True
+            else:                                   # walk hop: crossed a lock?
+                for dest, path_pos, _ in edges.get(prev, ()):
+                    if dest == pos and path_pos in fx_req:
+                        reset = True
+                        break
+        if pos == target:
+            if reset:
+                streak = 0
+            goal_stack = streak
+            continue
+        if pos != start:
+            if pos in ford:
+                fseen.add(pos)
+                reset = True                        # fortress boss
+            elif pos in forced or (gated(grid[pos[0]][pos[1]]) and pos in entries):
+                lseen.add(pos)
+                added_level = True
+            elif kinds.get(pos) == "pipe":
+                reset = True                        # pipe ride (deterministic)
+            # hammer_bro / toad_house / bonus_game / walk tiles: transparent.
+            # A hammer-bro *node* isn't a fight — the wandering sprite (dynamic,
+            # unmodeled) triggers battles, so a spriteless HB node is empty path.
+        if reset:
+            streak = 0
+        if added_level:
+            streak += 1
+            max_streak = max(max_streak, streak)
+    return {"forts": len(fseen), "levels": len(lseen),
+            "streak": max_streak, "goal_stack": goal_stack,
+            "path": [p for p, _, _ in chain]}
+
+
+def hammer_candidates(rom, world_idx, hammer_locks):
+    grid = rm.read_tile_grid(rom, world_idx)
+    breakable = ROCK_TILES | (LOCK_TILES if hammer_locks else set())
+    return [(r, c) for r in range(len(grid)) for c in range(len(grid[0]))
+            if grid[r][c] in breakable]
+
+
+def count_world(rom, world_idx):
+    """Level/fort census + map-topology metrics, with everything open
+    (all FX fired, all rocks/locks broken, canoe free)."""
+    grid = rm.read_tile_grid(rom, world_idx)
+    ford = fort_ordinals(rom, world_idx)
+    fx_req = fx_requirements(rom, world_idx, ford.values())
+    # Open every removable path tile, then plain BFS for reachability.
+    open_grid = [row[:] for row in grid]
+    for r in range(len(grid)):
+        for c in range(len(grid[0])):
+            if (r, c) in fx_req:
+                open_grid[r][c] = fx_req[(r, c)][1]
+            else:
+                open_grid[r][c] = REMOVE_TO.get(grid[r][c], grid[r][c])
+    pipes = rm.read_pipe_pairs(rom)[world_idx]
+    nodes, edges, _, _ = rm.walk_map(open_grid, pipes)
+    entries = entry_positions(rom, world_idx)
+    forced = forced_object_positions(rom, world_idx)
+    levels = sum(1 for (r, c) in nodes
+                 if (r, c) not in ford
+                 and (((r, c) in forced)
+                      or ((r, c) in entries
+                          and (gated(grid[r][c]) or grid[r][c] in SPECIAL_LEVEL_TILES)
+                          and grid[r][c] not in (TILE_AIRSHIP, TILE_BOWSER))))
+    forts_reach = sum(1 for f in ford if f in nodes)
+
+    # Topology: undirected edge count, fork nodes (degree >= 3), and
+    # independent cycles (E - N + components) — 0 for a pure tree/line,
+    # each +1 is one genuinely alternative route.
+    und = set()
+    for a, dests in edges.items():
+        for dest, _, _ in dests:
+            und.add(frozenset((a, dest)))
+    degree = Counter()
+    for e in und:
+        for p in e:
+            degree[p] += 1
+    forks = sum(1 for _, d in degree.items() if d >= 3)
+    cycles = len(und) - len(nodes) + 1  # walk_map graph is connected
+
+    # Physical level-adjacency: level nodes joined by a single walk edge
+    # (not a pipe/canoe teleport). Route-independent "levels side by side".
+    ford = fort_ordinals(rom, world_idx)
+    level_pos = {(r, c) for (r, c) in nodes
+                 if (r, c) not in ford
+                 and (((r, c) in forced)
+                      or ((r, c) in entries
+                          and (gated(grid[r][c]) or grid[r][c] in SPECIAL_LEVEL_TILES)
+                          and grid[r][c] not in (TILE_AIRSHIP, TILE_BOWSER)))}
+    adj = set()
+    for a, dests in edges.items():
+        if a not in level_pos:
+            continue
+        for dest, path_pos, _ in dests:
+            if path_pos is not None and dest in level_pos:
+                adj.add(frozenset((a, dest)))
+    return {"levels": levels, "forts": forts_reach,
+            "forks": forks, "cycles": cycles, "adj": len(adj)}
+
+
+def analyze_rom(path):
+    rom = open(path, "rb").read()
+    hammer_locks = detect_hammer_breaks_locks(rom)
+    results = []
+    for wi in range(8):
+        census = count_world(rom, wi)
+        no_h = analyze_world(rom, wi, hammer_locks)
+        best_h = no_h
+        for cand in hammer_candidates(rom, wi, hammer_locks):
+            r = analyze_world(rom, wi, hammer_locks, hammer_target=cand)
+            if r and (best_h is None
+                      or r["forts"] + r["levels"] < best_h["forts"] + best_h["levels"]):
+                best_h = r
+        results.append({**census, "no_hammer": no_h, "hammer": best_h})
+    return hammer_locks, results
+
+
+def fmt_clears(x):
+    if x is None:
+        return "UNREACHABLE"
+    return f"{x['forts']}F+{x['levels']}L={x['forts'] + x['levels']:2}"
+
+
+def main():
+    paths = sys.argv[1:]
+    if not paths:
+        print(__doc__)
+        sys.exit(1)
+
+    agg = [{"levels": [], "clears_nh": [], "clears_h": [], "req_ratio": [],
+            "opt": [], "streak": [], "goalstk": [], "adj": []} for _ in range(8)]
+    for path in paths:
+        hammer_locks, results = analyze_rom(path)
+        name = os.path.basename(path)
+        print(f"\n=== {name} ===")
+        print(f"  hammer breaks locks: {'yes' if hammer_locks else 'no (rocks only)'}")
+        print(f"  {'':4} {'lvls':>4} {'forts':>5} | {'no hammer':>12} | {'1 hammer':>12} |"
+              f" {'req%':>5} {'opt':>4} {'strk':>5} {'gstk':>5} {'adj':>4}")
+        tot_l = tot_nh = tot_h = 0
+        for wi, r in enumerate(results):
+            nh, h = r["no_hammer"], r["hammer"]
+            # Linearity: share of the world's levels that are mandatory
+            # (no-hammer). 100% = pure corridor, low = lots of choice.
+            ratio = (nh["levels"] / r["levels"] * 100
+                     if nh and r["levels"] else float("nan"))
+            opt = r["levels"] - nh["levels"] if nh else 0
+            s_nh = nh["streak"] if nh else 0
+            gstk = nh["goal_stack"] if nh else 0
+            print(f"  W{wi + 1}  {r['levels']:>4} {r['forts']:>5} |"
+                  f" {fmt_clears(nh):>12} | {fmt_clears(h):>12} |"
+                  f" {ratio:>4.0f}% {opt:>4} {s_nh:>5} {gstk:>5} {r['adj']:>4}")
+            tot_l += r["levels"]
+            if nh:
+                tot_nh += nh["forts"] + nh["levels"]
+                agg[wi]["clears_nh"].append(nh["forts"] + nh["levels"])
+                agg[wi]["streak"].append(s_nh)
+                agg[wi]["goalstk"].append(gstk)
+                agg[wi]["opt"].append(opt)
+                if r["levels"]:
+                    agg[wi]["req_ratio"].append(nh["levels"] / r["levels"] * 100)
+            if h:
+                tot_h += h["forts"] + h["levels"]
+                agg[wi]["clears_h"].append(h["forts"] + h["levels"])
+            agg[wi]["levels"].append(r["levels"])
+            agg[wi]["adj"].append(r["adj"])
+        print(f"  total levels on maps: {tot_l}   "
+              f"min clears to finish: {tot_nh} (no hammer) / {tot_h} (hammers)")
+
+    if len(paths) > 1:
+        def mmm(v, f=".1f"):
+            if not v:
+                return "-"
+            return f"{min(v):.0f}/{sum(v) / len(v):{f}}/{max(v):.0f}"
+        print(f"\n=== Aggregate over {len(paths)} ROMs (min/mean/max) ===")
+        print(f"  {'':4} {'levels':>12} | {'clears nh':>12} | {'clears 1h':>12} |"
+              f" {'req%':>12} | {'streak':>12} | {'goalstk':>12} | {'adj-pairs':>12}")
+        all_streak, all_gs = [], []
+        for wi in range(8):
+            a = agg[wi]
+            all_streak += a["streak"]
+            all_gs += a["goalstk"]
+            print(f"  W{wi + 1}  {mmm(a['levels']):>12} | {mmm(a['clears_nh']):>12} |"
+                  f" {mmm(a['clears_h']):>12} | {mmm(a['req_ratio'], '.0f'):>12} |"
+                  f" {mmm(a['streak']):>12} | {mmm(a['goalstk']):>12} | {mmm(a['adj']):>12}")
+        if all_streak:
+            ge2 = sum(1 for s in all_streak if s >= 2) / len(all_streak) * 100
+            ge3 = sum(1 for s in all_streak if s >= 3) / len(all_streak) * 100
+            gs2 = sum(1 for g in all_gs if g >= 2) / len(all_gs) * 100
+            mean_s = sum(all_streak) / len(all_streak)
+            print(f"  overall: mean streak {mean_s:.2f}  |  "
+                  f"≥2 in {ge2:.0f}% of worlds, ≥3 in {ge3:.0f}%  |  "
+                  f"goal-stack≥2 in {gs2:.0f}%")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reworks how the overworld builder places pipes and scores level placement to make maps feel less linear, driven by a new Rust-side linearity/pipe metric suite. Player-facing goal: cut the "levels stacked back-to-back with nothing between them" feel and stop producing pointless pipe loops.

## What changed

**1. Pipes chain through islands instead of expressing to the goal** (`48b6385`)
Multi-island worlds (7, 8) grow a connectivity chain outward from start, bridging the nearest unreached island each step, instead of piping start→goal directly. A direct goal link is used only as a last-pipe fallback. Start→goal "express" rate on W7/W8 dropped from ~100% to ~30%/~18%.

**2. Level path-bonus lowered 1.5 → 0.75** (`ad4c1c0`)
The weight gluing levels onto the start→airship trunk was the dominant linearity driver. Halving it drops the average run of consecutive must-play levels without over-thinning the route.

**3. Level-aware spare-pipe placement** (`28d1786`, the v0.12.0 headline)
Pipe placement is split into two phases. Connectivity pipes are placed first (island access + target reachability). The remaining "spare" pipes are now placed *after* levels exist, scored by how many forced levels each one skips, by converting low-value HammerBro filler slots into pipe endpoints. Previously spare pipes were scored on spatial spread / dead-ends / distance-from-airship — none of which correlates with usefulness, so ~52% came out redundant.

- Spare pipes go in **before** locks, so locks still account for every pipe (no teleporting across a closed lock).
- Endpoints come only from already-reachable HB slots, so a spare pipe can never strand content — it only shortcuts.
- HB→Pipe conversion is **count-preserving**: every world keeps its exact vanilla pipe count and slot budget.

**Supporting:** pipe classification by leave-one-out (conn / shortcut / access / scenic / redundant), breakable-rock-aware pipe stats, and `tools/required_progression.py` for analyzing external ROMs.

## Impact (2000 seeds, SAS off / on)

| metric | main | this PR |
|---|---|---|
| forced-level streak | 1.79 / 1.78 | **1.40 / 1.42** |
| goal-stack ≥2 | 24% / 22% | **14% / 13%** |
| pipe levels-skipped | 0.72 / 0.69 | **1.18 / 1.14** (+64% / +65%) |
| redundant pipes | 52% / 52% | **44% / 42%** |

Residual redundancy is now concentrated in the connectivity phase (W3/W5 canoe duplicates) and W8's pipe mesh — targeted by follow-up work, not this PR.

## Testing

- All 270 tests pass; `cargo clippy --all-targets` clean.
- Invariants verified: every world keeps its vanilla pipe count, all targets reachable (SAS on/off, HB shuffle on/off, raw + QoL ROM), locks never block their own fort.
- Caught and fixed a determinism bug in the first cut (a `HashSet` iteration order fed softmax sampling — would have diverged native vs WASM on the same seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)