### PR TITLE
fix: disable title-screen attract-mode demo (0.12.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [0.12.9] - 2026-07-18
+
 ### Fixed
 
 - The title screen no longer rolls the attract-mode demo. Sitting on the 1P/2P

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+### Fixed
+
+- The title screen no longer rolls the attract-mode demo. Sitting on the 1P/2P
+  menu now holds indefinitely instead of timing out into the recorded demo
+  playback.
+
 ## [0.12.8] - 2026-07-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2024"
 
 [lib]

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -3664,6 +3664,25 @@ Vanilla SMB3 leaves the 1P/2P select menu silent (the only title-screen music is
 
 The track is chosen deterministically from the seed via a curated 16-entry table (world map themes 1–9, plus level themes 0x10/0x20/0x30/0x40/0x60/0x80/0x90). See `src/randomize/title_screen.rs::MENU_MUSIC_TRACKS` and `pick_menu_music`. When `starting_items` is active it overwrites the lives-init hook, so `qol::write_starting_items` mirrors the same `STA $04F5` inside its own trampoline.
 
+### Attract-Mode Demo Trigger (PRG024)
+
+While the 1P/2P menu sits idle, a two-stage countdown decrements each frame: the
+menu handler at CPU **$8C4E** (file **0x30C45**) does `DEC $E0` (low byte, reloads
+to 0x60) and, on rollover, `DEC $DF` (high byte, seeded to 0x14 at CPU $8C28).
+When `$DF` hits zero it runs `LDA #$FF / STA $E1` — the `#$FF` operand is at file
+**0x30C5F**. A later check at CPU **$8979** (file 0x30989) reads the flag:
+
+```
+$8979:  A5 E1        LDA $E1
+$897B:  F0 03        BEQ +3
+$897D:  4C AF A8     JMP $A8AF   ; start recorded demo playback
+```
+
+`$E1` is written only at the timer site and read only here. Patching the operand
+at 0x30C5F from `0xFF` to `0x00` keeps `$E1` clear, so the `BEQ` is always taken
+and the demo never starts — the menu holds indefinitely. Applied by
+`title_screen.rs::write_seed_hash` (`DEMO_TRIGGER_OPERAND_OFFSET`).
+
 ---
 
 ## Autoscroll Disable

--- a/src/randomize/title_screen.rs
+++ b/src/randomize/title_screen.rs
@@ -46,6 +46,14 @@ const INTRO_SKIP_HOOK_OFFSET: usize = 0x308E2;
 const INTRO_SKIP_ROUTINE_OFFSET: usize = super::rom_data::FS_INTRO_SKIP;
 const INTRO_SKIP_CPU: u16 = super::rom_data::prg031_file_to_cpu(INTRO_SKIP_ROUTINE_OFFSET); // $E955
 
+/// Disable the attract-mode demo. When the 1P/2P menu sits idle, a countdown
+/// (`$DF` × `$E0` frames) expires and the title handler at PRG024 CPU $8C4E does
+/// `LDA #$FF / STA $E1`; a later check (`LDA $E1 / BEQ / JMP $A8AF` at CPU $8979)
+/// reads that flag and jumps into the recorded demo playback. Setting the stored
+/// value to 0 keeps `$E1` clear, so the `BEQ` is always taken and the demo never
+/// starts — the menu just holds. The byte at 0x30C5F is the `#$FF` operand.
+const DEMO_TRIGGER_OPERAND_OFFSET: usize = 0x30C5F;
+
 /// Curated music tracks for the title menu. Values are written to the music
 /// change trigger at $04F5 — each one is a looping theme that fits a static
 /// menu screen (map themes 1–8 plus a handful of level / mushroom / hilly
@@ -207,6 +215,10 @@ pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
     intro_routine.extend_from_slice(&intro_skip_music_bytes(seed));
     intro_routine.push(0x60); // RTS
     rom.write_range(INTRO_SKIP_ROUTINE_OFFSET, &intro_routine);
+
+    // Disable the attract-mode demo: LDA #$FF → LDA #$00 so the idle-timeout
+    // never raises the demo-trigger flag $E1 (see DEMO_TRIGGER_OPERAND_OFFSET).
+    rom.write_byte(DEMO_TRIGGER_OPERAND_OFFSET, 0x00);
 }
 
 #[cfg(test)]
@@ -272,6 +284,7 @@ mod tests {
     fn write_seed_hash_writes_sprite_data_to_rom() {
         let opts = Options::default();
         let mut rom = crate::randomize::qol::test_support::make_test_rom();
+        rom.write_byte(DEMO_TRIGGER_OPERAND_OFFSET, 0xFF); // vanilla operand
         write_seed_hash(&mut rom, 42, &opts);
 
         // The data table in ROM must be exactly what build_sprite_data emits.
@@ -282,6 +295,9 @@ mod tests {
         // Hook and intro-skip hook target the derived CPU addresses.
         assert_eq!(rom.read_range(HOOK_OFFSET, 3), &[0x4C, 0x14, 0xE9]);
         assert_eq!(rom.read_range(INTRO_SKIP_HOOK_OFFSET, 3), &[0x20, 0x55, 0xE9]);
+
+        // Attract-mode demo trigger neutralized: LDA #$FF operand becomes #$00.
+        assert_eq!(rom.read_byte(DEMO_TRIGGER_OPERAND_OFFSET), 0x00);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The intro-skip patch already jumps the title screen straight to the 1P/2P menu, but the **attract-mode demo** (the recorded Mario playthrough) still rolled after the menu sat idle. This disables that demo so the menu holds indefinitely.

## Mechanism

While the menu is idle, a two-stage countdown (`$DF` × `$E0` frames) decrements each frame. On expiry the handler at PRG024 CPU `$8C4E` runs:

```
030C5E: A9 FF     LDA #$FF      ; operand at 0x30C5F
030C60: 85 E1     STA $E1       ; raise demo-trigger flag
```

and a later check (CPU `$8979`) reads it:

```
A5 E1     LDA $E1
F0 03     BEQ +3       ; $E1 == 0 → stay on menu
4C AF A8  JMP $A8AF    ; $E1 != 0 → start recorded demo
```

`$E1` is written only at the timer and read only here. Patching the `#$FF` operand at `0x30C5F` to `#$00` keeps `$E1` clear, so the `BEQ` is always taken and the demo never starts.

## Changes

- `src/randomize/title_screen.rs` — `DEMO_TRIGGER_OPERAND_OFFSET` poke in `write_seed_hash`, plus a test asserting `FF`→`00`
- `docs/smb3_rom_reference.md` — documented the demo timer / `$E1` flag / patch
- `CHANGELOG.md` + `Cargo.toml`/`Cargo.lock` — 0.12.9

## Testing

Full suite passes (286 tests), clippy clean. Verified on a patched ROM: the menu holds on idle instead of timing out into the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)