### PR TITLE
fix: keep Dry Bones out of the Coin Ship reward fight (bump 0.12.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.7] - 2026-07-17
+
 ### Fixed
 
 - Randomized enemies no longer place a Dry Bones in the Coin Ship reward fight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Fixed
+
+- Randomized enemies no longer place a Dry Bones in the Coin Ship reward fight.
+  That room is enclosed and never scrolls, so a Dry Bones — which revives after
+  every stomp and has nowhere to wander off — could never be cleared.
+
 ## [0.12.6] - 2026-07-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2024"
 
 [lib]

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -3399,6 +3399,12 @@ WalkerSegmentRule::HammerBro`). This routes its enemy randomization through
 the HB-wild path (stompable-only pool, optionally one shell-killable + one
 shell partner).
 
+Dry Bones (`0x3F`) is additionally excluded from this segment's stompable pool
+(`is_coinship_fight` in `enemy_protections.rs`): the reward room is enclosed and
+never scrolls, so a Dry Bones revives after every stomp with no screen edge to
+wander off and can never be cleared. It stays a valid HB-wild pick everywhere
+else.
+
 ### Enemy Stompability Classification
 
 Used by the randomizer for Hammer Bro encounter constraints. Enemies are classified

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -12,7 +12,8 @@ use rand::Rng;
 use rand::seq::IndexedRandom;
 
 use crate::randomize::enemy_protections::{
-    entry_protection_at, walker_segment_rule_at, EntryProtection, WalkerSegmentRule,
+    entry_protection_at, is_coinship_fight, walker_segment_rule_at, EntryProtection,
+    WalkerSegmentRule,
 };
 use crate::randomize::rom_data::{
     ENEMY_DATA_END, ENEMY_DATA_START, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS, STOMPABLE_ENEMIES,
@@ -153,7 +154,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
 
         // HB Wild: batch-assign enemies with stompability constraints.
         if is_hb_segment && opts.hb_encounters == EnemyMode::Wild && !big_q_only {
-            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, rng);
+            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, seg_file_offset, rng);
             continue;
         }
 

--- a/src/randomize/enemies/segments.rs
+++ b/src/randomize/enemies/segments.rs
@@ -44,8 +44,19 @@ pub(super) fn randomize_hb_wild_segment<R: Rng>(
     data: &mut [u8],
     entries: &[SegmentEntry],
     hb_modes: &ClassModes,
+    seg_file_offset: usize,
     rng: &mut R,
 ) {
+    // The coin-ship reward room is enclosed and never scrolls, so Dry Bones
+    // (0x3F) — which revives after every stomp and has no edge to wander off —
+    // can never be cleared there. Drop it from the stompable pool for that one
+    // segment; everywhere else it's a fine HB-wild pick.
+    let stompable: Cow<[u8]> = if is_coinship_fight(seg_file_offset) {
+        Cow::Owned(STOMPABLE_ENEMIES.iter().copied().filter(|&id| id != 0x3F).collect())
+    } else {
+        Cow::Borrowed(STOMPABLE_ENEMIES)
+    };
+
     let swappable: Vec<usize> = entries.iter()
         .enumerate()
         .filter(|(_, e)| find_class_pool(e.obj_id, hb_modes).is_some())
@@ -62,7 +73,7 @@ pub(super) fn randomize_hb_wild_segment<R: Rng>(
     }
 
     if swappable.len() == 1 {
-        if let Some(chosen) = pick_compatible(STOMPABLE_ENEMIES, slot4, slot5, rng) {
+        if let Some(chosen) = pick_compatible(&stompable, slot4, slot5, rng) {
             swap_enemy(data, entries[swappable[0]].data_index, chosen);
         }
     } else if swappable.len() == 2 {
@@ -88,12 +99,12 @@ pub(super) fn randomize_hb_wild_segment<R: Rng>(
             }
         } else {
             // Both from stompable pool
-            if let Some(first) = pick_compatible(STOMPABLE_ENEMIES, slot4, slot5, rng) {
+            if let Some(first) = pick_compatible(&stompable, slot4, slot5, rng) {
                 swap_enemy(data, entries[swappable[0]].data_index, first);
                 let mut s4 = slot4;
                 let mut s5 = slot5;
                 commit_chr_page(first, &mut s4, &mut s5);
-                if let Some(second) = pick_compatible(STOMPABLE_ENEMIES, s4, s5, rng) {
+                if let Some(second) = pick_compatible(&stompable, s4, s5, rng) {
                     swap_enemy(data, entries[swappable[1]].data_index, second);
                 }
             }

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1355,6 +1355,34 @@
         );
     }
 
+    /// The coin-ship reward fight (2×BoomerangBro sub-area at enemy_ptr 0xDA0F,
+    /// file 0x0DA1F) must never receive a Dry Bones: that room is enclosed and
+    /// never scrolls, so a Dry Bones — which revives after every stomp and has
+    /// no edge to wander off — could never be cleared.
+    #[test]
+    fn coinship_fight_never_gets_dry_bones() {
+        let Some(base) = load_reference_rom() else {
+            eprintln!("reference ROM not present — skipping coinship_fight_never_gets_dry_bones");
+            return;
+        };
+        // Vanilla layout: [FF] 01 (page) | 82 03 17 | 82 0C 17 | BA 0F 11 | FF.
+        // The two 0x82 BoomerangBro obj_id bytes sit at 0x0DA20 and 0x0DA23.
+        const BRO0: usize = 0x0DA20;
+        const BRO1: usize = 0x0DA23;
+        assert_eq!(base.read_range(BRO0, 1)[0], 0x82, "vanilla layout drifted");
+        assert_eq!(base.read_range(BRO1, 1)[0], 0x82, "vanilla layout drifted");
+
+        for seed in 0..400u64 {
+            let mut rom = base.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom, &mut rng, &preset_recommended());
+            for off in [BRO0, BRO1] {
+                let id = rom.read_range(off, 1)[0];
+                assert_ne!(id, 0x3F, "seed {seed}: Dry Bones placed in coin-ship fight");
+            }
+        }
+    }
+
     /// Every cannon-fire family member carries the CHR bank its engine
     /// behavior demands (see the cfire arm in `sprite_bank`): bills and
     /// goomba pipes spawn $4F/+5 children; the cannonball family (plus the

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -305,6 +305,18 @@ pub(super) fn entry_protection_at(file_offset: usize) -> Option<EntryProtection>
         .find_map(|e| (e.offset == file_offset).then_some(e.rule))
 }
 
+/// CPU enemy pointer of the coin-ship reward fight (the 2×BoomerangBro
+/// sub-area past the end-pipe). Kept in sync with its `LEVEL_PROTECTIONS` row.
+const COINSHIP_FIGHT_ENEMY_PTR: u16 = 0xDA0F;
+
+/// Whether `segment_file_offset` is the coin-ship reward fight. That sub-area is
+/// an enclosed, non-scrolling room, so an enemy that can never be permanently
+/// cleared — Dry Bones revives after every stomp and has no screen edge to
+/// wander off — must be kept out of its wild pool.
+pub(super) fn is_coinship_fight(segment_file_offset: usize) -> bool {
+    enemy_ptr_to_file_offset(COINSHIP_FIGHT_ENEMY_PTR) == segment_file_offset
+}
+
 /// Walker rule for the segment whose page byte sits at this absolute file
 /// offset. Returns `Default` for unprotected segments.
 pub(super) fn walker_segment_rule_at(segment_file_offset: usize) -> WalkerSegmentRule {


### PR DESCRIPTION
## What

Randomized enemies could place a **Dry Bones** in the Coin Ship reward fight (the 2×Boomerang Bro sub-area past the end-pipe). That room is enclosed and never scrolls, so a Dry Bones — which revives after every stomp and has no screen edge to wander off — can never be cleared.

## Why it happened

The sub-area is already protected by a `LEVEL_PROTECTIONS` row that routes it through the Hammer-Bro wild path — but that path draws from `STOMPABLE_ENEMIES`, which includes Dry Bones (`0x3F`). So it was a legal roll.

## Fix

- New `is_coinship_fight(seg_file_offset)` predicate in `enemy_protections.rs` (keyed off enemy_ptr `0xDA0F`).
- `randomize_hb_wild_segment` filters `0x3F` out of the stompable pool **only** for that segment; Dry Bones stays a valid HB-wild pick everywhere else.
- 400-seed regression test `coinship_fight_never_gets_dry_bones`.
- Updated `docs/smb3_rom_reference.md` and `CHANGELOG.md`; bumped **0.12.7**.

`cargo clippy --all-targets` clean; full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)