### PR TITLE
feature: level-centric wild-injection rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ into a versioned section when a release is cut.
   correct enemy-data location (the old path was offset by 0x10, which could
   corrupt a level). Suns still spawn on screen 0. **Boss Bass is dropped from the
   injection pool** — it's a water-class enemy, so the enemy shuffle reshuffled an
-  injected one away; injections are now Lakitu + Angry Sun.
+  injected one away; injections are now Lakitu + Angry Sun. An injected Lakitu's
+  height is randomized between the replaced enemy's spot and a raised height, so
+  it isn't always at the harder low position.
 - Wild injections roll more often (~15% → ~40% per level) so a seed lands
   noticeably more Lakitu / Angry Sun chasers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ into a versioned section when a release is cut.
 - Wild injections reworked to be level-centric (driven by the node catalog
   instead of raw enemy pointers). Chasers are now placed into real action
   levels only: **fortresses, airships and Bowser are excluded by type**, so a
-  Lakitu / Angry Sun / Boss Bass can no longer turn up in a boss room. A level
-  is never given a chaser it already has (fixes a second Angry Sun stacking onto
-  2-Quicksand and breaking it), shared enemy sets inject at most once, and
-  injections now write to the correct enemy-data location (the old path was
-  offset by 0x10, which could corrupt a level). Suns still spawn on screen 0.
+  chaser can no longer turn up in a boss room. A level is never given a chaser it
+  already has (fixes a second Angry Sun stacking onto 2-Quicksand and breaking
+  it), shared enemy sets inject at most once, and injections now write to the
+  correct enemy-data location (the old path was offset by 0x10, which could
+  corrupt a level). Suns still spawn on screen 0. **Boss Bass is dropped from the
+  injection pool** — it's a water-class enemy, so the enemy shuffle reshuffled an
+  injected one away; injections are now Lakitu + Angry Sun.
 - Wild injections roll more often (~15% → ~40% per level) so a seed lands
-  noticeably more Lakitu / Angry Sun / Boss Bass chasers.
+  noticeably more Lakitu / Angry Sun chasers.
 
 ## [0.12.1] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ into a versioned section when a release is cut.
   correct enemy-data location (the old path was offset by 0x10, which could
   corrupt a level). Suns still spawn on screen 0. **Boss Bass is dropped from the
   injection pool** — it's a water-class enemy, so the enemy shuffle reshuffled an
-  injected one away; injections are now Lakitu + Angry Sun. An injected Lakitu's
-  height is randomized between the replaced enemy's spot and a raised height, so
-  it isn't always at the harder low position.
+  injected one away; injections are now Lakitu + Angry Sun, weighted ~2:1 toward
+  the sun since Lakitu is the harder chaser. An injected Lakitu's height is
+  randomized between the replaced enemy's spot and a raised height, so it isn't
+  always at the harder low position.
 - Wild injections roll more often (~15% → ~40% per level) so a seed lands
   noticeably more Lakitu / Angry Sun chasers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-07-16
