### PR TITLE
Overworld builder: pipe fort-skip, WorldPlan, family sampling — the curated ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ deploys.
   optional (a free "fort skip" shortcut for players who find it). Pipes that
   would bypass two or more fortresses, or reach the goal with every lock still
   closed, are never placed.
+- Fortress choice-forks no longer have a tell: the fort that really opens the
+  way forward is now equally likely to be any of the forked forts. Previously
+  it was almost always the farthest one to reach, so "always pick the far
+  fort" beat the choice 70% of the time.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ deploys.
   gating the deepest chokepoint. This adds variety — worlds can present a genuine
   "pick the right fort" fork, and W8 mixes a short chain into a final fork —
   rather than defaulting to a linear beat-fort-to-reach-next-fort grind.
+- Spare overworld pipes are now placed after fortress locks and may bridge
+  across one of them: at most one pipe per world can make a single fortress
+  optional (a free "fort skip" shortcut for players who find it). Pipes that
+  would bypass two or more fortresses, or reach the goal with every lock still
+  closed, are never placed.
 
 ### Added
 

--- a/src/randomize/map_walker.rs
+++ b/src/randomize/map_walker.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use crate::rom::Rom;
 
 use super::rom_data::{
-    self, BACKGROUND_TILES, VALID_HORZ, VALID_VERT,
+    self, BACKGROUND_TILES, TILE_AIRSHIP, TILE_BOWSER, VALID_HORZ, VALID_VERT,
     Grid, TeleportEdge,
 };
 
