### PR TITLE
Randomize spare-pipe skip cap (occasional big skips)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.6] - 2026-07-17
+
 ### Changed
 
 - Overworld shortcut pipes now vary how much they skip: each pipe rolls a random

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Changed
+
+- Overworld shortcut pipes now vary how much they skip: each pipe rolls a random
+  cap on how many forced levels it may bypass (usually 1–2, occasionally more)
+  instead of always grabbing the largest possible skip. Big skips still happen,
+  just less often — so a single pipe no longer routinely trivializes a short
+  world like 2 or 6, while the overall maps stay less linear.
+
 ## [0.12.5] - 2026-07-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2024"
 
 [lib]

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -260,6 +260,15 @@ pub(super) fn place_pipes<R: Rng>(
     placed_pairs
 }
 
+/// Per-pipe skip-cap weights: relative chance a spare pipe's max-skip is 1, 2,
+/// 3, or 4 levels. Each pipe rolls a cap from this distribution, then greedily
+/// takes the biggest skip up to it — so big skips happen *sometimes* (a pipe
+/// rolling a high cap) rather than every pipe grabbing the largest skip and
+/// trivializing short worlds. Tuned via a sweep (this shape ≈ halves W2/W6 skip
+/// size vs. uncapped while keeping most of the anti-linearity win); safe to
+/// retune if real gameplay feels off.
+const SPARE_CAP_WEIGHTS: [f64; 4] = [30.0, 25.0, 25.0, 20.0];
+
 /// Place `spare_needed` spare pipe pairs after `populate_sections`, converting
 /// the lowest-value filler (HammerBro) slots into pipe endpoints. Unlike the
 /// connectivity phase this runs with levels already placed, so each pair is
