### PR TITLE
feature: Remove Flashing visual option + always-on Tail Enemies stay-dead fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Added
+
+- **Remove Flashing** (MaCobra52): a Visual option that suppresses the
+  full-screen palette flash/fade animation for photosensitive-safe play. On by
+  default; not encoded in the flag key and consumes no RNG. Turn it off with
+  `--keep-flashing` on the CLI.
+
+### Fixed
+
+- **Tail Enemies don't respawn** (MaCobra52, always on): enemies defeated by the
+  Raccoon/Tanooki tail are now recorded in the level's persistent kill memory,
+  so they no longer respawn when scrolled off-screen and back.
+
 ## [0.12.2] - 2026-07-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-07-16
+
 ### Added
 
 - **Remove Flashing** (MaCobra52): a Visual option that suppresses the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 
 [lib]

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,11 @@ struct Cli {
     #[arg(long)]
     no_palettes: bool,
 
+    /// Keep the full-screen flash/fade animation (the "Remove Flashing"
+    /// accessibility patch is on by default). Cosmetic; not in the flag key.
+    #[arg(long)]
+    keep_flashing: bool,
+
     /// Recolor levels, enemies, and world maps with a random theme (world
     /// colors). Independent of player colors.
     /// Cosmetic; not encoded in the flag key.
@@ -457,6 +462,11 @@ fn build_options(cli: &Cli) -> Options {
                 if cli.player_color.is_some() {
                     opts.player_color = cli.player_color;
                 }
+                // remove_flashing is a cosmetic/accessibility default-on option,
+                // not in the flag key; --keep-flashing overlays it off.
+                if cli.keep_flashing {
+                    opts.remove_flashing = false;
+                }
                 // Same for skip_rom_validation — a property of the input ROM.
                 if cli.skip_rom_validation {
                     opts.skip_rom_validation = true;
@@ -474,6 +484,7 @@ fn build_options(cli: &Cli) -> Options {
             palettes: !cli.no_palettes,
             palette_themed: cli.themed_palettes,
             player_color: cli.player_color,
+            remove_flashing: !cli.keep_flashing,
             world_order: cli.world_order,
             world_count: cli.world_count,
             big_q_blocks: cli.big_q_blocks,
@@ -544,6 +555,7 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
         (true, Some(c)) => format!("${c:02X}"),
     });
     eprintln!("  World colors: {}", if options.palette_themed { "themed" } else { "vanilla" });
+    eprintln!("  Remove flashing: {}", if options.remove_flashing { "on" } else { "off" });
     eprintln!("  Enemies:  {}", if options.any_enemies_active() { "on" } else { "off" });
     eprintln!("  World order: {}", if options.world_order { "on" } else { "off" });
     if options.world_order && options.world_count < 7 {

--- a/src/randomize/qol/macobra.rs
+++ b/src/randomize/qol/macobra.rs
@@ -1,7 +1,7 @@
 //! MaCobra52 patch bundle: always-on bugfixes plus opt-in feature patches.
 
 use crate::rom::Rom;
-use crate::randomize::rom_data::{FS_FASTER_FROG, FS_HOLD_LEFT_HELPER};
+use crate::randomize::rom_data::{FS_FASTER_FROG, FS_HOLD_LEFT_HELPER, FS_TAIL_STAY_DEAD};
 
 // ---------------------------------------------------------------------------
 // MaCobra patches — always-on bundle
@@ -128,6 +128,25 @@ const HOLD_LEFT_RETARGETS: &[(usize, &[u8])] = &[
 const HOLD_LEFT_TAIL_OFFSET: usize = 0x111D4;
 const HOLD_LEFT_TAIL_BYTES: [u8; 12] =
     [0x07, 0xA9, 0x00, 0x85, 0x12, 0x20, 0x18, 0xC9, 0xA5, 0xAB, 0xF0, 0x38];
+
+// Tail Enemies don't respawn (by MaCobra52) — "SMB3 - Tail Enemies don't
+// respawn.ips". Bug: an enemy defeated by the Raccoon/Tanooki tail (or spin)
+// is only flagged dead in its on-screen slot ($0520,X), not in the level's
+// persistent kill memory, so scrolling it off and back respawns it. The fix
+// is two writes verified byte-for-byte against the IPS on USA Rev1:
+//
+//   1. An 8-byte routine dropped into a dead gap in PRG003 at CPU $A5F9
+//      (FS_TAIL_STAY_DEAD, file 0x06609 — between the `RTS` at 0x06608 and the
+//      routine at 0x06611):
+//          LDA #$FF          ; a9 ff
+//          STA $0659,X       ; 9d 59 06   persistent "stay dead" flag
+//          JMP $BA0B         ; 4c 0b ba   continue the vanilla defeat path
+//   2. The tail-defeat handler's `JMP $BA0B` (file 0x07E49) is retargeted to
+//      `JMP $A5F9` by rewriting its operand (file 0x07E4A: 0b ba -> f9 a5), so
+//      the new routine runs first and then falls through to the original code.
+const TAIL_STAY_DEAD_ROUTINE: [u8; 8] = [0xA9, 0xFF, 0x9D, 0x59, 0x06, 0x4C, 0x0B, 0xBA];
+const TAIL_STAY_DEAD_HOOK_OFFSET: usize = 0x07E4A;
+const TAIL_STAY_DEAD_HOOK_BYTES: [u8; 2] = [0xF9, 0xA5]; // JMP $A5F9 operand
 
 // ---------------------------------------------------------------------------
 // MaCobra patches — opt-in features
@@ -356,6 +375,58 @@ pub fn apply_no_game_over_penalty(rom: &mut Rom) {
     rom.write_range(NGO_NOP_OFFSET, &NGO_NOP_BYTES);
 }
 
+// Remove Flashing (by MaCobra52) — "SMB3 - Remove Flashing.ips". Suppresses
+// the full-screen palette-flash/fade animation (the rapid color strobing used
+// on some transitions and effects) to make the game safer for photosensitive
+// players. Eight writes, reproduced byte-for-byte from the IPS and verified
+// against USA Rev1. The core mechanism:
+//
+//   * The fade routine's per-color palette writes (`STA $0301,X` … `STA $030C,X`)
+//     are all redirected to a scratch address (`STA $0379,X`), so the computed
+//     flash colors are never committed to the active palette RAM.
+//   * The fade-index load `LDX $0300` is pinned to `LDX #$01` (+ NOP) so the
+//     animation no longer cycles.
+//   * Three single-byte tweaks (0x149F0, 0x1634E: 0x16->0x1F; 0x361B9:
+//     0x16->0x0F) in the related banks complete the effect.
+//
+// Cosmetic / accessibility only — not encoded in the flag key and consumes no
+// RNG. The IPS records are non-contiguous because it only overwrites the bytes
+// that differ from vanilla, so each record is reproduced as its own write.
+const REMOVE_FLASHING_WRITES: &[(usize, &[u8])] = &[
+    (0x0E19F, &[0xA2, 0x01, 0xEA]),
+    (
+        0x0E1BB,
+        &[
+            0x79, 0x03, 0xA9, 0x04, 0x9D, 0x79, 0x03, 0xA9, 0x08, 0x9D, 0x79, 0x03, 0xB9, 0x8B,
+            0xA1, 0x9D, 0x79, 0x03, 0x9D, 0x79, 0x03, 0x9D, 0x79, 0x03, 0x9D, 0x79, 0x03, 0xAD,
+            0xC5, 0x07, 0x9D, 0x79, 0x03, 0xAD, 0xC9, 0x07, 0x9D, 0x79, 0x03, 0xAD, 0xCB, 0x07,
+            0x9D, 0x79, 0x03, 0xAD, 0xCC, 0x07, 0x9D, 0x79, 0x03, 0xA9, 0x00, 0x9D, 0x79,
+        ],
+    ),
+    (0x0E1F8, &[0x79]),
+    (
+        0x0E209,
+        &[
+            0x79, 0x03, 0xA9, 0x10, 0x9D, 0x79, 0x03, 0xAD, 0xD2, 0x07, 0x9D, 0x79, 0x03, 0xAD,
+            0xD3, 0x07, 0x9D, 0x79, 0x03, 0xAD, 0xD4, 0x07, 0x9D, 0x79, 0x03, 0xA9, 0x3F, 0x9D,
+            0x79, 0x03, 0xA9, 0x04, 0x9D, 0x79, 0x03, 0xA9, 0x00, 0x9D, 0x79,
+        ],
+    ),
+    (0x0E236, &[0x79]),
+    (0x149F0, &[0x1F]),
+    (0x1634E, &[0x1F]),
+    (0x361B9, &[0x0F]),
+];
+
+/// Apply MaCobra52's "Remove Flashing" patch — suppresses the full-screen
+/// palette-flash/fade animation for photosensitive-safe play. Cosmetic /
+/// accessibility option; not in the flag key and uses no RNG.
+pub fn apply_remove_flashing(rom: &mut Rom) {
+    for &(offset, bytes) in REMOVE_FLASHING_WRITES {
+        rom.write_range(offset, bytes);
+    }
+}
+
 /// Apply MaCobra's always-on bugfixes and fairness patches.
 pub fn apply_macobra_patches(rom: &mut Rom) {
     // Prevent forced hammer bro fights (4 NOPs)
@@ -387,6 +458,11 @@ pub fn apply_macobra_patches(rom: &mut Rom) {
     rom.write_byte(HOTFOOT_TAIL_A, 0x00);
     rom.write_byte(HOTFOOT_TAIL_B, 0x00);
     rom.write_byte(HOTFOOT_TAIL_C, 0x25);
+
+    // Tail Enemies don't respawn: mark tail-defeated enemies dead in the
+    // level's persistent kill memory so they stay dead across scrolling.
+    rom.write_range(FS_TAIL_STAY_DEAD, &TAIL_STAY_DEAD_ROUTINE);
+    rom.write_range(TAIL_STAY_DEAD_HOOK_OFFSET, &TAIL_STAY_DEAD_HOOK_BYTES);
 
     // NOTE: MaCobra's "Bros don't stop on hands" (issue #14) used to live
     // here; it is subsumed by the overworld writer's march-veto trampoline
@@ -496,6 +572,37 @@ mod tests {
         let before = rom.read_range(0x17435, 3).to_vec();
         apply_macobra_patches(&mut rom);
         assert_eq!(rom.read_range(0x17435, 3), &before[..]);
+    }
+
+    #[test]
+    fn test_macobra_tail_stay_dead_writes() {
+        let mut rom = make_test_rom();
+        apply_macobra_patches(&mut rom);
+
+        // Routine lands in the PRG003 gap, and the defeat-handler JMP operand
+        // is retargeted to it ($A5F9).
+        assert_eq!(
+            rom.read_range(FS_TAIL_STAY_DEAD, TAIL_STAY_DEAD_ROUTINE.len()),
+            &TAIL_STAY_DEAD_ROUTINE
+        );
+        assert_eq!(
+            rom.read_range(TAIL_STAY_DEAD_HOOK_OFFSET, TAIL_STAY_DEAD_HOOK_BYTES.len()),
+            &TAIL_STAY_DEAD_HOOK_BYTES
+        );
+        // The retarget must name the routine's CPU address: PRG003 maps to
+        // $A000, so CPU = $A000 + (FS_TAIL_STAY_DEAD - 0x06010).
+        let routine_cpu = (0xA000 + (FS_TAIL_STAY_DEAD - 0x06010)) as u16;
+        assert_eq!(routine_cpu, 0xA5F9);
+        assert_eq!(u16::from_le_bytes(TAIL_STAY_DEAD_HOOK_BYTES), routine_cpu);
+    }
+
+    #[test]
+    fn test_remove_flashing_writes() {
+        let mut rom = make_test_rom();
+        apply_remove_flashing(&mut rom);
+        for &(offset, bytes) in REMOVE_FLASHING_WRITES {
+            assert_eq!(rom.read_range(offset, bytes.len()), bytes);
+        }
     }
 
     #[test]

--- a/src/randomize/qol/mod.rs
+++ b/src/randomize/qol/mod.rs
@@ -18,7 +18,7 @@ pub use hammer_breaks::hammer_breaks_tiles;
 pub use macobra::{
     apply_early_sun, apply_fast_mushroom_house, apply_faster_frog, apply_faster_tail_speed,
     apply_infinite_mushroom_houses, apply_japanese_damage, apply_limit_bro_movement,
-    apply_macobra_patches, apply_no_game_over_penalty,
+    apply_macobra_patches, apply_no_game_over_penalty, apply_remove_flashing,
 };
 pub use overworld_map::{
     apply_w8_bridges, apply_w8_canoe_and_paths, fix_w3_drawbridges, make_hammer_rocks,

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -38,6 +38,7 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x03FD0, 22, "koopa_y_clamp: clamp Koopaling Y position to screen"),
     (0x03FE6, 36, "fire_flower: position-hash suit routine + pool table"),
     // PRG003 (file 0x06010, CPU $A000–$BFFF) — object AI bank (Boom-Boom lives here)
+    (0x06609, 8, "tail_stay_dead: MaCobra respawn-suppress routine (CPU $A5F9 gap)"),
     (0x07FCF, 16, "boomboom_hits: per-fortress threshold table"),
     (0x07FDF, 44, "boomboom_hits: decoupled stomp-count subroutine"),
     // PRG006 (file 0x0C010, CPU $C000–$DFFF) — level enemy data bank
@@ -213,6 +214,12 @@ pub(crate) const KOOPA_FIRE_PRESET_CPU: u16  = 0xB84E;  // $A000 + (0x0385E - 0x
 // bank-local. Both allocations sit in the bank-end filler gap ($BFBF–$BFFF).
 //
 // Layout: 16-byte threshold table first, then the 44-byte subroutine.
+// PRG003 8-byte dead gap between an RTS (file 0x06608) and the routine that
+// starts at file 0x06611. MaCobra's "Tail Enemies don't respawn" fix drops an
+// 8-byte respawn-suppress routine here, reached by a bank-local `JMP $A5F9`
+// (see macobra.rs TAIL_STAY_DEAD_*).
+pub(crate) const FS_TAIL_STAY_DEAD: usize = 0x06609; // 8 bytes (CPU $A5F9)
+
 pub(crate) const FS_BOOMBOOM_HITS_TABLE: usize = 0x07FCF; // 16 bytes (CPU $BFBF)
 
 pub(crate) const BOOMBOOM_HITS_TABLE_CPU: u16  = 0xBFBF;  // $A000 + (0x07FCF - 0x06010)
@@ -291,6 +298,7 @@ mod free_space_tests {
             (FS_KOOPA_FIRE_PRESET, "FS_KOOPA_FIRE_PRESET"),
             (FS_KOOPA_Y_CLAMP, "FS_KOOPA_Y_CLAMP"),
             (FS_FIRE_FLOWER, "FS_FIRE_FLOWER"),
+            (FS_TAIL_STAY_DEAD, "FS_TAIL_STAY_DEAD"),
             (FS_BOOMBOOM_HITS_TABLE, "FS_BOOMBOOM_HITS_TABLE"),
             (FS_BOOMBOOM_HITS_SUB, "FS_BOOMBOOM_HITS_SUB"),
             (FS_HAND_ROOMS, "FS_HAND_ROOMS"),

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -310,6 +310,7 @@ impl Options {
             palettes: true,
             palette_themed: false, // cosmetic — not encoded in flag key
             player_color: None,    // cosmetic — not encoded in flag key
+            remove_flashing: true, // cosmetic/accessibility — not encoded in flag key
             hammer_breaks_locks: dtri((b1 >> 6) & 1 != 0, b11 & 1 != 0),
             koopaling_hits: (b1 >> 5) & 1 != 0,
             boomboom_hits: (b2 >> 3) & 1 != 0,

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -471,6 +471,14 @@ fn randomize_inner(
     rom.set_tag("qol/macobra");
     randomize::qol::apply_macobra_patches(rom);
 
+    // MaCobra52's "Remove Flashing" — suppress the palette-flash animation for
+    // photosensitive-safe play. On by default; accessibility/cosmetic option,
+    // not in the flag key and consumes no RNG.
+    if options.remove_flashing {
+        rom.set_tag("qol/remove_flashing");
+        randomize::qol::apply_remove_flashing(rom);
+    }
+
     // Faster Frog — speeds up Frog-Suit swimming. MUST run after
     // apply_macobra_patches: two of its writes patch inside the tail-swim
     // routine that macobra writes unconditionally, so it has to layer on top.

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -134,6 +134,12 @@ pub struct Options {
     /// Only takes effect while `palettes` is on.
     #[serde(default)]
     pub player_color: Option<u8>,
+    /// Remove the full-screen palette-flash/fade animation (MaCobra52's
+    /// "Remove Flashing" patch) so photosensitive players aren't exposed to
+    /// the strobing. On by default. Accessibility / cosmetic — not encoded in
+    /// the flag key and consumes no RNG.
+    #[serde(default = "default_true")]
+    pub remove_flashing: bool,
     #[serde(default)]
     pub world_order: bool,
     /// Number of worlds before Dark Land (1–7, default 7).
@@ -382,6 +388,7 @@ impl Default for Options {
             palettes: true,
             palette_themed: false,
             player_color: None,
+            remove_flashing: true,
             world_order: false,
             world_count: default_world_count(),
             big_q_blocks: false,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -32,6 +32,7 @@ fn make_test_rom() -> Option<Rom> {
 fn normalized(mut o: Options) -> Options {
     o.palettes = true;
     o.palette_themed = false;
+    o.remove_flashing = true;
     o
 }
 
@@ -303,8 +304,9 @@ fn flag_key_per_option_round_trip() {
 
     // Cosmetic: must NOT change the flag key.
     let cosmetic: Vec<OptionTweak> = vec![
-        ("palettes",       Box::new(|o| o.palettes = !o.palettes)),
-        ("palette_themed", Box::new(|o| o.palette_themed = !o.palette_themed)),
+        ("palettes",        Box::new(|o| o.palettes = !o.palettes)),
+        ("palette_themed",  Box::new(|o| o.palette_themed = !o.palette_themed)),
+        ("remove_flashing", Box::new(|o| o.remove_flashing = !o.remove_flashing)),
     ];
     for (label, mutate) in cosmetic {
         check_round_trip(label, mutate, false);
@@ -507,6 +509,7 @@ fn flag_key_encodes_every_bool_option() {
     const NOT_ENCODED: &[&str] = &[
         "palettes",            // cosmetic; uses OS randomness, not seed-derived
         "palette_themed",      // cosmetic
+        "remove_flashing",     // cosmetic/accessibility; static patch, no RNG
         "skip_rom_validation", // operational (CLI/WASM input handling), not randomization
     ];
 
@@ -605,6 +608,7 @@ fn all_off_options() -> Options {
         palettes: false,
         palette_themed: false,
         player_color: None,
+        remove_flashing: false,
         world_order: false,
         world_count: 7,
         big_q_blocks: false,
@@ -670,6 +674,7 @@ fn all_on_options() -> Options {
         palettes: false,
         palette_themed: false,
         player_color: None,
+        remove_flashing: true,
         world_order: true,
         world_count: 3,
         big_q_blocks: true,

--- a/web/options.js
+++ b/web/options.js
@@ -375,6 +375,11 @@ export const SCHEMA = [
 		label: "World colors",
 		tip: "Recolor levels, enemies, and world maps with a random color theme. Brightness stays the same, so everything stays easy to see.",
 		group: "cosmetic", inFlagKey: false },
+	{ id: "remove_flashing", type: "bool", default: true,
+		label: "Remove flashing",
+		tip: "Stop the full-screen flashing and fading effects. On by default so the game is safer for players sensitive to flashing lights.",
+		credit: { name: "MaCobra52", url: "https://github.com/macobra52" },
+		group: "cosmetic", inFlagKey: false },
 ];
 
 // Hardcoded fields sent to Rust that aren't user-facing.
@@ -953,7 +958,7 @@ export function getOptionsJson() {
 }
 
 // Apply a decoded flag-key payload back to the DOM. Skips non-flag-key
-// fields (palettes, palette_themed, skip_rom_validation) so applying a
+// fields (palettes, palette_themed, remove_flashing, skip_rom_validation) so applying a
 // shared key doesn't clobber the user's local cosmetic / ROM choices.
 export function applyOptions(opts) {
 	for (const entry of SCHEMA) {


### PR DESCRIPTION
Ports two MaCobra52 IPS patches from `patches/` into native Rust ROM writes.

## Remove Flashing (visual option, on by default)
- Source: `patches/SMB3 - Remove Flashing.ips`. Suppresses the full-screen palette flash/fade animation so the game is safer for photosensitive players.
- New cosmetic/accessibility option `remove_flashing` — **on by default**, **not encoded in the flag key**, and **consumes no RNG** (same model as the existing palette options). Disable via `--keep-flashing` (CLI) or the "Remove flashing" toggle in the web **Visual** section.
- Eight in-place code overwrites (redirect the palette-fade per-color writes to scratch RAM, pin the fade index, plus three related single-byte bank tweaks), reproduced byte-for-byte from the IPS and verified against USA Rev1.
- **MaCobra52 credited** on the web option (Credit line in the tooltip).

## Tail Enemies don't respawn (always-on fix)
- Source: `patches/SMB3 - Tail Enemies don't respawn.ips`. Enemies defeated by the Raccoon/Tanooki tail were only flagged dead in their on-screen slot, so scrolling them off and back respawned them.
- Folded into the always-on `apply_macobra_patches()`. Injects an 8-byte respawn-suppress routine into a genuinely dead PRG003 gap (CPU `$A5F9`, file `0x6609`, now registered in `free_space.rs`) and retargets the defeat handler's `JMP $BA0B` → `JMP $A5F9`.

## Verification
- `cargo test` (272 lib + integration, 0 fail) and `cargo clippy --all-targets` clean.
- End-to-end: generated ROMs match the IPS records exactly; with `--keep-flashing` the flash code stays vanilla while the tail fix remains applied.
- New unit tests: `test_remove_flashing_writes`, `test_macobra_tail_stay_dead_writes` (asserts the retarget names the routine's `$A5F9` CPU address). Flag-key round-trip + `NOT_ENCODED` guards updated so `remove_flashing` is proven cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)