### PR TITLE
release: 1.0.5 — drop "(beta)" from main title, distinguish /beta/ deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ deploys.
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-07-25
+
+### Changed
+
+- The main site's tab title is now "SMB3 Randomizer" (previously carried a
+  "(beta)" tag). The `/beta/` deploy is now visually distinct from the main
+  site: it shows a hazard-striped "BETA BUILD" banner, a violet frame, and a
+  BETA badge in the header, keyed on the URL path so it can't be confused with
+  the stable release page.
+
 ## [1.0.4] - 2026-07-24
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 
 [lib]

--- a/web/index.html
+++ b/web/index.html
@@ -3,15 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SMB3 Randomizer (beta)</title>
+    <title>SMB3 Randomizer</title>
     <!-- beta: refactor/frontend-schema -->
     <link rel="stylesheet" href="style.css">
+    <!-- The /beta/ deploy shares this HTML with the root site; key the beta
+         look on the URL path so a merge to main can't carry it over. Inline in
+         <head> so the class applies before first paint (no flash). -->
+    <script>
+        if (location.pathname.split("/").includes("beta")) {
+            document.documentElement.classList.add("beta-build");
+            document.title = "🚧 SMB3 Randomizer (BETA)";
+        }
+    </script>
 </head>
 <body>
     <div class="page-wrapper">
     <div class="container">
         <header>
-            <h1>SMB3 Randomizer <span id="version" class="version"></span></h1>
+            <h1>SMB3 Randomizer <span id="version" class="version"></span><span class="beta-badge">BETA</span></h1>
             <div class="pipe-divider">
                 <span class="pipe"></span>
                 <span class="pipe-label">Super Mario Bros. 3</span>

--- a/web/style.css
+++ b/web/style.css
@@ -886,3 +886,66 @@ footer p {
     box-shadow: 0 0 0 1px #000;
     transform: scale(1.1);
 }
+
+/* --- Beta build theme ---
+   Keyed on <html class="beta-build">, which the inline script in index.html
+   sets only when the URL path contains /beta/. Retints the structural frame
+   violet and adds a badge + warning stripe so the /beta/ deploy is obvious at a
+   glance versus the red main site. Interior controls keep their normal colors. */
+
+/* Badge in the header title — hidden unless this is the beta deploy. */
+.beta-badge {
+    display: none;
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 4px;
+    background: #a05cff;
+    color: #1a0a2e;
+    font-size: 0.6rem;
+    font-weight: bold;
+    letter-spacing: 0.1em;
+    vertical-align: middle;
+    text-shadow: none;
+}
+
+.beta-build .beta-badge {
+    display: inline-block;
+}
+
+.beta-build body {
+    padding-top: 3rem; /* clear the fixed banner below */
+    background-image:
+        radial-gradient(circle at 20% 50%, rgba(160, 92, 255, 0.06) 0%, transparent 50%),
+        radial-gradient(circle at 80% 20%, rgba(92, 148, 252, 0.05) 0%, transparent 50%);
+}
+
+/* Dashed warning stripe pinned to the top of the viewport. */
+.beta-build body::before {
+    content: "🚧 BETA BUILD — bleeding-edge features, expect bugs 🚧";
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    padding: 0.35rem 1rem;
+    text-align: center;
+    font-size: 0.72rem;
+    font-weight: bold;
+    letter-spacing: 0.06em;
+    color: #1a0a2e;
+    background: repeating-linear-gradient(
+        45deg,
+        #a05cff,
+        #a05cff 12px,
+        #ffd23f 12px,
+        #ffd23f 24px
+    );
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.beta-build .container {
+    border-color: #a05cff;
+    box-shadow:
+        0 0 20px rgba(160, 92, 255, 0.2),
+        0 8px 32px rgba(0, 0, 0, 0.4);
+}


### PR DESCRIPTION
Cherry-picks `6cfa133` from `beta/next` onto `main` and cuts it as release **1.0.5** — without dragging in the other in-progress `beta/next` work (world-plan, MaCobra poison, canoe-summon, 2P warp, lock archetypes, etc.).

## What changes
- **Main site tab title** drops the `(beta)` tag → now just `SMB3 Randomizer`.
- **`/beta/` deploy** becomes visually distinct: hazard-striped "BETA BUILD" banner, violet frame, and a header BETA badge — all keyed on the URL path (`location.pathname` contains `beta`), so the shared `index.html`/`style.css` render clean on the root site and only show the beta look under `/beta/`.
- **Version bump** 1.0.4 → 1.0.5 (`Cargo.toml` + `Cargo.lock`), CHANGELOG entry moved into a dated `[1.0.5]` section.

## Safety notes
- The `.beta-badge` is `display: none` by default and only shows under `.beta-build`, which is applied only on a `/beta/` path — so the root site stays clean.
- ⚠️ Merging this **redeploys the live site** (ci.yml on main is the Pages deploy). That's the intent — the "(beta)" title goes away for players.

## Verification
- `cargo build`, `cargo test`, `cargo clippy --all-targets` all clean.
- Diff is exactly 5 files: `CHANGELOG.md`, `Cargo.toml`, `Cargo.lock`, `web/index.html`, `web/style.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)