+
 ### Changed
 
 - Wild injections reworked to be level-centric (driven by the node catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ into a versioned section when a release is cut.
 
 ### Changed
 
+- Wild injections reworked to be level-centric (driven by the node catalog
+  instead of raw enemy pointers). Chasers are now placed into real action
+  levels only: **fortresses, airships and Bowser are excluded by type**, so a
+  Lakitu / Angry Sun / Boss Bass can no longer turn up in a boss room. A level
+  is never given a chaser it already has (fixes a second Angry Sun stacking onto
+  2-Quicksand and breaking it), shared enemy sets inject at most once, and
+  injections now write to the correct enemy-data location (the old path was
+  offset by 0x10, which could corrupt a level). Suns still spawn on screen 0.
 - Wild injections roll more often (~15% → ~40% per level) so a seed lands
   noticeably more Lakitu / Angry Sun / Boss Bass chasers.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 
 [lib]

--- a/docs/wild_injection_rework.md
+++ b/docs/wild_injection_rework.md
@@ -1,0 +1,94 @@
+# Wild-Injection Rework
+
+Level-centric redesign of the wild-injection pass (`enemies/injection.rs`),
+replacing the old raw-enemy-pointer approach.
+
+## What it does
+
+For each seed, injects Lakitu (`0x83`) / Angry Sun (`0xAF`) / Boss Bass (`0x2D`)
+into a random subset of real action levels, replacing each chosen level's first
+enemy with a CHR-compatible chaser.
+
+## Why it was reworked
+
+The old pass drove off `enemy_entry_points` (raw header pointers), which:
+
+- targeted a frozen set of ~32 levels every seed (eligibility computed on
+  pre-shuffle vanilla first-enemies);
+- hit shared / nested / mid-segment enemy pointers, so one injection could
+  land in two levels (e.g. `3-1` & `7-2` share an enemy set);
+- could not reliably exclude boss rooms — a fortress boss lives in a *different*
+  `0xFF` segment than the injection target, so a per-segment `0x4B/0x4C` scan
+  never saw it (`4F2`, `7F2` slipped through);
+- had **no guard against doubling** — a second Angry Sun could stack onto
+  2-Quicksand's existing sun and break the level;
+- used the raw pointer as a direct file index, which is **0x10 off** from the
+  `enemy_ptr_to_file_offset` frame the rest of the codebase uses — writing to
+  the wrong location.
+
+## Design
+
+Driven by `node_catalog`, which classifies every entry (`NodeKind::Level`,
+`Fortress`, `Airship`, `Bowser`, …) and carries each level's `obj_ptr`.
+
+```
+collect_candidates(rom, data, opts):
+    for entry in NodeCatalog::build(rom, include_beta_stages):
+        keep only NodeKind::Level                       # boss types excluded here
+        obj_ptr = entry.level_entry.obj_ptr
+        first_idx = enemy_ptr_to_file_offset(obj_ptr) - ENEMY_DATA_START (+page byte)
+        de-dupe by first_idx                            # shared enemy set = one candidate
+
+inject_wild_chasers:
+    shuffle(candidates)                                 # per-seed variety
+    for cand in candidates:
+        roll WILD_INJECTION_CHANCE
+        require first enemy swappable + unprotected      # don't clobber critical
+                                                         # objects / get reverted
+        CHR pin-scan the enclosing $FF segment
+        pick a chaser that is CHR-compatible, the level
+          does NOT already have (has_enemy_id), and
+          within the Big-Bertha per-segment cap
+        replace first enemy; re-seed suns to screen 0 (0x02, 0x11)
+```
+
+### Guards
+- **Boss exclusion** — by `NodeKind`, not enemy bytes. Reliable.
+- **No-double** — `has_enemy_id(rom, obj_ptr, chosen)` skips any chaser the level
+  already contains (the 2-Quicksand fix).
+- **Shared-pointer de-dup** — one physical enemy set injects at most once.
+- **Swappable + unprotected first enemy** — `find_class_pool` guards against
+  destroying a non-enemy object; `entry_protection_at` avoids walker reverts.
+- **CHR compatibility** — unchanged; the chaser's sprite page must fit the
+  segment's committed slots.
+- **Bertha cap** — `MAX_BERTHA_PER_SEGMENT`.
+
+### Frame
+Everything uses `obj_ptr` + `enemy_ptr_to_file_offset` (the same frame as
+`has_enemy_id`), verified against 1-1 (obj `0xC527` → first enemy at file
+`0xC538`).
+
+### Sun placement
+Kept as-is: injected suns are re-seeded to the vanilla 2-Quicksand spawn
+(screen 0, `Y=0x11`). Confirmed necessary — deep suns idle in the background.
+
+## Retained / removed
+- `enemy_entry_points` retained (used by the `chr_stats` integration test).
+- Removed: the old `inject_at_entry_points`, the per-segment `0x4B/0x4C` Boom-Boom
+  scan, and `is_injection_blocked` (its only consumer was the old pass).
+
+## Tests
+- `wild_injection_rework_guarantees` (real ROM, 30 seeds): injections occur,
+  every injected sun is on screen 0, no fortress/airship/Bowser receives a
+  chaser, no level is doubled.
+- `enemy_invariant_baseline` — its `injectable_offsets` oracle now mirrors the
+  catalog-based candidate set.
+
+## Known limitations / future work
+- **Variety** comes from random selection over a fixed candidate *set* (level
+  main areas with a swappable first enemy). The set is the same each seed; only
+  the chosen subset varies. Making the set itself vary would require running
+  injection after the enemy shuffle.
+- Only the level's **main area** first enemy is targeted (no sub-area injection).
+- **Rate** (`WILD_INJECTION_CHANCE = 102`, ~40%) now applies per candidate
+  level; may warrant re-measuring against the (larger, cleaner) pool.

--- a/docs/wild_injection_rework.md
+++ b/docs/wild_injection_rework.md
@@ -76,6 +76,13 @@ Everything uses `obj_ptr` + `enemy_ptr_to_file_offset` (the same frame as
 Kept as-is: injected suns are re-seeded to the vanilla 2-Quicksand spawn
 (screen 0, `Y=0x11`). Confirmed necessary — deep suns idle in the background.
 
+### Lakitu height
+Lakitu works at any spawn height, but inheriting the replaced first enemy's Y
+(usually a low ground-enemy spot) makes it too consistently punishing — the
+spinies land closer. So an injected Lakitu's Y is a coin-flip between the
+inherited height and `LAKITU_ALT_Y` (`0x12`, the common vanilla Lakitu height):
+half stay low, half lift up. X is always inherited.
+
 ## Retained / removed
 - `enemy_entry_points` retained (used by the `chr_stats` integration test).
 - Removed: the old `inject_at_entry_points`, the per-segment `0x4B/0x4C` Boom-Boom

--- a/docs/wild_injection_rework.md
+++ b/docs/wild_injection_rework.md
@@ -76,6 +76,11 @@ Everything uses `obj_ptr` + `enemy_ptr_to_file_offset` (the same frame as
 Kept as-is: injected suns are re-seeded to the vanilla 2-Quicksand spawn
 (screen 0, `Y=0x11`). Confirmed necessary — deep suns idle in the background.
 
+### Pick weighting
+When both chasers are eligible for a level, the pick is weighted toward the sun
+(`SUN_INJECTION_WEIGHT = 2`, i.e. ~1/3 Lakitu / 2/3 sun) — Lakitu is much harder
+to deal with, so it's kept rarer. Tune the constant to shift the mix.
+
 ### Lakitu height
 Lakitu works at any spawn height, but inheriting the replaced first enemy's Y
 (usually a low ground-enemy spot) makes it too consistently punishing — the

--- a/docs/wild_injection_rework.md
+++ b/docs/wild_injection_rework.md
@@ -5,9 +5,13 @@ replacing the old raw-enemy-pointer approach.
 
 ## What it does
 
-For each seed, injects Lakitu (`0x83`) / Angry Sun (`0xAF`) / Boss Bass (`0x2D`)
-into a random subset of real action levels, replacing each chosen level's first
-enemy with a CHR-compatible chaser.
+For each seed, injects a level-wide chaser — Lakitu (`0x83`) or Angry Sun
+(`0xAF`) — into a random subset of real action levels, replacing each chosen
+level's first enemy with a CHR-compatible chaser.
+
+**Boss Bass (`0x2D`) is excluded** from the pool: it's a `WATER_ENEMIES` member,
+so the later walker pass would reshuffle an injected one into an ordinary water
+enemy. Lakitu and Sun are in no class pool, so the walker leaves them alone.
 
 ## Why it was reworked
 

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -1,19 +1,35 @@
-//! Wild-injection pass: seed Lakitu / Angry Sun / Boss Bass into a fraction
-//! of level segments, keyed off authoritative level entry points.
+//! Wild-injection pass: seed Lakitu / Angry Sun / Boss Bass into a fraction of
+//! real action levels, selected via the `node_catalog` (not raw enemy pointers).
+//!
+//! Level-centric design (replaces the old entry-point / `enemy_entry_points`
+//! approach). Each candidate is a `NodeKind::Level` — fortresses, airships and
+//! Bowser are excluded *by type*, so a chaser never lands in a boss room. For
+//! each candidate we replace its first enemy with a CHR-compatible chaser the
+//! level does not already have. Suns are re-seeded to the vanilla screen-0
+//! spawn so they engage (deep suns idle in the background).
+//!
+//! Guards: boss-type exclusion, shared-enemy-set de-dup (one physical enemy set
+//! injects at most once), no-double (`has_enemy_id`), first-enemy must be a
+//! real swappable/unprotected enemy (don't clobber a critical object or get
+//! reverted by the walker), CHR compatibility, and the Big-Bertha per-segment
+//! cap. All offsets use the `enemy_ptr_to_file_offset` frame — the same one
+//! `has_enemy_id` and the rest of the codebase use.
+
+use std::collections::HashSet;
+
+use rand::seq::SliceRandom;
+
+use crate::randomize::node_catalog::{NodeCatalog, NodeKind};
+use crate::randomize::rom_data::{enemy_ptr_to_file_offset, has_enemy_id};
 
 use super::*;
 
 /// Collect every `enemy_ptr` value (bytes 2-3 of every 9-byte level
-/// header) from every region in [`LEVEL_DATA_REGIONS`]. This is the
-/// authoritative set of file offsets where the SMB3 level loader actually
-/// begins reading enemy data — the level/sub-area entry points. Used by
-/// [`inject_at_entry_points`] so wild_injection writes only land where a
-/// level will actually read them.
+/// header) from every region in [`LEVEL_DATA_REGIONS`]. Retained for the
+/// `chr_stats` integration test's distribution analysis; the injection pass
+/// itself no longer drives off this (it uses the node catalog).
 ///
 /// Returned values are unique and in first-seen order.
-///
-/// Exposed `pub` so integration tests (`tests/chr_stats.rs`) can use the
-/// same authoritative set for distribution / visibility analysis.
 pub fn enemy_entry_points(rom: &Rom) -> Vec<u16> {
     const LEVEL_HEADER_SIZE: usize = 9;
     let mut pts: Vec<u16> = Vec::new();
@@ -23,13 +39,11 @@ pub fn enemy_entry_points(rom: &Rom) -> Vec<u16> {
         let data = rom.read_range(region.start, len);
         let mut i = 0usize;
         while i + LEVEL_HEADER_SIZE < data.len() {
-            // Header at data[i..i+9]; enemy_ptr is bytes 2-3 (little-endian).
             let ep = (data[i + 2] as u16) | ((data[i + 3] as u16) << 8);
             if seen.insert(ep) {
                 pts.push(ep);
             }
             i += LEVEL_HEADER_SIZE;
-            // Walk commands until the level's $FF terminator.
             while i + 2 < data.len() {
                 if data[i] == 0xFF {
                     i += 1;
@@ -42,157 +56,166 @@ pub fn enemy_entry_points(rom: &Rom) -> Vec<u16> {
     pts
 }
 
-/// Wild-injection pass driven by *level entry points* rather than by
-/// `$FF`-bounded walker segments. For every `enemy_ptr` reported by
-/// [`enemy_entry_points`] that isn't an HB or protected segment, roll
-/// against `WILD_INJECTION_CHANCE` and — on success — replace the first
-/// entry the SMB3 level loader will actually read with a CHR-compatible
-/// Lakitu / Angry Sun / Boss Bass.
-///
-/// This replaces the in-walker injection block: the walker historically
-/// injected at `entries[0]` of every walker-segment, but most walker
-/// segments don't start at a level entry point (the level enters
-/// mid-segment). Driving the pass off `enemy_ptr` ensures injections are
-/// visible in-game.
-pub(super) fn inject_at_entry_points<R: Rng>(
+/// One candidate level for injection: its enemy-data location as an index into
+/// the `data` buffer (the first enemy entry, after any page byte).
+struct Candidate {
+    obj_ptr: u16,
+    /// Index into `data` of the first enemy entry (byte 0 = obj_id).
+    first_idx: usize,
+}
+
+/// Build the list of injectable levels from the node catalog: real action
+/// levels only (`NodeKind::Level`), de-duped by enemy-data location so a shared
+/// enemy set is a single candidate.
+fn collect_candidates(rom: &Rom, data: &[u8], opts: &Options) -> Vec<Candidate> {
+    let catalog = NodeCatalog::build(rom, opts.include_beta_stages);
+    let mut out = Vec::new();
+    let mut seen: HashSet<usize> = HashSet::new();
+    for e in &catalog.entries {
+        if !matches!(e.kind, NodeKind::Level) {
+            continue; // fortresses / airships / Bowser / non-levels excluded by type
+        }
+        let Some(le) = &e.level_entry else { continue };
+        let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
+        if obj_ptr < 0xC000 {
+            continue;
+        }
+        let file_off = enemy_ptr_to_file_offset(obj_ptr);
+        if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&file_off) {
+            continue;
+        }
+        let page_idx = file_off - ENEMY_DATA_START;
+        if page_idx >= data.len() {
+            continue;
+        }
+        // Skip the leading page-flag byte if present (real obj_ids never
+        // overlap 0x00/0x01, so the value is an unambiguous discriminator).
+        let first_idx = if matches!(data[page_idx], 0x00 | 0x01) {
+            page_idx + 1
+        } else {
+            page_idx
+        };
+        if first_idx >= data.len() || data[first_idx] == 0xFF {
+            continue; // empty level
+        }
+        if seen.insert(first_idx) {
+            out.push(Candidate { obj_ptr, first_idx });
+        }
+    }
+    out
+}
+
+/// Pick a CHR-compatible chaser this level doesn't already have, honoring the
+/// per-segment Big-Bertha cap. Returns `None` if nothing fits.
+#[allow(clippy::too_many_arguments)] // Reason: threading ROM + segment context
+                                     // for one focused selection step; splitting
+                                     // it would hide the guard set, not clarify.
+fn pick_injection<R: Rng>(
+    rom: &Rom,
+    obj_ptr: u16,
+    slot4: ChrSlot,
+    slot5: ChrSlot,
+    data: &[u8],
+    seg: &segment_writer::SegmentBounds,
+    first_idx: usize,
+    rng: &mut R,
+) -> Option<u8> {
+    let bertha_ct: u8 = (0..seg.entry_count)
+        .filter(|&k| BERTHA_IDS.contains(&data[seg.file_offset + 1 + k * 3]))
+        .count() as u8;
+    let first_is_bertha = BERTHA_IDS.contains(&data[first_idx]);
+    let eligible: Vec<u8> = WILD_INJECTION_IDS
+        .iter()
+        .copied()
+        .filter(|&id| {
+            if !is_chr_compatible(id, slot4, slot5) {
+                return false;
+            }
+            if has_enemy_id(rom, obj_ptr, id) {
+                return false; // no doubling (e.g. 2-Quicksand already has a sun)
+            }
+            if BERTHA_IDS.contains(&id) {
+                let post = bertha_ct
+                    .saturating_sub(first_is_bertha as u8)
+                    .saturating_add(1);
+                if post > MAX_BERTHA_PER_SEGMENT {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
+    eligible.choose(rng).copied()
+}
+
+/// Wild-injection pass. Shuffles the candidate levels for per-seed variety,
+/// then rolls each independently at [`WILD_INJECTION_CHANCE`].
+pub(super) fn inject_wild_chasers<R: Rng>(
     data: &mut [u8],
-    entry_ptrs: &[u16],
+    rom: &Rom,
     bounds: &[segment_writer::SegmentBounds],
     opts: &Options,
     rng: &mut R,
 ) {
     let normal_modes = ClassModes::from_options(opts);
+    let mut candidates = collect_candidates(rom, data, opts);
+    candidates.shuffle(rng);
 
-    for &ep_u16 in entry_ptrs {
-        let ep = ep_u16 as usize;
-        if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&ep) {
-            continue;
-        }
-        if is_injection_blocked(ep_u16) {
-            continue;
-        }
-
-        let ep_local = ep - ENEMY_DATA_START;
-        if ep_local >= data.len() {
-            continue;
-        }
-
-        // SMB3 enemy data has two layout flavors at an entry point:
-        //   (a) page byte (0x00 or 0x01) then 3-byte entries
-        //   (b) entries-only (the entry_ptr lands directly on the first obj_id)
-        // Real obj_ids never overlap 0x00/0x01, so the byte value is the
-        // unambiguous discriminator the walker has always used.
-        let first_entry_idx = if matches!(data[ep_local], 0x00 | 0x01) {
-            ep_local + 1
-        } else {
-            ep_local
-        };
-        if first_entry_idx >= data.len() || data[first_entry_idx] == 0xFF {
-            continue; // empty level — no enemy entries to inject into
-        }
-
-        // Gather entries from this entry point up to its $FF terminator.
-        let mut entries: Vec<SegmentEntry> = Vec::new();
-        let mut j = first_entry_idx;
-        while j + 2 < data.len() && data[j] != 0xFF {
-            entries.push(SegmentEntry {
-                data_index: j,
-                obj_id: data[j],
-                x_pos: data[j + 1],
-            });
-            j += 3;
-        }
-        if entries.is_empty() {
-            continue;
-        }
-
+    for Candidate { obj_ptr, first_idx } in candidates {
         let roll: u8 = rng.random_range(..=255);
         if roll >= WILD_INJECTION_CHANCE {
             continue;
         }
 
-        let entry = &entries[0];
-        let fo = ENEMY_DATA_START + entry.data_index;
-        // Skip if the walker pass would override or filter our pick: every
-        // protection either keeps the vanilla enemy (SkipSwap), silently
-        // replaces the injected enemy with a forced-pool member (e.g. 6-5's
-        // shell at 0xC5EB must stay shell for brick-break progression), or
-        // filters a Lakitu/Boss Bass back out (ExcludeHazards, e.g. 7F2's
-        // Boom-Boom arena).
-        let swappable = entry_protection_at(fo).is_none()
-            && find_class_pool(entry.obj_id, &normal_modes).is_some();
-        if !swappable {
+        // The entry we'd replace must be a real, swappable, unprotected enemy:
+        // don't clobber a critical object (find_class_pool guards that it is a
+        // shuffleable enemy) and don't get reverted by the walker's protection
+        // handlers (SkipSwap / forced-pool / ExcludeHazards).
+        let first_id = data[first_idx];
+        let fo = ENEMY_DATA_START + first_idx;
+        if entry_protection_at(fo).is_some() {
+            continue;
+        }
+        if find_class_pool(first_id, &normal_modes).is_none() {
             continue;
         }
 
-        // Pre-commit pinned CHR pages from the WHOLE $FF-bounded segment
-        // containing this ep — not just the ep's own run. Level enemy runs
-        // nest inside segments: an outer level's run starts earlier and
-        // reads straight through this ep, so the injected enemy (which
-        // chases the player level-wide — every WILD_INJECTION_ID is a
-        // chaser) is also on screen with entries *before* the ep when that
-        // level is played.
+        // Enclosing $FF segment for CHR pinning (chasers are level-wide, so the
+        // whole segment's pins constrain the pick).
         let Some(seg) = bounds.iter().find(|b| {
-            let entries_start = b.file_offset + 1;
-            let entries_end = entries_start + b.entry_count * 3;
-            (entries_start..entries_end).contains(&first_entry_idx)
+            let s = b.file_offset + 1;
+            let end = s + b.entry_count * 3;
+            (s..end).contains(&first_idx)
         }) else {
-            continue; // ep not inside any walkable segment — don't inject
-        };
-
-        // Never drop a level-wide chaser into a segment that holds a Boom-Boom.
-        // Same whole-segment scope as the CHR scan below and for the same
-        // reason: the chaser follows the player across the entire segment (and
-        // nested outer levels read through this ep), so a Boom-Boom anywhere in
-        // the segment could share the boss room with it. Content-based skip,
-        // like the Bertha cap — no offset list to keep in sync with the ROM.
-        if (0..seg.entry_count)
-            .any(|k| BOOMBOOM_SWAP.contains(&data[seg.file_offset + 1 + k * 3]))
-        {
             continue;
-        }
-
+        };
         let mut s4 = ChrSlot::Free;
         let mut s5 = ChrSlot::Free;
         for k in 0..seg.entry_count {
             let off = seg.file_offset + 1 + k * 3;
-            if off == entries[0].data_index {
-                continue; // the slot being replaced — its enemy goes away
+            if off == first_idx {
+                continue; // slot being replaced — its enemy goes away
             }
-            let fo = ENEMY_DATA_START + off;
-            if is_pinned(data[off], fo, &normal_modes) {
+            let fo2 = ENEMY_DATA_START + off;
+            if is_pinned(data[off], fo2, &normal_modes) {
                 commit_chr_page(data[off], &mut s4, &mut s5);
             }
         }
 
-        if let Some(chosen) = pick_compatible(WILD_INJECTION_IDS, s4, s5, rng) {
-            let bertha_count: u8 = entries.iter()
-                .filter(|e| BERTHA_IDS.contains(&e.obj_id))
-                .count() as u8;
-            let was_bertha = BERTHA_IDS.contains(&entries[0].obj_id);
-            let chosen_is_bertha = BERTHA_IDS.contains(&chosen);
-            let post_count = bertha_count
-                .saturating_sub(was_bertha as u8)
-                .saturating_add(chosen_is_bertha as u8);
-            if !(chosen_is_bertha && post_count > MAX_BERTHA_PER_SEGMENT) {
-                let di = entry.data_index;
-                swap_enemy(data, di, chosen);
-                // The Angry Sun idles in the background until its screen
-                // counter hits the attack threshold; the Early Sun QoL patch
-                // moves that threshold to screen 0, so a sun that spawns on any
-                // later screen never fires (and a stuck sun blocks the level's
-                // goal card). Injection inherits the replaced enemy's position,
-                // which is usually deep in the level. Re-seed the sun at the
-                // vanilla 2-Quicksand spawn (screen 0, Y=0x11) so it engages
-                // immediately with Early Sun on and matches the one working
-                // vanilla placement. The sun is already `entries[0]` (lowest X
-                // in the sorted run), so moving it to screen 0 keeps the run
-                // X-sorted for the writeback.
-                if chosen == ANGRY_SUN_ID {
-                    data[di + 1] = SUN_SPAWN_X; // X: screen 0
-                    data[di + 2] = SUN_SPAWN_Y; // Y: sky row
-                }
-            }
+        let Some(chosen) = pick_injection(rom, obj_ptr, s4, s5, data, seg, first_idx, rng)
+        else {
+            continue;
+        };
+
+        swap_enemy(data, first_idx, chosen);
+        // The Angry Sun idles in the background unless it spawns on the first
+        // screen (with Early Sun on). Injection would otherwise leave it at the
+        // replaced enemy's usually-deep position, so re-seed it to the vanilla
+        // 2-Quicksand spawn (screen 0, Y=0x11). The sun becomes the lowest-X
+        // entry, keeping the run X-sorted for the writeback.
+        if chosen == ANGRY_SUN_ID {
+            data[first_idx + 1] = SUN_SPAWN_X;
+            data[first_idx + 2] = SUN_SPAWN_Y;
         }
     }
 }

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -1,5 +1,6 @@
-//! Wild-injection pass: seed Lakitu / Angry Sun / Boss Bass into a fraction of
-//! real action levels, selected via the `node_catalog` (not raw enemy pointers).
+//! Wild-injection pass: seed a level-wide chaser (Lakitu or Angry Sun) into a
+//! fraction of real action levels, selected via the `node_catalog` (not raw
+//! enemy pointers).
 //!
 //! Level-centric design (replaces the old entry-point / `enemy_entry_points`
 //! approach). Each candidate is a `NodeKind::Level` — fortresses, airships and
@@ -8,12 +9,17 @@
 //! level does not already have. Suns are re-seeded to the vanilla screen-0
 //! spawn so they engage (deep suns idle in the background).
 //!
+//! The pool is Lakitu + Angry Sun only. Boss Bass is deliberately excluded: it's
+//! a `WATER_ENEMIES` member, so the later walker pass would reshuffle an injected
+//! one into an ordinary water enemy. Lakitu and Sun belong to no class pool, so
+//! the walker leaves them untouched.
+//!
 //! Guards: boss-type exclusion, shared-enemy-set de-dup (one physical enemy set
 //! injects at most once), no-double (`has_enemy_id`), first-enemy must be a
 //! real swappable/unprotected enemy (don't clobber a critical object or get
-//! reverted by the walker), CHR compatibility, and the Big-Bertha per-segment
-//! cap. All offsets use the `enemy_ptr_to_file_offset` frame — the same one
-//! `has_enemy_id` and the rest of the codebase use.
+//! reverted by the walker), and CHR compatibility. All offsets use the
+//! `enemy_ptr_to_file_offset` frame — the same one `has_enemy_id` and the rest
+//! of the codebase use.
 
 use std::collections::HashSet;
 
@@ -105,44 +111,22 @@ fn collect_candidates(rom: &Rom, data: &[u8], opts: &Options) -> Vec<Candidate> 
     out
 }
 
-/// Pick a CHR-compatible chaser this level doesn't already have, honoring the
-/// per-segment Big-Bertha cap. Returns `None` if nothing fits.
-#[allow(clippy::too_many_arguments)] // Reason: threading ROM + segment context
-                                     // for one focused selection step; splitting
-                                     // it would hide the guard set, not clarify.
+/// Pick a CHR-compatible chaser this level doesn't already have. Returns `None`
+/// if nothing fits.
 fn pick_injection<R: Rng>(
     rom: &Rom,
     obj_ptr: u16,
     slot4: ChrSlot,
     slot5: ChrSlot,
-    data: &[u8],
-    seg: &segment_writer::SegmentBounds,
-    first_idx: usize,
     rng: &mut R,
 ) -> Option<u8> {
-    let bertha_ct: u8 = (0..seg.entry_count)
-        .filter(|&k| BERTHA_IDS.contains(&data[seg.file_offset + 1 + k * 3]))
-        .count() as u8;
-    let first_is_bertha = BERTHA_IDS.contains(&data[first_idx]);
     let eligible: Vec<u8> = WILD_INJECTION_IDS
         .iter()
         .copied()
         .filter(|&id| {
-            if !is_chr_compatible(id, slot4, slot5) {
-                return false;
-            }
-            if has_enemy_id(rom, obj_ptr, id) {
-                return false; // no doubling (e.g. 2-Quicksand already has a sun)
-            }
-            if BERTHA_IDS.contains(&id) {
-                let post = bertha_ct
-                    .saturating_sub(first_is_bertha as u8)
-                    .saturating_add(1);
-                if post > MAX_BERTHA_PER_SEGMENT {
-                    return false;
-                }
-            }
-            true
+            // CHR-compatible with the segment's pinned pages, and not a chaser
+            // the level already has (no doubling — e.g. 2-Quicksand's sun).
+            is_chr_compatible(id, slot4, slot5) && !has_enemy_id(rom, obj_ptr, id)
         })
         .collect();
     eligible.choose(rng).copied()
@@ -202,8 +186,7 @@ pub(super) fn inject_wild_chasers<R: Rng>(
             }
         }
 
-        let Some(chosen) = pick_injection(rom, obj_ptr, s4, s5, data, seg, first_idx, rng)
-        else {
+        let Some(chosen) = pick_injection(rom, obj_ptr, s4, s5, rng) else {
             continue;
         };
 

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -129,7 +129,13 @@ fn pick_injection<R: Rng>(
             is_chr_compatible(id, slot4, slot5) && !has_enemy_id(rom, obj_ptr, id)
         })
         .collect();
-    eligible.choose(rng).copied()
+    // Favor the sun over the (harder) Lakitu when both fit.
+    eligible
+        .choose_weighted(rng, |&id| {
+            if id == ANGRY_SUN_ID { SUN_INJECTION_WEIGHT } else { 1 }
+        })
+        .ok()
+        .copied()
 }
 
 /// Wild-injection pass. Shuffles the candidate levels for per-seed variety,

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -199,6 +199,11 @@ pub(super) fn inject_wild_chasers<R: Rng>(
         if chosen == ANGRY_SUN_ID {
             data[first_idx + 1] = SUN_SPAWN_X;
             data[first_idx + 2] = SUN_SPAWN_Y;
+        } else if chosen == LAKITU_ID && rng.random_range(..2u8) == 0 {
+            // Lakitu works at any height, but the inherited Y is usually a low
+            // ground-enemy spot (harder). Coin-flip half of them up to the
+            // common vanilla Lakitu height; the other half keep the low Y.
+            data[first_idx + 2] = LAKITU_ALT_Y;
         }
     }
 }

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -12,8 +12,7 @@ use rand::Rng;
 use rand::seq::IndexedRandom;
 
 use crate::randomize::enemy_protections::{
-    entry_protection_at, is_injection_blocked, walker_segment_rule_at, EntryProtection,
-    WalkerSegmentRule,
+    entry_protection_at, walker_segment_rule_at, EntryProtection, WalkerSegmentRule,
 };
 use crate::randomize::rom_data::{
     ENEMY_DATA_END, ENEMY_DATA_START, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS, STOMPABLE_ENEMIES,
@@ -102,9 +101,8 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
     // $FF-bounded segment, not just the ep's own run (runs nest, and outer
     // levels see the injected enemy too).
     if opts.wild_injections && !big_q_only {
-        let entry_ptrs = enemy_entry_points(rom);
         let bounds = segment_writer::walk_segments(&data, 0, data.len(), &skip_ranges);
-        inject_at_entry_points(&mut data, &entry_ptrs, &bounds, opts, rng);
+        inject_wild_chasers(&mut data, rom, &bounds, opts, rng);
     }
 
     let mut i = 0;

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -352,6 +352,11 @@ pub(super) const ANGRY_SUN_ID: u8 = 0xAF;
 /// Lakitu (enemy-spawning variant) object id.
 pub(super) const LAKITU_ID: u8 = 0x83;
 
+/// Weight of the Angry Sun relative to Lakitu (weight 1) when both are eligible
+/// for an injection. Lakitu is much harder to deal with, so the sun is favored:
+/// 2:1 ≈ 1/3 Lakitu / 2/3 sun. Bump this to make Lakitu rarer still.
+pub(super) const SUN_INJECTION_WEIGHT: u32 = 2;
+
 /// Spawn position an injected Angry Sun is re-seeded to: screen 0, Y=0x11 —
 /// the vanilla 2-Quicksand placement, the one spawn that works with the Early
 /// Sun QoL patch (whose attack threshold fires only on screen 0). Injection

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -336,12 +336,14 @@ pub(super) const BIG_Q_BLOCKS: &[u8] = &[
 /// The W7 room is at enemy_ptr 0xC9A3; the Tanooki is the second entry.
 pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
-/// Injection candidates for wild_injections mode: special enemies injected after
-/// normal swaps. CHR compatibility checked via `sprite_bank()` at filter time.
+/// Injection candidates for wild_injections mode: level-wide chasers seeded into
+/// a level's first enemy. CHR compatibility checked via `sprite_bank()` at filter
+/// time. Both are in NO class pool, so the walker leaves an injected one alone.
+/// (Boss Bass 0x2D is deliberately excluded: it's a `WATER_ENEMIES` member, so
+/// the walker would reshuffle an injected one into an ordinary water enemy.)
 pub(super) const WILD_INJECTION_IDS: &[u8] = &[
     0x83, // Lakitu (enemy-spawning variant, CHR $0B/+4)
     ANGRY_SUN_ID, // Angry Sun
-    0x2D, // Boss Bass (Big Bertha — the leaping eater)
 ];
 
 /// Angry Sun object id.

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -342,12 +342,15 @@ pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 /// (Boss Bass 0x2D is deliberately excluded: it's a `WATER_ENEMIES` member, so
 /// the walker would reshuffle an injected one into an ordinary water enemy.)
 pub(super) const WILD_INJECTION_IDS: &[u8] = &[
-    0x83, // Lakitu (enemy-spawning variant, CHR $0B/+4)
+    LAKITU_ID,    // Lakitu (enemy-spawning variant, CHR $0B/+4)
     ANGRY_SUN_ID, // Angry Sun
 ];
 
 /// Angry Sun object id.
 pub(super) const ANGRY_SUN_ID: u8 = 0xAF;
+
+/// Lakitu (enemy-spawning variant) object id.
+pub(super) const LAKITU_ID: u8 = 0x83;
 
 /// Spawn position an injected Angry Sun is re-seeded to: screen 0, Y=0x11 —
 /// the vanilla 2-Quicksand placement, the one spawn that works with the Early
@@ -356,6 +359,13 @@ pub(super) const ANGRY_SUN_ID: u8 = 0xAF;
 /// sun stuck idling in the background.
 pub(super) const SUN_SPAWN_X: u8 = 0x02;
 pub(super) const SUN_SPAWN_Y: u8 = 0x11;
+
+/// An injected Lakitu's height is a coin-flip between the replaced enemy's Y and
+/// this value — the common vanilla Lakitu spawn height (7 of 10 vanilla Lakitu
+/// use it). Lakitu works at any height, but inheriting a low ground-enemy Y
+/// every time makes it too consistently punishing (spinies land closer), so
+/// half the time it lifts to this height for variety.
+pub(super) const LAKITU_ALT_Y: u8 = 0x12;
 
 /// Probability (out of 256) that a segment will receive an injection when wild_injections is on.
 /// ~40% chance per segment (102/256). Note the effective rate is lower because a

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1569,3 +1569,72 @@
         }
         assert!(saw_injection, "30 seeds and never saw a chaser injected into a level");
     }
+
+    /// An injected Lakitu's height coin-flips between the replaced enemy's Y and
+    /// LAKITU_ALT_Y (0x12): across many seeds we must see both outcomes, so it's
+    /// not always stuck at the (harder) low inherited height.
+    #[test]
+    fn wild_injected_lakitu_height_varies() {
+        use crate::randomize::node_catalog::NodeCatalog;
+        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
+        const LAKITU: u8 = 0x83;
+
+        let Some(base) = load_reference_rom() else {
+            eprintln!("reference ROM not present — skipping wild_injected_lakitu_height_varies");
+            return;
+        };
+        let len = ENEMY_DATA_END - ENEMY_DATA_START;
+        let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
+        let catalog = NodeCatalog::build(&base, false);
+
+        let first_idx = |obj_ptr: u16, data: &[u8]| -> Option<usize> {
+            if obj_ptr < 0xC000 {
+                return None;
+            }
+            let fo = enemy_ptr_to_file_offset(obj_ptr);
+            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&fo) {
+                return None;
+            }
+            let p = fo - ENEMY_DATA_START;
+            if p >= data.len() {
+                return None;
+            }
+            let first = if matches!(data[p], 0x00 | 0x01) { p + 1 } else { p };
+            if first >= data.len() || data[first] == 0xFF {
+                return None;
+            }
+            Some(first)
+        };
+
+        let opts = Options { wild_injections: true, ..preset_recommended() };
+        let mut saw_alt = false; // lifted to LAKITU_ALT_Y (0x12)
+        let mut saw_kept = false; // kept a non-0x12 inherited height
+        'seeds: for seed in 0..60u64 {
+            let mut rom = base.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom, &mut rng, &opts);
+            let patched = rom.read_range(ENEMY_DATA_START, len).to_vec();
+            for e in &catalog.entries {
+                let Some(le) = &e.level_entry else { continue };
+                let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
+                let Some(fi) = first_idx(obj_ptr, &patched) else { continue };
+                if patched[fi] != LAKITU {
+                    continue;
+                }
+                let van_first = first_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
+                if van_first == Some(LAKITU) {
+                    continue; // vanilla-native Lakitu, not injected
+                }
+                if patched[fi + 2] == 0x12 {
+                    saw_alt = true;
+                } else {
+                    saw_kept = true;
+                }
+                if saw_alt && saw_kept {
+                    break 'seeds;
+                }
+            }
+        }
+        assert!(saw_alt, "no injected Lakitu lifted to 0x12 in 60 seeds");
+        assert!(saw_kept, "no injected Lakitu kept its inherited height in 60 seeds");
+    }

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1638,3 +1638,69 @@
         assert!(saw_alt, "no injected Lakitu lifted to 0x12 in 60 seeds");
         assert!(saw_kept, "no injected Lakitu kept its inherited height in 60 seeds");
     }
+
+    /// The injection pick is weighted toward the Angry Sun over the (harder)
+    /// Lakitu: over many seeds, injected suns must clearly outnumber injected
+    /// Lakitu, and both must occur.
+    #[test]
+    fn wild_injection_favors_sun() {
+        use crate::randomize::node_catalog::NodeCatalog;
+        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
+
+        let Some(base) = load_reference_rom() else {
+            eprintln!("reference ROM not present — skipping wild_injection_favors_sun");
+            return;
+        };
+        let len = ENEMY_DATA_END - ENEMY_DATA_START;
+        let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
+        let catalog = NodeCatalog::build(&base, false);
+
+        let first_idx = |obj_ptr: u16, data: &[u8]| -> Option<usize> {
+            if obj_ptr < 0xC000 {
+                return None;
+            }
+            let fo = enemy_ptr_to_file_offset(obj_ptr);
+            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&fo) {
+                return None;
+            }
+            let p = fo - ENEMY_DATA_START;
+            if p >= data.len() {
+                return None;
+            }
+            let first = if matches!(data[p], 0x00 | 0x01) { p + 1 } else { p };
+            if first >= data.len() || data[first] == 0xFF {
+                return None;
+            }
+            Some(first)
+        };
+
+        let opts = Options { wild_injections: true, ..preset_recommended() };
+        let (mut suns, mut lakitus) = (0u32, 0u32);
+        for seed in 0..40u64 {
+            let mut rom = base.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom, &mut rng, &opts);
+            let patched = rom.read_range(ENEMY_DATA_START, len).to_vec();
+            for e in &catalog.entries {
+                let Some(le) = &e.level_entry else { continue };
+                let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
+                let Some(fi) = first_idx(obj_ptr, &patched) else { continue };
+                let pid = patched[fi];
+                let van_first = first_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
+                if van_first == Some(pid) {
+                    continue; // unchanged — vanilla-native, not injected
+                }
+                match pid {
+                    0xAF => suns += 1,
+                    0x83 => lakitus += 1,
+                    _ => {}
+                }
+            }
+        }
+        assert!(lakitus > 0, "no Lakitu injected at all across 40 seeds");
+        // 2:1 weighting over hundreds of samples — suns should clearly lead.
+        assert!(
+            suns > lakitus,
+            "expected sun-favored injection, got {suns} suns vs {lakitus} Lakitu"
+        );
+    }

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -26,24 +26,6 @@
         Rom::from_bytes_lax(&data, true).unwrap()
     }
 
-    /// Install a synthetic 9-byte level header at the start of the Plains
-    /// region whose `enemy_ptr` (header bytes 2-3) equals `ep`, followed
-    /// by an immediate `0xFF` terminator. Used by wild-injection tests so
-    /// the entry-point-driven injection pass treats `ep` as a real level
-    /// entry. Without this, the new injection pass has no entry points
-    /// pointing at the test segment and the test would never inject.
-    fn install_fake_entry_header(data: &mut [u8], ep: u16) {
-        let region_start = 0x1E512usize; // Plains (TS1) region start
-        data[region_start] = 0;
-        data[region_start + 1] = 0;
-        data[region_start + 2] = (ep & 0xFF) as u8;
-        data[region_start + 3] = ((ep >> 8) & 0xFF) as u8;
-        for k in 4..9 {
-            data[region_start + k] = 0;
-        }
-        data[region_start + 9] = 0xFF; // empty command stream
-    }
-
     fn make_test_rom() -> Rom {
         // A realistic enemy data segment: FF terminator, then a segment with
         // page flag + entries + FF. Entries MUST be sorted by ascending X
@@ -773,162 +755,6 @@
         assert_eq!(find_class_pool(0x51, &modes), Some(ClassPool::Wild));
     }
 
-    #[test]
-    fn test_wild_injection_occurs() {
-        // Run many seeds with wild_injections on, confirm at least one injection
-        let flags = Options {
-            wild_injections: true,
-            ..Options::default()
-        };
-        let mut data = blank_rom_image();
-        let seg = &[
-            0xFF, 0x01,
-            0x72, 0x10, 0x19, // Goomba
-            0x72, 0x20, 0x19, // Goomba
-            0x72, 0x30, 0x19, // Goomba
-            0x72, 0x40, 0x19, // Goomba
-            0xFF,
-        ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        // Make our synthetic segment a real entry point so the new
-        // entry-point-driven injection pass sees it. Page byte at +1.
-        install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
-
-        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
-        let mut saw_injection = false;
-        for seed in 0..2000u64 {
-            let mut rom_copy = rom.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom_copy, &mut rng, &flags);
-            for off in [2, 5, 8, 11] {
-                let id = rom_copy.read_byte(ENEMY_DATA_START + off);
-                if injection_ids.contains(&id) {
-                    saw_injection = true;
-                    break;
-                }
-            }
-            if saw_injection { break; }
-        }
-        assert!(saw_injection, "2000 seeds and never saw an injection");
-    }
-
-    #[test]
-    fn test_wild_injection_respects_chr() {
-        // Pre-commit slot 4 to an incompatible page via a non-swappable object.
-        let flags = Options {
-            wild_injections: true,
-            ..Options::default()
-        };
-        let mut data = blank_rom_image();
-        let seg = &[
-            0xFF, 0x01,
-            0x18, 0x05, 0x10, // Bowser (slot 4, page 0x3A — incompatible with all injections)
-            0x72, 0x10, 0x19, // Goomba
-            0x72, 0x20, 0x19, // Goomba
-            0xFF,
-        ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
-
-        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
-        for seed in 0..500u64 {
-            let mut rom_copy = rom.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom_copy, &mut rng, &flags);
-            assert_eq!(rom_copy.read_byte(ENEMY_DATA_START + 2), 0x18);
-            for off in [5, 8] {
-                let id = rom_copy.read_byte(ENEMY_DATA_START + off);
-                assert!(
-                    !injection_ids.contains(&id),
-                    "seed {seed}: injection 0x{id:02X} despite slot 4 conflict"
-                );
-            }
-        }
-    }
-
-    /// An injected Angry Sun must be re-seeded to the vanilla screen-0 spawn
-    /// (SUN_SPAWN_X/Y), not left at the replaced enemy's inherited position.
-    /// The sun idles in the background until its screen counter hits the attack
-    /// threshold; the Early Sun QoL patch moves that threshold to screen 0, so a
-    /// sun spawned on any later screen never fires (and a stuck sun blocks the
-    /// level goal card). The replaced entries[0] here sits deep at screen 5.
-    #[test]
-    fn test_injected_sun_repositioned_to_screen0() {
-        let flags = Options {
-            wild_injections: true,
-            ..Options::default()
-        };
-        let mut data = blank_rom_image();
-        // First (leftmost) enemy sits deep at screen 5; slot-5 Goombas keep
-        // slot 4 free so the sun (0x32/+4) is CHR-compatible and injectable.
-        let seg = &[
-            0xFF, 0x01,
-            0x72, 0x58, 0x19, // Goomba at screen 5 — the entries[0] a sun replaces
-            0x72, 0x62, 0x19, // Goomba
-            0x72, 0x70, 0x19, // Goomba
-            0xFF,
-        ];
-        data[ENEMY_DATA_START..ENEMY_DATA_START + seg.len()].copy_from_slice(seg);
-        install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
-
-        let mut saw_sun = false;
-        for seed in 0..2000u64 {
-            let mut rom_copy = rom.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom_copy, &mut rng, &flags);
-            if rom_copy.read_byte(ENEMY_DATA_START + 2) == ANGRY_SUN_ID {
-                saw_sun = true;
-                assert_eq!(
-                    rom_copy.read_byte(ENEMY_DATA_START + 3), SUN_SPAWN_X,
-                    "seed {seed}: injected sun X not re-seeded to screen 0"
-                );
-                assert_eq!(
-                    rom_copy.read_byte(ENEMY_DATA_START + 4), SUN_SPAWN_Y,
-                    "seed {seed}: injected sun Y not re-seeded"
-                );
-            }
-        }
-        assert!(saw_sun, "2000 seeds and never injected a sun to verify reposition");
-    }
-
-    /// Wild injection must never place a level-wide chaser into a segment that
-    /// holds a Boom-Boom, even when entries[0] is otherwise a valid target.
-    #[test]
-    fn test_no_injection_in_boomboom_segment() {
-        let flags = Options {
-            wild_injections: true,
-            ..Options::default()
-        };
-        let mut data = blank_rom_image();
-        let seg = &[
-            0xFF, 0x01,
-            0x72, 0x10, 0x19, // Goomba — a valid injectable entries[0]
-            0x4B, 0x20, 0x19, // Boom-Boom lives in this level
-            0x72, 0x30, 0x19, // Goomba
-            0xFF,
-        ];
-        data[ENEMY_DATA_START..ENEMY_DATA_START + seg.len()].copy_from_slice(seg);
-        install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
-
-        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
-        for seed in 0..1000u64 {
-            let mut rom_copy = rom.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom_copy, &mut rng, &flags);
-            let id = rom_copy.read_byte(ENEMY_DATA_START + 2);
-            assert!(
-                !injection_ids.contains(&id),
-                "seed {seed}: injected 0x{id:02X} into a Boom-Boom segment"
-            );
-        }
-    }
-
     /// A vanilla Lakitu (out-of-pool chaser) must pin its CHR page for the
     /// WHOLE level, not just its own proximity group — it follows the player
     /// across every group (see CHASER_IDS).
@@ -1041,101 +867,6 @@
         );
     }
 
-    /// Install two fake level headers so both eps are entry points: the outer
-    /// level's run starts at the segment head and reads straight through the
-    /// inner ep.
-    fn install_two_entry_headers(data: &mut [u8], ep_a: u16, ep_b: u16) {
-        let region_start = 0x1E512usize; // Plains (TS1) region start
-        let mut pos = region_start;
-        for ep in [ep_a, ep_b] {
-            data[pos] = 0;
-            data[pos + 1] = 0;
-            data[pos + 2] = (ep & 0xFF) as u8;
-            data[pos + 3] = ((ep >> 8) & 0xFF) as u8;
-            for k in 4..9 {
-                data[pos + k] = 0;
-            }
-            data[pos + 9] = 0xFF; // empty command stream
-            pos += 10;
-        }
-    }
-
-    /// The injection pin-scan must cover the whole $FF-bounded segment, not
-    /// just the ep's own run: an outer level reads straight through the inner
-    /// ep, so its pinned pages constrain the injected chaser too.
-    #[test]
-    fn test_injection_pin_scan_covers_outer_prefix() {
-        let flags = Options {
-            wild_injections: true,
-            ..Options::default()
-        };
-        let injection_ids: &[u8] = &[0x83, 0xAF, 0x2D];
-
-        // Outer ep → page byte at +1; inner ep → the Goomba entry at +5
-        // (entries-only form). The Thwomp sits BEFORE the inner ep — only the
-        // outer level sees it — and pins slot 4 to $12, which conflicts with
-        // every injection id (all slot 4: $0B / $32 / $1A).
-        let mut data = blank_rom_image();
-        let seg = &[
-            0xFF, 0x01,
-            0x8A, 0x05, 0x10, // Thwomp ($12/+4), class off by default → pinned
-            0x72, 0x10, 0x19, // Goomba (inner level's first entry)
-            0xFF,
-        ];
-        data[ENEMY_DATA_START..ENEMY_DATA_START + seg.len()].copy_from_slice(seg);
-        install_two_entry_headers(
-            &mut data,
-            (ENEMY_DATA_START + 1) as u16,
-            (ENEMY_DATA_START + 5) as u16,
-        );
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
-        for seed in 0..500u64 {
-            let mut rom_copy = rom.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom_copy, &mut rng, &flags);
-            let id = rom_copy.read_byte(ENEMY_DATA_START + 5);
-            assert!(
-                !injection_ids.contains(&id),
-                "seed {seed}: chaser 0x{id:02X} injected at the inner ep despite \
-                 the Thwomp ($12/+4) in the outer level's prefix"
-            );
-        }
-
-        // Positive control: swap the Thwomp for a slot-5 pin (wood block,
-        // $13/+5). All injection ids are slot 4, so injections must still
-        // land at the inner ep in some seeds — the wider pin-scan must not
-        // over-block.
-        let mut data2 = blank_rom_image();
-        let seg2 = &[
-            0xFF, 0x01,
-            0x2E, 0x05, 0x10, // Wood block ($13/+5), out-of-pool → pinned
-            0x72, 0x10, 0x19, // Goomba (inner level's first entry)
-            0xFF,
-        ];
-        data2[ENEMY_DATA_START..ENEMY_DATA_START + seg2.len()].copy_from_slice(seg2);
-        install_two_entry_headers(
-            &mut data2,
-            (ENEMY_DATA_START + 1) as u16,
-            (ENEMY_DATA_START + 5) as u16,
-        );
-        let rom2 = Rom::from_bytes_lax(&data2, true).unwrap();
-        let mut saw = false;
-        for seed in 0..500u64 {
-            let mut rom_copy = rom2.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom_copy, &mut rng, &flags);
-            if injection_ids.contains(&rom_copy.read_byte(ENEMY_DATA_START + 5)) {
-                saw = true;
-                break;
-            }
-        }
-        assert!(
-            saw,
-            "pin-scan over-blocks: no injection at the inner ep in 500 seeds \
-             with only a slot-5 pin present"
-        );
-    }
-
     #[test]
     fn test_chr_groups_split_distant_enemies() {
         // Two enemies far apart (screen 0 vs screen 5) should get independent
@@ -1229,49 +960,6 @@
         let groups = chr_groups(&entries);
         assert_eq!(groups.len(), 1, "all within gap — one group");
         assert_eq!(groups[0].len(), 3);
-    }
-
-    #[test]
-    fn test_boss_bass_capped_per_segment() {
-        // Build a segment full of water enemies. With water=Wild and
-        // wild_injections on, the segment should never end up with more
-        // than MAX_BERTHA_PER_SEGMENT (2) Boss Bass across all sources.
-        let flags = Options {
-            water: EnemyMode::Wild,
-            wild_injections: true,
-            ..Options::default()
-        };
-        let mut data = blank_rom_image();
-        // 6 water enemies clustered close together (so they share one CHR group)
-        let seg = &[
-            0xFF, 0x01,
-            0x62, 0x02, 0x10, // Blooper
-            0x62, 0x04, 0x10, // Blooper
-            0x62, 0x06, 0x10, // Blooper
-            0x62, 0x08, 0x10, // Blooper
-            0x62, 0x0A, 0x10, // Blooper
-            0x62, 0x0C, 0x10, // Blooper
-            0xFF,
-        ];
-        let start = ENEMY_DATA_START;
-        data[start..start + seg.len()].copy_from_slice(seg);
-        install_fake_entry_header(&mut data, (ENEMY_DATA_START + 1) as u16);
-        let rom = Rom::from_bytes_lax(&data, true).unwrap();
-
-        let entry_offsets = [2usize, 5, 8, 11, 14, 17];
-        for seed in 0..2000u64 {
-            let mut rom_copy = rom.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom_copy, &mut rng, &flags);
-            let bertha_count = entry_offsets.iter()
-                .filter(|&&off| BERTHA_IDS.contains(&rom_copy.read_byte(ENEMY_DATA_START + off)))
-                .count();
-            assert!(
-                bertha_count <= MAX_BERTHA_PER_SEGMENT as usize,
-                "seed {seed}: {bertha_count} Big Bertha in segment, cap is {}",
-                MAX_BERTHA_PER_SEGMENT
-            );
-        }
     }
 
     /// Regression: at the exact ROM offsets where `disable_autoscroll`
