### PR TITLE
feature: choice-first overworld — measure route choice and reroll for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ deploys.
 
 ### Changed
 
+- The overworld builder now rerolls each world looking for real route choice:
+  it rebuilds a world up to a few times and keeps the first version that offers
+  two or more roughly-equal paths to the goal (scored by how many levels each
+  path forces), instead of accepting whatever it first produced. This takes the
+  share of "single forced path" worlds from ~68% down to ~20%, so most worlds
+  now hand the player a genuine "which way do I go" decision. Deterministic —
+  the same seed still produces the same maps.
 - Overworld fortress locks now follow a per-world progression archetype (chain,
   single-gate, or a choice-fork with decoy fortresses) instead of always greedily
   gating the deepest chokepoint. This adds variety — worlds can present a genuine

--- a/docs/choice_first_charter.md
+++ b/docs/choice_first_charter.md
@@ -1,0 +1,472 @@
+# Choice-First Overworld Builder — Charter
+
+Status: **draft for review.** This is the plain-English contract for the feature.
+Every future slice is measured against it. No Rust here on purpose.
+
+> **A note on the name.** This started as a "mission-first" builder, and the code
+> still carries that name (the `Mission` struct, the `--mission-overworld` flag).
+> That name describes a *mechanism* — placing pieces to realize a per-world
+> progression — not the goal. The goal is the one thing below: **generate choices
+> for the player.** A mission is one tool we use to produce them. Read "mission"
+> throughout as an ingredient, never the north star.
+
+## What it is
+
+A **drop-in replacement** for `overworld_build`. It takes the cleared, empty map
+from the pickup phase and produces a **complete** overworld — every piece placed
+— handed to the existing writer unchanged.
+
+- **In:** the pickup phase's cleared per-world grids, the catalog, the seed's RNG,
+  the run's flags, the per-world **pipe count**, and the world's **rock info**
+  (which rocks were removed / optionally added).
+- **Out:** the same `BuildResult` the writer already consumes. Nothing downstream
+  changes.
+
+If you deleted the old builder and dropped this in, the ROM would still come out.
+
+## The point (the north star above everything else)
+
+**The builder's job is to hand the player decisions.** A good overworld is a
+sequence of route choices; a bad one is a hallway you walk down. Everything else
+in this charter exists to produce those choices. The decisions look like:
+
+- Is it worth spending a **hammer** (a limited resource) to skip these levels?
+- Is it worth playing an **extra level** to reach that pipe?
+- Do I clear this **fort now** while I'm here, or skip it and risk backtracking?
+- Which of these **forts** actually opens the way forward?
+
+Those tradeoffs *are* the game. Archetypes, locks, level steering, shortcuts,
+missions — all of it is **scaffolding that exists to generate those decisions.**
+The archetypes (chain / fork / single-gate) and the per-world *mission* are ways
+to *codify and produce* progression decisions; they are a means, never the end.
+
+The consequences of taking this seriously:
+
+- **A shape can be perfectly realized and still fail.** "Beat the one fort and
+  the whole world opens" is a valid SingleGate that asks the player *nothing* — a
+  100% on the realization scoreboard, a 0 on the real goal. When a build produces
+  no decision, it has failed, whatever the scoreboard says.
+- **Archetypes and missions may be bent or broken** whenever doing so buys a
+  better decision. They are the tool, not the contract.
+- **The metric that matters is decision density and the realness of the
+  tradeoffs** — is the shortcut genuinely tempting *and* genuinely costly? — not
+  "did we realize the sampled shape." Realization % is a means-check; it must not
+  be mistaken for the goal-check.
+
+Read the rest of this document through this lens: any rule that produces
+structure without producing a decision is serving the scaffolding, not the goal.
+
+## The four values (these win ties)
+
+These are operational values — *how* we build. They serve the north star above;
+when one of them conflicts with producing a real decision, the decision wins.
+
+1. **Drop-in.** Same input, same output, same seams. The writer, the ROM format,
+   and everything after are untouched. We never change the boundary.
+
+2. **Grug-brain.** The simplest code that does the job. Concrete over generic,
+   explicit over clever, readable and maintainable by one person with no AI. We
+   add complexity ONLY when a metric proves we need it — never on spec.
+
+3. **Proven with metrics.** Every step ships with a scoreboard number, the way
+   fort realization went from 34–49% to 100%. We measure; we don't guess. A step
+   isn't "done" until a metric says it is — and the metric that counts is whether
+   the map produces decisions, not just whether a shape embedded.
+
+4. **Clear knobs.** Tuning is done on **what to build**, in plain units you can
+   read and predict — counts, on/off, tile distances. NOT opaque scoring weights,
+   softmax temperatures, or percentages tuned to hit some other percentage. If you
+   can't look at a knob and say what the map will do, it's the wrong knob.
+
+   *This is the payoff of building to a plan:* a decision is discrete ("a 3-fort
+   chain, 1 optional"), so you tune the decision, not the physics.
+
+## What "complete" means — everything a build must produce
+
+The current builder produces all of this; the replacement must too. For each,
+"driven" = placed to create a decision, "filler" = mechanical placement into
+whatever slots are left.
+
+| Piece | Role |
+|---|---|
+| Pipes | driven: a **fixed count per world** (a given), each pipe assigned a role — connectivity / shortcut / alternative / scout / dead. See the Pipes section. |
+| Fortresses + locks | driven: create the world's routing decisions. See the Fortresses & locks section. |
+| Levels | driven: **the pathing/pacing/agency currency** (steer routes, price shortcuts). See the Levels section. |
+| Hammer Bros | filler |
+| Toad Houses | filler, with a light purpose: they can give players needed items if they are struggling, try to keep them even across worlds, fill space so the map doesn't look empty |
+| Spades / bonus games | filler, same light purpose |
+
+Nothing gets forgotten: the charter lists them so each has an owner.
+
+## Even distribution — the unifying placement structure
+
+Once the decision-bearing pieces are placed (the forts, locks, and pipes the
+progression needs), everything else — levels and filler — is spread as **evenly
+as possible** across the map. This is a first-class positive rule, not a deferred
+nicety: a good map has content spread across it, not clustered. The exact
+mechanism doesn't matter much once the shape is fixed; "as even as we can" is the
+goal. Filler (toad houses, spades) exists partly to fill gaps this leaves, so no
+corner of the map reads as empty.
+
+## The world plan — the decision structure of a world
+
+A world's plan is bigger than "a chain of forts." It's the world's whole **agency
+structure**: the mandatory level spine, where the shortcuts are and what kind,
+where the level-vs-level choices are, and which forts are detours off the path.
+Levels, pipes, rocks, and locks are all placed **together** to build that
+structure — the point of the whole thing is to hand the player *decisions*.
+
+This is the ambitious part, and it will be **built in iterations** — a simple
+version first (mandatory spine + one shortcut type), proven with metrics, then
+richer. We don't build the whole agency engine in one go.
+
+Note: `Mission` (the fort-role list we already have) is one *ingredient* of the
+world plan, not the whole thing. It is the mechanism for the fort/lock decisions
+specifically; the plan is everything that produces a choice.
+
+## Fortresses & locks
+
+Forts are the part we understand best — the embed step that realizes them is built
+and proven. This is the fullest section on purpose.
+
+### The mechanic
+
+A fort is a **key**; its lock is a **door**. Beating the fort opens its lock (a
+gap or bridge tile becomes passable). This is the world's **hard** gating —
+contrast levels, which are *soft* gating (just clear them). A lock only ever opens
+by beating its fort.
+
+### The placement rule
+
+A fort on the mandatory *walking* path is a wasted lock: the player walks onto it,
+plays it because it's in the way, clears it, and the lock opens without tension or
+agency — it's just a level. So the rule:
+
+> A fort is **physically optional** (off the mandatory walking path, a detour you
+> choose to visit) but its **lock is not** — the lock gates real progress or a
+> shortcut, so beating the fort still matters. You go *find* the fort to get the
+> key.
+
+This is the exact thing we measured as broken at the very start (forts stuck on
+the trunk, ~53%, feeling pointless). *Never say never* — the builder may break
+this occasionally for variety — but "walking-optional, lock-mandatory" is the
+default the embed step aims for.
+
+### Lock quality — the decision the lock forces
+
+A lock is a **routing-decision tool**. Gating progress is the mechanic; forcing
+the player to make a *good decision about their route* is the point. So lock
+quality is not measured by how much map it walls off — it's measured by the
+**quality of the decision it creates.** (An earlier scoring pass optimized for
+the smallest gated region; that was the wrong axis and is retired.)
+
+**Low-quality locks — no decision:**
+
+- **Fort on the mandatory walking path → the lock is redundant.** The player
+  passes the key on the way through, so the lock adds nothing. The cardinal sin
+  (and the sharper form of the placement rule above).
+- **Obvious + sole + mandatory.** One clear fort, it's the only accessible thing
+  to do, and opening it is the only way forward: "fort → lock → progress," no
+  thought. Busywork. *Moving the fort off the walking path but leaving it the
+  sole accessible option is still this* — off-path is necessary, not sufficient.
+- **A goal gate that consistently hugs the goal (<~3 tiles).** Reads as
+  artificial — tacked-on extra work, not part of the routing. Fine as an
+  occasional variant, never the default.
+
+**High-quality locks — a real decision:**
+
+- **Gate a shortcut, not the sole path.** The lock sits on a *lighter* route
+  (fewer levels — not necessarily the goal), so opening it is a weighed choice:
+  go find the fort and open the shortcut, or just take the longer way. The
+  player can guess wrong, and it feels good when they're right.
+- **Ambiguity — the fork.** Several plausible forts; the player must work out
+  *which* one opens the gate. This is how a **mandatory** goal gate earns agency:
+  you have to open it, but *which fort is the key?* A single goal gate in a
+  multi-fort world is exactly this and is a strong option.
+- **Distance is a visibility knob, not a length target.** A fort far from its
+  lock means the player can't see both at once, so they must *guess* what the
+  fort does — mystery in the routing. Goal-gate forts further from the goal feel
+  better for the same reason. "Far" is about hiding information, not maximizing
+  span.
+- **Backtrack tension.** A lock placed between a big shortcut (e.g. a pipe that
+  skips a lot of the world to near the goal) and the goal: the player takes the
+  shortcut, hits the lock, and may have to go *back* to find the fort. The
+  shortcut isn't free — a good, self-inflicted decision.
+
+**Goal gates specifically.** A goal gate is mandatory by definition — there's no
+"open it or don't" agency — so its quality comes from **ambiguity** (which fort;
+prefer the fork) and **mystery** (fort far from the goal, relationship hidden). A
+plain, obvious goal gate isn't *bad*, but it's "extra work without having to
+think" — acceptable in small doses, not the default the builder reaches for.
+
+*These are legible and measurable (an alternate route exists past the lock;
+fort and lock on different map screens; several candidate forts; the fort is off
+the mandatory spine) — so this section becomes the embed's candidate-ordering
+contract, replacing raw strand size.*
+
+### What a lock gates
+
+A fort's lock, once opened, can gate one of:
+
+- **the next fort** — a chain link (beat this one to reach the next),
+- **the goal** — the final gate onto the airship / Bowser,
+- **a shortcut or nothing important** — a decoy / optional fort whose lock only
+  opens a bypass or side content.
+
+### The shapes (each is a different player experience)
+
+- **Single gate.** One fort's key opens the goal; the others are optional decoys.
+  "Which fort actually matters?"
+- **Chain.** Beat a fort → its lock opens the way to the next fort → … → the last
+  opens the goal. A required sequence.
+- **Fork.** Several forts look equally plausible; one really opens the way forward,
+  the rest are decoys — "pick the right fort." Two rules make a fork *work*: the
+  branches must be **level-balanced** (an extra level on one branch and everyone
+  takes the other — see Levels), and the real fort must have **no tell** (it must
+  not be predictable — e.g. never always the farthest one, or "always pick the far
+  fort" beats the guess).
+
+### Count & optional forts
+
+Fort count is a **given** per world (like pipes and rocks) or distributed — a knob,
+not an emergent outcome. Some forts are **optional**: an optional fort simply has a
+**shortcut around its lock** (a pipe/rock/lock bypass), so a player who finds the
+bypass can skip it. "Optional fort" is not a new mechanism — it's a normal fort
+plus a shortcut.
+
+### Realization (why this is the proven part)
+
+Because the embed step places forts *to realize the chosen shape* — rather than
+scattering them and hoping a progression falls out — the intended shape forms
+~**100%** of the time. That is the direct fix for the old builder, which realized
+its intended chain links only **34–49%** of the time. Embed either finds a
+placement that realizes the shape, or honestly reports the map can't host it (then
+we pick a simpler shape) — never a silent, meaningless lock.
+
+Realization is a *means-check*, not the goal. A shape embedding at 100% still has
+to pass the real bar — did it create a decision? — from the north star above.
+
+**Hard rules (settled 2026-07-25):** every budgeted fort is placed and every
+fort gets a real lock — neither ever degrades. Only the *roles* degrade, down
+a fixed ladder: sampled shape → single gate → chain → **loose single gate**
+(the goal gate may strand Safe decoys — for cul-de-sac geometry where any
+goal-gating lock strands most of the map, e.g. swapped-start W7) → all-Safe.
+A map that can't host even all-Safe is a geometry-pipeline bug and fails
+loudly, never silently.
+
+### Forts and route topology
+
+Connectivity pipes create hub-vs-chain island layouts (see Pipes), and that
+topology decides *what a lock can gate*: a fort guarding the one bridge onto a hub
+island gates everything beyond it. So fort placement and pipe topology are
+co-designed, not independent.
+
+## Levels — the nuanced piece
+
+Levels are the world's **pathing currency** and its **pacing**. They exist to give
+the player decisions, not to fill space.
+
+- **Steering.** Players take the route with fewer levels. So level placement
+  faux-controls pathing: the intended way is lighter, heavier content sits where
+  you'd rather players not go by default.
+- **The mandatory spine.** Roughly **60% of a world's levels** sit on the must-play
+  path — dialed *down* when the world has more required forts (levels + forts
+  together are the "required effort" you're balancing). **At least one** level per
+  world is truly mandatory (no shortcut around it).
+- **Shortcuts are the joy.** A shortcut (pipe, hammerable rock, or lock/bridge)
+  lets a player *skip* levels, and *finding* it is a core pleasure. Placement is
+  **shape-driven** — levels go where they *make a planned shortcut work*:
+  - *Pipe skip:* cluster 2 levels and leave a gap on the other side so a pipe
+    hops them.
+  - *Lock bypass:* stack 3 levels on the upper path and keep the lower path
+    clear-ish, so a lock drops on the lower path — play the 3, or find the fort
+    and open the lock.
+- **Level-vs-level forks** are their own agency: choose level A or B; maybe A is a
+  long death-trap and you learn to take B.
+- **Fork balance.** For a real *fort* fork, the branches must cost about the same
+  in levels — one extra blocking level and everyone takes the lighter branch, and
+  the choice is gone.
+- **Pacing.** At most ~4 levels back-to-back, and only rarely; usually a run is
+  broken by a shortcut (`level → pipe skips 2 → level → level` beats three in a
+  row).
+- **Order** doesn't matter (a difficulty ramp is a later, flag-gated concern).
+
+## Shortcuts — pipes, rocks, locks (given, not invented)
+
+Shortcuts are how players earn agency, and they come from three sources that the
+builder **receives as input** and works *around* — it does not invent them:
+
+- **Pipes** — a fixed count per world (a given). Each is assigned a role
+  (connectivity or shortcut).
+- **Rocks** — handed to the builder: a few are removed to open maps up, and up to
+  2 are optionally added as shortcut-gates. The builder gets this before it runs
+  and keeps the alternate path around a rock clear-ish (or loads the *other* side
+  with levels) so the shortcut is a real option.
+- **Locks** — a fort's key opens a bridge/lock, which can itself be a shortcut
+  around a run of levels.
+
+Level placement and shortcut placement are one problem: you place levels *to make
+the shortcuts meaningful*.
+
+## Pipes — roles and philosophy
+
+Pipe count is a **fixed per-world allotment, given to the builder** (W1 might get
+0, W2 gets 1). It is *not* a builder decision — the builder gets the number and
+the world shape and builds to it. (Counts may be randomized someday, but blind to
+the builder.)
+
+Pipes serve several roles, and one pipe can wear more than one hat:
+
+- **Connectivity (primary).** Some maps literally can't be finished without a pipe
+  — a region or the goal is unreachable on foot. This is the non-negotiable job.
+- **Route-shaping.** Connectivity pipes decide the world's island topology — a
+  **hub** island feeding several, or a **chain** of islands in a row — and that
+  topology is a major lever on *how locks work* in the world. So connectivity and
+  progression are linked, not separate.
+- **Shortcut / alternative.** A **shortcut** is strictly better (skip a level, a
+  cluster, or a fort) — once found, the player always takes it. An **alternative
+  route** is a genuine either/or (the first path is long/hard, the pipe leads to a
+  different set) — a real choice, not a freebie.
+- **Scout.** A pipe that mostly reveals *information* — pops you to another part of
+  the map so you can see a locked bridge / a fort and learn whether you must go
+  back and beat something. Agency through knowledge.
+- **Dead / loop.** Does little or nothing — loops you back near where you started.
+  A *small* number of these are funny and fine. (Not "troll" — that name is taken.)
+- **Intended route.** A pipe can *be* the expected way through an area, not an
+  add-on — e.g. the pipe is how you reach the far side of a lock, and beating the
+  fort changes that access. Pipes are part of the layout, not just bonuses.
+
+### Topology rules (settled 2026-07-25, built in iteration 3)
+
+Connectivity pipes construct the world's island topology; the builder owns its
+own pipe pass. Three rules, all hard *preferences* with explicit fallbacks
+(completability always outranks topology quality):
+
+- **Choked entrances.** A pipe is untraversable if you can't walk to its
+  entrance, so an island whose source-side entrance sits behind a lockable
+  tile is gateable with one lock. Chain missions get chained, individually
+  gateable islands; a fork's terminal group gets a one-lock island home.
+- **Gate preservation.** New islands attach OUTSIDE the goal's best gate
+  (the smallest strand containing the goal), so their fort slots don't get
+  swallowed by the gate's strand and starve `GoalGate`'s feasibility.
+- **No start→goal express.** The pipe that connects the goal's component
+  avoids sourcing from the start island when the map allows depth.
+
+### The philosophy (this shapes the whole approach)
+
+- **Opportunities, not guarantees.** We don't hand-plan every shortcut. We leave
+  the geometry *open* for shortcuts to occur, and let randomization produce them.
+  A skip that shows up identically every world isn't fun.
+- **Discovery is the point.** A shortcut is best when you *can't see both ends on
+  one screen*. A pipe that visibly skips two levels right there gets taken by
+  everyone and is boring; a pipe you only realize skips content after exploring is
+  a reward. Prefer endpoints that aren't visible together.
+- **Geometry limits agency, and that's OK.** We aim to leave choices open; we don't
+  force them where the map won't allow.
+
+## The pipeline (ordered)
+
+Per world (exact ordering will be refined — see Open Qs — since levels and
+shortcuts are one coupled problem):
+
+1. **Decide the world plan.** Shape (chain / fork / single-gate), fort count, which
+   forts are optional, the mandatory-level target, and roughly where the shortcuts
+   and choices go — given this world's pipe count and rock info.
+2. **Find the islands.** Look at the cleared map's raw *walking* connectivity (no
+   pipes yet) — what regions are cut off?
+3. **Place the world's pipes (the given count).** First satisfy connectivity
+   (reach islands / the goal), choosing island topology — hub vs chain — that
+   **shapes the lock progression** and **preserves the chokepoints** the locks
+   need. Spend any leftover pipes as shortcuts / alternatives / scouts, favoring
+   endpoints you *can't see together* (discovery).
+4. **Embed forts + locks.** Forts as walking-optional detours; locks gating real
+   progress. (This part is built and proven at 100%.)
+5. **Place levels, leaving room for shortcuts (coupled).** Lay the mandatory level
+   spine (~60% target, ≥1 unskippable), keeping fork branches level-balanced, and
+   leave geometry *open* so shortcuts (pipe / rock / lock) can occur — we create
+   opportunities, we don't force every skip. Randomization fills them in.
+6. **Filler, spread evenly.** Hammer bros, toad houses, spades into leftover slots
+   via the even-distribution rule, filling empty corners.
+7. **Assemble** the `BuildResult` for the writer.
+
+We won't build all of this at once — start with steps 1–4 plus a minimal spine,
+prove it, then add shortcut shapes and choices iteration by iteration.
+
+## Metrics (how each step proves out)
+
+Each step lands with a diagnostic, run on demand over many seeds. The scoreboard
+numbers below are *means-checks* — necessary, not sufficient. The one that
+actually gates a step is the last: does the map produce decisions?
+
+- **Realization** — % of worlds where the sampled shape actually embeds
+  (target ~100%). Already have it. A means-check.
+- **Connectivity** — % of worlds where the shape stays embeddable *after* pipe
+  placement (proves step 3 doesn't over-connect).
+- **Shortcut correctness** — a shortcut pipe bypasses exactly its optional fort and
+  nothing else.
+- **Completability** — every produced world is beatable start-to-goal.
+- **Decision density (the goal-check)** — how many *real* route decisions the map
+  offers: locks that gate a genuine choice, shortcuts that are tempting and costly,
+  forts with no tell. A map that scores 100% on realization but offers no decision
+  is a *failure*, and this is the metric that says so.
+- **Whatever the knobs claim** — if a knob says "3-fort chains," the metric confirms
+  the maps have them.
+
+## The knobs (plain units, contrasted with the old builder)
+
+| We want (clear) | Not this (the old builder) |
+|---|---|
+| shape = chain / fork / single-gate | softmax_t = 4.0 |
+| fort count = 3, optional forts = 1 | path_bonus = 0.75 |
+| levels per world = 8 (vanilla-ish caps) | density_penalty = 3.0 |
+| mandatory-level share ≈ 60% (less with more forts) | family weights = 55/35/10% |
+| max levels in a row = 4 (rare) | dead_end_bonus = 5.0 |
+| shortcuts per world = 2 | path_detour_cap = 6.0 |
+
+You set what the world *is*. The builder either realizes it or reports it can't —
+no fuzzy scoring in between. (A share like "≈60% mandatory" is fine here — it's a
+*legible* target you can predict, unlike a weight tuned to hit some other number.)
+
+## Non-goals / what stays mechanical (don't over-engineer)
+
+- Hammer bros, toad houses, spades are **filler**. They carry no progression
+  meaning; they drop into leftover slots (spread by the even-distribution rule
+  above, and used to keep the map from looking empty). We do not invent decision
+  roles for them.
+- We do not chase aesthetic *perfection*. "Spread things evenly" is the whole
+  aesthetic rule; we don't add fussier placement scoring unless a metric proves
+  a real problem.
+
+## Settled by the interviews (2026-07-25)
+
+- The builder's north star is **player decisions**; "mission" is a mechanism that
+  serves it, not the goal.
+- Levels are **a pathing/pacing/agency tool**, not filler.
+- Forts are **walking-optional, lock-mandatory** detours (never say never).
+- The real "world plan" is the world's whole **agency structure**, built in
+  iterations.
+- Rocks and **pipe counts** are **given inputs**, not invented by the builder.
+- Pipes: connectivity is primary and its **island topology shapes the locks**; other
+  roles are shortcut / alternative / scout / dead. **Opportunities over guarantees** —
+  leave geometry open, let randomization create discoverable shortcuts.
+- Filler = hammer bros / toad houses / spades, spread evenly to fill space.
+
+## Open questions (still to settle)
+
+1. **Coupled levels + shortcuts (step 5).** Levels are placed *to make shortcuts
+   work*, so they can't be a clean separate pass. What's the actual algorithm —
+   place shortcut points first then levels around them, or co-solve? This plus…
+2. **Minimal connectivity (step 3).** …placing "just enough" pipes while keeping
+   chokepoints, are the two hardest new pieces.
+3. **Expressing the plan in data.** How do "optional fort", "planned shortcut of
+   size n", "level-fork here", "balanced branches" become concrete inputs the
+   placement steps read? (This is the `Mission`-grows-into-a-world-plan work.)
+4. **Fort counts.** A fixed knob per world, or distributed across worlds like today?
+5. **First iteration scope.** What's the smallest end-to-end version (steps 1–4 +
+   a minimal spine) that produces a complete, writable build to prove the seam?
+6. **Route topology as a lock lever.** Connectivity pipes shape hub-vs-chain island
+   layouts that change how locks work — how much does the plan *choose* this vs
+   take whatever the given pipes/geometry produce?
+7. **Measuring decision density.** The goal-check metric is still fuzzy. What's a
+   concrete, seed-averaged score for "how many real decisions does this map offer"?
+   Until we can measure it, the north star is a principle, not yet a scoreboard.

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -27,6 +27,7 @@ mod sections;
 mod pipes;
 mod locks;
 mod progression;
+mod route_choice;
 
 use capacity::{
     SPADE_BUDGET, assign_hb_sprites, distribute_levels, prepare_capacities, promote_hb_slots,
@@ -51,6 +52,9 @@ pub(crate) use progression::{
     analyze_required_progression, classify_pipes, dump_required_progression, hammer_skip,
     island_count, level_adjacency_pairs, start_goal_express_pipe, PipeClass,
 };
+// Choice-first route scorer (separate weighted model — see route_choice.rs).
+#[cfg(test)]
+pub(crate) use route_choice::{analyze_route_choice, dump_route_choice};
 
 #[cfg(test)]
 mod tests;
@@ -113,10 +117,13 @@ pub(crate) fn build<R: Rng>(
             max_non_pipe_slots,
             force_safe: false,
         };
-        let built = build_world(
+        // Reroll this world for real route choice — see `build_world_best_of_k`.
+        // Intrinsic to the builder, not a flag: a good overworld hands the
+        // player decisions. The seed-coordinated plan is tried first.
+        let built = build_world_best_of_k(
             wi,
             rom,
-            patched_grids[wi].clone(),
+            &patched_grids[wi],
             &fixed_positions[wi],
             &counts,
             &plans[wi],
@@ -182,4 +189,48 @@ pub(crate) fn build<R: Rng>(
     }
 
     BuildResult { worlds, fort_counts }
+}
+
+/// Reroll a world for route choice: build it from the seed-coordinated plan,
+/// and if that comes out linear, re-sample the plan and rebuild — up to
+/// `REROLL_LIMIT` builds total — returning the first version that offers real
+/// route choice (≥2 roughly-equal routes). If none do, keep the coordinated
+/// build (exactly what the builder would have produced without rerolling).
+/// Early-stops, so choiceful worlds cost a single build. Deterministic: rerolls
+/// draw from the seeded `rng` in order.
+// Reason: too_many_arguments — this is `build_world`'s own parameter list; the
+// reroll wraps it without adding state, so a struct would just indirect it.
+#[allow(clippy::too_many_arguments)]
+fn build_world_best_of_k<R: Rng>(
+    world_idx: usize,
+    rom: &Rom,
+    grid: &Grid,
+    fixed_positions: &HashSet<Pos>,
+    counts: &WorldSlotCounts,
+    first_plan: &WorldPlan,
+    shuffle_hammer_bros: bool,
+    rng: &mut R,
+) -> BuiltWorld {
+    let has_choice = |w: &BuiltWorld| {
+        route_choice::analyze_route_choice(w, route_choice::DEFAULT_SLACK)
+            .routes
+            .len()
+            >= 2
+    };
+    let build = |plan: &WorldPlan, rng: &mut R| {
+        build_world(world_idx, rom, grid.clone(), fixed_positions, counts, plan, shuffle_hammer_bros, rng)
+    };
+
+    let base = build(first_plan, rng);
+    if has_choice(&base) {
+        return base;
+    }
+    for _ in 1..route_choice::REROLL_LIMIT {
+        let plan = WorldPlan::sample(counts.fort_count, world_idx, rng);
+        let candidate = build(&plan, rng);
+        if has_choice(&candidate) {
+            return candidate;
+        }
+    }
+    base
 }

--- a/src/randomize/overworld_build/route_choice.rs
+++ b/src/randomize/overworld_build/route_choice.rs
@@ -1,0 +1,485 @@
+//! Choice-first route scorer — deliberately SEPARATE from `progression.rs`
+//! (which stays on its plain min-clears model) so the two can be compared.
+//!
+//! Weighted set-cost model, in plain points:
+//!   pipe = 1 (per use)   level = 3 (once)   fort = 5 (once)   rock = 8 (once)
+//!
+//! Each clearable (fort / level / rock) is charged ONCE, via a cleared-bitmask
+//! carried in the search state — so walking back through a played level, a
+//! beaten fort, or a broken rock is free ("played once, broken once"). A lock
+//! costs nothing at its tile, but you can only cross it once its fort is
+//! beaten, and beating the fort is where the 5 lands — so a lock implicitly
+//! drags in its fort's cost.
+//!
+//! A route's cost is that weighted set-cost. Two routes are the SAME route if
+//! they play the same set of levels. "Roughly equal" = within `slack` points
+//! (default 3 = one level).
+//!
+//! Enumeration is COMPLETE and needs no bans or backward pass: the cleared-mask
+//! already records exactly which levels a route played, so we run ONE Dijkstra,
+//! keep going until the popped cost exceeds `best + slack`, and read off every
+//! goal-state settled within budget — each is a route (mask → level-set). A
+//! domination filter then drops any route that only plays an EXTRA level for no
+//! benefit (a within-slack detour), so those don't masquerade as real choices.
+
+#![allow(dead_code)] // test-only today; re-exported under cfg(test)
+
+use super::*;
+use super::types::{BuiltWorld, SlotKind, stamp_slots};
+
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap};
+
+/// Weighted set-cost knobs, in plain points. Legible on purpose.
+pub(crate) const COST_PIPE: u32 = 1;
+pub(crate) const COST_LEVEL: u32 = 3;
+pub(crate) const COST_FORT: u32 = 5;
+pub(crate) const COST_ROCK: u32 = 8;
+/// "Roughly equal" band, in points. 3 = one level of wobble.
+pub(crate) const DEFAULT_SLACK: u32 = 3;
+
+/// How many times the builder rerolls a world looking for real route choice
+/// before giving up and keeping the best it found. Early-stops on the first
+/// choiceful roll, so easy worlds cost one build and only the stubborn ones
+/// (e.g. W8) pay the full price. ~8 takes linear worlds from ~68% to ~20%.
+pub(crate) const REROLL_LIMIT: usize = 8;
+
+/// Breakable overworld rocks and the path tile they open into
+/// ($51→$45 horizontal, $52→$46 vertical). $53 is unbreakable (stays a wall).
+const BREAKABLE_ROCKS: [(u8, u8); 2] = [(0x51, 0x45), (0x52, 0x46)];
+
+/// One distinct route to the goal.
+#[derive(Clone, Debug)]
+pub(crate) struct ChoiceRoute {
+    /// Weighted set-cost, in points.
+    pub cost: u32,
+    /// Distinct levels played — the route's identity (dedup key).
+    pub levels: BTreeSet<Pos>,
+    /// Distinct forts beaten / rocks broken (breakdown for display).
+    pub forts: u32,
+    pub rocks: u32,
+    /// Node path start..goal, for rendering.
+    pub path: Vec<Pos>,
+}
+
+/// Per-world choice summary.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RouteChoice {
+    pub reachable: bool,
+    pub best_cost: u32,
+    /// Distinct non-dominated routes within `slack` of best, cheapest first.
+    pub routes: Vec<ChoiceRoute>,
+    /// How many routes tie at `best_cost`.
+    pub tied_at_best: usize,
+    /// Cheapest strictly-worse in-band route minus best (the "gap"); `None`
+    /// when there is no in-band alternative (LINEAR).
+    pub runner_up_gap: Option<u32>,
+}
+
+/// Enumerate every distinct near-optimal route to the goal and summarise the
+/// choice they offer.
+pub(crate) fn analyze_route_choice(built: &BuiltWorld, slack: u32) -> RouteChoice {
+    // Working grid: open breakable rocks so walk_map makes edges through them
+    // (we charge 8 the first time one is crossed, below); then stamp nodes.
+    let mut grid = built.grid.clone();
+    let mut rock_tiles: HashSet<Pos> = HashSet::new();
+    for r in 0..grid.rows() {
+        for c in 0..grid.cols {
+            let t = grid.get(r, c);
+            for (closed, open) in BREAKABLE_ROCKS {
+                if t == closed {
+                    grid.set(r, c, open);
+                    rock_tiles.insert((r, c));
+                }
+            }
+        }
+    }
+    stamp_slots(&mut grid, &built.slots);
+
+    let (Some(start), Some(target)) = (
+        rom_data::find_start(&grid),
+        find_target(&grid, built.world_idx),
+    ) else {
+        return RouteChoice::default();
+    };
+    let walk = walk_map(&grid, &built.pipe_pairs, Some(start), built.world_idx);
+
+    // Slot kind + section per node; lock path-tiles → the fort section that
+    // opens them.
+    let mut kind_at: HashMap<Pos, &SlotKind> = HashMap::new();
+    let mut section_at: HashMap<Pos, usize> = HashMap::new();
+    for slot in &built.slots {
+        kind_at.insert(slot.pos, &slot.kind);
+        section_at.insert(slot.pos, slot.section);
+    }
+    let mut lock_section: HashMap<Pos, usize> = HashMap::new();
+    for lock in &built.locks {
+        lock_section.insert(lock.pos, lock.fort_section);
+    }
+
+    // Cleared-mask bit layout (u64): fort sections use bits 0..section_count,
+    // then one bit per level, then one bit per rock. `level_pos` inverts the
+    // level bits so we can read a goal mask back into a level-set.
+    let mut level_bit: HashMap<Pos, u32> = HashMap::new();
+    let mut level_pos: Vec<(u32, Pos)> = Vec::new();
+    let mut next = built.section_count as u32;
+    for slot in &built.slots {
+        if matches!(slot.kind, SlotKind::Level) {
+            level_bit.insert(slot.pos, next);
+            level_pos.push((next, slot.pos));
+            next += 1;
+        }
+    }
+    let mut rock_bit: HashMap<Pos, u32> = HashMap::new();
+    for &rp in &rock_tiles {
+        rock_bit.insert(rp, next);
+        next += 1;
+    }
+    debug_assert!(next <= 64, "too many clearables for a u64 mask ({next})");
+    let fort_bits: u64 = (0..built.section_count).map(|s| 1u64 << s).sum();
+    let rock_bits: u64 = rock_bit.values().map(|&b| 1u64 << b).sum();
+
+    // Node-entry cost: charge a level/fort the FIRST time (bit flip), free
+    // after. Pipes/other transit nodes are free at the node — a pipe RIDE is
+    // charged on its teleport edge instead.
+    let node_cost = |dest: Pos, mask: u64| -> (u32, u64) {
+        if dest == target {
+            return (0, mask);
+        }
+        match kind_at.get(&dest) {
+            Some(SlotKind::Fortress) => {
+                let bit = 1u64 << section_at[&dest];
+                if mask & bit == 0 { (COST_FORT, mask | bit) } else { (0, mask) }
+            }
+            Some(SlotKind::Level) => {
+                let bit = 1u64 << level_bit[&dest];
+                if mask & bit == 0 { (COST_LEVEL, mask | bit) } else { (0, mask) }
+            }
+            _ => (0, mask),
+        }
+    };
+
+    // Canoe (boat) — same model as progression.rs: one boat, rides move it.
+    let canoe_edges = rom_data::active_canoe_edges(built.world_idx, built.grid.eights_are_wild);
+    let canoe_pair_set: HashSet<(Pos, Pos)> =
+        canoe_edges.iter().flat_map(|&(a, b)| [(a, b), (b, a)]).collect();
+    let initial_boat = canoe_edges.first().map(|&(a, _)| a);
+
+    // Dijkstra over (pos, cleared-mask, boat). We do NOT stop at the first
+    // goal: once `best` is known (the first goal popped, by cost order), we
+    // keep going until the popped cost exceeds `best + slack`, collecting every
+    // goal-state in that band. Each is a distinct route (its mask says which
+    // levels/forts/rocks it used).
+    type State = (Pos, u64, Option<Pos>);
+    // (cost, pos, cleared-mask, boat) — cost first so the heap orders by it.
+    type HeapEntry = Reverse<(u32, Pos, u64, Option<Pos>)>;
+    let mut dist: HashMap<State, u32> = HashMap::new();
+    let mut prev: HashMap<State, State> = HashMap::new();
+    let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::new();
+
+    let init: State = (start, 0, initial_boat);
+    dist.insert(init, 0);
+    heap.push(Reverse((0, start, 0, initial_boat)));
+
+    let mut best: Option<u32> = None;
+    let mut goals: Vec<(State, u32)> = Vec::new(); // (goal state, cost)
+
+    while let Some(Reverse((cost, pos, mask, boat))) = heap.pop() {
+        let state = (pos, mask, boat);
+        if cost > *dist.get(&state).unwrap_or(&u32::MAX) {
+            continue;
+        }
+        if let Some(b) = best
+            && cost > b + slack
+        {
+            break; // everything left is out of band
+        }
+        if pos == target {
+            best.get_or_insert(cost);
+            goals.push((state, cost));
+            continue; // target is a sink — never expand through it
+        }
+
+        // Relax an edge: `edge_extra` is the pipe/rock surcharge and `mask_in`
+        // is the mask after any rock-break on the crossed path tile; then add
+        // the destination node's own cost.
+        let mut relax = |dest: Pos, boat_after: Option<Pos>, edge_extra: u32, mask_in: u64| {
+            let (nc, nm) = node_cost(dest, mask_in);
+            let new_cost = cost + edge_extra + nc;
+            let key = (dest, nm, boat_after);
+            if new_cost < *dist.get(&key).unwrap_or(&u32::MAX) {
+                dist.insert(key, new_cost);
+                prev.insert(key, state);
+                heap.push(Reverse((new_cost, dest, nm, boat_after)));
+            }
+        };
+
+        if let Some(edges) = walk.edges.get(&pos) {
+            for edge in edges {
+                match edge.path_pos {
+                    Some(pp) => {
+                        // Lock: crossable only once its fort's section is open.
+                        if let Some(&sec) = lock_section.get(&pp)
+                            && mask & (1u64 << sec) == 0
+                        {
+                            continue;
+                        }
+                        // Rock: break it (charge once) the first time crossed.
+                        let mut edge_extra = 0;
+                        let mut mask_after = mask;
+                        if let Some(&rb) = rock_bit.get(&pp) {
+                            let bit = 1u64 << rb;
+                            if mask_after & bit == 0 {
+                                edge_extra += COST_ROCK;
+                                mask_after |= bit;
+                            }
+                        }
+                        relax(edge.dest, boat, edge_extra, mask_after);
+                    }
+                    None => {
+                        // Teleport. Canoe rides handled below; here it's a pipe.
+                        if canoe_pair_set.contains(&(pos, edge.dest)) {
+                            continue;
+                        }
+                        relax(edge.dest, boat, COST_PIPE, mask);
+                    }
+                }
+            }
+        }
+
+        // Canoe rides: free, and only when the boat sits at the current node.
+        if boat == Some(pos) {
+            for &(a, b) in &canoe_edges {
+                let dest = if a == pos {
+                    b
+                } else if b == pos {
+                    a
+                } else {
+                    continue;
+                };
+                relax(dest, Some(dest), 0, mask);
+            }
+        }
+    }
+
+    let Some(best_cost) = best else {
+        return RouteChoice::default();
+    };
+
+    // Read each in-band goal state back into a route; keep the cheapest per
+    // distinct level-set (remembering the state so we can rebuild its path).
+    let mut by_levels: HashMap<BTreeSet<Pos>, (u32, State)> = HashMap::new();
+    for (state, cost) in goals {
+        let mask = state.1;
+        let levels: BTreeSet<Pos> = level_pos
+            .iter()
+            .filter(|(bit, _)| mask & (1u64 << bit) != 0)
+            .map(|&(_, pos)| pos)
+            .collect();
+        by_levels
+            .entry(levels)
+            .and_modify(|e| {
+                if cost < e.0 {
+                    *e = (cost, state);
+                }
+            })
+            .or_insert((cost, state));
+    }
+
+    // Rebuild the node path for a goal state by walking `prev` back to start.
+    let reconstruct = |goal: State| -> Vec<Pos> {
+        let mut nodes = vec![goal.0];
+        let mut cur = goal;
+        while let Some(&p) = prev.get(&cur) {
+            nodes.push(p.0);
+            cur = p;
+        }
+        nodes.reverse();
+        nodes
+    };
+
+    let mut routes: Vec<ChoiceRoute> = by_levels
+        .into_iter()
+        .map(|(levels, (cost, state))| ChoiceRoute {
+            cost,
+            levels,
+            forts: (state.1 & fort_bits).count_ones(),
+            rocks: (state.1 & rock_bits).count_ones(),
+            path: reconstruct(state),
+        })
+        .collect();
+
+    // Domination filter: drop a route that plays a strict superset of another
+    // route's levels at no lower cost — a within-slack detour, not a real
+    // choice. (Level-sets are already distinct, so subset ⇒ strict.)
+    let dominated: Vec<bool> = routes
+        .iter()
+        .map(|ri| {
+            routes
+                .iter()
+                .any(|rj| rj.cost <= ri.cost && rj.levels != ri.levels && rj.levels.is_subset(&ri.levels))
+        })
+        .collect();
+    let mut kept: Vec<ChoiceRoute> = routes
+        .drain(..)
+        .zip(dominated)
+        .filter_map(|(r, dom)| (!dom).then_some(r))
+        .collect();
+
+    kept.sort_by(|a, b| {
+        a.cost
+            .cmp(&b.cost)
+            .then_with(|| a.levels.iter().cmp(b.levels.iter()))
+    });
+    let tied_at_best = kept.iter().filter(|r| r.cost == best_cost).count();
+    let runner_up_gap = kept
+        .iter()
+        .map(|r| r.cost)
+        .find(|&c| c > best_cost)
+        .map(|c| c - best_cost);
+
+    RouteChoice {
+        reachable: true,
+        best_cost,
+        routes: kept,
+        tied_at_best,
+        runner_up_gap,
+    }
+}
+
+/// One-line route-choice verdict for a world (eyeball diagnostic).
+pub(crate) fn dump_route_choice(built: &BuiltWorld, slack: u32) {
+    let rc = analyze_route_choice(built, slack);
+    if !rc.reachable {
+        eprintln!("  W{}: UNREACHABLE", built.world_idx + 1);
+        return;
+    }
+    let costs: Vec<u32> = rc.routes.iter().map(|r| r.cost).collect();
+    let verdict = if rc.routes.len() == 1 {
+        "LINEAR — single best route".to_string()
+    } else if let Some(gap) = rc.runner_up_gap {
+        format!("{} tied at best, runner-up +{gap}", rc.tied_at_best)
+    } else {
+        format!("CHOICE — {} routes tied at {}", rc.tied_at_best, rc.best_cost)
+    };
+    eprintln!(
+        "  W{}: {} route(s), costs {:?}  |  {}",
+        built.world_idx + 1,
+        rc.routes.len(),
+        costs,
+        verdict,
+    );
+}
+
+/// ASCII render of every route through a world — one grid per route, the path
+/// drawn on the map — so the enumeration can be eyeballed against the geometry.
+pub(crate) fn render_route_choice(built: &BuiltWorld, slack: u32) -> String {
+    use std::fmt::Write as _;
+    let rc = analyze_route_choice(built, slack);
+
+    let mut grid = built.grid.clone();
+    stamp_slots(&mut grid, &built.slots);
+    let mut kind_at: HashMap<Pos, &SlotKind> = HashMap::new();
+    for slot in &built.slots {
+        kind_at.insert(slot.pos, &slot.kind);
+    }
+    let start = rom_data::find_start(&grid);
+    let target = find_target(&grid, built.world_idx);
+    let goal_ch = if built.world_idx == 7 { 'B' } else { 'A' };
+
+    // Bounding box of the non-background tiles, so we don't print a sea of blanks.
+    let (mut r0, mut r1, mut c0, mut c1) = (grid.rows(), 0usize, grid.cols, 0usize);
+    for r in 0..grid.rows() {
+        for c in 0..grid.cols {
+            if !BACKGROUND_TILES.contains(&grid.get(r, c)) {
+                r0 = r0.min(r);
+                r1 = r1.max(r);
+                c0 = c0.min(c);
+                c1 = c1.max(c);
+            }
+        }
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "\n=== W{} — {} route(s), slack {slack} ===",
+        built.world_idx + 1,
+        rc.routes.len(),
+    );
+    if !rc.reachable {
+        out.push_str("  UNREACHABLE\n");
+        return out;
+    }
+
+    for (i, route) in rc.routes.iter().enumerate() {
+        // Classify the cells the route touches: nodes, the walk-tile between
+        // consecutive nodes, and pipe/canoe teleport endpoints.
+        let nodes: HashSet<Pos> = route.path.iter().copied().collect();
+        let mut mids: HashSet<Pos> = HashSet::new();
+        let mut pipes: HashSet<Pos> = HashSet::new();
+        for w in route.path.windows(2) {
+            let (a, b) = (w[0], w[1]);
+            if a.0 == b.0 && a.1.abs_diff(b.1) == 2 {
+                mids.insert((a.0, (a.1 + b.1) / 2));
+            } else if a.1 == b.1 && a.0.abs_diff(b.0) == 2 {
+                mids.insert(((a.0 + b.0) / 2, a.1));
+            } else {
+                pipes.insert(a);
+                pipes.insert(b);
+            }
+        }
+        // Number the levels in the order they're played.
+        let mut order: HashMap<Pos, usize> = HashMap::new();
+        for &p in &route.path {
+            if matches!(kind_at.get(&p), Some(SlotKind::Level)) && !order.contains_key(&p) {
+                order.insert(p, order.len() + 1);
+            }
+        }
+
+        let _ = writeln!(
+            out,
+            "\n  route {}/{}: cost {} ({}L {}F {}R)",
+            i + 1,
+            rc.routes.len(),
+            route.cost,
+            route.levels.len(),
+            route.forts,
+            route.rocks,
+        );
+        for r in r0..=r1 {
+            out.push_str("  ");
+            for c in c0..=c1 {
+                let p = (r, c);
+                let ch = if Some(p) == start {
+                    'S'
+                } else if Some(p) == target {
+                    goal_ch
+                } else if nodes.contains(&p) && matches!(kind_at.get(&p), Some(SlotKind::Fortress)) {
+                    'F'
+                } else if let Some(&n) = order.get(&p) {
+                    if n <= 9 {
+                        (b'0' + n as u8) as char
+                    } else {
+                        (b'a' + (n - 10) as u8) as char
+                    }
+                } else if pipes.contains(&p) {
+                    'P'
+                } else if mids.contains(&p) {
+                    '*'
+                } else if nodes.contains(&p) {
+                    'o'
+                } else if BACKGROUND_TILES.contains(&grid.get(r, c)) {
+                    ' '
+                } else {
+                    '.'
+                };
+                out.push(ch);
+                out.push(' ');
+            }
+            out.push('\n');
+        }
+    }
+    out.push_str("  S=start  A/B=goal  F=fort  <n>=level(play order)  P=pipe  *=path  o=node\n");
+    out
+}

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -4095,3 +4095,182 @@ fn test_dump_required_progression() {
     std::fs::write(&filename, rom.output_bytes()).unwrap();
     eprintln!("\nWrote {filename}");
 }
+
+/// Choice-first route metric (weighted set-cost: pipe 1 / level 3 / fort 5 /
+/// rock 8, each clearable charged once). Aggregates how many distinct
+/// near-optimal routes each world offers over many seeds — LINEAR = one best
+/// route, CHOICE = 2+ within `slack` points. Verdict + gap are exact.
+///
+/// Run with:
+///   ROUTE_SEEDS=200 SLACK=3 cargo test --release \
+///     test_route_choice -- --ignored --nocapture
+/// DUMP_SEED=<n> also prints per-world one-liners for that seed.
+#[test]
+#[ignore]
+fn test_route_choice() {
+    let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let rom = match Rom::from_bytes(&rom_bytes) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("ROM parse failed: {e}");
+            return;
+        }
+    };
+    let rom = apply_qol_for_overworld(&rom);
+
+    let seeds: u64 = std::env::var("ROUTE_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    let slack: u32 = std::env::var("SLACK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(route_choice::DEFAULT_SLACK);
+    let dump_seed: Option<u64> = std::env::var("DUMP_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
+    let mut counts: Vec<Vec<usize>> = vec![Vec::new(); 8];
+
+    for seed in 0..seeds {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        if Some(seed) == dump_seed {
+            eprintln!("\n=== Route choice, seed {seed} (slack {slack}) ===");
+        }
+        for built in &result.worlds {
+            let rc = analyze_route_choice(built, slack);
+            counts[built.world_idx].push(if rc.reachable { rc.routes.len() } else { 0 });
+            if Some(seed) == dump_seed {
+                if std::env::var("RENDER").is_ok() {
+                    eprint!("{}", route_choice::render_route_choice(built, slack));
+                } else {
+                    dump_route_choice(built, slack);
+                }
+            }
+        }
+    }
+
+    eprintln!("\n=== Route choice over {seeds} seeds (slack {slack}) ===");
+    eprintln!("  {:<4} {:>6} {:>8} {:>8} {:>5}", "", "mean", "linear%", "choice%", "max");
+    let mut all: Vec<usize> = Vec::new();
+    for (wi, c) in counts.iter().enumerate() {
+        if c.is_empty() {
+            continue;
+        }
+        all.extend(c.iter().copied());
+        let mean = c.iter().sum::<usize>() as f64 / c.len() as f64;
+        let linear = c.iter().filter(|&&n| n <= 1).count() as f64 / c.len() as f64 * 100.0;
+        let choice = c.iter().filter(|&&n| n >= 2).count() as f64 / c.len() as f64 * 100.0;
+        let max = c.iter().copied().max().unwrap_or(0);
+        eprintln!("  W{:<3} {mean:>6.2} {linear:>7.0}% {choice:>7.0}% {max:>5}", wi + 1);
+    }
+    if !all.is_empty() {
+        let mean = all.iter().sum::<usize>() as f64 / all.len() as f64;
+        let linear = all.iter().filter(|&&n| n <= 1).count() as f64 / all.len() as f64 * 100.0;
+        eprintln!("  overall: mean {mean:.2} routes/world; {linear:.0}% linear");
+    }
+}
+
+/// Best-of-K feasibility experiment (no builder changes): does the builder's
+/// own random variation already contain more-choiceful versions of each world?
+///
+/// Build M seeds, record whether each world came out LINEAR (≤1 route) or
+/// CHOICE (≥2), then compute the best-of-K linear rate — the chance that all K
+/// independent tries come out linear, `∏(L-i)/(M-i)` over M samples with L
+/// linear. If that rate falls off fast as K grows, best-of-K helps; a world
+/// stuck near 100% at large K is geometry-capped (selection can't save it).
+///
+///   BEST_SEEDS=400 SLACK=3 cargo test --release \
+///     test_best_of_k -- --ignored --nocapture
+#[test]
+#[ignore]
+fn test_best_of_k() {
+    let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let rom = match Rom::from_bytes(&rom_bytes) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("ROM parse failed: {e}");
+            return;
+        }
+    };
+    let rom = apply_qol_for_overworld(&rom);
+
+    let m: u64 = std::env::var("BEST_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(400);
+    let slack: u32 = std::env::var("SLACK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(route_choice::DEFAULT_SLACK);
+
+    // Per world: how many of the M builds came out LINEAR.
+    let mut linear: [usize; 8] = [0; 8];
+    for seed in 0..m {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let (catalog, pickup) = build_catalog_pickup(&rom, seed);
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags { shuffle_toad_houses: true, ..Default::default() },
+        );
+        for built in &result.worlds {
+            let rc = analyze_route_choice(built, slack);
+            let is_choice = rc.reachable && rc.routes.len() >= 2;
+            if !is_choice {
+                linear[built.world_idx] += 1;
+            }
+        }
+    }
+
+    // P(all K of a random K-subset are linear) = ∏_{i<K} (L-i)/(M-i).
+    let best_of_k_linear = |l: usize, k: usize| -> f64 {
+        if l < k {
+            return 0.0;
+        }
+        (0..k).map(|i| (l - i) as f64 / (m as usize - i) as f64).product::<f64>() * 100.0
+    };
+
+    let ks = [1usize, 2, 4, 8, 16];
+    eprintln!("\n=== Best-of-K linear% over {m} seeds (slack {slack}) ===");
+    eprint!("  {:<5}", "");
+    for k in ks {
+        eprint!(" K={k:<5}");
+    }
+    eprintln!("  (geometry-capped if K=16 stays high)");
+    let mut overall = [0.0f64; 5];
+    for (wi, &l) in linear.iter().enumerate() {
+        eprint!("  W{:<4}", wi + 1);
+        for (j, &k) in ks.iter().enumerate() {
+            let v = best_of_k_linear(l, k);
+            overall[j] += v / 8.0;
+            eprint!(" {v:5.0}% ");
+        }
+        eprintln!();
+    }
+    eprint!("  {:<5}", "all");
+    for v in overall {
+        eprint!(" {v:5.0}% ");
+    }
+    eprintln!("  <- overall linear% by K");
+}


