### PR TITLE
fix: seed wild-injected Angry Suns at the vanilla screen-0 spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ into a versioned section when a release is cut.
 
 ### Fixed
 
+- Wild-injected Angry Suns no longer get stuck idling in the background (which
+  could also stop a level's goal card from spawning, making the level
+  uncompletable). Injection used to leave the sun at the replaced enemy's
+  position — usually deep in the level — but with Early Sun on, the sun only
+  attacks if it spawned on the first screen. Injected suns are now seeded at the
+  vanilla screen-0 spawn so they engage as intended.
 - The "Oops all Anchors" (`anchor_visuals`) toggle is now encoded in the
   shareable flag key, so turning it on/off actually changes the key and the
   option round-trips when a key is loaded. Previously it was silently dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Changed
+
+- Wild injections (Lakitu / Angry Sun / Boss Bass) are no longer placed in any
+  level segment that contains a Boom-Boom, so a level-wide chaser can't turn up
+  in a fortress boss room.
+
 ### Fixed
 
 - Wild-injected Angry Suns no longer get stuck idling in the background (which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-07-15
+
 ### Changed
 
 - Wild injections (Lakitu / Angry Sun / Boss Bass) are no longer placed in any

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 
 [lib]

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -164,6 +164,21 @@ pub(super) fn inject_at_entry_points<R: Rng>(
             if !(chosen_is_bertha && post_count > MAX_BERTHA_PER_SEGMENT) {
                 let di = entry.data_index;
                 swap_enemy(data, di, chosen);
+                // The Angry Sun idles in the background until its screen
+                // counter hits the attack threshold; the Early Sun QoL patch
+                // moves that threshold to screen 0, so a sun that spawns on any
+                // later screen never fires (and a stuck sun blocks the level's
+                // goal card). Injection inherits the replaced enemy's position,
+                // which is usually deep in the level. Re-seed the sun at the
+                // vanilla 2-Quicksand spawn (screen 0, Y=0x11) so it engages
+                // immediately with Early Sun on and matches the one working
+                // vanilla placement. The sun is already `entries[0]` (lowest X
+                // in the sorted run), so moving it to screen 0 keeps the run
+                // X-sorted for the writeback.
+                if chosen == ANGRY_SUN_ID {
+                    data[di + 1] = SUN_SPAWN_X; // X: screen 0
+                    data[di + 2] = SUN_SPAWN_Y; // Y: sky row
+                }
             }
         }
     }

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -139,6 +139,19 @@ pub(super) fn inject_at_entry_points<R: Rng>(
         }) else {
             continue; // ep not inside any walkable segment — don't inject
         };
+
+        // Never drop a level-wide chaser into a segment that holds a Boom-Boom.
+        // Same whole-segment scope as the CHR scan below and for the same
+        // reason: the chaser follows the player across the entire segment (and
+        // nested outer levels read through this ep), so a Boom-Boom anywhere in
+        // the segment could share the boss room with it. Content-based skip,
+        // like the Bertha cap — no offset list to keep in sync with the ROM.
+        if (0..seg.entry_count)
+            .any(|k| BOOMBOOM_SWAP.contains(&data[seg.file_offset + 1 + k * 3]))
+        {
+            continue;
+        }
+
         let mut s4 = ChrSlot::Free;
         let mut s5 = ChrSlot::Free;
         for k in 0..seg.entry_count {

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -340,9 +340,20 @@ pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 /// normal swaps. CHR compatibility checked via `sprite_bank()` at filter time.
 pub(super) const WILD_INJECTION_IDS: &[u8] = &[
     0x83, // Lakitu (enemy-spawning variant, CHR $0B/+4)
-    0xAF, // Angry Sun
+    ANGRY_SUN_ID, // Angry Sun
     0x2D, // Boss Bass (Big Bertha — the leaping eater)
 ];
+
+/// Angry Sun object id.
+pub(super) const ANGRY_SUN_ID: u8 = 0xAF;
+
+/// Spawn position an injected Angry Sun is re-seeded to: screen 0, Y=0x11 —
+/// the vanilla 2-Quicksand placement, the one spawn that works with the Early
+/// Sun QoL patch (whose attack threshold fires only on screen 0). Injection
+/// otherwise inherits the replaced enemy's usually-deep position, leaving the
+/// sun stuck idling in the background.
+pub(super) const SUN_SPAWN_X: u8 = 0x02;
+pub(super) const SUN_SPAWN_Y: u8 = 0x11;
 
 /// Probability (out of 256) that a segment will receive an injection when wild_injections is on.
 /// ~15% chance per segment.

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -850,6 +850,52 @@
         }
     }
 
