### PR TITLE
Fold version into seed hash; require version bump on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,37 @@ jobs:
           set -o pipefail
           python3 tools/offset_dups.py --exit-code | tee -a "$GITHUB_STEP_SUMMARY"
 
+  version-guard:
+    # Every PR to main must bump the Cargo.toml version. The title-screen seed
+    # hash folds in CARGO_PKG_VERSION, so a version bump is what makes two builds
+    # with different randomization logic produce different verification icons.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # need base history to read main's Cargo.toml
+      - name: Require a version bump
+        shell: bash
+        run: |
+          set -euo pipefail
+          ver() { sed -n 's/^version = "\(.*\)"/\1/p' "$1" | head -1; }
+          git show '${{ github.event.pull_request.base.sha }}:Cargo.toml' > /tmp/base-cargo.toml
+          base=$(ver /tmp/base-cargo.toml)
+          head=$(ver Cargo.toml)
+          echo "base version: $base"
+          echo "head version: $head"
+          if [ "$base" = "$head" ]; then
+            echo "::error file=Cargo.toml::Version unchanged ($head). Bump the version before merging to main."
+            exit 1
+          fi
+          # Enforce a strictly-increasing version (highest sorts last).
+          highest=$(printf '%s\n%s\n' "$base" "$head" | sort -V | tail -1)
+          if [ "$highest" != "$head" ]; then
+            echo "::error file=Cargo.toml::Version $head is not greater than main's $base."
+            exit 1
+          fi
+
   build:
     needs: ci
     if: github.event_name == 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-19
+
+### Changed
+
+- The title-screen seed-verification icons now depend on the randomizer version
+  in addition to the seed and options. Two builds with different randomization
+  logic no longer show identical icons for the same seed. (CI now requires a
+  version bump on every merge to `main`, so each release is a distinct version.)
+
 ## [0.12.9] - 2026-07-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "0.12.9"
+version = "1.0.0"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "0.12.9"
+version = "1.0.0"
 edition = "2024"
 
 [lib]

--- a/src/randomize/title_screen.rs
+++ b/src/randomize/title_screen.rs
@@ -100,10 +100,19 @@ pub(super) fn intro_skip_music_bytes(seed: u64) -> [u8; 9] {
 }
 
 /// Compute 5 icon indices and a palette choice from seed + flag bytes.
+///
+/// The randomizer version (`CARGO_PKG_VERSION`) is folded in so two builds with
+/// different randomization logic never collide on the same icons for a shared
+/// seed + options. CI (`version-guard` in `.github/workflows/ci.yml`) requires a
+/// version bump on every merge to `main`, so any output-affecting change lands
+/// under a distinct version and thus a distinct hash.
 fn compute_hash(seed: u64, options: &Options) -> ([usize; HASH_LENGTH], u8) {
     let flag_bytes = options.to_flag_bytes();
     let mut h = seed;
     for &b in &flag_bytes {
+        h = h.wrapping_mul(2_654_435_761).wrapping_add(b as u64);
+    }
+    for &b in env!("CARGO_PKG_VERSION").as_bytes() {
         h = h.wrapping_mul(2_654_435_761).wrapping_add(b as u64);
     }
 


### PR DESCRIPTION
## What

Closes the seed-hash collision where two randomizer builds with different randomization logic could produce different ROMs yet show **identical** title-screen verification icons for the same seed.

## Changes

- **`src/randomize/title_screen.rs`** — `compute_hash` folds `CARGO_PKG_VERSION` into the hash alongside seed + option flags, so a version change shifts the icons. Native and WASM read the same version string, so cross-platform determinism is preserved.
- **`.github/workflows/ci.yml`** — new `version-guard` job (PRs to `main` only) fails if `Cargo.toml`'s version is unchanged or not strictly greater than `main`'s. This is what makes "bump on everything" a guarantee rather than discipline — the reported collision came from a forgotten bump.
- **`Cargo.toml` / `Cargo.lock`** — bump to **1.0.0**.
- **`CHANGELOG.md`** — `[1.0.0]` section noting the icons now depend on version.

## Follow-up (manual, not in this PR)

`version-guard` only reports until it's marked a **required status check** in branch protection for `main`. Recommended order: let this PR's `version-guard` run once, merge, then require it. Otherwise a required-but-never-seen check can leave PRs stuck "waiting for status."

🤖 Generated with [Claude Code](https://claude.com/claude-code)