### PR DESCRIPTION
## Choice-first overworld: measure route choice, and reroll for it

The overworld builder now measures how much *route choice* each world offers
and rerolls worlds that come out linear, so most worlds hand the player a
genuine "which way do I go" decision instead of a single forced path.

### What's here

- **`route_choice.rs`** — a weighted set-cost route scorer:
  - cost model in plain points: **pipe 1 / level 3 / fort 5 / rock 8**, each
    clearable charged **once** (played-once / broken-once) via a cleared-bitmask
    in a `(pos, mask, boat)` Dijkstra. Locks are free at the tile but need their
    fort beaten, so a lock drags in its fort's cost.
  - **complete enumeration** of the distinct near-optimal routes within a slack
    band (one Dijkstra, no early exit), plus a **domination filter** so a
    within-slack detour that just replays extra levels isn't counted as choice.
  - `dump_route_choice` / `render_route_choice` diagnostics (test-only) for
    eyeballing routes on the map.
- **Builder integration** — `build_world_best_of_k` rerolls each world
  (re-sampling its plan) up to a cap, keeping the first version that offers
  **≥2 roughly-equal routes**; if none do, it keeps the coordinated build (exactly
  what the builder produced before). Intrinsic to the builder — no flag.

### Results

- Share of single-forced-path worlds drops from **~68% → ~20%** (200 seeds).
- **Deterministic** — same seed + `--no-palettes` is byte-identical.
- **Secret-exit-safe lock invariant intact** — 1000/1000 seeds still have one
  (guaranteed by the existing post-build backstop, which runs after the reroll).
- Full lib test suite green; clippy clean (`-D warnings`).

### Footprint

Production code touches only `mod.rs` (one call swapped to the reroll wrapper +
a ~40-line helper) and the new `route_choice.rs`. `tests.rs` adds two `#[ignore]`
measurement diagnostics. `docs/choice_first_charter.md` is the design charter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kRngdkseUshP7omErzMCZ
