### PR TITLE
Randomize Lakitu egg type under wild injections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ deploys.
 
 ### Changed
 
-- With wild injections on, Lakitus now throw either the real (red) Spiny Egg or
-  the harmless green "dud" egg, chosen deterministically per level from the seed
-  instead of the vanilla tileset rule that always gave injected Lakitus the real
-  egg. Applies to every Lakitu in the seed.
+- With wild injections on, Lakitus now throw either a red egg (which hatches into
+  a Spiny) or a non-hatching green egg, chosen deterministically per level from
+  the seed instead of the vanilla tileset rule that always gave injected Lakitus
+  the red egg. Applies to every Lakitu in the seed.
 
 ## [1.0.2] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ deploys.
 
 ## [Unreleased]
 
+### Changed
+
+- With wild injections on, Lakitus now throw either the real (red) Spiny Egg or
+  the harmless green "dud" egg, chosen deterministically per level from the seed
+  instead of the vanilla tileset rule that always gave injected Lakitus the real
+  egg. Applies to every Lakitu in the seed.
+
 ## [1.0.2] - 2026-07-20
 
 ### Added

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1063,6 +1063,29 @@ Source: `smb3.asm` from the [Southbird disassembly](https://github.com/captainso
 | 0xAD | OBJ_ROCKYWRENCH | Rocky Wrench |
 | 0xAF | OBJ_ENEMYSUN | Angry Sun |
 
+### Lakitu egg type & `Level_SlopeEn`
+
+A Lakitu (`0x83`) chooses what it throws in `Lakitu_TossEnemy` (PRG004, egg-select
+block at file `0x08E58`) from the level-wide flag **`Level_SlopeEn` (`$0563`)** —
+*not* from any per-enemy value:
+
+- `Level_SlopeEn == 0` → **`OBJ_SPINYEGG` (`0x84`)**, the real red egg that hatches
+  into a chasing Spiny (keeps `SPR_PAL1`).
+- `Level_SlopeEn != 0` → **`OBJ_SPINYEGGDUD` (`0x85`)**, the harmless green "dud"
+  egg that never hatches (`Objects_SprAttr` palette `2`).
+
+`Level_SlopeEn` is set once per level load by `LevelInit_EnableSlopes` (PRG008),
+derived purely from `Level_Tileset`: `1` for tileset 3 (Hills) and 14
+(Underground), else `0` (tileset 5's `Level_UnusedSlopesTS5` path is dead code).
+So the egg type is really "which tileset is the host level," and injected Lakitus
+(always in non-sloped levels) always throw the real egg.
+
+`Level_SlopeEn` is **load-bearing slope physics** — also read for slope-tile
+collision (PRG000), player sliding / ground-LUT / bounce (PRG008), and fireball
+collision (PRG007), plus the Lakitu *toss cadence* (`$7F` vs `$3F` mask). Do not
+flip or repurpose it. The `lakitu_egg` randomizer instead diverts only the
+egg-select branch to a position-hash routine (see `src/randomize/lakitu_egg.rs`).
+
 ---
 
 ## Power-Up / Item Data

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1069,16 +1069,16 @@ A Lakitu (`0x83`) chooses what it throws in `Lakitu_TossEnemy` (PRG004, egg-sele
 block at file `0x08E58`) from the level-wide flag **`Level_SlopeEn` (`$0563`)** —
 *not* from any per-enemy value:
 
-- `Level_SlopeEn == 0` → **`OBJ_SPINYEGG` (`0x84`)**, the real red egg that hatches
+- `Level_SlopeEn == 0` → **`OBJ_SPINYEGG` (`0x84`)**, the red egg that hatches
   into a chasing Spiny (keeps `SPR_PAL1`).
-- `Level_SlopeEn != 0` → **`OBJ_SPINYEGGDUD` (`0x85`)**, the harmless green "dud"
-  egg that never hatches (`Objects_SprAttr` palette `2`).
+- `Level_SlopeEn != 0` → **`OBJ_SPINYEGGDUD` (`0x85`)**, the green egg that does
+  not hatch (`Objects_SprAttr` palette `2`).
 
 `Level_SlopeEn` is set once per level load by `LevelInit_EnableSlopes` (PRG008),
 derived purely from `Level_Tileset`: `1` for tileset 3 (Hills) and 14
 (Underground), else `0` (tileset 5's `Level_UnusedSlopesTS5` path is dead code).
 So the egg type is really "which tileset is the host level," and injected Lakitus
-(always in non-sloped levels) always throw the real egg.
+(always in non-sloped levels) always throw the red egg.
 
 `Level_SlopeEn` is **load-bearing slope physics** — also read for slope-tile
 collision (PRG000), player sliding / ground-LUT / bounce (PRG008), and fireball

--- a/src/randomize/lakitu_egg.rs
+++ b/src/randomize/lakitu_egg.rs
@@ -1,0 +1,248 @@
+//! Random Lakitu egg type.
+//!
+//! Vanilla decides what a Lakitu throws from the level-wide `Level_SlopeEn`
+//! flag (a tileset property): non-sloped levels get the real **Spiny Egg**
+//! (`OBJ_SPINYEGG`, red, hatches into a chasing Spiny), sloped levels (Hills /
+//! Underground tilesets) get the harmless **green "dud" egg** (`OBJ_SPINYEGGDUD`,
+//! palette 2, never hatches). Because wild injections land in ordinary
+//! (non-sloped) levels, an injected Lakitu always throws the real red egg.
+//!
+//! This patch substitutes that hardcoded, tileset-driven choice for a
+//! position-hash — the same deterministic-without-RNG trick as
+//! [`super::fire_flower`]. Each Lakitu's egg type becomes a pure function of
+//! stable game state plus a seed-derived salt, so the same seed always plays the
+//! same way with no live/console RNG, and different levels can differ.
+//!
+//! ## How it works
+//!
+//! The egg-select inside `Lakitu_TossEnemy` (PRG004) is vanilla:
+//!
+//! ```text
+//! LDA #$00 / CMP Level_SlopeEn        ; carry set iff SlopeEn == 0
+//! LDA #OBJ_SPINYEGG ($84)             ; assume real egg
+//! BGE +7                              ; SlopeEn == 0 -> keep real egg
+//! LDA #$02 / STA Objects_SprAttr,Y    ; else palette 2
+//! LDA #OBJ_SPINYEGGDUD ($85)          ; ...and the green dud egg
+//! ```
+//!
+//! We overwrite that 16-byte block with a `JSR` to an injected routine (padded
+//! with NOPs) that computes, with `Y` still holding the egg's object slot:
+//!
+//! ```text
+//! low_bit_of(salt + World_Num + Level_LayPtr_AddrL) == 0 -> real red egg
+//!                                                    == 1 -> green dud egg
+//! ```
+//!
+//! and returns `A` = the chosen object id (setting `Objects_SprAttr,Y` to
+//! palette 2 for the dud). The block falls through into the vanilla
+//! `STA Level_ObjectID,Y` exactly as before.
+//!
+//! ## Why these inputs (and only these)
+//!
+//! The hash must use values that are constant for the whole level, or a single
+//! Lakitu would flip egg types as it moves — a Lakitu drifts across screens as
+//! it chases, so its live position is NOT stable (the same determinism trap
+//! documented in [`super::fire_flower`]). We therefore key only on:
+//!
+//! - **`salt`** — the shuffled starting world (`world_order`'s
+//!   [`WORLD_INIT_OPERAND`]); 0 when world-order shuffle is off. Seed-derived, so
+//!   the mapping rotates seed to seed.
+//! - **`World_Num`** (`$0727`) — spreads worlds apart; constant within a level.
+//! - **`Level_LayPtr_AddrL`** (`$61`) — the level layout pointer low byte, a
+//!   per-area constant set at level load. Distinguishes levels/areas.
+//!
+//! SMB3 only supports one active Lakitu at a time (`Lakitu_Active` is a single
+//! global), so per-(seed, world, area) resolution is effectively per-Lakitu.
+//!
+//! ## Scope
+//!
+//! Patches the shared toss routine, so **every** Lakitu in the ROM is affected
+//! (native and wild-injected alike) — deliberate, see the enemy-injection
+//! feature. The toss *cadence* (also keyed on `Level_SlopeEn`) is left untouched;
+//! only the egg type changes.
+
+use crate::rom::Rom;
+
+use super::rom_data::{FS_LAKITU_EGG, LAKITU_EGG_SUB_CPU};
+use super::world_order::WORLD_INIT_OPERAND;
+
+/// File offset of the egg-select block inside `Lakitu_TossEnemy` (PRG004). The
+/// 16 vanilla bytes here are `LDA #$00 / CMP $0563 / LDA #$84 / BGE +7 /
+/// LDA #$02 / STA $7FE7,Y / LDA #$85` — everything up to (but not including) the
+/// shared `STA $0671,Y` that stores the chosen object id.
+const HOOK_SITE: usize = 0x08E58;
+
+/// The 16 vanilla bytes we overwrite, asserted before patching so a shifted ROM
+/// can't be silently mispatched.
+#[rustfmt::skip]
+const HOOK_VANILLA: [u8; 16] = [
+    0xA9, 0x00,             // LDA #$00
+    0xCD, 0x63, 0x05,       // CMP $0563  (Level_SlopeEn)
+    0xA9, 0x84,             // LDA #$84   (OBJ_SPINYEGG)
+    0xB0, 0x07,             // BGE +7
+    0xA9, 0x02,             // LDA #$02
+    0x99, 0xE7, 0x7F,       // STA $7FE7,Y (Objects_SprAttr,Y)
+    0xA9, 0x85,             // LDA #$85   (OBJ_SPINYEGGDUD)
+];
+
+const OBJ_SPINYEGG: u8 = 0x84; // real egg (hatches into a Spiny), keeps SPR_PAL1
+const OBJ_SPINYEGGDUD: u8 = 0x85; // green dud egg (never hatches), palette 2
+const DUD_PALETTE: u8 = 0x02; // Objects_SprAttr value the vanilla dud path sets
+
+/// Length of the injected routine.
+const ROUTINE_LEN: u16 = 25;
+
+/// Install the Random Lakitu Egg patch. `enabled == false` is a no-op.
+///
+/// Must run after [`super::world_order`] so the starting-world salt is read from
+/// its final value (the orchestrator guarantees this ordering — it sits next to
+/// the `fire_flower` call, which shares the same salt).
+pub fn apply(rom: &mut Rom, enabled: bool) {
+    if !enabled {
+        return;
+    }
+
+    // Seed-derived salt: the shuffled starting world (0 when world-order shuffle
+    // is off). Baked as an immediate, so the mapping is deterministic per seed.
+    let salt = rom.read_byte(WORLD_INIT_OPERAND);
+
+    // Injected routine. Y still holds the egg object's slot on entry and is left
+    // untouched. Every summed input is constant for the whole level (see the
+    // module doc) so the egg type is stable across a Lakitu's tosses.
+    //   LDA #salt
+    //   CLC
+    //   ADC $0727        ; + World_Num
+    //   ADC $61          ; + Level_LayPtr_AddrL
+    //   AND #$01         ; coin flip: low bit of the sum
+    //   BEQ real         ; 0 -> real egg
+    //   LDA #$02
+    //   STA $7FE7,Y      ; Objects_SprAttr,Y = palette 2 (green)
+    //   LDA #OBJ_SPINYEGGDUD
+    //   SEC              ; downstream SBC #12 (egg spawn Y) expects carry set
+    //   RTS
+    // real:
+    //   LDA #OBJ_SPINYEGG ; SprAttr already SPR_PAL1 from before the hook
+    //   SEC
+    //   RTS
+    #[rustfmt::skip]
+    let code: Vec<u8> = vec![
+        0xA9, salt,             // LDA #salt
+        0x18,                   // CLC
+        0x6D, 0x27, 0x07,       // ADC $0727  (World_Num)
+        0x65, 0x61,             // ADC $61    (Level_LayPtr_AddrL)
+        0x29, 0x01,             // AND #$01
+        0xF0, 0x09,             // BEQ +9 -> real
+        0xA9, DUD_PALETTE,      // LDA #$02
+        0x99, 0xE7, 0x7F,       // STA $7FE7,Y (Objects_SprAttr,Y)
+        0xA9, OBJ_SPINYEGGDUD,  // LDA #$85
+        0x38,                   // SEC
+        0x60,                   // RTS
+        0xA9, OBJ_SPINYEGG,     // LDA #$84   (real @ +9 from the BEQ)
+        0x38,                   // SEC
+        0x60,                   // RTS
+    ];
+    debug_assert_eq!(code.len() as u16, ROUTINE_LEN);
+    rom.write_range(FS_LAKITU_EGG, &code);
+
+    // Divert the egg-select to our routine. The JSR (3 bytes) is NOP-padded to
+    // fill the 16-byte vanilla block; A (the chosen object id) and Y survive the
+    // NOPs and flow into the vanilla STA $0671,Y that follows.
+    assert_eq!(
+        rom.read_range(HOOK_SITE, HOOK_VANILLA.len()),
+        &HOOK_VANILLA[..],
+        "Lakitu egg-select hook site does not match vanilla bytes",
+    );
+    let lo = (LAKITU_EGG_SUB_CPU & 0xFF) as u8;
+    let hi = (LAKITU_EGG_SUB_CPU >> 8) as u8;
+    let mut hook = vec![0x20, lo, hi]; // JSR routine
+    hook.resize(HOOK_VANILLA.len(), 0xEA); // NOP pad to 16 bytes
+    rom.write_range(HOOK_SITE, &hook);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rom::Rom;
+
+    /// Mirror the injected routine's coin flip: low bit of the stable-input sum.
+    /// `true` = green dud egg, `false` = real red egg.
+    fn is_dud(salt: u8, world: u8, layptr: u8) -> bool {
+        salt.wrapping_add(world).wrapping_add(layptr) & 1 == 1
+    }
+
+    fn blank_rom() -> Rom {
+        // Minimal valid iNES image: header + 256 KiB PRG + 128 KiB CHR, zeroed.
+        let mut data = vec![0u8; 393232];
+        data[0..4].copy_from_slice(&[0x4E, 0x45, 0x53, 0x1A]);
+        data[4] = 16; // PRG pages
+        data[5] = 16; // CHR pages
+        data[6] = 0x40; // mapper 4 lower nibble
+        Rom::from_bytes_lax(&data, true).unwrap()
+    }
+
+    /// Plant the vanilla egg-select bytes so `apply` can assert against them.
+    fn rom_with_hook() -> Rom {
+        let mut rom = blank_rom();
+        rom.write_range(HOOK_SITE, &HOOK_VANILLA);
+        rom
+    }
+
+    #[test]
+    fn disabled_is_noop() {
+        let mut rom = rom_with_hook();
+        let before = rom.read_range(0, 393232).to_vec();
+        apply(&mut rom, false);
+        assert_eq!(rom.read_range(0, 393232), &before[..], "disabled must not touch the ROM");
+    }
+
+    #[test]
+    fn enabled_writes_hook_and_routine() {
+        let mut rom = rom_with_hook();
+        apply(&mut rom, true);
+
+        // Hook: JSR to the routine, then NOP padding to the full 16 bytes.
+        let lo = (LAKITU_EGG_SUB_CPU & 0xFF) as u8;
+        let hi = (LAKITU_EGG_SUB_CPU >> 8) as u8;
+        let hook = rom.read_range(HOOK_SITE, HOOK_VANILLA.len());
+        assert_eq!(&hook[0..3], &[0x20, lo, hi], "JSR to routine");
+        assert!(hook[3..].iter().all(|&b| b == 0xEA), "rest is NOP padding");
+
+        // Routine length + terminating RTS.
+        assert_eq!(
+            rom.read_range(FS_LAKITU_EGG, ROUTINE_LEN as usize).len(),
+            ROUTINE_LEN as usize,
+        );
+        assert_eq!(rom.read_byte(FS_LAKITU_EGG + ROUTINE_LEN as usize - 1), 0x60);
+        // Salt immediate is the starting world (0 in a blank ROM).
+        assert_eq!(rom.read_byte(FS_LAKITU_EGG), 0xA9);
+        assert_eq!(rom.read_byte(FS_LAKITU_EGG + 1), 0x00);
+    }
+
+    #[test]
+    fn wrong_salt_reflected_in_routine() {
+        // The salt immediate must track WORLD_INIT_OPERAND, not a constant.
+        let mut rom = rom_with_hook();
+        rom.write_byte(WORLD_INIT_OPERAND, 0x05);
+        apply(&mut rom, true);
+        assert_eq!(rom.read_byte(FS_LAKITU_EGG + 1), 0x05);
+    }
+
+    #[test]
+    fn coin_flip_is_deterministic_and_both_outcomes_occur() {
+        // Same inputs -> same egg; across realistic inputs we see both eggs.
+        let mut saw_real = false;
+        let mut saw_dud = false;
+        for salt in 0..9u8 {
+            for world in 0..9u8 {
+                for layptr in [0x00u8, 0x14, 0x2B, 0x40, 0x7F, 0xC3, 0xFE] {
+                    let a = is_dud(salt, world, layptr);
+                    let b = is_dud(salt, world, layptr);
+                    assert_eq!(a, b, "must be deterministic");
+                    saw_real |= !a;
+                    saw_dud |= a;
+                }
+            }
+        }
+        assert!(saw_real && saw_dud, "both egg types must be reachable");
+    }
+}

--- a/src/randomize/lakitu_egg.rs
+++ b/src/randomize/lakitu_egg.rs
@@ -1,11 +1,11 @@
 //! Random Lakitu egg type.
 //!
 //! Vanilla decides what a Lakitu throws from the level-wide `Level_SlopeEn`
-//! flag (a tileset property): non-sloped levels get the real **Spiny Egg**
-//! (`OBJ_SPINYEGG`, red, hatches into a chasing Spiny), sloped levels (Hills /
-//! Underground tilesets) get the harmless **green "dud" egg** (`OBJ_SPINYEGGDUD`,
-//! palette 2, never hatches). Because wild injections land in ordinary
-//! (non-sloped) levels, an injected Lakitu always throws the real red egg.
+//! flag (a tileset property): non-sloped levels get the **red egg**
+//! (`OBJ_SPINYEGG`, hatches into a chasing Spiny), sloped levels (Hills /
+//! Underground tilesets) get the **green egg** (`OBJ_SPINYEGGDUD`, palette 2)
+//! which does not hatch. Because wild injections land in ordinary (non-sloped)
+//! levels, an injected Lakitu always throws the red egg.
 //!
 //! This patch substitutes that hardcoded, tileset-driven choice for a
 //! position-hash — the same deterministic-without-RNG trick as
@@ -19,22 +19,22 @@
 //!
 //! ```text
 //! LDA #$00 / CMP Level_SlopeEn        ; carry set iff SlopeEn == 0
-//! LDA #OBJ_SPINYEGG ($84)             ; assume real egg
-//! BGE +7                              ; SlopeEn == 0 -> keep real egg
+//! LDA #OBJ_SPINYEGG ($84)             ; assume red egg
+//! BGE +7                              ; SlopeEn == 0 -> keep red egg
 //! LDA #$02 / STA Objects_SprAttr,Y    ; else palette 2
-//! LDA #OBJ_SPINYEGGDUD ($85)          ; ...and the green dud egg
+//! LDA #OBJ_SPINYEGGDUD ($85)          ; ...and the green egg
 //! ```
 //!
 //! We overwrite that 16-byte block with a `JSR` to an injected routine (padded
 //! with NOPs) that computes, with `Y` still holding the egg's object slot:
 //!
 //! ```text
-//! low_bit_of(salt + World_Num + Level_LayPtr_AddrL) == 0 -> real red egg
-//!                                                    == 1 -> green dud egg
+//! low_bit_of(salt + World_Num + Level_LayPtr_AddrL) == 0 -> red egg
+//!                                                    == 1 -> green egg
 //! ```
 //!
 //! and returns `A` = the chosen object id (setting `Objects_SprAttr,Y` to
-//! palette 2 for the dud). The block falls through into the vanilla
+//! palette 2 for the green egg). The block falls through into the vanilla
 //! `STA Level_ObjectID,Y` exactly as before.
 //!
 //! ## Why these inputs (and only these)
@@ -85,9 +85,9 @@ const HOOK_VANILLA: [u8; 16] = [
     0xA9, 0x85,             // LDA #$85   (OBJ_SPINYEGGDUD)
 ];
 
-const OBJ_SPINYEGG: u8 = 0x84; // real egg (hatches into a Spiny), keeps SPR_PAL1
-const OBJ_SPINYEGGDUD: u8 = 0x85; // green dud egg (never hatches), palette 2
-const DUD_PALETTE: u8 = 0x02; // Objects_SprAttr value the vanilla dud path sets
+const OBJ_SPINYEGG: u8 = 0x84; // red egg (hatches into a Spiny), keeps SPR_PAL1
+const OBJ_SPINYEGGDUD: u8 = 0x85; // green egg (does not hatch), palette 2
+const GREEN_EGG_PALETTE: u8 = 0x02; // Objects_SprAttr value the vanilla green-egg path sets
 
 /// Length of the injected routine.
 const ROUTINE_LEN: u16 = 25;
@@ -114,13 +114,13 @@ pub fn apply(rom: &mut Rom, enabled: bool) {
     //   ADC $0727        ; + World_Num
     //   ADC $61          ; + Level_LayPtr_AddrL
     //   AND #$01         ; coin flip: low bit of the sum
-    //   BEQ real         ; 0 -> real egg
+    //   BEQ red          ; 0 -> red egg
     //   LDA #$02
     //   STA $7FE7,Y      ; Objects_SprAttr,Y = palette 2 (green)
     //   LDA #OBJ_SPINYEGGDUD
     //   SEC              ; downstream SBC #12 (egg spawn Y) expects carry set
     //   RTS
-    // real:
+    // red:
     //   LDA #OBJ_SPINYEGG ; SprAttr already SPR_PAL1 from before the hook
     //   SEC
     //   RTS
@@ -131,13 +131,13 @@ pub fn apply(rom: &mut Rom, enabled: bool) {
         0x6D, 0x27, 0x07,       // ADC $0727  (World_Num)
         0x65, 0x61,             // ADC $61    (Level_LayPtr_AddrL)
         0x29, 0x01,             // AND #$01
-        0xF0, 0x09,             // BEQ +9 -> real
-        0xA9, DUD_PALETTE,      // LDA #$02
+        0xF0, 0x09,             // BEQ +9 -> red
+        0xA9, GREEN_EGG_PALETTE, // LDA #$02
         0x99, 0xE7, 0x7F,       // STA $7FE7,Y (Objects_SprAttr,Y)
         0xA9, OBJ_SPINYEGGDUD,  // LDA #$85
         0x38,                   // SEC
         0x60,                   // RTS
-        0xA9, OBJ_SPINYEGG,     // LDA #$84   (real @ +9 from the BEQ)
+        0xA9, OBJ_SPINYEGG,     // LDA #$84   (red @ +9 from the BEQ)
         0x38,                   // SEC
         0x60,                   // RTS
     ];
@@ -165,8 +165,8 @@ mod tests {
     use crate::rom::Rom;
 
     /// Mirror the injected routine's coin flip: low bit of the stable-input sum.
-    /// `true` = green dud egg, `false` = real red egg.
-    fn is_dud(salt: u8, world: u8, layptr: u8) -> bool {
+    /// `true` = green egg, `false` = red egg.
+    fn is_green(salt: u8, world: u8, layptr: u8) -> bool {
         salt.wrapping_add(world).wrapping_add(layptr) & 1 == 1
     }
 
@@ -230,19 +230,19 @@ mod tests {
     #[test]
     fn coin_flip_is_deterministic_and_both_outcomes_occur() {
         // Same inputs -> same egg; across realistic inputs we see both eggs.
-        let mut saw_real = false;
-        let mut saw_dud = false;
+        let mut saw_red = false;
+        let mut saw_green = false;
         for salt in 0..9u8 {
             for world in 0..9u8 {
                 for layptr in [0x00u8, 0x14, 0x2B, 0x40, 0x7F, 0xC3, 0xFE] {
-                    let a = is_dud(salt, world, layptr);
-                    let b = is_dud(salt, world, layptr);
+                    let a = is_green(salt, world, layptr);
+                    let b = is_green(salt, world, layptr);
                     assert_eq!(a, b, "must be deterministic");
-                    saw_real |= !a;
-                    saw_dud |= a;
+                    saw_red |= !a;
+                    saw_green |= a;
                 }
             }
         }
-        assert!(saw_real && saw_dud, "both egg types must be reachable");
+        assert!(saw_red && saw_green, "both egg types must be reachable");
     }
 }

--- a/src/randomize/mod.rs
+++ b/src/randomize/mod.rs
@@ -7,6 +7,7 @@ pub mod credits;
 pub mod enemies;
 pub mod enemy_protections;
 pub mod fire_flower;
+pub mod lakitu_egg;
 pub mod hand_rooms;
 pub mod hands_levels;
 pub mod items;

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -37,6 +37,8 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x0385E, 12, "koopa_fire_preset: set stomp counter from threshold table for fireball defeat"),
     (0x03FD0, 22, "koopa_y_clamp: clamp Koopaling Y position to screen"),
     (0x03FE6, 36, "fire_flower: position-hash suit routine + pool table"),
+    // PRG004 (file 0x08010, CPU $A000–$BFFF) — object AI bank (Lakitu lives here)
+    (0x09E66, 25, "lakitu_egg: position-hash egg-type routine (real vs green dud)"),
     // PRG003 (file 0x06010, CPU $A000–$BFFF) — object AI bank (Boom-Boom lives here)
     (0x06609, 8, "tail_stay_dead: MaCobra respawn-suppress routine (CPU $A5F9 gap)"),
     (0x07FCF, 16, "boomboom_hits: per-fortress threshold table"),
@@ -207,6 +209,14 @@ pub(crate) const FIRE_FLOWER_SUB_CPU: u16  = 0xBFD6; // $A000 + (0x03FE6 - 0x020
 pub(crate) const FS_KOOPA_FIRE_PRESET: usize = 0x0385E; // 12 bytes
 
 pub(crate) const KOOPA_FIRE_PRESET_CPU: u16  = 0xB84E;  // $A000 + (0x0385E - 0x02010)
+
+// PRG004 (file 0x08010, CPU $A000–$BFFF) — object AI bank where ObjNorm_Lakitu /
+// Lakitu_TossEnemy live. The routine that picks a tossed Lakitu's egg type sits
+// in the bank-end 0xFF filler (426 free bytes from 0x09E66), so the JSR from the
+// toss hook is bank-local. 25 bytes.
+pub(crate) const FS_LAKITU_EGG: usize      = 0x09E66;
+
+pub(crate) const LAKITU_EGG_SUB_CPU: u16   = 0xBE56; // $A000 + (0x09E66 - 0x08010)
 
 // PRG003 (file 0x06010, CPU $A000–$BFFF) — Boom-Boom stomp-count randomization.
 // The Boom-Boom boss AI (ObjInit_BoomBoom, BoomBoom_HitTest, the DynJump state

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -514,6 +514,17 @@ fn randomize_inner(
         randomize::fire_flower::apply(rom, options.fire_flower);
     }
 
+    // Random Lakitu egg type — rides on wild injections. Every Lakitu's tossed
+    // egg (real red Spiny Egg vs harmless green dud) becomes a deterministic
+    // position-hash of stable game state + the starting-world salt, instead of
+    // the vanilla tileset-driven choice that always gives injected Lakitus the
+    // real egg. Pure static patch (no RNG); must run after world_order so the
+    // salt is final (same salt as fire_flower above).
+    if options.wild_injections {
+        rom.set_tag("lakitu_egg");
+        randomize::lakitu_egg::apply(rom, options.wild_injections);
+    }
+
     // Stamp flag key + seed into free space at STAMP_OFFSET (PRG012):
     //   "S3R" magic + version byte, the flag key bytes (13 in v23), then the
     //   seed (little-endian u64). Sizes derive from to_flag_bytes() so the


### PR DESCRIPTION
## What

With **wild injections** on, every Lakitu in the seed now throws either a red egg (hatches into a chasing Spiny) or a non-hatching green egg, chosen deterministically per level — instead of the vanilla behavior where injected Lakitus (which always land in non-sloped levels) could only ever throw the red egg.

## Why

The egg type is vanilla-decided from the level-wide `Level_SlopeEn` (a tileset property), not from anything about the Lakitu: non-sloped tilesets → red egg, Hills/Underground tilesets → green egg. Since injections land in ordinary non-sloped levels, injected Lakitus were always the red type. This adds variety. (Both eggs damage on contact; the only behavioral difference is that the green egg does not hatch a Spiny.)

## How

Reuses the `fire_flower` position-hash pattern so it stays **deterministic with no console RNG** (per an explicit requirement):

- **Hook** the 16-byte egg-select block in `Lakitu_TossEnemy` (PRG004, file `0x08E58`) with a bank-local `JSR` (NOP-padded) to an injected routine in the PRG004 bank-end filler (`FS_LAKITU_EGG` = `0x09E66`, CPU `$BE56`).
- **Routine** coin-flips the egg from the low bit of `salt + World_Num ($0727) + Level_LayPtr_AddrL ($61)` — all level-constant, so a Lakitu's egg stays fixed across its tosses (a moving Lakitu's live position would flicker — the same trap `fire_flower` documents). Sets palette 2 for the green egg and `SEC` so the downstream egg-spawn `SBC #12` is unaffected.
- **Salt** = the shuffled starting world (`WORLD_INIT_OPERAND`), 0 when world-order shuffle is off; rotates the mapping seed to seed. Runs right after `fire_flower` so the salt is final.

Because SMB3 only supports one active Lakitu at a time, per-(seed, world, area) resolution is effectively per-Lakitu.

## Scope

- Gated on the existing `wild_injections` flag (no new flag).
- Patches the shared toss routine, so **all** Lakitus are affected (native + injected) — intended, per discussion.
- Toss *cadence* (also keyed on `Level_SlopeEn`) is deliberately left untouched; only the egg type changes.

## Verification

- New module tests: no-op when disabled, correct hook/JSR/routine bytes, salt tracks `WORLD_INIT_OPERAND`, coin flip deterministic + both outcomes reachable.
- The vanilla-bytes assertion in `apply` (which caught an off-by-2 during development) passes on the real ROM under the full `all_on` determinism test.
- Full suite green (290 passed); clippy clean.
- Confirmed end-to-end on a generated ROM: hook = `20 56 BE EA×13`, routine bytes exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)