### PR TITLE
release: 1.0.6 — keep 7-1 starting Green Troopas in the shell pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ deploys.
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-07-27
+
+### Fixed
+
+- 7-1: the two Green Troopas near the start now always stay in the shell pool,
+  so the enemy shuffle can no longer replace them with something unsafe there.
+
 ## [1.0.5] - 2026-07-25
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 
 [lib]

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -130,6 +130,15 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
         ],
     },
     LevelProtection {
+        label: "7-1 sub-area (scr=0 GreenTroopas kept in the shell pool)",
+        enemy_ptr: 0xCD93,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0CDA7, rule: EntryProtection::ForceShell }, // GreenTroopa scr=0 col=2
+            EntryRule { offset: 0x0CDAA, rule: EntryProtection::ForceShell }, // GreenTroopa scr=0 col=4
+        ],
+    },
+    LevelProtection {
         label: "6-5 sub-area (shell needed for progression)",
         enemy_ptr: 0xC5EB,
         walker_segment: WalkerSegmentRule::Default,


### PR DESCRIPTION
Live fix: the two scr=0 GreenTroopas in the 7-1 sub-area (offsets 0x0CDA7/0x0CDAA, enemy_ptr 0xCD93) now carry a `ForceShell` entry protection, so the enemy shuffle always picks them from the shell pool. When shell-class randomization is off, the entries keep their vanilla troopas — the spots hold a shell in every flag configuration. Wild injection also skips protected positions, so it can't bypass this.

Verified: clippy clean, full suite green including `enemy_invariant_baseline` (500 seeds against the real ROM), which asserts the new protection on every swap.

Bumps 1.0.5 → 1.0.6 and dates the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kRngdkseUshP7omErzMCZ