### PR TITLE
fix: remove the dead Pipe Shuffle flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ deploys.
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-07-24
+
+### Removed
+
+- The "Pipe Shuffle" option (web checkbox and `--no-shuffle-pipes` CLI flag).
+  It has been a no-op since the overworld builder took over pipe placement —
+  pipes are always placed by the builder. Flag keys bump to v26; old keys
+  encoding the dead bit are no longer accepted.
+
 ## [1.0.3] - 2026-07-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 
 [lib]

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,10 +201,6 @@ struct Cli {
     #[arg(long)]
     keep_whistles: bool,
 
-    /// Disable pipe shuffle (on by default)
-    #[arg(long)]
-    no_shuffle_pipes: bool,
-
     /// Disable airship shuffle (on by default)
     #[arg(long)]
     no_shuffle_airships: bool,
@@ -488,7 +484,6 @@ fn build_options(cli: &Cli) -> Options {
             world_order: cli.world_order,
             world_count: cli.world_count,
             big_q_blocks: cli.big_q_blocks,
-            shuffle_pipes: !cli.no_shuffle_pipes,
             shuffle_airships: !cli.no_shuffle_airships,
             shuffle_hammer_bros: !cli.no_shuffle_hammer_bros,
             disable_autoscroll: !cli.keep_autoscroll,
@@ -563,7 +558,6 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
     }
     eprintln!("  Big ? Blocks: {}", if options.big_q_blocks { "on" } else { "off" });
     eprintln!("  Starting Lives: {}", options.starting_lives);
-    eprintln!("  Pipe shuffle: {}", if options.shuffle_pipes { "on" } else { "off" });
     eprintln!("  Airship shuffle: {}", if options.shuffle_airships { "on" } else { "off" });
     eprintln!("  Hammer Bro shuffle: {}", if options.shuffle_hammer_bros { "on" } else { "off" });
     eprintln!("  Autoscroll: {}", if options.disable_autoscroll { "disabled" } else { "enabled" });

--- a/src/randomize/map_walker.rs
+++ b/src/randomize/map_walker.rs
@@ -698,7 +698,6 @@ mod tests {
         let mut rom = Rom::from_bytes(&rom_data_bytes.unwrap()).unwrap();
 
         let options = crate::randomizer::Options {
-            shuffle_pipes: true,
             shuffle_airships: true,
             ..Default::default()
         };

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 
-pub(super) const FLAG_KEY_VERSION: u8 = 25;
+pub(super) const FLAG_KEY_VERSION: u8 = 26;
 
 pub(super) const FLAG_KEY_PREFIX: &str = "SMB3R-";
 
@@ -89,12 +89,12 @@ impl Options {
             | (self.shuffle_hammer_bros as u8) << 1
             | (self.chest_items as u8);
 
+        // b2 bit 5 is free (formerly shuffle_pipes, a dead flag removed in v26).
         // b2 bit 4 = faster_frog (reuses the slot formerly fix_drawbridges,
         // now always-on).
         // b2 bit 3 = boomboom_hits (reuses the slot formerly remove_rocks).
         let b2 = (self.remove_whistles as u8) << 7
             | (self.hands_levels as u8) << 6
-            | (self.shuffle_pipes as u8) << 5
             | (self.faster_frog as u8) << 4
             | (self.boomboom_hits as u8) << 3
             | (self.troll_pipes.is_on() as u8) << 2
@@ -321,7 +321,6 @@ impl Options {
             chest_items: b1 & 1 != 0,
             remove_whistles: (b2 >> 7) & 1 != 0,
             hands_levels: (b2 >> 6) & 1 != 0,
-            shuffle_pipes: (b2 >> 5) & 1 != 0,
             faster_frog: (b2 >> 4) & 1 != 0,
             shuffle_airships: b2 & 1 != 0,
             shuffle_toad_houses: (b2 >> 1) & 1 != 0,

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -147,9 +147,6 @@ pub struct Options {
     pub world_count: u8,
     #[serde(default)]
     pub big_q_blocks: bool,
-    /// Shuffle pipe endpoint positions during the overworld rebuild.
-    #[serde(default = "default_true")]
-    pub shuffle_pipes: bool,
     /// Shuffle airship levels across worlds 1-7.
     #[serde(default = "default_true")]
     pub shuffle_airships: bool,
@@ -392,7 +389,6 @@ impl Default for Options {
             world_order: false,
             world_count: default_world_count(),
             big_q_blocks: false,
-            shuffle_pipes: true,
             shuffle_airships: true,
             shuffle_hammer_bros: true,
             disable_autoscroll: true,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -124,7 +124,6 @@ fn flag_key_round_trip_all_wild() {
         palettes: true,
         world_order: true,
         big_q_blocks: true,
-        shuffle_pipes: true,
         shuffle_airships: true,
         shuffle_hammer_bros: true,
         disable_autoscroll: true,
@@ -317,7 +316,6 @@ fn flag_key_per_option_round_trip() {
         ("powerups",                     Box::new(|o| o.powerups = !o.powerups)),
         ("world_order",                  Box::new(|o| o.world_order = !o.world_order)),
         ("big_q_blocks",                 Box::new(|o| o.big_q_blocks = !o.big_q_blocks)),
-        ("shuffle_pipes",                Box::new(|o| o.shuffle_pipes = !o.shuffle_pipes)),
         ("shuffle_airships",             Box::new(|o| o.shuffle_airships = !o.shuffle_airships)),
         ("shuffle_hammer_bros",          Box::new(|o| o.shuffle_hammer_bros = !o.shuffle_hammer_bros)),
         ("disable_autoscroll",           Box::new(|o| o.disable_autoscroll = !o.disable_autoscroll)),
@@ -454,7 +452,6 @@ fn flag_key_per_option_round_trip() {
     everything.powerups = !everything.powerups;
     everything.world_order = !everything.world_order;
     everything.big_q_blocks = !everything.big_q_blocks;
-    everything.shuffle_pipes = !everything.shuffle_pipes;
     everything.shuffle_airships = !everything.shuffle_airships;
     everything.shuffle_hammer_bros = !everything.shuffle_hammer_bros;
     everything.disable_autoscroll = !everything.disable_autoscroll;
@@ -612,7 +609,6 @@ fn all_off_options() -> Options {
         world_order: false,
         world_count: 7,
         big_q_blocks: false,
-        shuffle_pipes: false,
         shuffle_airships: false,
         shuffle_hammer_bros: false,
         disable_autoscroll: false,
@@ -678,7 +674,6 @@ fn all_on_options() -> Options {
         world_order: true,
         world_count: 3,
         big_q_blocks: true,
-        shuffle_pipes: false,
         shuffle_airships: true,
         shuffle_hammer_bros: true,
         disable_autoscroll: true,

--- a/web/options.js
+++ b/web/options.js
@@ -106,10 +106,6 @@ export const SCHEMA = [
 	// --- Map ---
 	// Icons are clipped from web/assets/sprites.png. Coordinates picked via
 	// web/sprite-picker.html. Format: { x, y, w, h } in sprite-sheet pixels.
-	{ id: "shuffle_pipes", type: "bool", default: true,
-		label: "Pipe Shuffle",
-		tip: "Shuffle pipe endpoint positions on the overworld map",
-		group: "map", inFlagKey: true },
 	{ id: "shuffle_spade_games", type: "bool", default: true,
 		label: "Shuffle Spade Games",
 		tip: "Move spade (card-matching) games to random spots on the map",


### PR DESCRIPTION
## Summary

`shuffle_pipes` has been a no-op since the overworld builder took over pipe placement — nothing in the pipeline reads it (`randomize()` never consumes `options.shuffle_pipes`; the builder always places pipes). The web page was still showing a "Pipe Shuffle" checkbox that did nothing.

Removed:
- `Options.shuffle_pipes` field
- `--no-shuffle-pipes` CLI arg and its printout
- the "Pipe Shuffle" checkbox in `web/options.js` (no preset referenced it)
- the flag-key bit (b2 bit 5, now documented free); flag-key version bumped 25 → 26, so stale keys get the standard "unsupported version" rejection

Version bumped to **1.0.4** for the main merge. Same change is also on `feature/remove-dead-pipe-shuffle-flag` (off `beta/next`) with identical content, so the eventual merge-back is trivial.

## Testing

- `cargo clippy --all-targets` — clean
- `cargo test` — 286 lib + integration tests pass (includes flag-key round-trip tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kRngdkseUshP7omErzMCZ