### PR TITLE
fix: apply anchor_visuals when loading a flag key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ into a versioned section when a release is cut.
 - The "Oops all Anchors" (`anchor_visuals`) toggle is now encoded in the
   shareable flag key, so turning it on/off actually changes the key and the
   option round-trips when a key is loaded. Previously it was silently dropped
-  from the flag key (flag-key version bumped to 25).
+  from the flag key (flag-key version bumped to 25). Also fixed the web UI so
+  applying a flag key with the toggle off actually clears it — the option was
+  marked as not-in-flag-key, so `applyOptions` skipped it and left a
+  previously-enabled checkbox on.
 
 ## [0.12.0] - 2026-07-12
 

--- a/web/options.js
+++ b/web/options.js
@@ -147,7 +147,7 @@ export const SCHEMA = [
 	{ id: "anchor_visuals", type: "bool", default: false,
 		label: "Oops all Anchors", flavor: "Anchors aweigh.",
 		tip: "Every item in your inventory looks like an Anchor. It still works the same — a mushroom still grows you.",
-		group: "map", inFlagKey: false },
+		group: "map", inFlagKey: true },
 	{ id: "include_beta_stages", type: "bool", default: false,
 		label: "Include Beta Stages",
 		tip: "Adds 9 stages previously not included in the vanilla game.",


### PR DESCRIPTION
## Problem

Loading the flag key `SMB3R-37ZZPEQXNCNAM00FXA90G` (which has **Oops all Anchors** off) did not clear the toggle when it was already on.

## Root cause

Commit #85 taught the Rust flag-key codec to encode/decode `anchor_visuals` (b12 bit 4 in `src/randomizer/flag_key.rs`), but `web/options.js` still marked the schema entry `inFlagKey: false`. The web `applyOptions()` skips every `!inFlagKey` field, so applying a key was one-directional:

- **Encoding** picked the toggle up (`getOptions()` reads all schema entries), so turning it on changed the key.
- **Decoding** — Rust correctly returned `anchor_visuals: false`, but `applyOptions` refused to write it back, leaving a previously-on checkbox on.

## Fix

Flip `anchor_visuals` to `inFlagKey: true`. Safe with the surrounding machinery: `applyPreset` resets it to its `false` default, `assertPresetParity` is unaffected (no preset references it), and `selfTestRoundTrip` now includes it — Rust already round-trips it correctly.

Web/docs-only change; `cargo build` clean. `[ci skip]` on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)