@@ -318,7 +327,8 @@ pub(super) fn place_spare_pipes<R: Rng>(
             .collect();
 
         let avail = &available;
-        let mut candidates: Vec<(TeleportEdge, f64)> = Vec::new();
+        // (pair, skipped levels, jump distance) for every pair that hops >=2.
+        let mut candidates: Vec<(TeleportEdge, usize, usize)> = Vec::new();
         for i in 0..avail.len() {
             for j in (i + 1)..avail.len() {
                 let a = avail[i];
@@ -334,15 +344,44 @@ pub(super) fn place_spare_pipes<R: Rng>(
                 // Levels whose route distance sits strictly between the two
                 // endpoints are the ones the teleport lets the player skip.
                 let skipped = level_d.iter().filter(|&&d| d > lo && d < hi).count();
-                let score = skipped as f64 * 10.0 + (hi - lo) as f64;
-                candidates.push(((a, b), score));
+                candidates.push(((a, b), skipped, hi - lo));
             }
         }
 
-        // Prefer a level-skipping pair; if none qualifies, fall back to the
-        // most distance-separated pair so the world still reaches its vanilla
-        // pipe count.
-        let chosen = pick_softmax_by_score(candidates, PIPE_SOFTMAX_T, rng).or_else(|| {
+        // Roll this pipe's skip cap from the weighted distribution.
+        let cap = {
+            let total: f64 = SPARE_CAP_WEIGHTS.iter().sum();
+            let mut roll = rng.random_range(0.0..total);
+            let mut c = SPARE_CAP_WEIGHTS.len();
+            for (i, w) in SPARE_CAP_WEIGHTS.iter().enumerate() {
+                roll -= w;
+                if roll <= 0.0 {
+                    c = i + 1;
+                    break;
+                }
+            }
+            c
+        };
+
+        // Greedily take the biggest skip within the cap (softmax breaks near
+        // ties). If every shortcut skips more than the cap, take the smallest
+        // one (least overshoot) so the pipe still stays as modest as possible.
+        let within: Vec<(TeleportEdge, f64)> = candidates
+            .iter()
+            .filter(|&&(_, s, _)| (1..=cap).contains(&s))
+            .map(|&(p, s, j)| (p, s as f64 * 10.0 + j as f64))
+            .collect();
+        let chosen = pick_softmax_by_score(within, PIPE_SOFTMAX_T, rng).or_else(|| {
+            candidates
+                .iter()
+                .filter(|&&(_, s, _)| s >= 1)
+                .min_by_key(|&&(_, s, _)| s)
+                .map(|&(p, _, _)| p)
+        });
+
+        // Fall back to the most distance-separated pair if nothing qualified, so
+        // the world still reaches its fixed vanilla pipe count.
+        let chosen = chosen.or_else(|| {
             let mut best: Option<(TeleportEdge, usize)> = None;
             for i in 0..avail.len() {
                 for j in (i + 1)..avail.len() {

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -2030,6 +2030,84 @@ fn report_w8_bridge_locks() {
     }
 }
 
+/// Distribution of how many forced levels each W2 / W6 shortcut pipe skips.
+/// (Concern: these small worlds' pipes may skip too much at once.) A pipe's
+/// "skip" is the rise in minimum required clears when it's removed — i.e. the
+/// forced levels it lets the player bypass. Reports a per-pipe histogram plus
+/// mean/max for both start↔airship modes, using the shipped pipeline.
+///
+/// Run: cargo test --release report_w2_w6_pipe_skips -- --ignored --nocapture
+/// Override seed count with PROG_SEEDS=N.
+#[test]
+#[ignore]
+fn report_w2_w6_pipe_skips() {
+    let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let seeds: u64 = std::env::var("PROG_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2000);
+    let base = crate::Options {
+        palettes: false,
+        palette_themed: false,
+        ..Default::default()
+    };
+
+    for (label, sas) in [("SAS off", false), ("SAS on", true)] {
+        let mut opts = base.clone();
+        opts.swap_start_airship = sas;
+
+        // Per world_idx: histogram of Shortcut(n) skip counts (n capped at 9).
+        let mut hist: [[u32; 10]; 8] = [[0; 10]; 8];
+        for seed in 0..seeds {
+            let (_rom, result) =
+                match crate::randomize_rom_with_overworld_capture(&rom_bytes, seed, &opts, None) {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+            for built in &result.worlds {
+                let wi = built.world_idx;
+                for class in classify_pipes(built) {
+                    if let PipeClass::Shortcut(n) = class {
+                        hist[wi][n.min(9)] += 1;
+                    }
+                }
+            }
+        }
+
+        eprintln!("\n=== [{label}] W2 / W6 shortcut-pipe levels-skipped ({seeds} seeds) ===");
+        for &wi in &[1usize, 5] {
+            let h = &hist[wi];
+            let total: u32 = h.iter().sum();
+            let t = total.max(1) as f64;
+            let sum: u64 = h.iter().enumerate().map(|(n, &c)| n as u64 * c as u64).sum();
+            let mean = sum as f64 / t;
+            let max = h.iter().rposition(|&c| c > 0).unwrap_or(0);
+            let ge3: u32 = h[3..].iter().sum();
+            let ge4: u32 = h[4..].iter().sum();
+            eprintln!(
+                "  W{}: {total} shortcut pipes total, mean skip {mean:.2}, max {max}",
+                wi + 1
+            );
+            for (n, &c) in h.iter().enumerate() {
+                if c > 0 {
+                    eprintln!("     skips {n}: {c:>5}  ({:>4.1}%)", c as f64 / t * 100.0);
+                }
+            }
+            eprintln!(
+                "     >=3 skipped: {ge3} ({:.1}%)   >=4 skipped: {ge4} ({:.1}%)",
+                ge3 as f64 / t * 100.0,
+                ge4 as f64 / t * 100.0,
+            );
+        }
+    }
+}
+
 /// Required-progression / linearity analyzer.
 ///
 /// Per world, computes the minimum fortress + level entries the player must


### PR DESCRIPTION
## Problem

The level-aware spare-pipe scorer (shipped in 0.12.0) always picked the pair skipping the **most** forced levels. In short worlds — **2 and 6** — that meant one pipe routinely skipped 3–4 of only ~5 levels, effectively trivializing the world. Measured over 2000 seeds: W2 mean skip **2.36** (skips ≥4: **11%**), W6 mean **2.82** (≥4: **28%**).

## Fix

Each spare pipe now rolls a **random skip cap** (`SPARE_CAP_WEIGHTS = [30, 25, 25, 20]` → relative chance of a max-skip of 1/2/3/4) and greedily takes the biggest skip *up to* that cap. Big skips still happen — just occasionally, when a pipe rolls a high cap — instead of every pipe grabbing the maximum.

Pipes stay useful (each still skips ≥1 where possible), so redundancy is unchanged.

## Data

Chosen from a 5-point sweep of the cap distribution (the tradeoff is smooth: bigger-skip weights → less linear but more over-skipping). `30/25/25/20` is the deliberate midpoint.

| metric | before (greedy) | this PR |
|---|---|---|
| W2 mean skip | 2.36 | **1.72** |
| W2 skips ≥4 | 11% | **1.4%** |
| W6 mean skip | 2.82 | **1.47** |
| W6 skips ≥4 | 28% | **1.0%** |
| overall forced-level streak | 1.40 | **1.74** |
| redundant pipes | ~45% | ~45% |

For W2/W6 specifically, "how often a pipe skips big" and "how non-linear the world is" are the same dial (those worlds have few other streak-breakers), so this is a chosen point on that curve — easy to retune via `SPARE_CAP_WEIGHTS` if real gameplay feels off.

## Testing

- All 282 tests pass; `cargo clippy --all-targets` clean; determinism intact.
- Adds `report_w2_w6_pipe_skips` diagnostic (`PROG_SEEDS=N`) for the per-pipe skip distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)