### PR TITLE
7-F1 Tanooki-gate ? block: flower or leaf, never star

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ into a versioned section when a release is cut.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-20
+
+### Changed
+
+- The 7-Fortress 1 ? block that gates the Tanooki area now randomizes 50/50
+  between a Fire Flower and a Super Leaf instead of always being a Fire Flower.
+  It can never roll a star, so small Mario always gets a power-up that lets him
+  break the bricks to reach the area.
+
 ## [1.0.0] - 2026-07-19
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 
 [lib]

--- a/src/randomize/powerups.rs
+++ b/src/randomize/powerups.rs
@@ -53,8 +53,17 @@ const PROTECTED_OFFSETS: &[usize] = &[
     0x23DB0, // 7-7 Q-star byte2 (screen 2)
     0x23E1F, // 7-7 Q-star byte2 (screen 5)
     0x23EA0, // 7-7 Q-star byte2 (screen 8)
-    0x2B39E, // 7-F1 Q-flower — small Mario needs mushroom to break bricks for Tanooki area
     0x2B900, // 8-F brick-flower (sub-area 2) — player must be big to break a block later
+];
+
+/// ? block byte2 offsets that randomize between flower and leaf only — never a
+/// star — regardless of the airship no-star option. Both flower and leaf power
+/// small Mario up so he can break bricks, but a star would leave him small.
+///
+/// 7-F1: the Q-block gating the Tanooki area. Small Mario must break bricks to
+/// reach it, so the block has to grant a persistent power-up (flower or leaf).
+const FLOWER_OR_LEAF_QBLOCK_OFFSETS: &[usize] = &[
+    0x2B39E, // 7-F1 Q-block — flower/leaf so small Mario can break bricks for Tanooki area
 ];
 
 /// Airship Q-block byte2 offsets (all 9 powerup blocks across W1-W7 airships).
@@ -71,6 +80,20 @@ const AIRSHIP_QBLOCK_OFFSETS: &[usize] = &[
     0x2F50D, // W7 airship (block 1)
     0x2F572, // W7 airship (block 2)
 ];
+
+/// Pick the shape pool for a ? block at `file_offset`. Blocks that gate
+/// progression on breaking bricks (`FLOWER_OR_LEAF_QBLOCK_OFFSETS`) always
+/// exclude the star; airship blocks exclude it only when `no_airship_stars`
+/// is set. Everything else may become flower, leaf, or star.
+fn qblock_pool(file_offset: usize, no_airship_stars: bool) -> &'static [u8] {
+    let exclude_star = FLOWER_OR_LEAF_QBLOCK_OFFSETS.contains(&file_offset)
+        || (no_airship_stars && AIRSHIP_QBLOCK_OFFSETS.contains(&file_offset));
+    if exclude_star {
+        QBLOCK_SHAPES_NO_STAR
+    } else {
+        QBLOCK_SHAPES
+    }
+}
 
 /// Randomize per-level powerup block types by scanning all level data regions
 /// for generator commands that place powerup blocks, and swapping the shape
@@ -117,11 +140,7 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, no_airship_stars: bool) {
                 // guard applies to group 1 alone (group 2 is never checked).
                 if group == GEN_GROUP_POWERBLOCK && !PROTECTED_OFFSETS.contains(&file_offset) {
                     if QBLOCK_SHAPES.contains(&shape) {
-                        let pool = if no_airship_stars && AIRSHIP_QBLOCK_OFFSETS.contains(&file_offset) {
-                            QBLOCK_SHAPES_NO_STAR
-                        } else {
-                            QBLOCK_SHAPES
-                        };
+                        let pool = qblock_pool(file_offset, no_airship_stars);
                         data[i + 2] = *pool.choose(rng).unwrap();
                     } else if BRICK_SHAPES.contains(&shape) {
                         data[i + 2] = *BRICK_SHAPES.choose(rng).unwrap();
@@ -199,6 +218,33 @@ mod tests {
 
         let b2_brick = rom.read_byte(start + 8);
         assert!(BRICK_SHAPES.contains(&b2_brick), "Brick became 0x{b2_brick:02X}");
+    }
+
+    #[test]
+    fn qblock_pool_7f1_is_flower_or_leaf_never_star() {
+        // 7-F1's Tanooki-gate block: flower or leaf, never star, regardless of
+        // the airship no-star flag.
+        for no_airship_stars in [false, true] {
+            let pool = qblock_pool(0x2B39E, no_airship_stars);
+            assert_eq!(pool, QBLOCK_SHAPES_NO_STAR);
+            assert!(pool.contains(&0x00), "flower missing from pool");
+            assert!(pool.contains(&0x01), "leaf missing from pool");
+            assert!(!pool.contains(&0x02), "star must never be in the 7-F1 pool");
+        }
+    }
+
+    #[test]
+    fn qblock_pool_airship_star_gated_by_flag() {
+        // An airship block keeps the star unless the no-star option is set.
+        assert_eq!(qblock_pool(0x2ED22, false), QBLOCK_SHAPES);
+        assert_eq!(qblock_pool(0x2ED22, true), QBLOCK_SHAPES_NO_STAR);
+    }
+
+    #[test]
+    fn qblock_pool_ordinary_block_allows_star() {
+        // A normal block (not in either special list) can still roll a star.
+        assert_eq!(qblock_pool(0x12345, false), QBLOCK_SHAPES);
+        assert_eq!(qblock_pool(0x12345, true), QBLOCK_SHAPES);
     }
 
     #[test]


### PR DESCRIPTION
## What

The ? block gating 7-Fortress 1's Tanooki area was frozen as a Fire Flower (via `PROTECTED_OFFSETS`). This makes it randomize **50/50 between a Fire Flower and a Super Leaf**, but never a star.

## Why this is safe

Small Mario needs a power-up at that block to break bricks and reach the Tanooki area. Both a flower and a leaf grow him into a form that can break bricks; only a star would leave him small and stuck. So the progression guarantee is preserved while adding variety.

## Changes

- **`src/randomize/powerups.rs`** — move `0x2B39E` out of `PROTECTED_OFFSETS` into a new `FLOWER_OR_LEAF_QBLOCK_OFFSETS` list; add a `qblock_pool()` helper that returns `{flower, leaf}` for these offsets (and for airship blocks when `no_airship_stars` is set) and `{flower, leaf, star}` otherwise. Three unit tests cover the pool decision.
- **`Cargo.toml` / `Cargo.lock`** — bump to **1.0.1**.
- **`CHANGELOG.md`** — `[1.0.1]` entry.

## Merge order

This targets `main` and is versioned **1.0.1**, intended to merge **after** #100 (1.0.0). Note: this branch was cut before #100, so it doesn't yet contain the `version-guard` CI job. After #100 merges, update this branch (rebase / "Update branch") to pick up the check and resolve the likely trivial `CHANGELOG.md` conflict (the `[1.0.1]` and `[1.0.0]` sections both sit just under `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)