@@ -167,6 +167,21 @@ fn walk_from(
 
     while let Some((r, c)) = queue.pop_front() {
         edges.entry((r, c)).or_default();
+
+        // The airship/Bowser target blocks through-movement until completed —
+        // and completing it ends the world — so the player can never pass
+        // THROUGH it. Model it as enterable but not exitable (a sink): the
+        // region behind the target is a separate island to every walk, which
+        // is what the game actually plays like (and what lets the pipe
+        // connectivity phase serve that region its own access). Exception:
+        // when the walk STARTS on the target, expansion stays enabled — a
+        // from-target walk asks "which nodes can reach me", and since every
+        // other edge is symmetric, expanding out of the sink source keeps
+        // that meaning intact.
+        let tile_here = grid.get(r, c);
+        if (tile_here == TILE_AIRSHIP || tile_here == TILE_BOWSER) && (r, c) != start {
+            continue;
+        }
 
         // Orthogonal movement: node → path tile → node (2 tiles)
         for &(dr, dc, is_horz) in &DIRECTIONS {

--- a/src/randomize/overworld_build/locks.rs
+++ b/src/randomize/overworld_build/locks.rs
@@ -2,119 +2,13 @@
 
 use super::*;
 
+use super::plan::{LockRole, WorldPlan};
 use super::types::{BuildResult, LockAssignment, SlotAssignment, SlotKind, stamp_slots};
 
 /// The five always-on W8 screen-3 bridges (see `qol::overworld_map`'s
 /// `W8_BRIDGE_EDITS`). Locking one gaps it out as water until its fortress is
 /// beaten — a deliberate showcase, so the lock scorer nudges toward them.
 const W8_BRIDGE_LOCK_POSITIONS: &[(usize, usize)] = &[(5, 51), (5, 53), (5, 55), (5, 57), (5, 59)];
-
-/// Score bonus for locking a W8 showcase bridge. Sized to noticeably raise how
-/// often a bridge is chosen without overriding the `blocks_later_fort` (+100)
-/// progression signal or the hard reachability rules. Tuned via a 200k-seed
-/// sweep: +8 puts ≥1 bridge out in ~99.6% of seeds, two out in ~30%, and all
-/// four (the ceiling — W8 has 4 forts = 4 locks) out in ~0.08% (a rare treat).
-const W8_BRIDGE_LOCK_BONUS: i32 = 8;
-
-/// The role a fortress's lock plays in the world's progression archetype.
-/// Decided per-world in [`sample_lock_plan`] and consumed by [`place_locks`],
-/// which places each lock to satisfy its role using the shared positional
-/// scorer. See the `fort_topology_archetypes` design notes.
-#[derive(Clone, Debug)]
-pub(super) enum LockRole {
-    /// Lock must gate (make unreachable) every fort section in `targets` — a
-    /// chain link (gate the next fort) or the prefix→fork entrance (gate the
-    /// whole terminal group at once).
-    ChainLink { targets: Vec<usize> },
-    /// Lock must gate the airship/Bowser target while stranding no fortress.
-    GoalGate,
-    /// Lock must gate nothing important (no fort, no target) — the fortress
-    /// stays reachable. Decoy and inert forts.
-    Safe,
-}
-
-/// Weighted per-world archetype sample → per-section lock roles.
-///
-/// - 1 fort: SingleGate (the lone fort gates the goal).
-/// - W8 (dense, 4 forts): 25% Chain / 75% Fork; Fork = chain-2 → 2-way fork.
-/// - other multi-fort worlds: 30% Chain / 30% SingleGate / 40% Fork; a Fork
-///   samples a terminal width `k` (capped at 3, surplus forts chain in front),
-///   so a 3-fort Fork is a 50/50 mix of chain-1→2-fork and a pure 3-way fork.
-pub(super) fn sample_lock_plan<R: Rng>(
-    fort_count: usize,
-    world_idx: usize,
-    rng: &mut R,
-) -> Vec<LockRole> {
-    match fort_count {
-        0 => return Vec::new(),
-        1 => return vec![LockRole::GoalGate],
-        _ => {}
-    }
-
-    enum Arch {
-        Chain,
-        Single,
-        Fork,
-    }
-    let arch = if world_idx == 7 {
-        if rng.random_range(..100u32) < 25 { Arch::Chain } else { Arch::Fork }
-    } else {
-        let r = rng.random_range(..100u32);
-        if r < 30 {
-            Arch::Chain
-        } else if r < 60 {
-            Arch::Single
-        } else {
-            Arch::Fork
-        }
-    };
-
-    match arch {
-        Arch::Chain => (0..fort_count)
-            .map(|i| {
-                if i + 1 < fort_count {
-                    LockRole::ChainLink { targets: vec![i + 1] }
-                } else {
-                    LockRole::GoalGate
-                }
-            })
-            .collect(),
-        Arch::Single => (0..fort_count)
-            .map(|i| if i + 1 == fort_count { LockRole::GoalGate } else { LockRole::Safe })
-            .collect(),
-        Arch::Fork => {
-            // W8 and 2-fort worlds: a plain 2-way fork. 3-fort worlds mix
-            // 50/50 between chain-1 → 2-fork (k=2) and a pure 3-way fork (k=3).
-            let k = if world_idx == 7 || fort_count == 2 {
-                2
-            } else {
-                2 + rng.random_range(..2u32) as usize
-            };
-            fork_roles(fort_count, k)
-        }
-    }
-}
-
-/// Chain the first `n - k` forts, then a `k`-way fork (one GoalGate + `k-1`
-/// Safe decoys). `k` is capped at 3 and at `n`.
-fn fork_roles(n: usize, k: usize) -> Vec<LockRole> {
-    let k = k.min(n).min(3);
-    let prefix = n - k;
-    let mut roles = Vec::with_capacity(n);
-    for i in 0..prefix {
-        let targets = if i + 1 < prefix {
-            vec![i + 1]
-        } else {
-            // Last prefix link opens the whole terminal fork as a unit.
-            (prefix..n).collect()
-        };
-        roles.push(LockRole::ChainLink { targets });
-    }
-    for i in prefix..n {
-        roles.push(if i == n - 1 { LockRole::GoalGate } else { LockRole::Safe });
-    }
-    roles
-}
 
 /// A scored lock candidate tracked during selection.
 #[derive(Clone, Copy)]
@@ -128,7 +22,7 @@ struct ScoredLock {
 }
 
 // Reason: every argument represents a distinct, independent input to lock
-// placement (geometry, slot list, count, safety flag, RNG). No subset
+// placement (geometry, slot list, count, plan, safety flag, RNG). No subset
 // clusters into a meaningful concept — bundling would be a clippy bandage,
 // not a real abstraction.
 #[allow(clippy::too_many_arguments)]
@@ -139,11 +33,13 @@ pub(super) fn place_locks<R: Rng>(
     target_pos: Option<(usize, usize)>,
     slots: &[SlotAssignment],
     fort_count: usize,
-    roles: &[LockRole],
+    plan: &WorldPlan,
     force_safe: bool,
     world_idx: usize,
     rng: &mut R,
 ) -> Vec<LockAssignment> {
+    let knobs = &plan.lock;
+    let roles = &plan.roles;
     let mut locks: Vec<LockAssignment> = Vec::new();
     let mut locked_tiles: HashSet<(usize, usize)> = HashSet::new();
 
@@ -308,38 +204,39 @@ pub(super) fn place_locks<R: Rng>(
                     && !walk.nodes.contains(&s.pos)
             });
             if blocks_later_fort {
-                score += 100;
+                score += knobs.blocks_later_fort_bonus;
             }
 
             // Bonus: blocks the target (airship/bowser) — only credited to
             // the first such lock in the world; subsequent target-blockers
             // would just pile up next to the airship.
             if !target_reachable && !target_already_locked {
-                score += 10;
+                score += knobs.blocks_target_bonus;
             }
 
             // Spread penalty: discourage placing this lock close to any
             // already-placed lock in the world. Falls off linearly with
-            // Manhattan distance, zero past 8 tiles.
+            // Manhattan distance, zero past `spread_radius` tiles.
             if let Some(min_dist) = locks
                 .iter()
                 .map(|l| cand_pos.0.abs_diff(l.pos.0) + cand_pos.1.abs_diff(l.pos.1))
                 .min()
             {
-                score -= (8i32 - min_dist as i32).max(0) * 2;
+                score -= (knobs.spread_radius - min_dist as i32).max(0)
+                    * knobs.spread_penalty_per_tile;
             }
 
             // Slight preference for bridge tiles — water gaps look better
             // than locks on regular path tiles.
             if tile == 0xB3 {
-                score += 1;
+                score += knobs.bridge_bonus;
             }
 
             // W8-specific: bias harder toward the screen-3 showcase bridges so
             // they're gated out more often than raw chokepoint value alone
             // would pick them.
             if world_idx == 7 && W8_BRIDGE_LOCK_POSITIONS.contains(&cand_pos) {
-                score += W8_BRIDGE_LOCK_BONUS;
+                score += knobs.w8_bridge_bonus;
             }
 
             // Track best overall and best safe separately. (A safe lock
@@ -384,7 +281,7 @@ pub(super) fn place_locks<R: Rng>(
         // Prefer safe when forced (retry) or when best score is low —
         // no point picking an impactful lock if there are none.
         let best_score = best.map(|b| b.score).unwrap_or(0);
-        let prefer_safe = force_safe || best_score < 5;
+        let prefer_safe = force_safe || best_score < knobs.weak_lock_threshold;
 
         // Archetype role wins when realizable; otherwise fall back to the
         // unconstrained pick (feasibility fallback — this world's geometry

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -20,6 +20,7 @@ use super::rom_data::{
 };
 
 mod types;
+mod plan;
 mod scoring;
 mod capacity;
 mod sections;
@@ -31,8 +32,9 @@ use capacity::{
     SPADE_BUDGET, assign_hb_sprites, distribute_levels, prepare_capacities, promote_hb_slots,
     redistribute_fortresses,
 };
-use locks::{LockRole, place_locks, sample_lock_plan};
+use locks::place_locks;
 use pipes::VANILLA_PIPE_PAIRS;
+use plan::WorldPlan;
 use scoring::{LEVEL_SPREAD_EXPONENT, VANILLA_LEVEL_COUNT};
 use sections::build_world;
 use types::{CapacityPrep, WorldSlotCounts};
@@ -103,15 +105,16 @@ pub(crate) fn build<R: Rng>(
             max_non_pipe_slots,
             force_safe: false,
         };
-        // Sample this world's progression archetype → per-fort lock roles.
-        let roles = sample_lock_plan(fort_counts[wi], wi, rng);
+        // Sample this world's plan: progression archetype → per-fort lock
+        // roles + every scoring knob the placement passes consume.
+        let plan = WorldPlan::sample(fort_counts[wi], wi, rng);
         let built = build_world(
             wi,
             rom,
             patched_grids[wi].clone(),
             &fixed_positions[wi],
             &counts,
-            &roles,
+            &plan,
             shuffle_hammer_bros,
             rng,
         );
@@ -130,8 +133,8 @@ pub(crate) fn build<R: Rng>(
             let start_pos = rom_data::find_start(&built.grid);
             let target_pos = find_target(&built.grid, wi);
             // Retry aims only to surface a secret-exit-safe lock, so ask for
-            // all-Safe roles (matches force_safe) rather than the world's shape.
-            let safe_roles = vec![LockRole::Safe; fort_counts[wi]];
+            // an all-Safe plan (matches force_safe) rather than the world's shape.
+            let safe_plan = WorldPlan::all_safe(fort_counts[wi]);
             let new_locks = place_locks(
                 &built.grid,
                 &built.pipe_pairs,
@@ -139,7 +142,7 @@ pub(crate) fn build<R: Rng>(
                 target_pos,
                 &built.slots,
                 fort_counts[wi],
-                &safe_roles,
+                &safe_plan,
                 true, // force_safe
                 wi,
                 rng,

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -88,6 +88,14 @@ pub(crate) fn build<R: Rng>(
     // hoarding levels, so the old W6-specific clamp is no longer needed.
     let level_counts = distribute_levels(&capacities, VANILLA_LEVEL_COUNT, LEVEL_SPREAD_EXPONENT, rng);
 
+    // Sample every world's plan up front, then enforce the seed-level
+    // invariant (>=1 Safe role somewhere) before any placement happens —
+    // cheaper and shape-preserving compared to the post-build force_safe
+    // retry, which remains only as a backstop.
+    let mut plans: Vec<WorldPlan> = (0..8)
+        .map(|wi| WorldPlan::sample(fort_counts[wi], wi, rng))
+        .collect();
+    plan::ensure_seed_safe_role(&mut plans, rng);
 
     let mut worlds = Vec::with_capacity(8);
     for wi in 0..8 {
@@ -105,16 +113,13 @@ pub(crate) fn build<R: Rng>(
             max_non_pipe_slots,
             force_safe: false,
         };
-        // Sample this world's plan: progression archetype → per-fort lock
-        // roles + every scoring knob the placement passes consume.
-        let plan = WorldPlan::sample(fort_counts[wi], wi, rng);
         let built = build_world(
             wi,
             rom,
             patched_grids[wi].clone(),
             &fixed_positions[wi],
             &counts,
-            &plan,
+            &plans[wi],
             shuffle_hammer_bros,
             rng,
         );
@@ -149,6 +154,9 @@ pub(crate) fn build<R: Rng>(
             );
             if new_locks.iter().any(|l| l.secret_exit_safe) {
                 worlds[wi].locks = new_locks;
+                // Keep the stored plan truthful for diagnostics — this world
+                // is now all-Safe, whatever it originally sampled.
+                worlds[wi].plan = safe_plan;
                 break;
             }
         }

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -4,7 +4,7 @@ use super::*;
 
 use super::scoring::{PIPE_SOFTMAX_T, TARGET_MAX_DIST, pick_softmax_by_score};
 use super::sections::split_blanks_by_reachability;
-use super::types::{SlotAssignment, SlotKind};
+use super::types::{LockAssignment, SlotAssignment, SlotKind, stamp_slots};
 
 /// Number of pipe pairs (not endpoints) per world in the vanilla ROM.
 pub(super) const VANILLA_PIPE_PAIRS: [usize; 8] = [
@@ -269,20 +269,26 @@ pub(super) fn place_pipes<R: Rng>(
 /// retune if real gameplay feels off.
 const SPARE_CAP_WEIGHTS: [f64; 4] = [30.0, 25.0, 25.0, 20.0];
 
-/// Place `spare_needed` spare pipe pairs after `populate_sections`, converting
-/// the lowest-value filler (HammerBro) slots into pipe endpoints. Unlike the
-/// connectivity phase this runs with levels already placed, so each pair is
-/// scored by how many level slots it lets the player skip: a pipe from a
-/// near-start node to a far node teleports past every level on the stretch
-/// between them (approximated by route-distance band). Endpoints are drawn
-/// only from HammerBro slots — never levels or forts — and both are already
-/// reachable, so a spare pipe can never strand content; it only shortcuts.
-/// Pairs that skip nothing are still placed (a fall-back keeps the world at
-/// its fixed vanilla pipe count).
+/// Place `spare_needed` spare pipe pairs after `populate_sections` AND
+/// `place_locks`, converting the lowest-value filler (HammerBro) slots into
+/// pipe endpoints. Unlike the connectivity phase this runs with levels already
+/// placed, so each pair is scored by how many level slots it lets the player
+/// skip: a pipe from a near-start node to a far node teleports past every
+/// level on the stretch between them (approximated by route-distance band).
+/// Endpoints are drawn only from HammerBro slots — never levels or forts —
+/// and both are already reachable, so a spare pipe can never strand content;
+/// it only shortcuts. Pairs that skip nothing are still placed (a fall-back
+/// keeps the world at its fixed vanilla pipe count).
+///
+/// Because locks are already placed, every pair is also checked against them:
+/// a pair that would bypass exactly ONE mandatory fortress is the fort-skip
+/// prize and is taken whenever one exists (at most once per world); a pair
+/// that would bypass two or more fortresses, or make the goal reachable with
+/// every lock still closed, is rejected outright.
 // Reason: each argument is a distinct placement input (grid, slots to convert,
-// the pipe list to extend, budget, reserved sprite tiles, start anchor, world,
-// RNG). They don't form a cohesive concept, so bundling adds indirection
-// without clarity — same call shape as `place_pipes`.
+// the pipe list to extend, budget, reserved sprite tiles, locks, anchors,
+// world, RNG). They don't form a cohesive concept, so bundling adds
+// indirection without clarity — same call shape as `place_pipes`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn place_spare_pipes<R: Rng>(
     grid: &mut Grid,
@@ -290,7 +296,9 @@ pub(super) fn place_spare_pipes<R: Rng>(
     pipe_pairs: &mut Vec<TeleportEdge>,
     spare_needed: usize,
     reserved: &HashSet<(usize, usize)>,
+    locks: &[LockAssignment],
     start_pos: Option<(usize, usize)>,
+    target_pos: Option<(usize, usize)>,
     world_idx: usize,
     rng: &mut R,
 ) {
@@ -298,13 +306,30 @@ pub(super) fn place_spare_pipes<R: Rng>(
         return;
     }
 
+    // Rows 7 and 8 share a Map_Completions bit, and a pipe is
+    // completion-relevant — the same engine bug `place_locks` guards against.
+    // Locks no longer see future spare pipes, so the exclusion runs this way
+    // instead: never convert a slot whose row-7/8 partner column holds a lock.
+    let lock_row78_conflicts: HashSet<(usize, usize)> = locks
+        .iter()
+        .filter_map(|l| match l.pos.0 {
+            7 => Some((8, l.pos.1)),
+            8 => Some((7, l.pos.1)),
+            _ => None,
+        })
+        .collect();
+
     // Convertible endpoints: HammerBro filler slots, minus any reserved
     // (mandatory HB sprite) positions that must keep their sprite. Kept as an
     // ordered Vec (slot order) — candidate order feeds softmax sampling, so it
     // must be deterministic across runs, unlike HashSet iteration.
     let mut available: Vec<(usize, usize)> = slots
         .iter()
-        .filter(|s| s.kind == SlotKind::HammerBro && !reserved.contains(&s.pos))
+        .filter(|s| {
+            s.kind == SlotKind::HammerBro
+                && !reserved.contains(&s.pos)
+                && !lock_row78_conflicts.contains(&s.pos)
+        })
         .map(|s| s.pos)
         .collect();
 
@@ -313,6 +338,9 @@ pub(super) fn place_spare_pipes<R: Rng>(
         .filter(|s| s.kind == SlotKind::Level)
         .map(|s| s.pos)
         .collect();
+
+    // At most one fort skip per world — the prize stays special.
+    let mut fort_skip_placed = false;
 
     for _ in 0..spare_needed {
         if available.len() < 2 {
@@ -326,9 +354,52 @@ pub(super) fn place_spare_pipes<R: Rng>(
             .filter_map(|p| dist.get(p).copied())
             .collect();
 
+        // Per-lock start-side / goal-side components with that lock closed
+        // and every other lock open (the progression state in which beating
+        // that fort is the player's obstacle). A candidate pipe whose
+        // endpoints straddle the two components makes the fort optional.
+        // Only locks that actually gate the goal in that state count —
+        // decoy/safe locks yield None and are skipped.
+        let mut stamped = grid.clone();
+        stamp_slots(&mut stamped, slots);
+        let split_components = |g: &Grid| -> Option<(HashSet<Pos>, HashSet<Pos>)> {
+            let tp = target_pos?;
+            let comp_start = walk_map(g, pipe_pairs, start_pos, world_idx).nodes;
+            if comp_start.contains(&tp) {
+                return None; // goal reachable in this state — nothing to bypass
+            }
+            let comp_target = walk_map(g, pipe_pairs, Some(tp), world_idx).nodes;
+            Some((comp_start, comp_target))
+        };
+        let lock_components: Vec<(HashSet<Pos>, HashSet<Pos>)> = locks
+            .iter()
+            .filter_map(|l| {
+                let mut g = stamped.clone();
+                g.set(l.pos.0, l.pos.1, l.gap_tile);
+                split_components(&g)
+            })
+            .collect();
+        // All-locks-closed split: a pipe straddling THIS one makes the goal
+        // reachable with zero forts beaten — always rejected.
+        let all_closed_components = {
+            let mut g = stamped.clone();
+            for l in locks {
+                g.set(l.pos.0, l.pos.1, l.gap_tile);
+            }
+            split_components(&g)
+        };
+        let straddles = |(cs, ct): &(HashSet<Pos>, HashSet<Pos>), a: Pos, b: Pos| {
+            (cs.contains(&a) && ct.contains(&b)) || (cs.contains(&b) && ct.contains(&a))
+        };
+
         let avail = &available;
-        // (pair, skipped levels, jump distance) for every pair that hops >=2.
+        // Level-skip candidates: (pair, skipped levels, jump distance) for
+        // every non-rejected pair that hops >=2 and bypasses no fort.
         let mut candidates: Vec<(TeleportEdge, usize, usize)> = Vec::new();
+        // Fort-skip candidates: pairs that bypass exactly one mandatory fort.
+        let mut fort_candidates: Vec<(TeleportEdge, f64)> = Vec::new();
+        // Most distance-separated non-rejected pair, the last-resort pick.
+        let mut widest: Option<(TeleportEdge, usize)> = None;
         for i in 0..avail.len() {
             for j in (i + 1)..avail.len() {
                 let a = avail[i];
@@ -337,65 +408,72 @@ pub(super) fn place_spare_pipes<R: Rng>(
                     (Some(&da), Some(&db)) => (da, db),
                     _ => continue,
                 };
-                let (lo, hi) = (da.min(db), da.max(db));
-                if hi - lo < 2 {
-                    continue; // too small a jump to be a real shortcut
+                let bypassed = lock_components.iter().filter(|c| straddles(c, a, b)).count();
+                let opens_goal = all_closed_components
+                    .as_ref()
+                    .is_some_and(|c| straddles(c, a, b));
+                if opens_goal || bypassed >= 2 || (bypassed == 1 && fort_skip_placed) {
+                    continue;
                 }
+                let (lo, hi) = (da.min(db), da.max(db));
                 // Levels whose route distance sits strictly between the two
                 // endpoints are the ones the teleport lets the player skip.
                 let skipped = level_d.iter().filter(|&&d| d > lo && d < hi).count();
-                candidates.push(((a, b), skipped, hi - lo));
+                if bypassed == 1 {
+                    fort_candidates.push(((a, b), skipped as f64 * 10.0 + (hi - lo) as f64));
+                    continue;
+                }
+                if hi - lo >= 2 {
+                    candidates.push(((a, b), skipped, hi - lo));
+                }
+                if widest.is_none_or(|(_, wj)| hi - lo > wj) {
+                    widest = Some(((a, b), hi - lo));
+                }
             }
         }
 
-        // Roll this pipe's skip cap from the weighted distribution.
-        let cap = {
-            let total: f64 = SPARE_CAP_WEIGHTS.iter().sum();
-            let mut roll = rng.random_range(0.0..total);
-            let mut c = SPARE_CAP_WEIGHTS.len();
-            for (i, w) in SPARE_CAP_WEIGHTS.iter().enumerate() {
-                roll -= w;
-                if roll <= 0.0 {
-                    c = i + 1;
-                    break;
-                }
-            }
-            c
-        };
-
-        // Greedily take the biggest skip within the cap (softmax breaks near
-        // ties). If every shortcut skips more than the cap, take the smallest
-        // one (least overshoot) so the pipe still stays as modest as possible.
-        let within: Vec<(TeleportEdge, f64)> = candidates
-            .iter()
-            .filter(|&&(_, s, _)| (1..=cap).contains(&s))
-            .map(|&(p, s, j)| (p, s as f64 * 10.0 + j as f64))
-            .collect();
-        let chosen = pick_softmax_by_score(within, PIPE_SOFTMAX_T, rng).or_else(|| {
-            candidates
-                .iter()
-                .filter(|&&(_, s, _)| s >= 1)
-                .min_by_key(|&&(_, s, _)| s)
-                .map(|&(p, _, _)| p)
-        });
-
-        // Fall back to the most distance-separated pair if nothing qualified, so
-        // the world still reaches its fixed vanilla pipe count.
-        let chosen = chosen.or_else(|| {
-            let mut best: Option<(TeleportEdge, usize)> = None;
-            for i in 0..avail.len() {
-                for j in (i + 1)..avail.len() {
-                    let (a, b) = (avail[i], avail[j]);
-                    if let (Some(&da), Some(&db)) = (dist.get(&a), dist.get(&b)) {
-                        let jump = da.abs_diff(db);
-                        if best.is_none_or(|(_, bj)| jump > bj) {
-                            best = Some(((a, b), jump));
-                        }
+        // A fort skip is the prize: take one whenever it exists (softmax
+        // breaks ties toward the pair that also skips the most levels).
+        let chosen = if !fort_candidates.is_empty() {
+            fort_skip_placed = true;
+            pick_softmax_by_score(fort_candidates, PIPE_SOFTMAX_T, rng)
+        } else {
+            // Roll this pipe's skip cap from the weighted distribution.
+            let cap = {
+                let total: f64 = SPARE_CAP_WEIGHTS.iter().sum();
+                let mut roll = rng.random_range(0.0..total);
+                let mut c = SPARE_CAP_WEIGHTS.len();
+                for (i, w) in SPARE_CAP_WEIGHTS.iter().enumerate() {
+                    roll -= w;
+                    if roll <= 0.0 {
+                        c = i + 1;
+                        break;
                     }
                 }
-            }
-            best.map(|(pair, _)| pair)
-        });
+                c
+            };
+
+            // Greedily take the biggest skip within the cap (softmax breaks
+            // near ties). If every shortcut skips more than the cap, take the
+            // smallest one (least overshoot) so the pipe still stays as modest
+            // as possible. Fall back to the most distance-separated pair if
+            // nothing qualified, so the world still reaches its fixed vanilla
+            // pipe count.
+            let within: Vec<(TeleportEdge, f64)> = candidates
+                .iter()
+                .filter(|&&(_, s, _)| (1..=cap).contains(&s))
+                .map(|&(p, s, j)| (p, s as f64 * 10.0 + j as f64))
+                .collect();
+            pick_softmax_by_score(within, PIPE_SOFTMAX_T, rng)
+                .or_else(|| {
+                    candidates
+                        .iter()
+                        .filter(|&&(_, s, _)| s >= 1)
+                        .min_by_key(|&&(_, s, _)| s)
+                        .map(|&(p, _, _)| p)
+                })
+                .or_else(|| widest.map(|(pair, _)| pair))
+        };
 
         let (a, b) = match chosen {
             Some(pair) => pair,

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -377,13 +377,23 @@ pub(super) fn place_spare_pipes<R: Rng>(
             .collect();
         // All-locks-closed split: a pipe straddling THIS one makes the goal
         // reachable with zero forts beaten — always rejected.
-        let all_closed_components = {
+        let all_closed_grid = {
             let mut g = stamped.clone();
             for l in locks {
                 g.set(l.pos.0, l.pos.1, l.gap_tile);
             }
-            split_components(&g)
+            g
         };
+        let all_closed_components = split_components(&all_closed_grid);
+        // Per-lock closed grids, kept for the exact verification below.
+        let lock_grids: Vec<Grid> = locks
+            .iter()
+            .map(|l| {
+                let mut g = stamped.clone();
+                g.set(l.pos.0, l.pos.1, l.gap_tile);
+                g
+            })
+            .collect();
         let straddles = |(cs, ct): &(HashSet<Pos>, HashSet<Pos>), a: Pos, b: Pos| {
             (cs.contains(&a) && ct.contains(&b)) || (cs.contains(&b) && ct.contains(&a))
         };
@@ -394,8 +404,8 @@ pub(super) fn place_spare_pipes<R: Rng>(
         let mut candidates: Vec<(TeleportEdge, usize, usize)> = Vec::new();
         // Fort-skip candidates: pairs that bypass exactly one mandatory fort.
         let mut fort_candidates: Vec<(TeleportEdge, f64)> = Vec::new();
-        // Most distance-separated non-rejected pair, the last-resort pick.
-        let mut widest: Option<(TeleportEdge, usize)> = None;
+        // All non-rejected pairs with their jump, for the last-resort pick.
+        let mut allowed_pairs: Vec<(TeleportEdge, usize)> = Vec::new();
         for i in 0..avail.len() {
             for j in (i + 1)..avail.len() {
                 let a = avail[i];
@@ -427,61 +437,128 @@ pub(super) fn place_spare_pipes<R: Rng>(
                 if hi - lo >= 2 {
                     candidates.push(((a, b), skipped, hi - lo));
                 }
-                if widest.is_none_or(|(_, wj)| hi - lo > wj) {
-                    widest = Some(((a, b), hi - lo));
-                }
+                allowed_pairs.push(((a, b), hi - lo));
             }
         }
 
-        // A fort skip is the prize: take one whenever it exists (softmax
-        // breaks ties toward the pair that also skips the most levels).
-        let chosen = if !fort_candidates.is_empty() {
-            fort_skip_placed = true;
-            pick_softmax_by_score(fort_candidates, knobs.softmax_t, rng)
-        } else {
-            // Roll this pipe's skip cap from the weighted distribution.
-            let cap = {
-                let total: f64 = knobs.spare_cap_weights.iter().sum();
-                let mut roll = rng.random_range(0.0..total);
-                let mut c = knobs.spare_cap_weights.len();
-                for (i, w) in knobs.spare_cap_weights.iter().enumerate() {
-                    roll -= w;
-                    if roll <= 0.0 {
-                        c = i + 1;
-                        break;
-                    }
-                }
-                c
-            };
+        // Exact pre-walks for verification (candidate-independent, per round).
+        let exact_state: Option<(bool, Vec<bool>)> = match (start_pos, target_pos) {
+            (Some(sp), Some(tp)) => {
+                let sealed = !walk_map(&all_closed_grid, pipe_pairs, Some(sp), world_idx)
+                    .nodes
+                    .contains(&tp);
+                let lock_sealed: Vec<bool> = lock_grids
+                    .iter()
+                    .map(|g| !walk_map(g, pipe_pairs, Some(sp), world_idx).nodes.contains(&tp))
+                    .collect();
+                Some((sealed, lock_sealed))
+            }
+            _ => None,
+        };
 
-            // Greedily take the biggest skip within the cap (softmax breaks
-            // near ties). If every shortcut skips more than the cap, take the
-            // smallest one (least overshoot) so the pipe still stays as modest
-            // as possible. Fall back to the most distance-separated pair if
-            // nothing qualified, so the world still reaches its fixed vanilla
-            // pipe count.
-            let within: Vec<(TeleportEdge, f64)> = candidates
+        // Selection + EXACT verification. The component-straddle model above
+        // assumes a candidate pipe only merges its two endpoints' components.
+        // The canoe systems (W3; W8 under `8s are Wild`) break that: walk_map
+        // enables canoe edges only while the mainland dock is reachable, so
+        // one pipe can open routes far from either endpoint (observed: W3
+        // "goal open at start" worlds where a level-skip spare silently
+        // opened the goal through the canoe network). Every winning pair is
+        // re-checked with real walks; a pair the exact model rejects is
+        // banned and selection re-runs without it.
+        let mut banned: HashSet<TeleportEdge> = HashSet::new();
+        let mut verified_fort_skip = false;
+        let chosen: Option<TeleportEdge> = loop {
+            // A fort skip is the prize: take one whenever it exists (softmax
+            // breaks ties toward the pair that also skips the most levels).
+            let fc: Vec<(TeleportEdge, f64)> = fort_candidates
                 .iter()
-                .filter(|&&(_, s, _)| (1..=cap).contains(&s))
-                .map(|&(p, s, j)| {
-                    (p, s as f64 * knobs.level_skip_weight + j as f64 * knobs.jump_weight)
-                })
+                .filter(|(p, _)| !banned.contains(p))
+                .copied()
                 .collect();
-            pick_softmax_by_score(within, knobs.softmax_t, rng)
-                .or_else(|| {
-                    candidates
-                        .iter()
-                        .filter(|&&(_, s, _)| s >= 1)
-                        .min_by_key(|&&(_, s, _)| s)
-                        .map(|&(p, _, _)| p)
+            let pick = if !fc.is_empty() {
+                pick_softmax_by_score(fc, knobs.softmax_t, rng)
+            } else {
+                // Roll this pipe's skip cap from the weighted distribution.
+                let cap = {
+                    let total: f64 = knobs.spare_cap_weights.iter().sum();
+                    let mut roll = rng.random_range(0.0..total);
+                    let mut c = knobs.spare_cap_weights.len();
+                    for (i, w) in knobs.spare_cap_weights.iter().enumerate() {
+                        roll -= w;
+                        if roll <= 0.0 {
+                            c = i + 1;
+                            break;
+                        }
+                    }
+                    c
+                };
+
+                // Greedily take the biggest skip within the cap (softmax
+                // breaks near ties). If every shortcut skips more than the
+                // cap, take the smallest one (least overshoot). Fall back to
+                // the most distance-separated pair if nothing qualified, so
+                // the world still reaches its fixed vanilla pipe count.
+                let within: Vec<(TeleportEdge, f64)> = candidates
+                    .iter()
+                    .filter(|(p, s, _)| !banned.contains(p) && (1..=cap).contains(s))
+                    .map(|&(p, s, j)| {
+                        (p, s as f64 * knobs.level_skip_weight + j as f64 * knobs.jump_weight)
+                    })
+                    .collect();
+                pick_softmax_by_score(within, knobs.softmax_t, rng)
+                    .or_else(|| {
+                        candidates
+                            .iter()
+                            .filter(|(p, s, _)| !banned.contains(p) && *s >= 1)
+                            .min_by_key(|&&(_, s, _)| s)
+                            .map(|&(p, _, _)| p)
+                    })
+                    .or_else(|| {
+                        allowed_pairs
+                            .iter()
+                            .filter(|(p, _)| !banned.contains(p))
+                            .max_by_key(|&&(_, j)| j)
+                            .map(|&(p, _)| p)
+                    })
+            };
+            let Some(pair) = pick else { break None };
+
+            // Exact verification with real walks.
+            let Some((sealed, lock_sealed)) = &exact_state else { break Some(pair) };
+            let (Some(sp), Some(tp)) = (start_pos, target_pos) else { break Some(pair) };
+            let mut trial: Vec<TeleportEdge> = pipe_pairs.clone();
+            trial.push(pair);
+            let opens_goal = *sealed
+                && walk_map(&all_closed_grid, &trial, Some(sp), world_idx).nodes.contains(&tp);
+            if opens_goal {
+                banned.insert(pair);
+                continue;
+            }
+            let bypass = lock_grids
+                .iter()
+                .zip(lock_sealed.iter())
+                .filter(|(g, was_sealed)| {
+                    **was_sealed
+                        && walk_map(g, &trial, Some(sp), world_idx).nodes.contains(&tp)
                 })
-                .or_else(|| widest.map(|(pair, _)| pair))
+                .count();
+            let skip_allowed =
+                knobs.fort_skip == FortSkipPolicy::AnyOneFort && !fort_skip_placed;
+            if bypass >= 2 || (bypass == 1 && !skip_allowed) {
+                banned.insert(pair);
+                continue;
+            }
+            verified_fort_skip = bypass == 1;
+            break Some(pair);
         };
 
         let (a, b) = match chosen {
             Some(pair) => pair,
             None => break,
         };
+        if verified_fort_skip {
+            fort_skip_placed = true;
+        }
 
         grid.set(a.0, a.1, TILE_PIPE);
         grid.set(b.0, b.1, TILE_PIPE);

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -2,7 +2,8 @@
 
 use super::*;
 
-use super::scoring::{PIPE_SOFTMAX_T, TARGET_MAX_DIST, pick_softmax_by_score};
+use super::plan::{FortSkipPolicy, PipeScoring};
+use super::scoring::pick_softmax_by_score;
 use super::sections::split_blanks_by_reachability;
 use super::types::{LockAssignment, SlotAssignment, SlotKind, stamp_slots};
 
@@ -42,6 +43,7 @@ pub(super) fn place_pipes<R: Rng>(
     target_pos: Option<(usize, usize)>,
     pair_count: usize,
     fixed_endpoints: &[(usize, usize)],
+    knobs: &PipeScoring,
     world_idx: usize,
     rng: &mut R,
 ) -> Vec<TeleportEdge> {
@@ -211,12 +213,14 @@ pub(super) fn place_pipes<R: Rng>(
                         .map(|&a| (a.0.abs_diff(b.0) + a.1.abs_diff(b.1)) as f64)
                         .fold(f64::INFINITY, f64::min);
                     // Nearer to the reachable frontier = higher score.
-                    let proximity =
-                        (TARGET_MAX_DIST - frontier_dist.min(TARGET_MAX_DIST)) / TARGET_MAX_DIST * 5.0;
+                    let proximity = (knobs.frontier_max_dist
+                        - frontier_dist.min(knobs.frontier_max_dist))
+                        / knobs.frontier_max_dist
+                        * knobs.frontier_weight;
                     (b, proximity)
                 })
                 .collect();
-            let b = pick_softmax_by_score(b_scored, PIPE_SOFTMAX_T, rng).unwrap();
+            let b = pick_softmax_by_score(b_scored, knobs.softmax_t, rng).unwrap();
 
             // Reachable side: the frontier blank nearest to b (shortest bridge),
             // so the pipe extends the frontier to that island rather than
@@ -228,7 +232,7 @@ pub(super) fn place_pipes<R: Rng>(
                     (a, -d) // nearer to b = higher
                 })
                 .collect();
-            let a = pick_softmax_by_score(a_scored, PIPE_SOFTMAX_T, rng).unwrap();
+            let a = pick_softmax_by_score(a_scored, knobs.softmax_t, rng).unwrap();
 
             grid.set(a.0, a.1, TILE_PIPE);
             grid.set(b.0, b.1, TILE_PIPE);
@@ -260,15 +264,6 @@ pub(super) fn place_pipes<R: Rng>(
     placed_pairs
 }
 
-/// Per-pipe skip-cap weights: relative chance a spare pipe's max-skip is 1, 2,
-/// 3, or 4 levels. Each pipe rolls a cap from this distribution, then greedily
-/// takes the biggest skip up to it — so big skips happen *sometimes* (a pipe
-/// rolling a high cap) rather than every pipe grabbing the largest skip and
-/// trivializing short worlds. Tuned via a sweep (this shape ≈ halves W2/W6 skip
-/// size vs. uncapped while keeping most of the anti-linearity win); safe to
-/// retune if real gameplay feels off.
-const SPARE_CAP_WEIGHTS: [f64; 4] = [30.0, 25.0, 25.0, 20.0];
-
 /// Place `spare_needed` spare pipe pairs after `populate_sections` AND
 /// `place_locks`, converting the lowest-value filler (HammerBro) slots into
 /// pipe endpoints. Unlike the connectivity phase this runs with levels already
@@ -297,6 +292,7 @@ pub(super) fn place_spare_pipes<R: Rng>(
     spare_needed: usize,
     reserved: &HashSet<(usize, usize)>,
     locks: &[LockAssignment],
+    knobs: &PipeScoring,
     start_pos: Option<(usize, usize)>,
     target_pos: Option<(usize, usize)>,
     world_idx: usize,
@@ -412,7 +408,9 @@ pub(super) fn place_spare_pipes<R: Rng>(
                 let opens_goal = all_closed_components
                     .as_ref()
                     .is_some_and(|c| straddles(c, a, b));
-                if opens_goal || bypassed >= 2 || (bypassed == 1 && fort_skip_placed) {
+                let skip_allowed = knobs.fort_skip == FortSkipPolicy::AnyOneFort
+                    && !fort_skip_placed;
+                if opens_goal || bypassed >= 2 || (bypassed == 1 && !skip_allowed) {
                     continue;
                 }
                 let (lo, hi) = (da.min(db), da.max(db));
@@ -420,7 +418,10 @@ pub(super) fn place_spare_pipes<R: Rng>(
                 // endpoints are the ones the teleport lets the player skip.
                 let skipped = level_d.iter().filter(|&&d| d > lo && d < hi).count();
                 if bypassed == 1 {
-                    fort_candidates.push(((a, b), skipped as f64 * 10.0 + (hi - lo) as f64));
+                    fort_candidates.push((
+                        (a, b),
+                        skipped as f64 * knobs.level_skip_weight + (hi - lo) as f64 * knobs.jump_weight,
+                    ));
                     continue;
                 }
                 if hi - lo >= 2 {
@@ -436,14 +437,14 @@ pub(super) fn place_spare_pipes<R: Rng>(
         // breaks ties toward the pair that also skips the most levels).
         let chosen = if !fort_candidates.is_empty() {
             fort_skip_placed = true;
-            pick_softmax_by_score(fort_candidates, PIPE_SOFTMAX_T, rng)
+            pick_softmax_by_score(fort_candidates, knobs.softmax_t, rng)
         } else {
             // Roll this pipe's skip cap from the weighted distribution.
             let cap = {
-                let total: f64 = SPARE_CAP_WEIGHTS.iter().sum();
+                let total: f64 = knobs.spare_cap_weights.iter().sum();
                 let mut roll = rng.random_range(0.0..total);
-                let mut c = SPARE_CAP_WEIGHTS.len();
-                for (i, w) in SPARE_CAP_WEIGHTS.iter().enumerate() {
+                let mut c = knobs.spare_cap_weights.len();
+                for (i, w) in knobs.spare_cap_weights.iter().enumerate() {
                     roll -= w;
                     if roll <= 0.0 {
                         c = i + 1;
@@ -462,9 +463,11 @@ pub(super) fn place_spare_pipes<R: Rng>(
             let within: Vec<(TeleportEdge, f64)> = candidates
                 .iter()
                 .filter(|&&(_, s, _)| (1..=cap).contains(&s))
-                .map(|&(p, s, j)| (p, s as f64 * 10.0 + j as f64))
+                .map(|&(p, s, j)| {
+                    (p, s as f64 * knobs.level_skip_weight + j as f64 * knobs.jump_weight)
+                })
                 .collect();
-            pick_softmax_by_score(within, PIPE_SOFTMAX_T, rng)
+            pick_softmax_by_score(within, knobs.softmax_t, rng)
                 .or_else(|| {
                     candidates
                         .iter()

--- a/src/randomize/overworld_build/plan.rs
+++ b/src/randomize/overworld_build/plan.rs
@@ -1,0 +1,381 @@
+//! The per-world plan: one sampled `WorldPlan` carries the progression
+//! archetype AND every scoring knob the placement passes consume.
+//!
+//! This is the single place to look to understand what a world will try to
+//! be. Placement passes never branch on the archetype — they only read their
+//! own knob struct (`plan.fort`, `plan.level`, `plan.lock`, `plan.pipe`), so
+//! an archetype's entire personality is expressed as data in
+//! [`WorldPlan::sample`], and adding a new archetype never touches placement
+//! code.
+//!
+//! Two kinds of "awareness" flow through the pipeline:
+//! - awareness of the PAST (things already placed) — passes read real state;
+//! - awareness of the FUTURE (things not placed yet) — passes read this plan.
+//!
+//! Feasibility: knobs are soft biases and can never fail. The enforcing
+//! passes (locks realizing `roles`, spare pipes realizing `pipe.fort_skip`)
+//! apply hard filters with explicit fallbacks — geography that can't host
+//! the sampled shape degrades the shape, never completability.
+
+use super::*;
+
+/// The world's sampled progression archetype. Stored on the plan for
+/// diagnostics and census; placement passes must NOT branch on it — its
+/// effects live entirely in `roles` and the scoring knobs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Archetype {
+    /// One fort (or one designated fort) gates the goal; other forts are
+    /// safe decoys/inerts.
+    SingleGate,
+    /// Each fort gates the next; the last gates the goal. The classic
+    /// beat-fort-to-advance grind — valued, but not meant to dominate.
+    Chain,
+    /// The first `fort_count - k` forts chain, then a `k`-way terminal fork:
+    /// one GoalGate + `k - 1` accessible decoys ("pick the right fort").
+    Fork {
+        /// Terminal fork width, capped at 3 (a 4-way fork reads as a field
+        /// of fakes).
+        k: usize,
+    },
+}
+
+/// The role a fortress's lock plays in the world's progression archetype.
+/// Derived per-fort from the archetype in [`WorldPlan::sample`] and realized
+/// by `place_locks` as a hard candidate filter (with feasibility fallback).
+#[derive(Clone, Debug)]
+pub(crate) enum LockRole {
+    /// Lock must gate (make unreachable) every fort section in `targets` — a
+    /// chain link (gate the next fort) or the prefix→fork entrance (gate the
+    /// whole terminal group at once).
+    ChainLink { targets: Vec<usize> },
+    /// Lock must gate the airship/Bowser target while stranding no fortress.
+    GoalGate,
+    /// Lock must gate nothing important (no fort, no target) — the fortress
+    /// stays reachable. Decoy and inert forts.
+    Safe,
+}
+
+/// Whether the spare-pipe pass may realize a fort-skip (a pipe bridging
+/// across one closed lock, making that fort optional).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FortSkipPolicy {
+    /// No pipe may bypass any mandatory fort — pairs that would are rejected.
+    // Reason: not yet sampled — every plan currently uses AnyOneFort. This
+    // variant is the "plan says no skip" arm the sampler starts choosing when
+    // fort-skips become plan-gated (next step); the consuming check in
+    // place_spare_pipes already honors it.
+    #[allow(dead_code)]
+    Never,
+    /// The first candidate pair that bypasses exactly ONE mandatory fort is
+    /// taken (the prize), at most once per world. Pairs bypassing 2+ forts,
+    /// or opening the goal with every lock closed, are always rejected
+    /// regardless of policy.
+    AnyOneFort,
+}
+
+/// Spread/density weights shared by the level and fortress scorers
+/// (`score_with_weights`). Embedded separately in [`FortScoring`] and
+/// [`LevelScoring`] so archetypes can diverge the two independently.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SpreadScoring {
+    /// Weight on min Manhattan distance to already-placed content
+    /// (visual/spatial spread).
+    pub manhattan: f64,
+    /// Weight on min BFS-distance difference (traversal spread — weighted
+    /// above grid distance so spread follows the walk, not the screen).
+    pub bfs: f64,
+    /// Penalty per already-placed tile within `density_radius`.
+    pub density_penalty: f64,
+    /// Combined manhattan+BFS distance that counts as "nearby" for the
+    /// density penalty.
+    pub density_radius: usize,
+    /// Cap on each separation metric's contribution, so one huge gap can't
+    /// dominate the score.
+    pub separation_cap: f64,
+}
+
+impl Default for SpreadScoring {
+    fn default() -> Self {
+        SpreadScoring {
+            manhattan: 1.0,
+            bfs: 1.5,
+            density_penalty: 3.0,
+            density_radius: 4,
+            separation_cap: 8.0,
+        }
+    }
+}
+
+/// Knobs for fortress placement (`populate_sections` phase 1).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FortScoring {
+    pub spread: SpreadScoring,
+    /// Bonus for one-exit positions — fortresses naturally belong at path
+    /// termini.
+    pub dead_end_bonus: f64,
+    /// Bonus for the designated island positions in
+    /// `FORTRESS_BONUS_POSITIONS` (isolated spots that rarely win placement
+    /// without a boost).
+    pub island_bonus: f64,
+    /// Softmax temperature. Score range ≈ [-12, +15] including the dead-end
+    /// bonus; 4.0 keeps top candidates favored without determinism.
+    pub softmax_t: f64,
+}
+
+impl Default for FortScoring {
+    fn default() -> Self {
+        FortScoring {
+            spread: SpreadScoring::default(),
+            dead_end_bonus: 5.0,
+            island_bonus: 0.5,
+            softmax_t: 4.0,
+        }
+    }
+}
+
+/// Knobs for level placement (`populate_sections` phase 2).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LevelScoring {
+    pub spread: SpreadScoring,
+    /// Bonus for one-exit positions (small — levels only mildly prefer
+    /// dead ends).
+    pub dead_end_bonus: f64,
+    /// Path-relevance weight: positions on the main start→target route (low
+    /// detour) score higher. Max bonus = `path_detour_cap * path_bonus`.
+    ///
+    /// THE dominant linearity lever. Lowered 1.5 → 0.75 to cut back-to-back
+    /// forced-level streaks (route bias was gluing levels onto the trunk).
+    /// Sweep via test_required_progression: 1.5→streak 2.12, 1.0→1.89,
+    /// 0.75→1.79 (≈ the reference randomizer), 0.5→1.70, 0.0→1.34
+    /// (overshoots and thins the required route). History: 3.0 clumped hard;
+    /// 0.5 was "decorative" at the old weightings.
+    pub path_bonus: f64,
+    /// Max detour (BFS hops off the shortest start→target route) that still
+    /// earns any path bonus.
+    pub path_detour_cap: f64,
+}
+
+impl Default for LevelScoring {
+    fn default() -> Self {
+        LevelScoring {
+            spread: SpreadScoring::default(),
+            dead_end_bonus: 0.5,
+            path_bonus: 0.75,
+            path_detour_cap: 6.0,
+        }
+    }
+}
+
+/// Knobs for lock placement (`place_locks`). Scores are integer points on a
+/// base of "gated node count" (how much of the map the closed lock walls
+/// off).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LockScoring {
+    /// Bonus when the closed lock makes a LATER fort unreachable — the
+    /// strong chain-progression signal. Sized to dominate gated-node counts;
+    /// sweeps showed 100→50 changes nothing and →0 only modestly reduces
+    /// chains (greedy converges to chains regardless — that's what the
+    /// archetype roles are for).
+    pub blocks_later_fort_bonus: i32,
+    /// Bonus for the FIRST lock in a world that gates the airship/Bowser.
+    /// Later target-blockers get nothing (they'd pile up next to the
+    /// airship).
+    pub blocks_target_bonus: i32,
+    /// Spread penalty radius: locks closer than this (Manhattan) to an
+    /// already-placed lock are penalized...
+    pub spread_radius: i32,
+    /// ...by this many points per tile of shortfall.
+    pub spread_penalty_per_tile: i32,
+    /// Nudge toward bridge tiles (water gaps read better than path locks).
+    pub bridge_bonus: i32,
+    /// W8 only: extra bias toward the screen-3 showcase bridges. Tuned via a
+    /// 200k-seed sweep: +8 puts ≥1 bridge out in ~99.6% of seeds, two in
+    /// ~30%, all four in ~0.08% (a rare treat).
+    pub w8_bridge_bonus: i32,
+    /// If the best candidate scores below this, prefer a safe lock instead —
+    /// no point spending an impactful-lock slot on a weak chokepoint.
+    pub weak_lock_threshold: i32,
+}
+
+impl Default for LockScoring {
+    fn default() -> Self {
+        LockScoring {
+            blocks_later_fort_bonus: 100,
+            blocks_target_bonus: 10,
+            spread_radius: 8,
+            spread_penalty_per_tile: 2,
+            bridge_bonus: 1,
+            w8_bridge_bonus: 8,
+            weak_lock_threshold: 5,
+        }
+    }
+}
+
+/// Knobs for pipe placement — both the connectivity pass (`place_pipes`) and
+/// the post-lock spare-pipe pass (`place_spare_pipes`).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PipeScoring {
+    /// Softmax temperature for every pipe candidate pick. Score range is
+    /// typically ~[-8, +12].
+    pub softmax_t: f64,
+    /// Connectivity build-outward: Manhattan distance at which an island
+    /// blank's frontier-proximity score reaches zero (normalization cap).
+    pub frontier_max_dist: f64,
+    /// Connectivity build-outward: weight on frontier proximity (nearer
+    /// islands are bridged first, growing a chain instead of jumping to the
+    /// goal).
+    pub frontier_weight: f64,
+    /// Per-spare-pipe skip-cap weights: relative chance the pipe's max
+    /// level-skip is 1, 2, 3, or 4. Each pipe rolls a cap, then greedily
+    /// takes the biggest skip within it — big skips happen sometimes, not
+    /// every pipe. Tuned via sweep (≈ halves W2/W6 skip size vs uncapped
+    /// while keeping most of the anti-linearity win).
+    pub spare_cap_weights: [f64; 4],
+    /// Spare-pipe score: points per level the pipe lets the player skip.
+    pub level_skip_weight: f64,
+    /// Spare-pipe score: points per hop of route-distance jump (tie-breaker
+    /// under `level_skip_weight`).
+    pub jump_weight: f64,
+    /// Whether a spare pipe may deliberately bridge across one closed lock.
+    /// See [`FortSkipPolicy`]. Rejection of 2+-fort bypasses and goal-opening
+    /// pipes applies under every policy.
+    pub fort_skip: FortSkipPolicy,
+}
+
+impl Default for PipeScoring {
+    fn default() -> Self {
+        PipeScoring {
+            softmax_t: 4.0,
+            frontier_max_dist: 20.0,
+            frontier_weight: 5.0,
+            spare_cap_weights: [30.0, 25.0, 25.0, 20.0],
+            level_skip_weight: 10.0,
+            jump_weight: 1.0,
+            fort_skip: FortSkipPolicy::AnyOneFort,
+        }
+    }
+}
+
+/// A complete per-world intent: sampled once before any placement. Every
+/// placement pass reads ONLY its own section; the sampler is the ONLY place
+/// where an archetype turns into behavior.
+#[derive(Clone, Debug)]
+pub(crate) struct WorldPlan {
+    // Reason: placement passes must NOT branch on the archetype (its effects
+    // are the roles + knobs), so nothing reads it yet. It's stored for the
+    // diagnostics/census tests to compare sampled intent vs realized topology
+    // (plan-realization rate) as those get built out.
+    #[allow(dead_code)]
+    pub archetype: Archetype,
+    /// Per-fort lock roles (index = fort section), derived from the
+    /// archetype. Realized as hard filters by `place_locks`.
+    pub roles: Vec<LockRole>,
+    pub fort: FortScoring,
+    pub level: LevelScoring,
+    pub lock: LockScoring,
+    pub pipe: PipeScoring,
+}
+
+impl WorldPlan {
+    /// Weighted per-world archetype sample → the full plan.
+    ///
+    /// - 1 fort: SingleGate (the lone fort gates the goal).
+    /// - W8 (dense, 4 forts): 25% Chain / 75% Fork; Fork = chain-2 → 2-way fork.
+    /// - other multi-fort worlds: 30% Chain / 30% SingleGate / 40% Fork; a
+    ///   Fork samples a terminal width `k` (capped at 3, surplus forts chain
+    ///   in front), so a 3-fort Fork is a 50/50 mix of chain-1→2-fork and a
+    ///   pure 3-way fork.
+    ///
+    /// All scoring knobs are currently the uniform defaults — archetypes gain
+    /// scoring opinions here (and only here) as sweeps justify them.
+    pub(crate) fn sample<R: Rng>(fort_count: usize, world_idx: usize, rng: &mut R) -> Self {
+        let archetype = match fort_count {
+            0 | 1 => Archetype::SingleGate,
+            _ if world_idx == 7 => {
+                if rng.random_range(..100u32) < 25 {
+                    Archetype::Chain
+                } else {
+                    Archetype::Fork { k: 2 }
+                }
+            }
+            _ => {
+                let r = rng.random_range(..100u32);
+                if r < 30 {
+                    Archetype::Chain
+                } else if r < 60 {
+                    Archetype::SingleGate
+                } else {
+                    // W8 and 2-fort worlds: a plain 2-way fork. 3-fort worlds
+                    // mix 50/50 between chain-1 → 2-fork and a pure 3-way fork.
+                    let k = if fort_count == 2 {
+                        2
+                    } else {
+                        2 + rng.random_range(..2u32) as usize
+                    };
+                    Archetype::Fork { k }
+                }
+            }
+        };
+
+        WorldPlan::from_archetype(archetype, fort_count)
+    }
+
+    /// Derive the full plan (roles + knobs) from a decided archetype.
+    pub(crate) fn from_archetype(archetype: Archetype, fort_count: usize) -> Self {
+        let roles = match (fort_count, archetype) {
+            (0, _) => Vec::new(),
+            (1, _) => vec![LockRole::GoalGate],
+            (n, Archetype::Chain) => (0..n)
+                .map(|i| {
+                    if i + 1 < n {
+                        LockRole::ChainLink { targets: vec![i + 1] }
+                    } else {
+                        LockRole::GoalGate
+                    }
+                })
+                .collect(),
+            (n, Archetype::SingleGate) => (0..n)
+                .map(|i| if i + 1 == n { LockRole::GoalGate } else { LockRole::Safe })
+                .collect(),
+            (n, Archetype::Fork { k }) => fork_roles(n, k),
+        };
+
+        WorldPlan {
+            archetype,
+            roles,
+            fort: FortScoring::default(),
+            level: LevelScoring::default(),
+            lock: LockScoring::default(),
+            pipe: PipeScoring::default(),
+        }
+    }
+
+    /// The retry-path plan: every lock Safe (used with `force_safe` when no
+    /// world produced a secret-exit-safe lock), default knobs.
+    pub(crate) fn all_safe(fort_count: usize) -> Self {
+        let mut plan = WorldPlan::from_archetype(Archetype::SingleGate, fort_count);
+        plan.roles = vec![LockRole::Safe; fort_count];
+        plan
+    }
+}
+
+/// Chain the first `n - k` forts, then a `k`-way fork (one GoalGate + `k-1`
+/// Safe decoys). `k` is capped at 3 and at `n`.
+fn fork_roles(n: usize, k: usize) -> Vec<LockRole> {
+    let k = k.min(n).min(3);
+    let prefix = n - k;
+    let mut roles = Vec::with_capacity(n);
+    for i in 0..prefix {
+        let targets = if i + 1 < prefix {
+            vec![i + 1]
+        } else {
+            // Last prefix link opens the whole terminal fork as a unit.
+            (prefix..n).collect()
+        };
+        roles.push(LockRole::ChainLink { targets });
+    }
+    for i in prefix..n {
+        roles.push(if i == n - 1 { LockRole::GoalGate } else { LockRole::Safe });
+    }
+    roles
+}

--- a/src/randomize/overworld_build/plan.rs
+++ b/src/randomize/overworld_build/plan.rs
@@ -358,10 +358,18 @@ impl WorldPlan {
             }
         };
 
-        WorldPlan::from_archetype(archetype, fort_count)
+        let mut plan = WorldPlan::from_archetype(archetype, fort_count);
+        plan.shuffle_goal(rng);
+        plan
     }
 
     /// Derive the full plan (roles + knobs) from a decided archetype.
+    ///
+    /// Deterministic derivation: the GoalGate lands on the LAST section (the
+    /// farthest BFS band). `sample` then calls [`WorldPlan::shuffle_goal`] to
+    /// move it — without that, the real fort is always the farthest one, a
+    /// systematic tell (measured pre-shuffle: the GoalGate fort was the most
+    /// expensive fork fort to reach in 70% of forks, cheapest in 3%).
     pub(crate) fn from_archetype(archetype: Archetype, fort_count: usize) -> Self {
         let roles = match (fort_count, archetype) {
             (0, _) => Vec::new(),
@@ -389,6 +397,35 @@ impl WorldPlan {
             lock: LockScoring::default(),
             pipe: PipeScoring::default(),
         }
+    }
+
+    /// Move the GoalGate role to a uniformly random section within its
+    /// swappable group, killing the "the real fort is always the farthest
+    /// one" tell:
+    /// - SingleGate: swap with any Safe section (any fort may be the gate).
+    /// - Fork: swap with any Safe section in the TERMINAL group (chain-prefix
+    ///   links stay in front).
+    /// - Chain: no-op — the GoalGate is inherently the chain's last link.
+    fn shuffle_goal<R: Rng>(&mut self, rng: &mut R) {
+        let Some(goal_idx) = self
+            .roles
+            .iter()
+            .position(|r| matches!(r, LockRole::GoalGate))
+        else {
+            return;
+        };
+        let swappable: Vec<usize> = self
+            .roles
+            .iter()
+            .enumerate()
+            .filter(|(_, r)| matches!(r, LockRole::Safe | LockRole::GoalGate))
+            .map(|(i, _)| i)
+            .collect();
+        if swappable.len() < 2 {
+            return;
+        }
+        let new_idx = swappable[rng.random_range(..swappable.len() as u32) as usize];
+        self.roles.swap(goal_idx, new_idx);
     }
 
     /// The retry-path plan: every lock Safe (used with `force_safe` when no

--- a/src/randomize/overworld_build/plan.rs
+++ b/src/randomize/overworld_build/plan.rs
@@ -276,37 +276,78 @@ pub(crate) struct WorldPlan {
     pub pipe: PipeScoring,
 }
 
+/// Top-level progression family: how much of the world's fort content is
+/// compulsory. This is the dimension players feel (beat everything / choose /
+/// free) and the one the census metrics measure, so sampling weights live at
+/// this level — adding a shape to a family never silently shifts how often
+/// "you must beat every fort" worlds appear.
+// Reason: enum_variant_names — the shared "Forts" postfix is the point: the
+// family axis IS "how many forts are compulsory" (all / partial / none), and
+// bare All/Partial/None would read as generic quantifiers.
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Family {
+    /// Every fort is required. Shapes: Chain (ordered). (TwinGates — an
+    /// unordered tail — is this family's parked second shape.)
+    AllForts,
+    /// One fort really matters; the rest are decoys. Shapes: SingleGate,
+    /// Fork.
+    PartialForts,
+    /// No fort is required. RESERVED at weight 0 until an open/shortcut
+    /// shape exists to populate it.
+    NoForts,
+}
+
+/// Family weights [AllForts, PartialForts, NoForts] out of 100, W1–W7.
+/// NoForts stays 0 until it has a shape; any weight past AllForts falls
+/// through to PartialForts.
+const FAMILY_WEIGHTS: [u32; 3] = [30, 70, 0];
+/// W8 family weights — denser (4 forts), forks stay dominant. AllForts=Chain
+/// keeps W8's pre-family 25% chain rate.
+const W8_FAMILY_WEIGHTS: [u32; 3] = [25, 75, 0];
+/// Within PartialForts: [SingleGate, Fork] out of 100.
+const PARTIAL_SPLIT: [u32; 2] = [40, 60];
+
 impl WorldPlan {
-    /// Weighted per-world archetype sample → the full plan.
+    /// Family-first per-world sample → the full plan.
     ///
     /// - 1 fort: SingleGate (the lone fort gates the goal).
-    /// - W8 (dense, 4 forts): 25% Chain / 75% Fork; Fork = chain-2 → 2-way fork.
-    /// - other multi-fort worlds: 30% Chain / 30% SingleGate / 40% Fork; a
-    ///   Fork samples a terminal width `k` (capped at 3, surplus forts chain
-    ///   in front), so a 3-fort Fork is a 50/50 mix of chain-1→2-fork and a
-    ///   pure 3-way fork.
+    /// - Family rolled from `FAMILY_WEIGHTS` (`W8_FAMILY_WEIGHTS` for W8),
+    ///   then the shape within it: AllForts → Chain; PartialForts →
+    ///   SingleGate/Fork per `PARTIAL_SPLIT` (W8's Fork is always
+    ///   chain-2 → 2-way). A Fork samples terminal width `k` (capped at 3,
+    ///   surplus forts chain in front), so a 3-fort Fork is a 50/50 mix of
+    ///   chain-1→2-fork and a pure 3-way fork.
     ///
     /// All scoring knobs are currently the uniform defaults — archetypes gain
     /// scoring opinions here (and only here) as sweeps justify them.
     pub(crate) fn sample<R: Rng>(fort_count: usize, world_idx: usize, rng: &mut R) -> Self {
-        let archetype = match fort_count {
-            0 | 1 => Archetype::SingleGate,
-            _ if world_idx == 7 => {
-                if rng.random_range(..100u32) < 25 {
-                    Archetype::Chain
-                } else {
+        if fort_count <= 1 {
+            return WorldPlan::from_archetype(Archetype::SingleGate, fort_count);
+        }
+
+        let weights = if world_idx == 7 { &W8_FAMILY_WEIGHTS } else { &FAMILY_WEIGHTS };
+        let roll = rng.random_range(..100u32);
+        let family = if roll < weights[0] {
+            Family::AllForts
+        } else if roll < weights[0] + weights[1] {
+            Family::PartialForts
+        } else {
+            Family::NoForts
+        };
+
+        let archetype = match family {
+            Family::AllForts => Archetype::Chain,
+            // NoForts has no shapes yet (weight 0); fall through to the
+            // partial shapes so a nonzero weight can't brick sampling.
+            Family::PartialForts | Family::NoForts => {
+                if world_idx == 7 {
                     Archetype::Fork { k: 2 }
-                }
-            }
-            _ => {
-                let r = rng.random_range(..100u32);
-                if r < 30 {
-                    Archetype::Chain
-                } else if r < 60 {
+                } else if rng.random_range(..100u32) < PARTIAL_SPLIT[0] {
                     Archetype::SingleGate
                 } else {
-                    // W8 and 2-fort worlds: a plain 2-way fork. 3-fort worlds
-                    // mix 50/50 between chain-1 → 2-fork and a pure 3-way fork.
+                    // 2-fort worlds: a plain 2-way fork. 3-fort worlds mix
+                    // 50/50 between chain-1 → 2-fork and a pure 3-way fork.
                     let k = if fort_count == 2 {
                         2
                     } else {
@@ -356,6 +397,42 @@ impl WorldPlan {
         let mut plan = WorldPlan::from_archetype(Archetype::SingleGate, fort_count);
         plan.roles = vec![LockRole::Safe; fort_count];
         plan
+    }
+}
+
+/// Seed-level invariant: at least one lock role somewhere in the seed must
+/// be Safe. Without it, a seed can sample Chain everywhere (plus 1-fort
+/// GoalGates) — zero Safe roles — and the only escape hatch is the
+/// post-build force_safe retry, which flattens a whole world to all-Safe
+/// (measured: ~1.4% of seeds). Downgrading up front is shape-preserving:
+/// the LAST ChainLink of one random Chain world becomes Safe (its chain
+/// shortens by one link; that fort becomes a decoy). Runs after all 8 plans
+/// are sampled, before any placement.
+pub(super) fn ensure_seed_safe_role<R: Rng>(plans: &mut [WorldPlan], rng: &mut R) {
+    let has_safe = plans
+        .iter()
+        .any(|p| p.roles.iter().any(|r| matches!(r, LockRole::Safe)));
+    if has_safe {
+        return;
+    }
+    // No Safe anywhere ⇒ every multi-fort world rolled Chain (multi-fort
+    // SingleGate and Fork always carry Safes), so ChainLink roles exist.
+    let candidates: Vec<usize> = plans
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.roles.iter().any(|r| matches!(r, LockRole::ChainLink { .. })))
+        .map(|(i, _)| i)
+        .collect();
+    let Some(&wi) = candidates.choose(rng) else {
+        return;
+    };
+    let plan = &mut plans[wi];
+    if let Some(idx) = plan
+        .roles
+        .iter()
+        .rposition(|r| matches!(r, LockRole::ChainLink { .. }))
+    {
+        plan.roles[idx] = LockRole::Safe;
     }
 }
 

--- a/src/randomize/overworld_build/scoring.rs
+++ b/src/randomize/overworld_build/scoring.rs
@@ -1,6 +1,12 @@
 //! Candidate scoring: softmax sampling and the per-placement weight functions.
+//!
+//! Every tunable weight lives in the `plan` knob structs (`SpreadScoring`,
+//! `LevelScoring`, `FortScoring`, `LockScoring`, `PipeScoring`) — this module
+//! only holds the scoring *mechanics* and fixed geometry facts.
 
 use super::*;
+
+use super::plan::{FortScoring, LevelScoring, SpreadScoring};
 
 /// Sample a candidate weighted by softmax(score / temperature). Higher
 /// temperature flattens the distribution (more random); lower temperature
@@ -44,8 +50,6 @@ pub(super) const FORTRESS_BONUS_POSITIONS: &[(usize, (usize, usize))] = &[
     (2, (3, 28)), // W3 canoe island
 ];
 
-pub(super) const FORTRESS_BONUS: f64 = 0.5;
-
 /// Total vanilla levels across all worlds (62 Level entries in the catalog).
 pub(super) const VANILLA_LEVEL_COUNT: usize = 62;
 
@@ -86,22 +90,16 @@ pub(super) fn is_row78_conflict(
     }
 }
 
-// Shared spread/density weights (used by level, fortress, and pipe scoring).
-const W_MANHATTAN: f64 = 1.0;    // visual/spatial spread
-const W_BFS: f64 = 1.5;          // traversal spread (weighted higher than grid distance)
-const W_DENSITY: f64 = 3.0;      // penalty per nearby occupied tile
-const DENSITY_RADIUS: usize = 4; // combined manhattan+BFS distance threshold
-const SEP_CAP: f64 = 8.0;        // max separation contribution per metric
-
 /// Shared spread/density quantities of `pos` relative to a set of reference
 /// positions: (min manhattan distance, min BFS-distance difference, count of
-/// reference positions within DENSITY_RADIUS). The min values are
+/// reference positions within `density_radius`). The min values are
 /// `usize::MAX` / `None` when they can't be computed (empty set / no BFS
 /// data) — callers apply their own fallbacks.
 fn spread_and_density(
     pos: (usize, usize),
     others: &HashSet<(usize, usize)>,
     bfs_distances: &HashMap<(usize, usize), usize>,
+    density_radius: usize,
 ) -> (usize, Option<usize>, usize) {
     let (r, c) = pos;
     let my_bfs = bfs_distances.get(&pos).copied().unwrap_or(0);
@@ -126,7 +124,7 @@ fn spread_and_density(
                 .get(&(cr, cc))
                 .map(|&d| my_bfs.abs_diff(d))
                 .unwrap_or(manhattan);
-            manhattan.max(bfs_diff) <= DENSITY_RADIUS
+            manhattan.max(bfs_diff) <= density_radius
         })
         .count();
 
@@ -139,35 +137,21 @@ pub(super) fn score_with_weights(
     pos: (usize, usize),
     completable: &HashSet<(usize, usize)>,
     bfs_distances: &HashMap<(usize, usize), usize>,
+    spread: &SpreadScoring,
     dead_end_bonus_value: f64,
 ) -> f64 {
     let (min_manhattan, min_bfs_diff, nearby) =
-        spread_and_density(pos, completable, bfs_distances);
+        spread_and_density(pos, completable, bfs_distances, spread.density_radius);
     let min_bfs_diff = min_bfs_diff.unwrap_or(usize::MAX);
 
-    let manhattan_score = (min_manhattan as f64).min(SEP_CAP) * W_MANHATTAN;
-    let bfs_score = (min_bfs_diff as f64).min(SEP_CAP) * W_BFS;
-    let density_penalty = nearby as f64 * W_DENSITY;
+    let manhattan_score = (min_manhattan as f64).min(spread.separation_cap) * spread.manhattan;
+    let bfs_score = (min_bfs_diff as f64).min(spread.separation_cap) * spread.bfs;
+    let density_penalty = nearby as f64 * spread.density_penalty;
 
     let dead_end_bonus = if is_dead_end(grid, pos) { dead_end_bonus_value } else { 0.0 };
 
     manhattan_score + bfs_score + dead_end_bonus - density_penalty
 }
-
-/// Path relevance: max detour (in BFS hops) that still earns a bonus.
-pub(super) const PATH_DETOUR_CAP: f64 = 6.0;
-
-/// Path relevance weight. Max bonus = PATH_DETOUR_CAP * W_PATH = 4.5.
-/// Lowered from 1.5 → 0.75 to cut back-to-back forced-level streaks: the route
-/// bias was gluing levels onto the start→target trunk, which was the dominant
-/// driver of overworld linearity (mean forced-level streak ~2.1, well above
-/// the reference SMB3 randomizer's ~1.8). A W_PATH sweep via
-/// test_required_progression's linearity block: 1.5→streak 2.12, 1.0→1.89,
-/// 0.75→1.79 (≈ reference), 0.5→1.70, 0.0→1.34 (overshoots and thins the
-/// required route too much). 0.75 keeps a meaningful route bias while landing
-/// streak at the reference level. (History: 3.0 dominated and clumped hard;
-/// 0.5 was once considered "decorative" at the old weightings.)
-pub(super) const W_PATH: f64 = 0.75;
 
 /// Score a candidate position for level placement. Higher = better.
 /// Includes a path relevance bonus: positions on the main start→target
@@ -179,8 +163,11 @@ pub(super) fn score_candidate(
     bfs_distances: &HashMap<(usize, usize), usize>,
     reverse_bfs: &HashMap<(usize, usize), usize>,
     target_bfs_dist: Option<usize>,
+    knobs: &LevelScoring,
 ) -> f64 {
-    let base = score_with_weights(grid, pos, completable, bfs_distances, 0.5);
+    let base = score_with_weights(
+        grid, pos, completable, bfs_distances, &knobs.spread, knobs.dead_end_bonus,
+    );
 
     // Path relevance: detour = dist(start→pos) + dist(pos→target) - dist(start→target).
     // Zero detour = perfectly on the shortest path. Higher detour = side branch.
@@ -188,7 +175,8 @@ pub(super) fn score_candidate(
         (Some(target_dist), Some(&rev_d)) => {
             let fwd_d = bfs_distances.get(&pos).copied().unwrap_or(0);
             let detour = (fwd_d + rev_d).saturating_sub(target_dist);
-            (PATH_DETOUR_CAP - (detour as f64).min(PATH_DETOUR_CAP)) * W_PATH
+            (knobs.path_detour_cap - (detour as f64).min(knobs.path_detour_cap))
+                * knobs.path_bonus
         }
         _ => 0.0,
     };
@@ -197,33 +185,23 @@ pub(super) fn score_candidate(
 }
 
 /// Score a candidate position for fortress placement. Higher = better.
-/// Fortresses get a larger dead-end bonus (+5.0) since they naturally
-/// belong at path termini, plus a bonus for designated island positions.
+/// Fortresses get a larger dead-end bonus since they naturally belong at
+/// path termini, plus a bonus for designated island positions.
 pub(super) fn score_fortress_candidate(
     grid: &Grid,
     pos: (usize, usize),
     completable: &HashSet<(usize, usize)>,
     bfs_distances: &HashMap<(usize, usize), usize>,
     world_idx: usize,
+    knobs: &FortScoring,
 ) -> f64 {
-    let base = score_with_weights(grid, pos, completable, bfs_distances, 5.0);
+    let base = score_with_weights(
+        grid, pos, completable, bfs_distances, &knobs.spread, knobs.dead_end_bonus,
+    );
     let island_bonus = if FORTRESS_BONUS_POSITIONS.iter().any(|&(wi, p)| wi == world_idx && p == pos) {
-        FORTRESS_BONUS
+        knobs.island_bonus
     } else {
         0.0
     };
     base + island_bonus
 }
-
-/// Max manhattan distance for pipe frontier-proximity normalization (used by
-/// the connectivity build-outward scoring in `place_pipes`).
-pub(super) const TARGET_MAX_DIST: f64 = 20.0;
-
-/// Softmax temperature for pipe placement. Higher = more random, lower =
-/// more concentrated on top-scoring candidates. Tuned for typical pipe
-/// score range of ~[-8, +12].
-pub(super) const PIPE_SOFTMAX_T: f64 = 4.0;
-
-/// Softmax temperature for fortress placement. Score range is similar to
-/// pipes (~[-12, +15] including the +5 dead-end bonus).
-pub(super) const FORTRESS_SOFTMAX_T: f64 = 4.0;

--- a/src/randomize/overworld_build/sections.rs
+++ b/src/randomize/overworld_build/sections.rs
@@ -198,6 +198,7 @@ pub(super) fn build_world<R: Rng>(
         pipe_pairs,
         // Filled in after the per-world loop when shuffle_hammer_bros is on.
         hb_sprites: Vec::new(),
+        plan: plan.clone(),
     }
 }
 

--- a/src/randomize/overworld_build/sections.rs
+++ b/src/randomize/overworld_build/sections.rs
@@ -151,23 +151,9 @@ pub(super) fn build_world<R: Rng>(
         slots = kept;
     }
 
-    // Step 3.5: Spare pipes. Now that levels are placed, fill the remaining
-    // pipe budget by converting HammerBro filler slots into pipe endpoints
-    // aimed to skip levels. Runs before locks so `place_locks` accounts for
-    // every pipe (a post-lock pipe could otherwise teleport across a lock).
-    let spare_needed = pipe_pair_count.saturating_sub(pipe_pairs.len());
-    place_spare_pipes(
-        &mut grid,
-        &mut slots,
-        &mut pipe_pairs,
-        spare_needed,
-        &hb_sprite_positions,
-        start_pos,
-        world_idx,
-        rng,
-    );
-
-    // Step 4: Lock placement
+    // Step 4: Lock placement. Runs BEFORE the spare-pipe pass so locks are
+    // placed on pure geography (connectivity pipes only) — the spare pipes
+    // below may then deliberately bridge across ONE of them (a fort skip).
     let locks = place_locks(
         &grid,
         &pipe_pairs,
@@ -177,6 +163,26 @@ pub(super) fn build_world<R: Rng>(
         fort_count,
         roles,
         force_safe,
+        world_idx,
+        rng,
+    );
+
+    // Step 4.5: Spare pipes. Now that levels AND locks exist, fill the
+    // remaining pipe budget by converting HammerBro filler slots into pipe
+    // endpoints. Each pair is scored lock-aware: at most one pair per world
+    // may bypass a single mandatory fortress (the fort-skip prize); pairs
+    // that would bypass 2+ forts or open the goal outright are rejected;
+    // the rest aim to skip levels as before.
+    let spare_needed = pipe_pair_count.saturating_sub(pipe_pairs.len());
+    place_spare_pipes(
+        &mut grid,
+        &mut slots,
+        &mut pipe_pairs,
+        spare_needed,
+        &hb_sprite_positions,
+        &locks,
+        start_pos,
+        target_pos,
         world_idx,
         rng,
     );

--- a/src/randomize/overworld_build/sections.rs
+++ b/src/randomize/overworld_build/sections.rs
@@ -2,16 +2,16 @@
 
 use super::*;
 
-use super::locks::{LockRole, place_locks};
+use super::locks::place_locks;
 use super::pipes::{FIXED_PIPE_ENDPOINTS, PIPE_EXCLUDED_POSITIONS, place_pipes, place_spare_pipes};
+use super::plan::WorldPlan;
 use super::scoring::{
-    FORTRESS_SOFTMAX_T, is_row78_conflict, pick_softmax_by_score, score_candidate,
-    score_fortress_candidate,
+    is_row78_conflict, pick_softmax_by_score, score_candidate, score_fortress_candidate,
 };
 use super::types::{BuiltWorld, SlotAssignment, SlotKind, WorldSlotCounts};
 
 // Reason: each arg is a distinct build input (world, rom, grid, fixed slots,
-// budgets, lock roles, HB flag, RNG). No subset forms a cohesive concept worth
+// budgets, world plan, HB flag, RNG). No subset forms a cohesive concept worth
 // a struct — bundling would add indirection without clarifying anything.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_world<R: Rng>(
@@ -20,7 +20,7 @@ pub(super) fn build_world<R: Rng>(
     mut grid: Grid,
     fixed_positions: &HashSet<(usize, usize)>,
     counts: &WorldSlotCounts,
-    roles: &[LockRole],
+    plan: &WorldPlan,
     shuffle_hammer_bros: bool,
     rng: &mut R,
 ) -> BuiltWorld {
@@ -63,6 +63,7 @@ pub(super) fn build_world<R: Rng>(
         target_pos,
         pipe_pair_count,
         &fixed_pipe_eps,
+        &plan.pipe,
         world_idx,
         rng,
     );
@@ -102,7 +103,7 @@ pub(super) fn build_world<R: Rng>(
     let target_bfs_dist = target_pos.and_then(|tp| bfs_distances.get(&tp).copied());
 
     // Step 3: Populate sections
-    let mut slots = populate_sections(&grid, &sections, fort_count, level_count, &pipe_positions, &bfs_distances, &reverse_bfs, target_bfs_dist, world_idx, rng);
+    let mut slots = populate_sections(&grid, &sections, fort_count, level_count, &pipe_positions, &bfs_distances, &reverse_bfs, target_bfs_dist, plan, world_idx, rng);
 
     // Add mandatory HammerBro slots for HB sprite starting positions.
     // These were excluded from find_blank_slots (so levels/forts/pipes
@@ -161,7 +162,7 @@ pub(super) fn build_world<R: Rng>(
         target_pos,
         &slots,
         fort_count,
-        roles,
+        plan,
         force_safe,
         world_idx,
         rng,
@@ -181,6 +182,7 @@ pub(super) fn build_world<R: Rng>(
         spare_needed,
         &hb_sprite_positions,
         &locks,
+        &plan.pipe,
         start_pos,
         target_pos,
         world_idx,
@@ -370,12 +372,12 @@ pub(super) fn bfs_section(
     sections
 }
 
-// Reason: 10 args is over clippy's 7-arg default. Candidate bundles
+// Reason: 11 args is over clippy's 7-arg default. Candidate bundles
 // investigated (`BfsCtx` for the 3 distance args, reusing `WorldSlotCounts`
 // for the 2 budget args) — none reveals a concept beyond what the inline
 // arg names already convey. Each arg is a distinct input (geometry,
-// sections, budgets, pipe positions, BFS data, world, RNG) and bundling
-// them would add indirection without clarity.
+// sections, budgets, pipe positions, BFS data, plan, world, RNG) and
+// bundling them would add indirection without clarity.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn populate_sections<R: Rng>(
     grid: &Grid,
@@ -386,6 +388,7 @@ pub(super) fn populate_sections<R: Rng>(
     bfs_distances: &HashMap<(usize, usize), usize>,
     reverse_bfs: &HashMap<(usize, usize), usize>,
     target_bfs_dist: Option<usize>,
+    plan: &WorldPlan,
     world_idx: usize,
     rng: &mut R,
 ) -> Vec<SlotAssignment> {
@@ -426,12 +429,12 @@ pub(super) fn populate_sections<R: Rng>(
             .iter()
             .filter(|pos| !is_row78_conflict(**pos, &completable))
             .map(|&pos| {
-                (pos, score_fortress_candidate(grid, pos, &placed_levels_and_forts, bfs_distances, world_idx))
+                (pos, score_fortress_candidate(grid, pos, &placed_levels_and_forts, bfs_distances, world_idx, &plan.fort))
             })
             .collect();
 
         // Sample by softmax; fallback to any section slot if none passed the row78 filter.
-        let pos = pick_softmax_by_score(candidates, FORTRESS_SOFTMAX_T, rng)
+        let pos = pick_softmax_by_score(candidates, plan.fort.softmax_t, rng)
             .unwrap_or_else(|| section[rng.random_range(..section.len())]);
 
         completable.insert(pos);
@@ -468,7 +471,7 @@ pub(super) fn populate_sections<R: Rng>(
             .filter(|(pos, _)| !level_positions.contains(pos))
             .filter(|(pos, _)| !is_row78_conflict(*pos, &completable))
             .map(|&(pos, _)| {
-                let score = score_candidate(grid, pos, &placed_levels_and_forts, bfs_distances, reverse_bfs, target_bfs_dist);
+                let score = score_candidate(grid, pos, &placed_levels_and_forts, bfs_distances, reverse_bfs, target_bfs_dist, &plan.level);
                 (pos, score)
             })
             .max_by(|(_, sa), (_, sb)| sa.partial_cmp(sb).unwrap_or(std::cmp::Ordering::Equal));

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -594,6 +594,135 @@ fn least_levels_from(
     dist
 }
 
+/// Baseline pipe diagnostics: per-world pipe-pair counts, how many levels the
+/// pipe set shaves off the least-levels path to the goal (the "level skip"
+/// value), and how often a pipe already makes an otherwise-mandatory fort
+/// optional (the "fort skip" — expected ~0 on current code, since spare pipes
+/// are placed before locks and `place_locks` gates around them). Run with:
+///   cargo test --lib pipe_metrics -- --ignored --nocapture
+#[test]
+#[ignore]
+fn pipe_metrics() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    const SEEDS: u64 = 1000;
+
+    let mut pairs_hist = [0u64; 12]; // pipe-pair count per world
+    let mut worlds_with_pipes = 0u64;
+    let mut conn_required = 0u64; // goal unreachable on foot (pipes needed for access)
+    let mut shortcut_worlds = 0u64; // goal reachable on foot; pipes are pure shortcuts
+    let mut saved_hist = [0u64; 12]; // levels the pipe set saves (shortcut worlds)
+    let mut skipped_forts = 0u64; // forts mandatory on foot but optional with pipes
+    let mut forts_examined = 0u64; // forts in foot-reachable pipe worlds
+    let mut worlds_fort_skip = 0u64;
+
+    for seed in 0..SEEDS {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            let mut base = built.grid.clone();
+            stamp_slots(&mut base, &built.slots);
+            let Some(start) = rom_data::find_start(&base) else { continue };
+            let Some(target) = find_target(&base, wi) else { continue };
+
+            let npairs = built.pipe_pairs.len();
+            pairs_hist[npairs.min(11)] += 1;
+            if npairs == 0 {
+                continue;
+            }
+            worlds_with_pipes += 1;
+
+            let blocking: HashSet<Pos> = built
+                .slots
+                .iter()
+                .filter(|s| matches!(s.kind, SlotKind::Level | SlotKind::Fortress))
+                .map(|s| s.pos)
+                .collect();
+
+            // Least-levels to goal with all locks OPEN (pure geography), with the
+            // pipe set vs with no pipes at all.
+            let with = least_levels_from(&base, &built.pipe_pairs, start, wi, &blocking);
+            let without = least_levels_from(&base, &[], start, wi, &blocking);
+            let foot_reachable = without.contains_key(&target);
+            if !foot_reachable {
+                conn_required += 1;
+                continue; // can't separate a pipe "skip" from required access
+            }
+            shortcut_worlds += 1;
+            let saved = without[&target].saturating_sub(*with.get(&target).unwrap_or(&without[&target]));
+            saved_hist[saved.min(11)] += 1;
+
+            // Fort skip: with each lock closed (others open), is the fort
+            // mandatory on foot but bypassed once pipes are included?
+            let all_sections: HashSet<usize> = built.locks.iter().map(|l| l.fort_section).collect();
+            let grid_with = |opened: &HashSet<usize>| -> Grid {
+                let mut g = base.clone();
+                for l in &built.locks {
+                    if opened.contains(&l.fort_section) {
+                        g.set(l.pos.0, l.pos.1, l.replace_tile);
+                    } else {
+                        g.set(l.pos.0, l.pos.1, l.gap_tile);
+                    }
+                }
+                g
+            };
+            let mut world_skips = 0u64;
+            for sec in &all_sections {
+                forts_examined += 1;
+                let mut others = all_sections.clone();
+                others.remove(sec);
+                let g = grid_with(&others);
+                let mand_pipes = !walk_map(&g, &built.pipe_pairs, Some(start), wi).nodes.contains(&target);
+                let mand_foot = !walk_map(&g, &[], Some(start), wi).nodes.contains(&target);
+                if mand_foot && !mand_pipes {
+                    skipped_forts += 1;
+                    world_skips += 1;
+                }
+            }
+            if world_skips >= 1 {
+                worlds_fort_skip += 1;
+            }
+        }
+    }
+
+    eprintln!("\n=== Pipe pairs per world ({SEEDS} seeds, 8000 worlds) ===");
+    let ptot: u64 = pairs_hist.iter().sum();
+    for (n, &c) in pairs_hist.iter().enumerate() {
+        if c == 0 {
+            continue;
+        }
+        let label = if n == 11 { "11+".to_string() } else { n.to_string() };
+        eprintln!("  {label:>3} pairs: {c:6} ({:5.1}%)", 100.0 * c as f64 / ptot as f64);
+    }
+
+    eprintln!("\n=== Level skip (worlds with >=1 pipe: {worlds_with_pipes}) ===");
+    eprintln!("  goal needs pipes for access (connectivity): {conn_required} ({:5.1}%)", 100.0 * conn_required as f64 / worlds_with_pipes as f64);
+    eprintln!("  pipes are pure shortcuts (foot-reachable goal): {shortcut_worlds} ({:5.1}%)", 100.0 * shortcut_worlds as f64 / worlds_with_pipes as f64);
+    eprintln!("  levels saved by the pipe set (shortcut worlds):");
+    let stot: u64 = saved_hist.iter().sum();
+    for (s, &c) in saved_hist.iter().enumerate() {
+        if c == 0 {
+            continue;
+        }
+        let label = if s == 11 { "11+".to_string() } else { s.to_string() };
+        eprintln!("    saves {label:>3}: {c:6} ({:5.1}%)", 100.0 * c as f64 / stot as f64);
+    }
+
+    eprintln!("\n=== Fort skip ({forts_examined} forts in foot-reachable pipe worlds) ===");
+    eprintln!("  forts mandatory on foot but bypassed by a pipe: {skipped_forts} ({:5.2}%)", 100.0 * skipped_forts as f64 / forts_examined.max(1) as f64);
+    eprintln!("  worlds with >=1 pipe-skipped fort: {worlds_fort_skip} ({:5.2}% of pipe worlds)", 100.0 * worlds_fort_skip as f64 / worlds_with_pipes as f64);
+}
+
 /// Player-model fort taxonomy over many seeds. Classifies every fortress that
 /// owns a lock into: mandatory (goal unreachable without it), shortcut (optional
 /// but beating it cuts >=2 levels off the route, counting the fort itself),

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -24,20 +24,30 @@ fn shannon_entropy<'a>(counts: impl IntoIterator<Item = &'a u32>, total: f64) ->
         .sum()
 }
 
+/// Load the test ROM with the always-on pre-builder QoL patches applied —
+/// the same map state production hands the builder. Diagnostics measured on
+/// the raw ROM lie about connectivity: e.g. W2's secret-path rock (row 0)
+/// walls off a pocket that production opens, turning W2's only pipe pair
+/// into an island bridge in tests while production gets a spare pipe.
 fn load_rom() -> Option<Rom> {
     let data = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
-    Rom::from_bytes(&data).ok()
+    let rom = Rom::from_bytes(&data).ok()?;
+    Some(apply_qol_for_overworld(&rom))
 }
 
 /// Apply the QoL patches that the real pipeline runs before the overworld
-/// builder (`randomizer.rs` ~L657-670). These mutate the world-map grid —
-/// rocks blocking pipe shortcuts, W3 drawbridge tiles, big-Q rooms — so
-/// the catalog must see the post-patch state, not vanilla.
+/// builder (`randomizer.rs` pre-build block). These mutate the world-map
+/// grid — rocks blocking pipe shortcuts, W3 drawbridge tiles, big-Q rooms,
+/// the always-on W8 screen-3 water/bridge page — so the catalog must see
+/// the post-patch state, not vanilla. (The W8 canoe edits are gated behind
+/// `8s are Wild` and are NOT applied here.) Idempotent: `load_rom` already
+/// applies it; explicit callers just re-write the same bytes.
 fn apply_qol_for_overworld(rom: &Rom) -> Rom {
     let mut out = rom.clone();
     super::super::qol::fix_w3_drawbridges(&mut out);
     super::super::qol::remove_rocks(&mut out);
     super::super::qol::fix_big_q_block_rooms(&mut out);
+    super::super::qol::apply_w8_bridges(&mut out);
     out
 }
 

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -5,7 +5,7 @@ use super::capacity::{
 };
 use super::locks::debug_stamp_rom;
 use super::pipes::VANILLA_PIPE_PAIRS;
-use super::plan::{Archetype, LockRole};
+use super::plan::{Archetype, FortSkipPolicy, LockRole};
 use super::scoring::{VANILLA_LEVEL_COUNT, is_dead_end};
 use super::sections::find_blank_slots;
 use super::types::stamp_slots;
@@ -834,6 +834,443 @@ fn world_topology(built: &BuiltWorld) -> Option<WorldTopology> {
         forts_at_start,
         fort_skip: if foot_ok { Some(fort_skip) } else { None },
     })
+}
+
+/// TEMP probe: dump full detail for every world where the goal is reachable
+/// with ALL locks closed (the rare "goal open at start" census bucket).
+#[test]
+#[ignore]
+fn goal_open_probe() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    for seed in 0..1000u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        let hit = result.worlds.iter().any(|b| {
+            world_topology(b).is_some_and(|t| t.fort_count >= 2 && t.depth == 0)
+        });
+        if !hit {
+            continue;
+        }
+        eprintln!("seed {seed}: full-seed picture (goal-open world marked *)");
+        for built in &result.worlds {
+            let t = world_topology(built);
+            let open = t.as_ref().is_some_and(|t| t.fort_count >= 2 && t.depth == 0);
+            let safe_roles = built
+                .plan
+                .roles
+                .iter()
+                .filter(|r| matches!(r, LockRole::Safe))
+                .count();
+            let safe_locks = built.locks.iter().filter(|l| l.secret_exit_safe).count();
+            eprintln!(
+                "  {}W{}: {:?}, forts {}, Safe roles {}, safe locks {}/{}",
+                if open { "*" } else { " " },
+                built.world_idx + 1,
+                built.plan.archetype,
+                built.locks.len(),
+                safe_roles,
+                safe_locks,
+                built.locks.len(),
+            );
+            // For the goal-open world: is the goal gateable AT ALL — does any
+            // single lockable tile, gapped, sever the target (pipes+canoes
+            // considered)?
+            if open {
+                let wi = built.world_idx;
+                let mut base = built.grid.clone();
+                stamp_slots(&mut base, &built.slots);
+                let start = rom_data::find_start(&base).unwrap();
+                let target = find_target(&base, wi).unwrap();
+                let mut gateable = 0usize;
+                for r in 0..base.rows() {
+                    for c in 0..base.cols {
+                        let tile = base.get(r, c);
+                        if !LOCKABLE_TILES.contains(&tile) {
+                            continue;
+                        }
+                        let mut g = base.clone();
+                        g.set(r, c, gap_tile_for(tile));
+                        if !walk_map(&g, &built.pipe_pairs, Some(start), wi)
+                            .nodes
+                            .contains(&target)
+                        {
+                            gateable += 1;
+                        }
+                    }
+                }
+                eprintln!(
+                    "     -> single-lock-gateable candidate tiles for the goal: {gateable}"
+                );
+            }
+        }
+    }
+}
+
+/// How NESTED are a world's locks? A chain-link lock is "nested" when closing
+/// it alone (others open) blocks the GOAL — i.e. its gated region contains
+/// the rest of the progression, not just the next fort's local pocket. The
+/// fort-skip machinery can only see nested locks (its splits are goal-anchored),
+/// so a world whose chain links gate local pockets is invisible to it.
+#[test]
+#[ignore]
+fn lock_nesting_probe() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    // (nonfinal locks blocking goal, nonfinal total, final blocking, final total)
+    let mut per_world = [(0u64, 0u64, 0u64, 0u64); 8];
+    for seed in 0..300u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        for built in &result.worlds {
+            if built.locks.len() < 2 {
+                continue;
+            }
+            let wi = built.world_idx;
+            let mut base = built.grid.clone();
+            stamp_slots(&mut base, &built.slots);
+            let Some(start) = rom_data::find_start(&base) else { continue };
+            let Some(target) = find_target(&base, wi) else { continue };
+            let all_secs: HashSet<usize> = built.locks.iter().map(|l| l.fort_section).collect();
+            let max_sec = *all_secs.iter().max().unwrap();
+            for l in &built.locks {
+                let mut g = base.clone();
+                for l2 in &built.locks {
+                    let t = if l2.fort_section == l.fort_section { l2.gap_tile } else { l2.replace_tile };
+                    g.set(l2.pos.0, l2.pos.1, t);
+                }
+                let blocks =
+                    !walk_map(&g, &built.pipe_pairs, Some(start), wi).nodes.contains(&target);
+                let s = &mut per_world[wi];
+                if l.fort_section == max_sec {
+                    s.3 += 1;
+                    if blocks { s.2 += 1; }
+                } else {
+                    s.1 += 1;
+                    if blocks { s.0 += 1; }
+                }
+            }
+        }
+    }
+    eprintln!("\n=== lock_nesting_probe (300 seeds, multi-lock worlds) ===");
+    eprintln!("world  nonfinal-locks-blocking-goal%   final-lock-blocking-goal%");
+    for (wi, &(nb, nt, fb, ft)) in per_world.iter().enumerate() {
+        if nt + ft == 0 { continue; }
+        eprintln!(
+            "  W{}   {:>6.1}% ({}/{})              {:>6.1}% ({}/{})",
+            wi + 1,
+            100.0 * nb as f64 / nt.max(1) as f64, nb, nt,
+            100.0 * fb as f64 / ft.max(1) as f64, fb, ft,
+        );
+    }
+}
+
+/// TEMP: dissect W2 fort-skip failures at placement-time fidelity — W2 has
+/// no connectivity pipes, so the placer's view is exactly pipes=[]. For the
+/// first N skip-allowed W2 worlds, print each lock's split and the candidate
+/// endpoint situation the spare-pipe pass actually faced.
+#[test]
+#[ignore]
+fn w2_skip_dissect() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let mut shown = 0;
+    for seed in 0..200u64 {
+        if shown >= 6 {
+            break;
+        }
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        let built = &result.worlds[1]; // W2
+        if built.plan.pipe.fort_skip != FortSkipPolicy::AnyOneFort || built.locks.len() < 2 {
+            continue;
+        }
+        shown += 1;
+        let mut base = built.grid.clone();
+        stamp_slots(&mut base, &built.slots);
+        let start = rom_data::find_start(&base).unwrap();
+        let target = find_target(&base, 1).unwrap();
+        let reserved: HashSet<Pos> =
+            rom_data::read_hb_sprite_positions(&rom, 1).into_iter().collect();
+        let lock_row78: HashSet<Pos> = built
+            .locks
+            .iter()
+            .filter_map(|l| match l.pos.0 {
+                7 => Some((8, l.pos.1)),
+                8 => Some((7, l.pos.1)),
+                _ => None,
+            })
+            .collect();
+        let endpoints: Vec<Pos> = built
+            .slots
+            .iter()
+            .filter(|s| {
+                matches!(s.kind, SlotKind::HammerBro | SlotKind::ToadHouse | SlotKind::BonusGame)
+                    && !reserved.contains(&s.pos)
+                    && !lock_row78.contains(&s.pos)
+            })
+            .map(|s| s.pos)
+            .collect();
+        eprintln!(
+            "\nseed {seed} W2: {:?}, pipes {}, forts {}, HB-ish endpoints {} (reserved {})",
+            built.plan.archetype,
+            built.pipe_pairs.len(),
+            built.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count(),
+            endpoints.len(),
+            reserved.len(),
+        );
+        let all_secs: HashSet<usize> = built.locks.iter().map(|l| l.fort_section).collect();
+        for l in &built.locks {
+            let mut g = base.clone();
+            for l2 in &built.locks {
+                let t = if l2.fort_section == l.fort_section { l2.gap_tile } else { l2.replace_tile };
+                g.set(l2.pos.0, l2.pos.1, t);
+            }
+            // Placement-time view: no pipes (W2 has no connectivity pipes).
+            let cs = walk_map(&g, &[], Some(start), 1).nodes;
+            let blocks = !cs.contains(&target);
+            if !blocks {
+                eprintln!(
+                    "  lock sec {} at {:?}: does NOT block goal (others open) -> invisible to skip eval",
+                    l.fort_section, l.pos
+                );
+                continue;
+            }
+            let ct = walk_map(&g, &[], Some(target), 1).nodes;
+            let ea = endpoints.iter().filter(|p| cs.contains(p)).count();
+            let eb = endpoints.iter().filter(|p| ct.contains(p)).count();
+            // Unclassified nodes: reachable from neither (stranded by this lock).
+            let neither = endpoints.iter().filter(|p| !cs.contains(p) && !ct.contains(p)).count();
+            eprintln!(
+                "  lock sec {} at {:?}: BLOCKS goal; start-side {} nodes/{} endpts, goal-side {} nodes/{} endpts, neither {}",
+                l.fort_section, l.pos, cs.len(), ea, ct.len(), eb, neither
+            );
+        }
+        // All-closed split (the goal-open rejection state).
+        let mut g = base.clone();
+        for l2 in &built.locks {
+            g.set(l2.pos.0, l2.pos.1, l2.gap_tile);
+        }
+        let cs = walk_map(&g, &[], Some(start), 1).nodes;
+        let ct = walk_map(&g, &[], Some(target), 1).nodes;
+        let ea = endpoints.iter().filter(|p| cs.contains(p)).count();
+        let eb = endpoints.iter().filter(|p| ct.contains(p)).count();
+        eprintln!(
+            "  ALL-CLOSED: start-side {} endpts, goal-side {} endpts (a straddle here = goal-open reject)",
+            ea, eb
+        );
+        // Where did the actual spare pipe land relative to each gating lock?
+        for &(a, b) in &built.pipe_pairs {
+            for l in &built.locks {
+                let mut g = base.clone();
+                for l2 in &built.locks {
+                    let t = if l2.fort_section == l.fort_section { l2.gap_tile } else { l2.replace_tile };
+                    g.set(l2.pos.0, l2.pos.1, t);
+                }
+                let cs = walk_map(&g, &[], Some(start), 1).nodes;
+                if cs.contains(&target) {
+                    continue;
+                }
+                let ct = walk_map(&g, &[], Some(target), 1).nodes;
+                let side = |p: Pos| {
+                    if cs.contains(&p) { "start" } else if ct.contains(&p) { "goal" } else { "mid" }
+                };
+                eprintln!(
+                    "  placed pipe {:?}<->{:?} vs lock sec {}: {} <-> {}",
+                    a, b, l.fort_section, side(a), side(b)
+                );
+            }
+        }
+        let _ = all_secs;
+    }
+}
+
+/// Per-world pipe budget composition: how many of each world's pairs are
+/// island bridges (an endpoint unreachable by walk alone, locks open) vs
+/// spares (both endpoints on the walk-connected mainland). Bridges are
+/// placed by the connectivity phase; only spares can become fort-skips.
+#[test]
+#[ignore]
+fn pipe_budget_probe() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let mut per_world = [(0u64, 0u64, 0u64); 8]; // (pairs, bridges, worlds)
+    for seed in 0..300u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            let mut base = built.grid.clone();
+            stamp_slots(&mut base, &built.slots);
+            let Some(start) = rom_data::find_start(&base) else { continue };
+            let open_walk = walk_map(&base, &[], Some(start), wi).nodes;
+            let bridges = built
+                .pipe_pairs
+                .iter()
+                .filter(|&&(a, b)| !open_walk.contains(&a) || !open_walk.contains(&b))
+                .count();
+            let s = &mut per_world[wi];
+            s.0 += built.pipe_pairs.len() as u64;
+            s.1 += bridges as u64;
+            s.2 += 1;
+        }
+    }
+    eprintln!("\n=== pipe_budget_probe (300 seeds) ===");
+    eprintln!("world  avg pairs  avg bridges  avg spares");
+    for (wi, &(pairs, bridges, n)) in per_world.iter().enumerate() {
+        if n == 0 { continue; }
+        let n = n as f64;
+        eprintln!(
+            "  W{}     {:>5.2}      {:>5.2}       {:>5.2}",
+            wi + 1,
+            pairs as f64 / n,
+            bridges as f64 / n,
+            (pairs - bridges) as f64 / n,
+        );
+    }
+}
+
+/// TEMP: for goal-open W3 worlds, replicate the GoalGate section's candidate
+/// evaluation with the other locks as actually placed, and report WHY each
+/// goal-severing tile was rejected (rule 1: own fort stranded; role: which
+/// fort stranded; row78; already locked). Ground truth for the fallback bug.
+#[test]
+#[ignore]
+fn w3_goalgate_dissect() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let mut shown = 0;
+    for seed in 0..1000u64 {
+        if shown >= 3 {
+            break;
+        }
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        let built = &result.worlds[2]; // W3
+        let Some(t) = world_topology(built) else { continue };
+        if t.fort_count < 2 || t.depth != 0 {
+            continue;
+        }
+        shown += 1;
+        let wi = 2;
+        let mut base = built.grid.clone();
+        stamp_slots(&mut base, &built.slots);
+        let start = rom_data::find_start(&base).unwrap();
+        let target = find_target(&base, wi).unwrap();
+        let goal_sec = built
+            .plan
+            .roles
+            .iter()
+            .position(|r| matches!(r, LockRole::GoalGate))
+            .unwrap();
+        let forts: Vec<(usize, Pos)> = built
+            .slots
+            .iter()
+            .filter(|s| s.kind == SlotKind::Fortress)
+            .map(|s| (s.section, s.pos))
+            .collect();
+        eprintln!(
+            "\nseed {seed} W3 {:?}: roles {:?}, GoalGate sec {goal_sec}, forts {:?}, start {:?}, target {:?}",
+            built.plan.archetype, built.plan.roles, forts, start, target
+        );
+        eprintln!("  placed locks: {:?}", built.locks.iter().map(|l| (l.fort_section, l.pos)).collect::<Vec<_>>());
+        eprintln!("  pipes: {:?}", built.pipe_pairs);
+
+        // Which pipe subset creates the all-locks-closed route to the goal?
+        {
+            let mut g = base.clone();
+            for l in &built.locks {
+                g.set(l.pos.0, l.pos.1, l.gap_tile);
+            }
+            for n in 0..=built.pipe_pairs.len() {
+                let subset = &built.pipe_pairs[..n];
+                let reach = walk_map(&g, subset, Some(start), wi).nodes.contains(&target);
+                eprintln!("  all-closed, first {n} pipes: target reachable = {reach}");
+            }
+        }
+
+        // Evaluate every goal-severing lockable tile as a GoalGate candidate
+        // with the OTHER sections' actual locks in their place_locks state
+        // (earlier sections open, later closed).
+        let other_locks: Vec<_> = built
+            .locks
+            .iter()
+            .filter(|l| l.fort_section != goal_sec)
+            .collect();
+        for r in 0..base.rows() {
+            for c in 0..base.cols {
+                let tile = base.get(r, c);
+                if !LOCKABLE_TILES.contains(&tile) {
+                    continue;
+                }
+                if built.locks.iter().any(|l| l.pos == (r, c)) {
+                    continue;
+                }
+                let mut g = base.clone();
+                for l in &other_locks {
+                    let t2 = if l.fort_section < goal_sec { l.replace_tile } else { l.gap_tile };
+                    g.set(l.pos.0, l.pos.1, t2);
+                }
+                g.set(r, c, gap_tile_for(tile));
+                let walk = walk_map(&g, &built.pipe_pairs, Some(start), wi);
+                if walk.nodes.contains(&target) {
+                    continue; // doesn't sever the goal — not interesting
+                }
+                let own_fort = forts.iter().find(|(s, _)| *s == goal_sec).map(|(_, p)| *p);
+                let own_stranded =
+                    own_fort.is_some_and(|p| !walk.nodes.contains(&p));
+                let stranded: Vec<usize> = forts
+                    .iter()
+                    .filter(|(_, p)| !walk.nodes.contains(p))
+                    .map(|(s, _)| *s)
+                    .collect();
+                eprintln!(
+                    "  severs-goal ({r},{c}) tile {tile:02X}: own-fort-stranded {} | stranded sections {:?}",
+                    own_stranded, stranded
+                );
+            }
+        }
+    }
 }
 
 /// Fork-balance diagnostic: how "true" is the choice a Fork world presents?

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -734,30 +734,19 @@ fn pipe_metrics() {
     eprintln!("  worlds with >=1 pipe-skipped fort: {worlds_fort_skip} ({:5.2}% of pipe worlds)", 100.0 * worlds_fort_skip as f64 / worlds_with_pipes as f64);
 }
 
-/// Per-world topology snapshot used by the plan-sweep harness. Distilled from
-/// the `progression_metrics` / `pipe_metrics` logic: same lock-state model
-/// (grid holds locks open; close by stamping gap tiles), same walk_map
-/// traversal.
-// Reason: consumed by the census/goal-open diagnostics (next commit); the
-// fork-tell pick lands first so each rung stays a single concern.
-#[allow(dead_code)]
+/// Per-world topology snapshot for the goal-open probes. Distilled from the
+/// `progression_metrics` logic: same lock-state model (grid holds locks
+/// open; close by stamping gap tiles), same walk_map traversal. (The parked
+/// plan-sweep harness carried richer fields — mandatory/forts_at_start/
+/// fort_skip — restore them from the backup branch when a census consumer
+/// returns.)
 struct WorldTopology {
     fort_count: usize,
     /// Rounds of "beat every reachable fort" until the goal opens (with
     /// pipes). 0 = goal open at start; 99 = infeasible (never observed).
     depth: usize,
-    /// Forts whose lock, closed alone (others open), blocks the goal.
-    mandatory: usize,
-    /// Forts reachable with every lock closed.
-    forts_at_start: usize,
-    /// Some fort is mandatory on foot but optional once pipes are included —
-    /// a realized fort-skip. None = not measurable (goal needs pipes even
-    /// with all locks open, so foot-mandatoriness is vacuous).
-    fort_skip: Option<bool>,
 }
 
-// Reason: see WorldTopology above — consumers land with the diagnostics rung.
-#[allow(dead_code)]
 fn world_topology(built: &BuiltWorld) -> Option<WorldTopology> {
     let wi = built.world_idx;
     let mut base = built.grid.clone();
@@ -810,40 +799,7 @@ fn world_topology(built: &BuiltWorld) -> Option<WorldTopology> {
         depth += 1;
     }
 
-    let closed = grid_with(&HashSet::new());
-    let walk0 = walk_map(&closed, &built.pipe_pairs, Some(start), wi);
-    let forts_at_start = forts.iter().filter(|(_, p)| walk0.nodes.contains(p)).count();
-
-    // Foot-mandatoriness is only meaningful if the goal is reachable on foot
-    // at all (all locks open, no pipes).
-    let all_open = grid_with(&all_secs);
-    let foot_ok = walk_map(&all_open, &[], Some(start), wi).nodes.contains(&target);
-
-    let mut mandatory = 0usize;
-    let mut fort_skip = false;
-    for l in &built.locks {
-        let mut others = all_secs.clone();
-        others.remove(&l.fort_section);
-        let g = grid_with(&others);
-        let mand_pipes = !walk_map(&g, &built.pipe_pairs, Some(start), wi).nodes.contains(&target);
-        if mand_pipes {
-            mandatory += 1;
-        }
-        if foot_ok {
-            let mand_foot = !walk_map(&g, &[], Some(start), wi).nodes.contains(&target);
-            if mand_foot && !mand_pipes {
-                fort_skip = true;
-            }
-        }
-    }
-
-    Some(WorldTopology {
-        fort_count: forts.len(),
-        depth,
-        mandatory,
-        forts_at_start,
-        fort_skip: if foot_ok { Some(fort_skip) } else { None },
-    })
+    Some(WorldTopology { fort_count: forts.len(), depth })
 }
 
 /// TEMP probe: dump full detail for every world where the goal is reachable
@@ -920,6 +876,220 @@ fn goal_open_probe() {
                 eprintln!(
                     "     -> single-lock-gateable candidate tiles for the goal: {gateable}"
                 );
+            }
+        }
+    }
+}
+
+/// How close do goal-blocking locks sit to the goal, and how much deeper
+/// COULD they sit if forts weren't in the way? For every world with a
+/// realized target-blocking lock: its Manhattan distance to the target and
+/// its gated-node count, vs the deepest fort-free severing tile available
+/// on that map (the placement headroom). Answers "are doorstep gates a
+/// lock-scoring problem or a fort-placement problem?"
+#[test]
+#[ignore]
+fn goal_gate_depth_probe() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let mut dist_hist = [0usize; 12]; // Manhattan distance, last bucket = 11+
+    let mut chosen_gated: Vec<usize> = Vec::new();
+    let mut best_gated: Vec<usize> = Vec::new();
+    let mut at_headroom = 0usize; // chosen gate is within 2 nodes of best available
+    let mut worlds_with_gate = 0usize;
+    for seed in 0..300u64 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        for built in &result.worlds {
+            let wi = built.world_idx;
+            let Some(gate) = built.locks.iter().find(|l| l.blocks_target) else {
+                continue;
+            };
+            let mut base = built.grid.clone();
+            stamp_slots(&mut base, &built.slots);
+            let start = rom_data::find_start(&base);
+            let Some(target) = find_target(&base, wi) else { continue };
+            worlds_with_gate += 1;
+
+            let d = gate.pos.0.abs_diff(target.0) + gate.pos.1.abs_diff(target.1);
+            dist_hist[d.min(11)] += 1;
+
+            let open_nodes = walk_map(&base, &built.pipe_pairs, start, wi).nodes;
+            let forts: Vec<(usize, usize)> = built
+                .slots
+                .iter()
+                .filter(|s| s.kind == SlotKind::Fortress)
+                .map(|s| s.pos)
+                .collect();
+
+            // Chosen gate's gated-node count.
+            let mut g = base.clone();
+            g.set(gate.pos.0, gate.pos.1, gate.gap_tile);
+            let chosen =
+                open_nodes.len() - walk_map(&g, &built.pipe_pairs, start, wi).nodes.len();
+            chosen_gated.push(chosen);
+
+            // Deepest fort-free severing tile available on this map.
+            let mut best = 0usize;
+            for r in 0..base.rows() {
+                for c in 0..base.cols {
+                    let tile = base.get(r, c);
+                    if !LOCKABLE_TILES.contains(&tile) {
+                        continue;
+                    }
+                    let mut g2 = base.clone();
+                    g2.set(r, c, gap_tile_for(tile));
+                    let walk = walk_map(&g2, &built.pipe_pairs, start, wi);
+                    if walk.nodes.contains(&target) {
+                        continue;
+                    }
+                    if forts.iter().any(|f| !walk.nodes.contains(f)) {
+                        continue; // strands a fort — not usable headroom
+                    }
+                    best = best.max(open_nodes.len() - walk.nodes.len());
+                }
+            }
+            best_gated.push(best);
+            if chosen + 2 >= best {
+                at_headroom += 1;
+            }
+        }
+    }
+    eprintln!("\n=== goal_gate_depth_probe (300 seeds, {worlds_with_gate} gated worlds) ===");
+    eprint!("  gate->target Manhattan dist: ");
+    for (d, n) in dist_hist.iter().enumerate() {
+        if *n > 0 {
+            eprint!("{}{}={} ", if d == 11 { "≥" } else { "" }, d, n);
+        }
+    }
+    let mean = |v: &Vec<usize>| v.iter().sum::<usize>() as f64 / v.len().max(1) as f64;
+    eprintln!(
+        "\n  doorstep gates (dist <=2): {} ({:.1}%)",
+        dist_hist[..3].iter().sum::<usize>(),
+        100.0 * dist_hist[..3].iter().sum::<usize>() as f64 / worlds_with_gate as f64
+    );
+    eprintln!(
+        "  gated nodes: chosen mean {:.1} vs best-available (fort-free) mean {:.1}; chosen within 2 of best: {} ({:.1}%)",
+        mean(&chosen_gated),
+        mean(&best_gated),
+        at_headroom,
+        100.0 * at_headroom as f64 / worlds_with_gate as f64
+    );
+}
+
+/// Rule-aware dissect of SAS goal-open worlds: the rule-blind scan says the
+/// goal IS single-lock gateable (3-10 severing tiles), yet place_locks ends
+/// all-safe. For each severing tile, report WHICH lock rule refuses it:
+/// row-7/8 completion-bit exclusion, rule 1 (strands its own section's
+/// fort), rule 2 (strands an earlier section's fort), or GoalGate role
+/// rejection (strands any fort). Run with SAS=1.
+#[test]
+#[ignore]
+fn w7_sas_rule_dissect() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let mut dissected = 0usize;
+    for seed in 0..1000u64 {
+        if dissected >= 5 {
+            break;
+        }
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        for built in &result.worlds {
+            let open = world_topology(built).is_some_and(|t| t.fort_count >= 2 && t.depth == 0);
+            if !open {
+                continue;
+            }
+            dissected += 1;
+            let wi = built.world_idx;
+            let mut base = built.grid.clone();
+            stamp_slots(&mut base, &built.slots);
+            let start = rom_data::find_start(&base);
+            let target = find_target(&base, wi).unwrap();
+
+            // Fort positions by section, ordered.
+            let forts: Vec<(usize, (usize, usize))> = {
+                let mut f: Vec<(usize, (usize, usize))> = built
+                    .slots
+                    .iter()
+                    .filter(|s| s.kind == SlotKind::Fortress)
+                    .map(|s| (s.section, s.pos))
+                    .collect();
+                f.sort();
+                f
+            };
+            eprintln!(
+                "\nseed {seed} W{}: {:?}, forts {:?}, roles {:?}",
+                wi + 1,
+                built.plan.archetype,
+                forts,
+                built.plan.roles,
+            );
+            for l in &built.locks {
+                eprintln!(
+                    "  placed lock: sec {} at {:?} safe={} blocks_target={}",
+                    l.fort_section, l.pos, l.secret_exit_safe, l.blocks_target
+                );
+            }
+
+            for r in 0..base.rows() {
+                for c in 0..base.cols {
+                    let tile = base.get(r, c);
+                    if !LOCKABLE_TILES.contains(&tile) {
+                        continue;
+                    }
+                    let mut g = base.clone();
+                    g.set(r, c, gap_tile_for(tile));
+                    let walk = walk_map(&g, &built.pipe_pairs, start, wi);
+                    if walk.nodes.contains(&target) {
+                        continue; // not goal-severing
+                    }
+                    // Row 7/8 completion-bit exclusion, as in place_locks.
+                    let row78 = (r == 7 || r == 8) && {
+                        let paired = if r == 7 { 8 } else { 7 };
+                        built.slots.iter().any(|s| {
+                            s.pos == (paired, c)
+                                && matches!(
+                                    s.kind,
+                                    SlotKind::Level
+                                        | SlotKind::Fortress
+                                        | SlotKind::Pipe
+                                        | SlotKind::BonusGame
+                                        | SlotKind::ToadHouse
+                                )
+                        })
+                    };
+                    let stranded: Vec<usize> = forts
+                        .iter()
+                        .filter(|(_, fp)| !walk.nodes.contains(fp))
+                        .map(|(sec, _)| *sec)
+                        .collect();
+                    eprintln!(
+                        "  severing ({r},{c}) tile {tile:02X}: row78_excluded={} strands_fort_sections={:?} gated_nodes={}",
+                        row78,
+                        stranded,
+                        {
+                            let open_walk = walk_map(&base, &built.pipe_pairs, start, wi);
+                            open_walk.nodes.len() - walk.nodes.len()
+                        },
+                    );
+                }
             }
         }
     }

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -594,11 +594,11 @@ fn least_levels_from(
     dist
 }
 
-/// Baseline pipe diagnostics: per-world pipe-pair counts, how many levels the
-/// pipe set shaves off the least-levels path to the goal (the "level skip"
-/// value), and how often a pipe already makes an otherwise-mandatory fort
-/// optional (the "fort skip" — expected ~0 on current code, since spare pipes
-/// are placed before locks and `place_locks` gates around them). Run with:
+/// Pipe diagnostics: per-world pipe-pair counts, how many levels the pipe set
+/// shaves off the least-levels path to the goal (the "level skip" value), and
+/// how often a pipe makes an otherwise-mandatory fort optional (the "fort
+/// skip"). Baseline before the lock-aware spare-pipe pass was ~0 fort skips
+/// (2026-07: 1 of 3735 forts); the fort-skip pass should raise it. Run with:
 ///   cargo test --lib pipe_metrics -- --ignored --nocapture
 #[test]
 #[ignore]

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -5,6 +5,7 @@ use super::capacity::{
 };
 use super::locks::debug_stamp_rom;
 use super::pipes::VANILLA_PIPE_PAIRS;
+use super::plan::{Archetype, LockRole};
 use super::scoring::{VANILLA_LEVEL_COUNT, is_dead_end};
 use super::sections::find_blank_slots;
 use super::types::stamp_slots;
@@ -721,6 +722,290 @@ fn pipe_metrics() {
     eprintln!("\n=== Fort skip ({forts_examined} forts in foot-reachable pipe worlds) ===");
     eprintln!("  forts mandatory on foot but bypassed by a pipe: {skipped_forts} ({:5.2}%)", 100.0 * skipped_forts as f64 / forts_examined.max(1) as f64);
     eprintln!("  worlds with >=1 pipe-skipped fort: {worlds_fort_skip} ({:5.2}% of pipe worlds)", 100.0 * worlds_fort_skip as f64 / worlds_with_pipes as f64);
+}
+
+/// Per-world topology snapshot used by the plan-sweep harness. Distilled from
+/// the `progression_metrics` / `pipe_metrics` logic: same lock-state model
+/// (grid holds locks open; close by stamping gap tiles), same walk_map
+/// traversal.
+// Reason: consumed by the census/goal-open diagnostics (next commit); the
+// fork-tell pick lands first so each rung stays a single concern.
+#[allow(dead_code)]
+struct WorldTopology {
+    fort_count: usize,
+    /// Rounds of "beat every reachable fort" until the goal opens (with
+    /// pipes). 0 = goal open at start; 99 = infeasible (never observed).
+    depth: usize,
+    /// Forts whose lock, closed alone (others open), blocks the goal.
+    mandatory: usize,
+    /// Forts reachable with every lock closed.
+    forts_at_start: usize,
+    /// Some fort is mandatory on foot but optional once pipes are included —
+    /// a realized fort-skip. None = not measurable (goal needs pipes even
+    /// with all locks open, so foot-mandatoriness is vacuous).
+    fort_skip: Option<bool>,
+}
+
+// Reason: see WorldTopology above — consumers land with the diagnostics rung.
+#[allow(dead_code)]
+fn world_topology(built: &BuiltWorld) -> Option<WorldTopology> {
+    let wi = built.world_idx;
+    let mut base = built.grid.clone();
+    stamp_slots(&mut base, &built.slots);
+    let start = rom_data::find_start(&base)?;
+    let target = find_target(&base, wi)?;
+    let forts: Vec<(usize, Pos)> = built
+        .slots
+        .iter()
+        .filter(|s| s.kind == SlotKind::Fortress)
+        .map(|s| (s.section, s.pos))
+        .collect();
+    if forts.is_empty() {
+        return None;
+    }
+    let all_secs: HashSet<usize> = built.locks.iter().map(|l| l.fort_section).collect();
+    let grid_with = |opened: &HashSet<usize>| -> Grid {
+        let mut g = base.clone();
+        for l in &built.locks {
+            if opened.contains(&l.fort_section) {
+                g.set(l.pos.0, l.pos.1, l.replace_tile);
+            } else {
+                g.set(l.pos.0, l.pos.1, l.gap_tile);
+            }
+        }
+        g
+    };
+
+    // Chain depth: rounds of beat-all-reachable until the goal opens.
+    let mut opened: HashSet<usize> = HashSet::new();
+    let mut depth = 0usize;
+    loop {
+        let g = grid_with(&opened);
+        let walk = walk_map(&g, &built.pipe_pairs, Some(start), wi);
+        if walk.nodes.contains(&target) {
+            break;
+        }
+        let newly: Vec<usize> = forts
+            .iter()
+            .filter(|(sec, pos)| {
+                walk.nodes.contains(pos) && all_secs.contains(sec) && !opened.contains(sec)
+            })
+            .map(|(sec, _)| *sec)
+            .collect();
+        if newly.is_empty() {
+            depth = 99;
+            break;
+        }
+        opened.extend(newly);
+        depth += 1;
+    }
+
+    let closed = grid_with(&HashSet::new());
+    let walk0 = walk_map(&closed, &built.pipe_pairs, Some(start), wi);
+    let forts_at_start = forts.iter().filter(|(_, p)| walk0.nodes.contains(p)).count();
+
+    // Foot-mandatoriness is only meaningful if the goal is reachable on foot
+    // at all (all locks open, no pipes).
+    let all_open = grid_with(&all_secs);
+    let foot_ok = walk_map(&all_open, &[], Some(start), wi).nodes.contains(&target);
+
+    let mut mandatory = 0usize;
+    let mut fort_skip = false;
+    for l in &built.locks {
+        let mut others = all_secs.clone();
+        others.remove(&l.fort_section);
+        let g = grid_with(&others);
+        let mand_pipes = !walk_map(&g, &built.pipe_pairs, Some(start), wi).nodes.contains(&target);
+        if mand_pipes {
+            mandatory += 1;
+        }
+        if foot_ok {
+            let mand_foot = !walk_map(&g, &[], Some(start), wi).nodes.contains(&target);
+            if mand_foot && !mand_pipes {
+                fort_skip = true;
+            }
+        }
+    }
+
+    Some(WorldTopology {
+        fort_count: forts.len(),
+        depth,
+        mandatory,
+        forts_at_start,
+        fort_skip: if foot_ok { Some(fort_skip) } else { None },
+    })
+}
+
+/// Fork-balance diagnostic: how "true" is the choice a Fork world presents?
+/// For every sampled-Fork world, simulate progression to the FORK MOMENT
+/// (first state with >=2 unbeaten terminal-fork forts co-accessible), then
+/// compare the player cost (least-levels from start, current lock state) of
+/// reaching each fork fort. A true 50/50 means near-equal costs and no
+/// systematic tell on which fort is the real GoalGate. Run with:
+///   cargo test --release --lib fork_balance -- --ignored --nocapture
+#[test]
+#[ignore]
+fn fork_balance() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let (catalog, pickup) = build_catalog_pickup(&rom, 0);
+    let seeds: u64 = std::env::var("SWEEP_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(500);
+
+    let mut sampled = 0u64;
+    let mut realized = 0u64; // fork moment reached with >=2 co-accessible
+    let mut asym_hist = [0u64; 6]; // max-min cost among fork forts (capped 5)
+    let mut goal_cheapest = 0u64;
+    let mut goal_tied = 0u64;
+    let mut goal_dearest = 0u64;
+    let mut goal_inaccessible = 0u64; // goal fort not in the co-accessible set
+
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        for built in &result.worlds {
+            let Archetype::Fork { .. } = built.plan.archetype else { continue };
+            sampled += 1;
+
+            let wi = built.world_idx;
+            let mut base = built.grid.clone();
+            stamp_slots(&mut base, &built.slots);
+            let Some(start) = rom_data::find_start(&base) else { continue };
+            let Some(target) = find_target(&base, wi) else { continue };
+            let fort_pos: HashMap<usize, Pos> = built
+                .slots
+                .iter()
+                .filter(|s| s.kind == SlotKind::Fortress)
+                .map(|s| (s.section, s.pos))
+                .collect();
+            let all_secs: HashSet<usize> = built.locks.iter().map(|l| l.fort_section).collect();
+            let grid_with = |opened: &HashSet<usize>| -> Grid {
+                let mut g = base.clone();
+                for l in &built.locks {
+                    if opened.contains(&l.fort_section) {
+                        g.set(l.pos.0, l.pos.1, l.replace_tile);
+                    } else {
+                        g.set(l.pos.0, l.pos.1, l.gap_tile);
+                    }
+                }
+                g
+            };
+            // Terminal fork sections: the Safe decoys + the GoalGate.
+            let terminal: Vec<usize> = built
+                .plan
+                .roles
+                .iter()
+                .enumerate()
+                .filter(|(_, r)| matches!(r, LockRole::Safe | LockRole::GoalGate))
+                .map(|(i, _)| i)
+                .collect();
+            let goal_sec = built
+                .plan
+                .roles
+                .iter()
+                .position(|r| matches!(r, LockRole::GoalGate));
+
+            // Advance progression until the fork is on the table.
+            let mut opened: HashSet<usize> = HashSet::new();
+            let fork_state: Option<(Grid, Vec<usize>)> = loop {
+                let g = grid_with(&opened);
+                let walk = walk_map(&g, &built.pipe_pairs, Some(start), wi);
+                let acc_terminal: Vec<usize> = terminal
+                    .iter()
+                    .copied()
+                    .filter(|sec| {
+                        !opened.contains(sec)
+                            && fort_pos.get(sec).is_some_and(|p| walk.nodes.contains(p))
+                    })
+                    .collect();
+                if acc_terminal.len() >= 2 {
+                    break Some((g, acc_terminal));
+                }
+                if walk.nodes.contains(&target) {
+                    break None; // goal opened before any real fork appeared
+                }
+                let newly: Vec<usize> = fort_pos
+                    .iter()
+                    .filter(|(sec, pos)| {
+                        walk.nodes.contains(pos)
+                            && all_secs.contains(*sec)
+                            && !opened.contains(*sec)
+                    })
+                    .map(|(sec, _)| *sec)
+                    .collect();
+                if newly.is_empty() {
+                    break None;
+                }
+                opened.extend(newly);
+            };
+
+            let Some((g, acc)) = fork_state else { continue };
+            realized += 1;
+
+            let blocking: HashSet<Pos> = built
+                .slots
+                .iter()
+                .filter(|s| matches!(s.kind, SlotKind::Level | SlotKind::Fortress))
+                .map(|s| s.pos)
+                .collect();
+            let dist = least_levels_from(&g, &built.pipe_pairs, start, wi, &blocking);
+            let costs: Vec<(usize, usize)> = acc
+                .iter()
+                .filter_map(|sec| dist.get(&fort_pos[sec]).map(|&d| (*sec, d)))
+                .collect();
+            if costs.len() < 2 {
+                continue;
+            }
+            let min = costs.iter().map(|&(_, c)| c).min().unwrap();
+            let max = costs.iter().map(|&(_, c)| c).max().unwrap();
+            asym_hist[(max - min).min(5)] += 1;
+
+            match goal_sec.and_then(|gs| costs.iter().find(|&&(s, _)| s == gs)) {
+                None => goal_inaccessible += 1,
+                Some(&(gs, gc)) => {
+                    let others_min = costs
+                        .iter()
+                        .filter(|&&(s, _)| s != gs)
+                        .map(|&(_, c)| c)
+                        .min()
+                        .unwrap();
+                    if gc < others_min {
+                        goal_cheapest += 1;
+                    } else if gc == others_min {
+                        goal_tied += 1;
+                    } else {
+                        goal_dearest += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!("\n=== fork_balance ({seeds} seeds) ===");
+    eprintln!("  sampled Fork worlds: {sampled}; fork moment realized: {realized} ({:.1}%)",
+        100.0 * realized as f64 / sampled.max(1) as f64);
+    eprintln!("  cost asymmetry (levels, max-min) among co-accessible fork forts:");
+    let tot: u64 = asym_hist.iter().sum();
+    for (d, &c) in asym_hist.iter().enumerate() {
+        if c == 0 { continue; }
+        let label = if d == 5 { "5+".to_string() } else { d.to_string() };
+        eprintln!("    diff {label:>2}: {c:5} ({:5.1}%)", 100.0 * c as f64 / tot.max(1) as f64);
+    }
+    eprintln!("  which fork fort is the REAL GoalGate:");
+    let gtot = goal_cheapest + goal_tied + goal_dearest;
+    eprintln!("    cheapest: {goal_cheapest} ({:.1}%)  tied: {goal_tied} ({:.1}%)  dearest: {goal_dearest} ({:.1}%)  (inaccessible at fork: {goal_inaccessible})",
+        100.0 * goal_cheapest as f64 / gtot.max(1) as f64,
+        100.0 * goal_tied as f64 / gtot.max(1) as f64,
+        100.0 * goal_dearest as f64 / gtot.max(1) as f64);
 }
 
 /// Player-model fort taxonomy over many seeds. Classifies every fortress that

--- a/src/randomize/overworld_build/types.rs
+++ b/src/randomize/overworld_build/types.rs
@@ -121,6 +121,11 @@ pub(crate) struct BuiltWorld {
     /// Redistributed wandering Hammer Bro sprites for this world. Empty when
     /// `shuffle_hammer_bros` is off (the writer keeps the vanilla sprites).
     pub hb_sprites: Vec<HbSprite>,
+    /// The plan this world was built from — sampled intent, kept for the
+    /// diagnostics/census tests to compare against realized topology. The
+    /// force_safe retry overwrites it with the all-Safe plan it actually
+    /// used, so this field is always truthful.
+    pub plan: super::plan::WorldPlan,
 }
 
 /// Complete Phase 3 output.


### PR DESCRIPTION
## Summary

Curated rebuild of the overworld-builder work as a verified ladder — each commit is a single concern, clippy-clean, 289 tests green. Everything that didn't earn its place is parked on `backup/world-plan-full` for later one-at-a-time A/B re-adds.

- **Pipe fort-skip** (`7d74c22`): spare pipes placed after locks; at most one pipe per world may bypass exactly one fortress (rejects 2+-fort bypasses and goal-opening pipes).
- **WorldPlan refactor** (`6d3b66e`): archetype + every placement scoring knob in one documented struct; verified byte-identical against its parent.
- **Family-first sampling** (`a2e5658`): AllForts / PartialForts / NoForts as the top-level roll ([30,70,0]; W8 [25,75,0]); plus the seed-level Safe-role guarantee (shape-preserving fix for the all-Safe-retry goal-open class).
- **Fork-tell fix** (`1420d4e`): the real GoalGate fort shuffles within the fork group — "always pick the far fort" no longer beats the choice (~70% → ~uniform).
- **Walker sink** (`c1ad013`): airship/Bowser tiles block through-movement, matching engine behavior.
- **Canoe-exact spare verification** (`af3c10f`): every winning spare pipe is re-verified with real walks — closes the W3 canoe goal-open leak (component-split models are unsound in canoe worlds).
- **Diagnostics** (`2a4e4ca`, `55becc7`): production-parity test grids + probe suite (goal-open, SAS rule dissect, gate depth, lock nesting, fork balance, W2/W3 dissects, pipe budget).

## Measured baseline (1000-seed census / 200-per-mode linearity)

- Goal-open at start: **0/1000 SAS-off**
- Linearity: streak 1.68, goal-stack≥2 17% (SAS-on 1.73 / 17%)
- Census: chain 24.7%, single-gate+optional 62.1%, either-key 8.1%, parallel-AND 3.3%; fork tell dead (31.5 / 32.8 / 35.7 cheapest/tied/dearest)

## Known limitation

Under `swap_start_airship` (SAS=1), W7-style mid-maze swapped targets can leave the goal open at start (202/1000 in the fixed-layout probe): every goal-severing tile there is a start-corridor choke that strands all forts, so no legal gate exists. This predates this PR in different forms and is a separate swap-layer workstream (goal-corridor construction); `w7_sas_rule_dissect` documents the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kRngdkseUshP7omErzMCZ