@@ -1381,31 +1069,39 @@
 
     /// The deterministic set of enemy-data offsets (relative to ENEMY_DATA_START)
     /// that the wild-injection pass may overwrite: the first real entry of each
-    /// non-blocked, non-class-protected, swappable entry point. Mirrors
-    /// inject_at_entry_points' target selection. RNG decides *whether* a slot is
-    /// injected, but the candidate set is fixed.
+    /// `NodeKind::Level` whose first enemy is swappable and unprotected. Mirrors
+    /// `inject_wild_chasers`' candidate selection. RNG decides *whether* a slot
+    /// is injected, but the candidate set is fixed.
     fn injectable_offsets(
         base: &Rom,
         vanilla: &[u8],
         modes: &ClassModes,
     ) -> std::collections::HashSet<usize> {
+        use crate::randomize::node_catalog::{NodeCatalog, NodeKind};
+        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
         let mut set = std::collections::HashSet::new();
-        for ep in enemy_entry_points(base) {
-            let ep = ep as usize;
-            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&ep) {
+        let catalog = NodeCatalog::build(base, false);
+        for e in &catalog.entries {
+            if !matches!(e.kind, NodeKind::Level) {
                 continue;
             }
-            if is_injection_blocked(ep as u16) {
+            let Some(le) = &e.level_entry else { continue };
+            let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
+            if obj_ptr < 0xC000 {
                 continue;
             }
-            let ep_local = ep - ENEMY_DATA_START;
-            if ep_local >= vanilla.len() {
+            let file_off = enemy_ptr_to_file_offset(obj_ptr);
+            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&file_off) {
                 continue;
             }
-            let first = if matches!(vanilla[ep_local], 0x00 | 0x01) {
-                ep_local + 1
+            let page_idx = file_off - ENEMY_DATA_START;
+            if page_idx >= vanilla.len() {
+                continue;
+            }
+            let first = if matches!(vanilla[page_idx], 0x00 | 0x01) {
+                page_idx + 1
             } else {
-                ep_local
+                page_idx
             };
             if first >= vanilla.len() || vanilla[first] == 0xFF {
                 continue;
@@ -1754,4 +1450,122 @@
                  cannonball family fits beside a $37/+5 fire jet"
             );
         }
+    }
+
+    /// End-to-end guarantees of the level-centric wild-injection rework against
+    /// the real ROM: injections happen; every injected sun spawns on screen 0;
+    /// no boss level (fortress / airship / Bowser) receives a chaser; and a
+    /// level is never given a chaser it already has (the 2-Quicksand double).
+    #[test]
+    fn wild_injection_rework_guarantees() {
+        use crate::randomize::node_catalog::{NodeCatalog, NodeKind};
+        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
+        const INJ: [u8; 3] = [0x83, 0xAF, 0x2D];
+
+        let Some(base) = load_reference_rom() else {
+            eprintln!("reference ROM not present — skipping wild_injection_rework_guarantees");
+            return;
+        };
+        let len = ENEMY_DATA_END - ENEMY_DATA_START;
+        let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
+        let catalog = NodeCatalog::build(&base, false);
+
+        // First-enemy data index for a level's obj_ptr (after any page byte).
+        let first_idx = |obj_ptr: u16, data: &[u8]| -> Option<usize> {
+            if obj_ptr < 0xC000 {
+                return None;
+            }
+            let fo = enemy_ptr_to_file_offset(obj_ptr);
+            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&fo) {
+                return None;
+            }
+            let p = fo - ENEMY_DATA_START;
+            if p >= data.len() {
+                return None;
+            }
+            let first = if matches!(data[p], 0x00 | 0x01) { p + 1 } else { p };
+            if first >= data.len() || data[first] == 0xFF {
+                return None;
+            }
+            Some(first)
+        };
+        // Count occurrences of `id` across a level's first $FF run.
+        let run_count = |obj_ptr: u16, data: &[u8], id: u8| -> usize {
+            let Some(mut i) = first_idx(obj_ptr, data) else {
+                return 0;
+            };
+            let mut n = 0;
+            while i + 2 < data.len() && data[i] != 0xFF {
+                if data[i] == id {
+                    n += 1;
+                }
+                i += 3;
+            }
+            n
+        };
+
+        let opts = Options { wild_injections: true, ..preset_recommended() };
+        let mut saw_injection = false;
+        for seed in 0..30u64 {
+            let mut rom = base.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom, &mut rng, &opts);
+            let patched = rom.read_range(ENEMY_DATA_START, len).to_vec();
+
+            for e in &catalog.entries {
+                let Some(le) = &e.level_entry else { continue };
+                let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
+                let Some(fi) = first_idx(obj_ptr, &patched) else { continue };
+                let pid = patched[fi];
+                let van_first = first_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
+
+                // Boss levels are excluded by type — a chaser at their first
+                // enemy can only be a vanilla-native one, never injected.
+                if matches!(
+                    e.kind,
+                    NodeKind::Fortress { .. } | NodeKind::Airship | NodeKind::Bowser
+                ) {
+                    if INJ.contains(&pid) {
+                        assert_eq!(
+                            Some(pid), van_first,
+                            "seed {seed}: boss level {} got chaser 0x{pid:02X}", e.name
+                        );
+                    }
+                    continue;
+                }
+                if !matches!(e.kind, NodeKind::Level) {
+                    continue;
+                }
+
+                // An injected chaser (first enemy changed to a chaser).
+                let injected_here = INJ.contains(&pid) && van_first != Some(pid);
+                if injected_here {
+                    saw_injection = true;
+                    // Suns must spawn on screen 0.
+                    if pid == 0xAF {
+                        assert_eq!(
+                            patched[fi + 1], SUN_SPAWN_X,
+                            "seed {seed}: injected sun in {} not at screen 0", e.name
+                        );
+                        assert_eq!(
+                            patched[fi + 2], SUN_SPAWN_Y,
+                            "seed {seed}: injected sun in {} wrong Y", e.name
+                        );
+                    }
+                }
+
+                // No-double: a chaser the level already had is never added again
+                // (walker never creates chasers, so any increase is injection).
+                for &c in &INJ {
+                    let van = run_count(obj_ptr, &vanilla, c);
+                    if van > 0 {
+                        assert!(
+                            run_count(obj_ptr, &patched, c) <= van,
+                            "seed {seed}: {} doubled chaser 0x{c:02X}", e.name
+                        );
+                    }
+                }
+            }
+        }
+        assert!(saw_injection, "30 seeds and never saw a chaser injected into a level");
     }

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1460,7 +1460,7 @@
     fn wild_injection_rework_guarantees() {
         use crate::randomize::node_catalog::{NodeCatalog, NodeKind};
         use crate::randomize::rom_data::enemy_ptr_to_file_offset;
-        const INJ: [u8; 3] = [0x83, 0xAF, 0x2D];
+        const INJ: [u8; 2] = [0x83, 0xAF]; // Lakitu + Angry Sun (Boss Bass dropped)
 
         let Some(base) = load_reference_rom() else {
             eprintln!("reference ROM not present — skipping wild_injection_rework_guarantees");

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -10,9 +10,9 @@
 //!
 //! Adding a new protection is one block here with a label and a reason.
 //! Both passes (the walker in `enemies::randomize_object_data` and
-//! `enemies::inject_at_entry_points`) consume the registry through the
-//! derived helpers (`entry_protection_at`, `is_injection_blocked`,
-//! `walker_segment_rule_at`) — never the table directly.
+//! `enemies::inject_wild_chasers`) consume the registry through the
+//! derived helpers (`entry_protection_at`, `walker_segment_rule_at`)
+//! — never the table directly.
 
 use super::rom_data::enemy_ptr_to_file_offset;
 
@@ -303,15 +303,6 @@ pub(super) fn entry_protection_at(file_offset: usize) -> Option<EntryProtection>
         .iter()
         .flat_map(|l| l.entries)
         .find_map(|e| (e.offset == file_offset).then_some(e.rule))
-}
-
-/// True if `wild_injection` should not fire at this entry_ptr. Any row with a
-/// non-`Default` walker rule blocks injection too — `Skip` and `HammerBro`
-/// segments both override or replace the player-visible enemy choice.
-pub(super) fn is_injection_blocked(enemy_ptr: u16) -> bool {
-    LEVEL_PROTECTIONS
-        .iter()
-        .any(|l| l.enemy_ptr == enemy_ptr && l.walker_segment != WalkerSegmentRule::Default)
 }
 
 /// Walker rule for the segment whose page byte sits at this absolute file


### PR DESCRIPTION
Reworks the wild-injection pass from raw enemy pointers to a **level-centric** design driven by `node_catalog`. Addresses the structural problems we found: fixed pool, boss-room injection, chaser doubling, shared-pointer collateral, and an offset-frame mismatch.

## What changed
- **Boss levels excluded by type** (`NodeKind::Fortress`/`Airship`/`Bowser`) — a chaser can no longer land in a boss room. The old per-segment `0x4B/0x4C` scan couldn't see a fortress boss that lives in a *sibling* segment (4F2, 7F2 slipped through).
- **No-double guard** (`has_enemy_id`) — a level is never given a chaser it already has. Fixes a second Angry Sun stacking onto **2-Quicksand** and breaking it.
- **Shared enemy sets inject once** (3-1 / 7-2 share a pointer).
- **Correct frame** — uses `obj_ptr` + `enemy_ptr_to_file_offset` (verified against 1-1 → file `0xC538`). The old path indexed raw header pointers **0x10 early**, writing to the wrong location (a likely source of corruption).
- **Suns still spawn on screen 0** (unchanged — confirmed necessary).

## Removed / retained
- Removed: old `inject_at_entry_points`, the per-segment Boom-Boom byte scan, and `is_injection_blocked` (its only user).
- Retained: `enemy_entry_points` (used by `chr_stats`). `injectable_offsets` (the `enemy_invariant_baseline` oracle) now mirrors the catalog-based candidate set.

## Verification
- New `wild_injection_rework_guarantees` (real ROM, 30 seeds): injections occur, every injected sun is on screen 0, no fortress/airship/Bowser gets a chaser, no level is doubled.
- `enemy_invariant_baseline` + `chr_page_stats` green. Full suite (268) + clippy clean.
- End-to-end: injected suns land at correct level offsets (e.g. `0xc538` = 1-1's real enemy data), 2-Quicksand preserved.

## Known limitations (see `docs/wild_injection_rework.md`)
- Variety is random *selection* over a fixed candidate set; making the set itself vary per seed would need injection to run after the enemy shuffle.
- Only the level's main-area first enemy is targeted (no sub-areas).
- Rate (~40%) now applies per candidate level; may warrant re-measuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)