### PR TITLE
fix: encode anchor_visuals in the flag key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Fixed
+
+- The "Oops all Anchors" (`anchor_visuals`) toggle is now encoded in the
+  shareable flag key, so turning it on/off actually changes the key and the
+  option round-trips when a key is loaded. Previously it was silently dropped
+  from the flag key (flag-key version bumped to 25).
+
 ## [0.12.0] - 2026-07-12
 
 ### Fixed

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 
-pub(super) const FLAG_KEY_VERSION: u8 = 24;
+pub(super) const FLAG_KEY_VERSION: u8 = 25;
 
 pub(super) const FLAG_KEY_PREFIX: &str = "SMB3R-";
 
@@ -220,10 +220,11 @@ impl Options {
         }
 
         // b12: piranha_shuffle(1-0), antechamber_shuffle ON bit (2) and
-        // Maybe bit (3). Bits 7-4 free for future flags.
+        // Maybe bit (3), anchor_visuals(4). Bits 7-5 free for future flags.
         let b12 = pm(self.piranha_shuffle)
             | (self.antechamber_shuffle.is_on() as u8) << 2
-            | (self.antechamber_shuffle.is_maybe() as u8) << 3;
+            | (self.antechamber_shuffle.is_maybe() as u8) << 3
+            | (self.anchor_visuals as u8) << 4;
 
         [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12]
     }
@@ -383,7 +384,7 @@ impl Options {
                 if wc == 0 { 7 } else { wc.clamp(1, 7) }
             },
             skip_rom_validation: false,
-            anchor_visuals: false,
+            anchor_visuals: (b12 >> 4) & 1 != 0,
         })
     }
 

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -333,6 +333,7 @@ fn flag_key_per_option_round_trip() {
         ("shuffle_spade_games",           Box::new(|o| o.shuffle_spade_games = !o.shuffle_spade_games)),
         ("shuffle_toad_houses",          Box::new(|o| o.shuffle_toad_houses = !o.shuffle_toad_houses)),
         ("wild_injections",              Box::new(|o| o.wild_injections = !o.wild_injections)),
+        ("anchor_visuals",               Box::new(|o| o.anchor_visuals = !o.anchor_visuals)),
     ];
     for (label, mutate) in bools {
         check_round_trip(label, mutate, true);
@@ -491,6 +492,54 @@ fn flag_key_per_option_round_trip() {
     let expected = normalized(everything.clone());
     let recovered = Options::from_flag_key(&everything.to_flag_key()).unwrap();
     assert_eq!(recovered, expected, "all-fields-flipped: round-trip mismatch");
+}
+
+/// Exhaustive guard: every boolean field on `Options` must either be encoded
+/// in the flag key (flipping it changes the key) or be a deliberate cosmetic /
+/// operational exclusion listed below. Driven by serde so a NEW bool field
+/// added to `Options` is automatically covered — if it's dropped from the flag
+/// key (the exact bug that hid `anchor_visuals`), this test fails until the
+/// author either encodes it or consciously adds it to `NOT_ENCODED`.
+#[test]
+fn flag_key_encodes_every_bool_option() {
+    // Bool fields intentionally absent from the flag key, with the reason.
+    // Adding to this list is a conscious decision, not an oversight.
+    const NOT_ENCODED: &[&str] = &[
+        "palettes",            // cosmetic; uses OS randomness, not seed-derived
+        "palette_themed",      // cosmetic
+        "skip_rom_validation", // operational (CLI/WASM input handling), not randomization
+    ];
+
+    let default_key = Options::default().to_flag_key();
+    let default_json = serde_json::to_value(Options::default()).unwrap();
+    let obj = default_json.as_object().unwrap();
+
+    let mut checked_encoded = 0;
+    for (field, value) in obj {
+        let Some(b) = value.as_bool() else { continue };
+
+        // Flip this one bool in the serialized form and rebuild Options.
+        let mut mutated_json = default_json.clone();
+        mutated_json[field] = serde_json::Value::Bool(!b);
+        let mutated: Options = serde_json::from_value(mutated_json).unwrap();
+        let mutated_key = mutated.to_flag_key();
+
+        if NOT_ENCODED.contains(&field.as_str()) {
+            assert_eq!(
+                default_key, mutated_key,
+                "'{field}' is on the NOT_ENCODED list but flipping it changed the flag key",
+            );
+        } else {
+            assert_ne!(
+                default_key, mutated_key,
+                "bool option '{field}' does not affect the flag key — encode it in \
+                 to_flag_bytes/from_flag_key, or add it to NOT_ENCODED with a reason",
+            );
+            checked_encoded += 1;
+        }
+    }
+
+    assert!(checked_encoded > 0, "no encoded bool fields found — serde reflection broke?");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

"Oops all Anchors" (`anchor_visuals`) never affected the shareable flag key. `to_flag_bytes` had no bit for it and `from_flag_key` hardcoded `anchor_visuals: false`. The web page derives its flag string from the options, so toggling the option couldn't change the key — and loading a key always reset the option to off. Because `anchor_visuals` is a **deterministic** ROM patch (unlike palettes, which use OS randomness), it belongs in the key so a shared key+seed reproduces it.

## Fix

- Encode `anchor_visuals` in `b12` bit 4; decode it back.
- Bump `FLAG_KEY_VERSION` 24 → 25, matching the repo convention for claiming reserved bits (antechamber_shuffle did the same for 23 → 24). The change is additively backward-compatible (old keys had that bit zero = the old default), but the version tracks the schema.

## Why the existing test didn't catch it

`flag_key_per_option_round_trip` is a **hand-maintained list** of options — `anchor_visuals` was simply never registered there, the same omission that dropped it from the encoder. This PR adds `flag_key_encodes_every_bool_option`: a serde-reflection-driven guard that flips **every** boolean field on `Options` and asserts each flip changes the flag key, unless the field is on an explicit `NOT_ENCODED` allowlist (`palettes`, `palette_themed`, `skip_rom_validation`, each with a stated reason). Any new bool silently dropped from the key now fails the build.

## Testing

- `cargo test --lib flag_key` — 13 pass (incl. the new exhaustive guard)
- `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)