### PR TITLE
release: bump 0.12.8 — protect 4-1 Big Green Troopa from hazards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.8] - 2026-07-18
+
+### Fixed
+
+- The final Big Green Troopa in 4-1 is now covered by the level's hazard
+  protection, like the Big Red Troopas earlier in the stage. Each troopa sits on
+  a small platform Mario must land on to progress, so a hazard enemy there could
+  force an unavoidable hit.
+
 ## [0.12.7] - 2026-07-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2024"
 
 [lib]

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -241,6 +241,7 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
             EntryRule { offset: 0x0CEBD, rule: EntryProtection::ExcludeHazards }, // BigRedTroopa scr=5 col=8
             EntryRule { offset: 0x0CEC0, rule: EntryProtection::ExcludeHazards }, // BigRedTroopa scr=5 col=15
             EntryRule { offset: 0x0CEC3, rule: EntryProtection::ExcludeHazards }, // BigRedTroopa scr=6 col=4
+            EntryRule { offset: 0x0CEC9, rule: EntryProtection::ExcludeHazards }, // BigGreenTroopa scr=7 col=10
         ],
     },
     LevelProtection {


### PR DESCRIPTION
Bumps version to **0.12.8**.

## Change

Adds the final Big Green Troopa in 4-1 (`0x0CEC9`, scr 7 col 10) to the level's existing hazard-protection block, alongside the three Big Red Troopas already covered. Each troopa sits on a small platform Mario must land on to progress, so enemy randomization placing a hazard enemy there could force an unavoidable hit.

## Verification

- `cargo build`, `cargo test` (283 + suites, all pass, incl. enemy-invariant baseline), `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)