### PR TITLE
feature: retune overworld builder for more route choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ deploys.
 
 ## [Unreleased]
 
+### Changed
+
+- Overworld maps now offer real route choice more often: worlds with only
+  one reasonable way through drop from ~35% to ~33% across all worlds. Two
+  builder weights were retuned — the lock pass looks harder for placements
+  that fork the route, and levels sit a little more on the main path (which
+  reads as more distinct near-optimal routes). The trade is slightly longer
+  runs of back-to-back required levels; seed generation stays well under the
+  browser's speed budget.
+
 ## [1.1.0] - 2026-07-27
 
 ### Changed

--- a/src/randomize/overworld_build/knobs.rs
+++ b/src/randomize/overworld_build/knobs.rs
@@ -98,12 +98,16 @@ pub(crate) struct LevelScoring {
     /// Path-relevance weight: positions on the main start→target route (low
     /// detour) score higher. Max bonus = `path_detour_cap * path_bonus`.
     ///
-    /// THE dominant linearity lever. Lowered 1.5 → 0.75 to cut back-to-back
-    /// forced-level streaks (route bias was gluing levels onto the trunk).
-    /// Sweep via test_required_progression: 1.5→streak 2.12, 1.0→1.89,
-    /// 0.75→1.79 (≈ the reference randomizer), 0.5→1.70, 0.0→1.34
-    /// (overshoots and thins the required route). History: 3.0 clumped hard;
-    /// 0.5 was "decorative" at the old weightings.
+    /// THE dominant linearity lever — and a deliberate choice↔streak trade.
+    /// Raising it puts more levels on the trunk, which the route scorer reads
+    /// as more distinct near-optimal routes (lower `test_route_choice`
+    /// linear%) but also lengthens back-to-back forced-level streaks. Set to
+    /// 1.0 (user decision 2026-07-28: accept the streak hit for the choice).
+    /// Measured: route-choice linear% 34.8→32.5 (2000-seed) at 1.0 vs 0.75;
+    /// forced-level streak 1.79→~1.89 (test_required_progression). Curve is
+    /// non-monotonic for choice — 1.0 is the optimum; 1.25–2.0 regress.
+    /// History: was 0.75 (lowered from 1.5 to cut streaks; streak sweep
+    /// 1.5→2.12, 1.0→1.89, 0.75→1.79, 0.5→1.70, 0.0→1.34). 3.0 clumped hard.
     pub path_bonus: f64,
     /// Max detour (BFS hops off the shortest start→target route) that still
     /// earns any path bonus.
@@ -120,7 +124,7 @@ impl Default for LevelScoring {
         LevelScoring {
             spread: SpreadScoring::default(),
             dead_end_bonus: 0.5,
-            path_bonus: 0.75,
+            path_bonus: 1.0,
             path_detour_cap: 6.0,
             random_first_half: false,
         }
@@ -157,7 +161,14 @@ pub(crate) struct LockScoring {
     /// no point spending an impactful-lock slot on a weak chokepoint.
     pub weak_lock_threshold: i32,
     /// Max candidate locks per section re-measured by the choice-guard
-    /// before giving up and accepting the top-scored one.
+    /// before giving up and accepting the top-scored one. The lock pass is
+    /// where route choice is actually manufactured, and this is its budget:
+    /// higher = the guard finds route-creating locks more often (lower
+    /// linear%), at the cost of more route measures per build. Set to 8
+    /// (from 4) — a modest, streak-free, ~+5ms/build choice gain that keeps
+    /// worst-case build latency inside the WASM budget. Sweep (2000-seed
+    /// route-choice linear%, all else default): 4→34.8, 8→33.5, 12→31.8,
+    /// 16→30.0, 24→29.6, but build-time mean climbs 60→74→90ms+ past 12.
     pub choice_guard_tries: usize,
     /// Whether some lock MUST sever the goal (the goal-gate duty). Default
     /// FALSE (user decision 2026-07-27): the shipped guarantee is the C1
@@ -181,7 +192,7 @@ impl Default for LockScoring {
             bridge_bonus: 1,
             w8_bridge_bonus: 8,
             weak_lock_threshold: 5,
-            choice_guard_tries: 4,
+            choice_guard_tries: 8,
             goal_gate: false,
         }
     }

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -3979,7 +3979,7 @@ fn test_route_choice() {
     if !all.is_empty() {
         let mean = all.iter().sum::<usize>() as f64 / all.len() as f64;
         let linear = all.iter().filter(|&&n| n <= 1).count() as f64 / all.len() as f64 * 100.0;
-        eprintln!("  overall: mean {mean:.2} routes/world; {linear:.0}% linear");
+        eprintln!("  overall: mean {mean:.3} routes/world; {linear:.2}% linear (n={})", all.len());
     }
 }
 


### PR DESCRIPTION
## What

Raises two overworld-builder scoring defaults to make generated maps offer real route choice more often.

| Knob (`knobs.rs`) | Old | New |
|---|---|---|
| `LevelScoring::path_bonus` | 0.75 | 1.0 |
| `LockScoring::choice_guard_tries` | 4 | 8 |

## Why

A systematic env-var sweep of **every** `Knobs` field against the `test_route_choice` linear% metric found that the real linearity levers live in the **lock and level passes** — the pipe knobs (`spare_cap_weights`, `frontier_weight`, `jump_weight`, choice-pool size/bonus) are almost entirely inert. Route choice is manufactured in the lock pass (`choice_guard_tries`), which had been capped low purely for build speed.

## Result (2000-seed route-choice census, realistic flag mix)

- **Linear worlds: 34.8% → 32.7%** (−2.2pt), mean routes 1.93 → 1.96
- Forced-level streak 1.79 → ~1.89 (the accepted `path_bonus` trade)
- C1-floor `<14` unchanged at **0.1%**, goal-open **1.4%**, `min 12` — no playability regression
- Build **64.6 ms mean** (was 60), within the <100 ms WASM budget
- `level_skip_weight` and `blocks_target_bonus` deliberately left at defaults (keep the big-skip moments)

Two-number change, no logic change. Knob doc-comments now record the measured sweep curves and the choice↔streak rationale.

## Test

- 291 lib tests pass, `cargo clippy --all-targets` clean
- `all_world_targets_reachable`, `test_c1_floor_probe`, `test_build_time` all verified with the new defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)