+    /// An injected Angry Sun must be re-seeded to the vanilla screen-0 spawn
+    /// (SUN_SPAWN_X/Y), not left at the replaced enemy's inherited position.
+    /// The sun idles in the background until its screen counter hits the attack
+    /// threshold; the Early Sun QoL patch moves that threshold to screen 0, so a
+    /// sun spawned on any later screen never fires (and a stuck sun blocks the
+    /// level goal card). The replaced entries[0] here sits deep at screen 5.
+    #[test]
+    fn test_injected_sun_repositioned_to_screen0() {
+        let flags = Options {
+            wild_injections: true,
+            ..Options::default()
+        };
+        let mut data = blank_rom_image();
+        // First (leftmost) enemy sits deep at screen 5; slot-5 Goombas keep
+        // slot 4 free so the sun (0x32/+4) is CHR-compatible and injectable.
+        let seg = &[
+            0xFF, 0x01,
+            0x72, 0x58, 0x19, // Goomba at screen 5 — the entries[0] a sun replaces
+            0x72, 0x62, 0x19, // Goomba
+            0x72, 0x70, 0x19, // Goomba
+            0xFF,
+        ];
+        data[ENEMY_DATA_START..ENEMY_DATA_START + seg.len()].copy_from_slice(seg);
+        install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
+        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+
+        let mut saw_sun = false;
+        for seed in 0..2000u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            if rom_copy.read_byte(ENEMY_DATA_START + 2) == ANGRY_SUN_ID {
+                saw_sun = true;
+                assert_eq!(
+                    rom_copy.read_byte(ENEMY_DATA_START + 3), SUN_SPAWN_X,
+                    "seed {seed}: injected sun X not re-seeded to screen 0"
+                );
+                assert_eq!(
+                    rom_copy.read_byte(ENEMY_DATA_START + 4), SUN_SPAWN_Y,
+                    "seed {seed}: injected sun Y not re-seeded"
+                );
+            }
+        }
+        assert!(saw_sun, "2000 seeds and never injected a sun to verify reposition");
+    }
+
     /// A vanilla Lakitu (out-of-pool chaser) must pin its CHR page for the
     /// WHOLE level, not just its own proximity group — it follows the player
     /// across every group (see CHASER_IDS).

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -896,6 +896,39 @@
         assert!(saw_sun, "2000 seeds and never injected a sun to verify reposition");
     }
 
+    /// Wild injection must never place a level-wide chaser into a segment that
+    /// holds a Boom-Boom, even when entries[0] is otherwise a valid target.
+    #[test]
+    fn test_no_injection_in_boomboom_segment() {
+        let flags = Options {
+            wild_injections: true,
+            ..Options::default()
+        };
+        let mut data = blank_rom_image();
+        let seg = &[
+            0xFF, 0x01,
+            0x72, 0x10, 0x19, // Goomba — a valid injectable entries[0]
+            0x4B, 0x20, 0x19, // Boom-Boom lives in this level
+            0x72, 0x30, 0x19, // Goomba
+            0xFF,
+        ];
+        data[ENEMY_DATA_START..ENEMY_DATA_START + seg.len()].copy_from_slice(seg);
+        install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
+        let rom = Rom::from_bytes_lax(&data, true).unwrap();
+
+        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
+        for seed in 0..1000u64 {
+            let mut rom_copy = rom.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_copy, &mut rng, &flags);
+            let id = rom_copy.read_byte(ENEMY_DATA_START + 2);
+            assert!(
+                !injection_ids.contains(&id),
+                "seed {seed}: injected 0x{id:02X} into a Boom-Boom segment"
+            );
+        }
+    }
+
     /// A vanilla Lakitu (out-of-pool chaser) must pin its CHR page for the
     /// WHOLE level, not just its own proximity group — it follows the player
     /// across every group (see CHASER_IDS).


### PR DESCRIPTION
Two related wild-injection changes.

## 1. Angry Sun stuck in the background (fix)

Wild-injected **Angry Suns** frequently just sat idling in the sky and never attacked. Worse, a stuck sun could stop the level's **goal card from spawning**, leaving the level uncompletable.

**Root cause:** the sun holds in the background until its screen counter reaches an attack threshold (`Sun_WaitFarEnough`, PRG005). The **Early Sun** QoL patch changes that threshold from screen 5 to screen **0** — so a sun only attacks if it *spawned on the first screen*. `inject_at_entry_points` swaps only the object-id byte of a level's first enemy entry and **keeps that enemy's X/Y** (usually deep, screen 5–6), so with Early Sun on the sun's counter never returns to 0 and it never fires. Vanilla's one sun (2-Quicksand) is at screen 0, `X=0x02`, `Y=0x11` — the one placement that works.

**Fix:** re-seed injected Angry Suns to the vanilla screen-0 spawn. The sun is already `entries[0]` (lowest X in the sorted run), so this keeps the run X-sorted for writeback. Boss Bass (needs water) and Lakitu (no threshold) keep their inherited positions.

## 2. No chasers in Boom-Boom segments (new rule)

A level-wide chaser (Lakitu / Angry Sun / Boss Bass) injected into a fortress boss room shares the screen with the Boom-Boom. Injection now skips any level whose `$FF`-bounded segment contains a Boom-Boom (`0x4B`/`0x4C`).

Uses the **same whole-segment scope as the CHR pin-scan** (chasers follow the player across the segment; nested outer levels read through the entry point) and the **same content-based gating style as the Bertha cap** — no offset list to keep in sync with the ROM.

## Verification

- `test_injected_sun_repositioned_to_screen0`: over 2000 seeds, every injected sun re-seeds to `SUN_SPAWN_X`/`SUN_SPAWN_Y`.
- `test_no_injection_in_boomboom_segment`: over 1000 seeds, a Boom-Boom segment never receives an injection (confirmed discriminating — fails with the gate disabled).
- Full suite green (273 passed), clippy clean.
- Confirmed on hand-injected **vanilla** 1-1 test ROMs: Early-Sun + screen-0 sun attacks immediately; Early-Sun + screen-5 sun idles forever and blocks the goal card. Randomizer output now places all injected suns at screen 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)