### PR TITLE
fix: 2P map-warp fired in 1-player mode

### DIFF
--- a/src/randomize/qol/map_warp.rs
+++ b/src/randomize/qol/map_warp.rs
@@ -80,9 +80,10 @@ const MAP_REENTRY_CPU: u16 = 0x84D7;
 /// returns with the Z flag intact, so the vanilla `BEQ` after the hook still
 /// decides the A-button path.
 #[rustfmt::skip]
-const MAP_WARP_ROUTINE: [u8; 160] = [
-    0xAD, 0x2B, 0x07,       // LDA Total_Players ($072B)
-    0xF0, 0x13,             // BEQ pass          (1P game -> normal input)
+const MAP_WARP_ROUTINE: [u8; 162] = [
+    0xAD, 0x2B, 0x07,       // LDA Total_Players ($072B) — 1 for 1P, 2 for 2P
+    0xC9, 0x02,             // CMP #$02
+    0xD0, 0x13,             // BNE pass           (not a 2-player game -> skip)
     0xB5, 0xF7,             // LDA Controller1,X  (held input, current player)
     0x29, 0x30,             // AND #$30           (Start | Select)
     0xC9, 0x30,             // CMP #$30           (both held?)

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -25,7 +25,7 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     // PRG010 (file 0x14010, CPU $C000–$DFFF during map)
     (0x15554, 80, "fx_screen_check: cross-screen lock patch (Fred's algorithm verbatim)"),
     (0x15DF0, 35, "canoe_fix: death respawn position save"),
-    (0x15E13, 160, "map_warp: 2P Start+Select warp-to-partner routine"),
+    (0x15E13, 162, "map_warp: 2P Start+Select warp-to-partner routine"),
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
     (0x17C87, 36, "start_airship_swap: game-over twirl finalize helper"),
     (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
@@ -143,7 +143,7 @@ pub(crate) const FS_KING_QUOTES: usize       = 0x379D9; // 894 bytes
 pub(crate) const FS_FX_SCREEN_CHECK: usize   = 0x15554; // 80 bytes (Fred's algorithm)
 
 pub(crate) const FS_CANOE_RESPAWN: usize     = 0x15DF0; // 35 bytes
-pub(crate) const FS_MAP_WARP: usize          = 0x15E13; // 160 bytes (CPU $DE03)
+pub(crate) const FS_MAP_WARP: usize          = 0x15E13; // 162 bytes (CPU $DE03)
 
 // PRG011
 pub(crate) const FS_CANOE_BACKUP: usize      = 0x17D00; // 66 bytes


### PR DESCRIPTION
Follow-up fix to #106. The `Total_Players` guard was wrong: the value is **1 for 1P / 2 for 2P** (a stale equate comment claimed 0/1), so `BEQ pass` never skipped and Start+Select warped the lone 1-player player toward the empty Luigi slot. Now gated on `CMP #$02 / BNE pass` — fires only in 2-player, falls through to normal input in 1-player.

Byte-verified in generated ROM output; lib + free-space tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)