### PR TITLE
fix: archived version snapshots ship their WASM bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,12 @@ jobs:
             mkdir -p "v/$VER"
             cp -r ../main-src/web/. "v/$VER/"
             cp -r ../main-src/pkg   "v/$VER/pkg"
-            git add -A
+            # wasm-pack writes a `pkg/.gitignore` containing `*`, which makes
+            # `git add` skip the entire WASM bundle and leaves the frozen
+            # snapshot with an empty pkg/ (so its app fails to boot). Drop that
+            # ignore file and force-add so the snapshot actually ships its pkg/.
+            rm -f "v/$VER/pkg/.gitignore"
+            git add -Af "v/$VER"
             git commit -m "archive v$VER"
             git push origin site-versions
             echo "Archived v$VER."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ deploys.
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-07-21
+
+### Fixed
+
+- Archived version pages (`.../smb3-rs/v/<version>/`) were shipping without their
+  WASM bundle, so they loaded a blank shell with no options. The snapshot step
+  now force-includes `pkg/`, which `wasm-pack`'s generated `.gitignore` had been
+  causing `git add` to skip.
+
 ## [1.0.2] - 2026-07-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Problem

Archived version pages (`.../smb3-rs/v/<version>/`) load a blank shell with no options. Verified live: `v/1.0.2/index.html`, `app.js`, `options.js` all return 200, but every file under `v/1.0.2/pkg/` returns **404**. With no WASM, `init()` rejects and the schema-driven options never render.

## Root cause

`wasm-pack` writes a `pkg/.gitignore` containing `*`. The two paths `pkg/` takes into the deploy diverge:

- **Root app** (`_site/pkg`) — staged with plain `cp` → WASM present → works.
- **Archived snapshot** (`v/<ver>/pkg`) — committed to `site-versions` via `git add -A`, which honors that `*` ignore and silently skips the entire bundle.

## Fix

The archive step now removes the copied `pkg/.gitignore` and uses `git add -Af`, so snapshots actually ship their WASM. Bumps to 1.0.3 (code-identical to 1.0.2; `v/1.0.3` will be the first snapshot that boots).

Note: the already-broken `v/1.0.2` snapshot won't self-repair (archive only writes the current version); it's being removed from `site-versions` separately since no links to it were shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)