### PR TITLE
feature: junction-preference connectivity-pipe endpoints (issue #121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ deploys.
 
 ### Changed
 
+- Connectivity pipes (the ones that bridge otherwise-cut-off parts of a map)
+  now land their island end on a **junction** instead of the nearest dead-end
+  tip, so a bridged-in region joins the map as something you can route
+  *through* rather than a one-way spur. This adds route choice on most worlds
+  (World 8 single-route seeds ~39%→17%, World 5 ~16%→10%; ~24%→20% overall) at
+  no speed cost. World 4 keeps the old shortest-bridge behavior — its central
+  tiles sit next to the airship, so a junction bridge there just became a free
+  express to the goal. (issue #121)
 - Overworld maps now offer real route choice more often: worlds with only
   one reasonable way through drop from ~35% to ~33% across all worlds. Two
   builder weights were retuned — the lock pass looks harder for placements

--- a/src/randomize/map_walker.rs
+++ b/src/randomize/map_walker.rs
@@ -378,6 +378,38 @@ pub(super) fn walk_reachable(
     reach_from(grid, start, &pipe_lookup, &canoe_lookup)
 }
 
+/// Walk-degree of a node: how many of the 4 orthogonal directions lead to a
+/// real neighbor node (valid path tile at +1, non-background node at +2). This
+/// is pure grid topology — pipes and canoes are ignored, and reachability from
+/// any start is irrelevant. Degree 1 marks a dead-end tip; degree 3-4 marks a
+/// junction/branch node. Used by the connectivity-pipe pass to prefer landing
+/// a bridge on a junction (integrating an island as a routable subgraph) over
+/// a dead-end tip (a one-way spur). Mirrors [`walk_from`]'s expansion exactly.
+pub(super) fn walk_degree(grid: &Grid, (r, c): (usize, usize)) -> usize {
+    let mut degree = 0;
+    for &(dr, dc, is_horz) in &DIRECTIONS {
+        let pr = r as i16 + dr as i16;
+        let pc = c as i16 + dc as i16;
+        if pr < 0 || pr >= grid.rows() as i16 || pc < 0 || pc >= grid.cols as i16 {
+            continue;
+        }
+        let path_tile = grid.get(pr as usize, pc as usize);
+        let valid = if is_horz { VALID_HORZ } else { VALID_VERT };
+        if !valid.contains(&path_tile) {
+            continue;
+        }
+        let nr = r as i16 + 2 * dr as i16;
+        let nc = c as i16 + 2 * dc as i16;
+        if nr < 0 || nr >= grid.rows() as i16 || nc < 0 || nc >= grid.cols as i16 {
+            continue;
+        }
+        if !BACKGROUND_TILES.contains(&grid.get(nr as usize, nc as usize)) {
+            degree += 1;
+        }
+    }
+    degree
+}
+
 // ---------------------------------------------------------------------------
 // Chokepoint detection
 // ---------------------------------------------------------------------------

--- a/src/randomize/overworld_build/knobs.rs
+++ b/src/randomize/overworld_build/knobs.rs
@@ -205,13 +205,17 @@ pub(crate) struct PipeScoring {
     /// Softmax temperature for every pipe candidate pick. Score range is
     /// typically ~[-8, +12].
     pub softmax_t: f64,
-    /// Connectivity build-outward: Manhattan distance at which an island
-    /// blank's frontier-proximity score reaches zero (normalization cap).
-    pub frontier_max_dist: f64,
-    /// Connectivity build-outward: weight on frontier proximity (nearer
-    /// islands are bridged first, growing a chain instead of jumping to the
-    /// goal).
-    pub frontier_weight: f64,
+    /// Connectivity build-outward (issue #121): weight on an endpoint's
+    /// walk-degree, so a bridge lands on a junction (a branch node the later
+    /// passes can fork) rather than a dead-end tip (a one-way spur). This is
+    /// the topology-aware endpoint bias — it shapes HOW an island connects,
+    /// never whether (reachability is enforced by the reachable/unreachable
+    /// split, not scored).
+    pub junction_weight: f64,
+    /// Connectivity build-outward: penalty per Manhattan hop of bridge length.
+    /// Keeps the junction bias from reaching back across the map — the island
+    /// still joins via a short bridge to a NEARBY junction, not a distant one.
+    pub bridge_penalty: f64,
     /// Per-spare-pipe skip-cap weights: relative chance the pipe's max
     /// level-skip is 1, 2, 3, or 4. Each pipe rolls a cap, then greedily
     /// takes the biggest skip within it — big skips happen sometimes, not
@@ -233,8 +237,8 @@ impl Default for PipeScoring {
     fn default() -> Self {
         PipeScoring {
             softmax_t: 4.0,
-            frontier_max_dist: 20.0,
-            frontier_weight: 5.0,
+            junction_weight: 5.0,
+            bridge_penalty: 5.0,
             spare_cap_weights: [30.0, 25.0, 25.0, 20.0],
             level_skip_weight: 10.0,
             jump_weight: 1.0,

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use rand::Rng;
 use rand::seq::{IndexedRandom, SliceRandom};
 
-use super::map_walker::{Reach, walk_map, walk_reachable};
+use super::map_walker::{Reach, walk_degree, walk_map, walk_reachable};
 use super::node_catalog::{NodeCatalog, NodeKind};
 use super::overworld_helpers::{find_target, gap_tile_for, LOCKABLE_TILES};
 use super::overworld_pickup::PickupResult;

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -60,6 +60,28 @@ const PROXIMITY_ENDPOINT_WORLDS: &[usize] = &[
     3, // W4 (Giant Land) — junction island tiles are goal-adjacent
 ];
 
+/// Whether `world_idx`'s connectivity-pipe island endpoint uses the old
+/// nearest-frontier scoring instead of junction preference. In release this is
+/// purely the constant above; under `cfg(test)` two env knobs A/B the passes
+/// for census sweeps (`PIPEMODE=proximity` forces every world to proximity,
+/// `FORCEJUNCTION=1` forces every world to junction). Compiled out of the
+/// shipped/WASM binary.
+#[cfg(not(test))]
+#[inline]
+fn use_proximity_endpoint(world_idx: usize) -> bool {
+    PROXIMITY_ENDPOINT_WORLDS.contains(&world_idx)
+}
+#[cfg(test)]
+fn use_proximity_endpoint(world_idx: usize) -> bool {
+    if std::env::var("FORCEJUNCTION").is_ok() {
+        false
+    } else if std::env::var("PIPEMODE").ok().as_deref() == Some("proximity") {
+        true
+    } else {
+        PROXIMITY_ENDPOINT_WORLDS.contains(&world_idx)
+    }
+}
+
 /// Nearest-frontier island score (proximity opt-out only): Manhattan distance
 /// at which the score saturates to zero, and the weight it scales to. Retained
 /// from the pre-#121 scorer so opted-out worlds keep their exact behavior.
@@ -246,7 +268,7 @@ pub(super) fn place_pipes<R: Rng>(
             // passes can fork. A mild per-hop bridge penalty keeps the junction
             // bias from reaching across the map. Worlds in
             // PROXIMITY_ENDPOINT_WORLDS opt out (see that constant).
-            let use_proximity = PROXIMITY_ENDPOINT_WORLDS.contains(&world_idx);
+            let use_proximity = use_proximity_endpoint(world_idx);
             let island_score = |b: (usize, usize), frontier_dist: f64| -> f64 {
                 if use_proximity {
                     // Nearer the frontier = higher (shortest bridge), saturated.

--- a/src/randomize/overworld_build/pipes.rs
+++ b/src/randomize/overworld_build/pipes.rs
@@ -46,6 +46,26 @@ pub(super) const PIPE_EXCLUDED_POSITIONS: &[(usize, (usize, usize))] = &[
     (2, (8, 6)), // W3 between two rocks near start — HB only, not a pipe slot
 ];
 
+/// Worlds that keep the OLD nearest-frontier (shortest-bridge) island endpoint
+/// instead of the junction-preference one (issue #121). Junction preference
+/// helps every other world's route choice, but on a compact world whose
+/// central (high walk-degree) island tiles sit next to the airship, landing
+/// the mandatory island bridge on that junction builds a near-start→near-goal
+/// express that dominates every walking route. Measured: W4 regresses 20%→39%
+/// linear under junction endpoints while W5/W7/W8 all improve, and no
+/// world-agnostic knob (bridge penalty, goal-distance bias) separated the two
+/// cases — the split is geometric, so W4 simply opts out. See
+/// `test_pipe_probe` for the per-seed mechanism.
+const PROXIMITY_ENDPOINT_WORLDS: &[usize] = &[
+    3, // W4 (Giant Land) — junction island tiles are goal-adjacent
+];
+
+/// Nearest-frontier island score (proximity opt-out only): Manhattan distance
+/// at which the score saturates to zero, and the weight it scales to. Retained
+/// from the pre-#121 scorer so opted-out worlds keep their exact behavior.
+const FRONTIER_CAP: f64 = 20.0;
+const FRONTIER_WEIGHT: f64 = 5.0;
+
 // Reason: each argument is a distinct pipe-placement input (grid, candidate
 // blanks, start/target anchors, pair budget, fixed endpoints, world, RNG).
 // They don't form a cohesive concept, so bundling would add indirection
@@ -215,11 +235,28 @@ pub(super) fn place_pipes<R: Rng>(
         }
 
         if !unreachable_blanks.is_empty() && !reachable_blanks.is_empty() {
-            // Build outward: bridge the reachable frontier to the NEAREST
-            // unreachable island, connecting its closest two blanks. This
-            // grows the pipe network as a chain from start (start → i1 → i2 →
-            // … → goal) instead of teleporting straight to the goal island.
-            // Island side: prefer the blank nearest to the current frontier.
+            // Build outward: bridge the reachable frontier to the nearest
+            // unreachable island. The ISLAND endpoint lands on a JUNCTION rather
+            // than the closest dead-end tip (issue #121). A connectivity pipe is
+            // placed before any level exists, so the old scorer took the island
+            // blank nearest the frontier — usually a corridor tip — and the
+            // island joined as a one-way spur (a spanning tree, the most linear
+            // shape there is). Landing on a high walk-degree tile instead
+            // integrates the island as a routable subgraph the later measured
+            // passes can fork. A mild per-hop bridge penalty keeps the junction
+            // bias from reaching across the map. Worlds in
+            // PROXIMITY_ENDPOINT_WORLDS opt out (see that constant).
+            let use_proximity = PROXIMITY_ENDPOINT_WORLDS.contains(&world_idx);
+            let island_score = |b: (usize, usize), frontier_dist: f64| -> f64 {
+                if use_proximity {
+                    // Nearer the frontier = higher (shortest bridge), saturated.
+                    (FRONTIER_CAP - frontier_dist.min(FRONTIER_CAP)) / FRONTIER_CAP
+                        * FRONTIER_WEIGHT
+                } else {
+                    walk_degree(grid, b) as f64 * knobs.junction_weight
+                        - frontier_dist * knobs.bridge_penalty
+                }
+            };
             let b_scored: Vec<((usize, usize), f64)> = unreachable_blanks
                 .iter()
                 .map(|&b| {
@@ -227,19 +264,17 @@ pub(super) fn place_pipes<R: Rng>(
                         .iter()
                         .map(|&a| (a.0.abs_diff(b.0) + a.1.abs_diff(b.1)) as f64)
                         .fold(f64::INFINITY, f64::min);
-                    // Nearer to the reachable frontier = higher score.
-                    let proximity = (knobs.frontier_max_dist
-                        - frontier_dist.min(knobs.frontier_max_dist))
-                        / knobs.frontier_max_dist
-                        * knobs.frontier_weight;
-                    (b, proximity)
+                    (b, island_score(b, frontier_dist))
                 })
                 .collect();
             let b = pick_softmax_by_score(b_scored, knobs.softmax_t, rng).unwrap();
 
-            // Reachable side: the frontier blank nearest to b (shortest bridge),
-            // so the pipe extends the frontier to that island rather than
-            // reaching back across the map.
+            // Frontier (mainland) side: the blank nearest b — a short bridge, so
+            // the pipe extends the frontier to the island rather than reaching
+            // back across the map. Junction preference here proved both worse
+            // for choice and slower (distant central bridges cost the downstream
+            // measure passes ~5ms/build), so the mainland mouth stays nearest-b
+            // on every world.
             let a_scored: Vec<((usize, usize), f64)> = reachable_blanks
                 .iter()
                 .map(|&a| {

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -4070,6 +4070,77 @@ fn test_pipe_probe() {
     }
 }
 
+/// Route-choice linear% split by whether each world was Start↔Airship
+/// swapped, so the #121 junction endpoints can be checked separately under
+/// SAS on/off. Rebuilds like `census_build` but reads the per-world swap
+/// flag. Combine with PIPEMODE=proximity / FORCEJUNCTION to A/B.
+///   SAS_SEEDS=2000 cargo test --release --lib test_sas_split -- --ignored --nocapture
+#[test]
+#[ignore]
+fn test_sas_split() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let seeds: u64 = std::env::var("SAS_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(2000);
+    // (world, swapped) -> (linear_count, total)
+    let per_seed = par_seeds(seeds, |seed| {
+        let arm = census_arm(seed);
+        let rom = apply_qol_variant(&rom, arm == CensusArm::HammerRocks, arm == CensusArm::EightsWild);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut catalog = NodeCatalog::build(&rom, false);
+        let mut swap_rng = ChaCha8Rng::seed_from_u64(seed);
+        super::super::start_airship_swap::pick_swaps(&mut catalog, &mut swap_rng);
+        let swapped = catalog.start_airship_swapped;
+        let pickup = super::super::overworld_pickup::pick_up(
+            &rom,
+            &catalog,
+            super::super::overworld_pickup::PickupFlags {
+                shuffle_spade_games: true,
+                shuffle_toad_houses: true,
+                ..Default::default()
+            },
+        );
+        let result = build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            BuildFlags {
+                shuffle_toad_houses: true,
+                eights_are_wild: arm == CensusArm::EightsWild,
+                ..Default::default()
+            },
+        );
+        let mut rows = Vec::new();
+        for built in &result.worlds {
+            let rc = analyze_route_choice(built, route_choice::DEFAULT_SLACK);
+            let n = if rc.reachable { rc.routes.len() } else { 0 };
+            rows.push((built.world_idx, swapped[built.world_idx], n <= 1));
+        }
+        rows
+    });
+    // Aggregate.
+    let mut lin = [[0usize; 2]; 8];
+    let mut tot = [[0usize; 2]; 8];
+    for rows in &per_seed {
+        for &(wi, sw, is_lin) in rows {
+            let s = sw as usize;
+            tot[wi][s] += 1;
+            if is_lin { lin[wi][s] += 1; }
+        }
+    }
+    eprintln!("\n=== linear% by SAS state ({seeds} seeds) ===");
+    eprintln!("  {:<4} {:>16} {:>16}", "", "SAS-off", "SAS-on");
+    for wi in 0..8 {
+        let pct = |s: usize| if tot[wi][s] == 0 { "-".to_string() }
+            else { format!("{:.0}% (n={})", lin[wi][s] as f64 / tot[wi][s] as f64 * 100.0, tot[wi][s]) };
+        eprintln!("  W{:<3} {:>16} {:>16}", wi + 1, pct(0), pct(1));
+    }
+}
+
 /// Per-seed build wall time — the number the WASM app's generate latency
 /// tracks. Serial on purpose (per-seed timing, no thread contention).
 ///   TIME_SEEDS=40 cargo test --release --lib test_build_time -- --ignored --nocapture

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -4016,6 +4016,60 @@ fn test_route_choice() {
 }
 
 
+/// Probe how a world (WORLD=n, 1-based; default 4) places connectivity pipes.
+/// For each base-arm seed it prints the world's route count plus, per pipe
+/// pair, each endpoint's walk-degree and BFS hops from start / to target. This
+/// is the tool that diagnosed the W4 junction-endpoint regression (issue #121)
+/// — junction bridges landed the island mouth next to the airship (low t),
+/// building a goal express; see `PROXIMITY_ENDPOINT_WORLDS`.
+///   PROBE_SEEDS=200 WORLD=4 cargo test --release --lib test_pipe_probe -- --ignored --nocapture
+#[test]
+#[ignore]
+fn test_pipe_probe() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let seeds: u64 = std::env::var("PROBE_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(200);
+    let world: usize = std::env::var("WORLD").ok().and_then(|s| s.parse().ok()).unwrap_or(4);
+    let wi = world - 1;
+    for seed in 0..seeds {
+        if census_arm(seed) != CensusArm::Base {
+            continue; // one flag arm, so on/off compare like-for-like
+        }
+        let result = census_build(&rom, seed);
+        let Some(built) = result.worlds.iter().find(|b| b.world_idx == wi) else { continue };
+        let rc = analyze_route_choice(built, route_choice::DEFAULT_SLACK);
+        let n = if rc.reachable { rc.routes.len() } else { 0 };
+
+        let mut grid = built.grid.clone();
+        stamp_slots(&mut grid, &built.slots);
+        let start = rom_data::find_start(&grid);
+        let target = find_target(&grid, wi);
+        let d_start = walk_map(&grid, &built.pipe_pairs, start, wi).distances;
+        let d_target = target.map(|t| walk_map(&grid, &built.pipe_pairs, Some(t), wi).distances);
+        let stat = |p: (usize, usize)| -> String {
+            let deg = walk_degree(&grid, p);
+            let ds = d_start.get(&p).map(|d| d.to_string()).unwrap_or_else(|| "-".into());
+            let dt = d_target
+                .as_ref()
+                .and_then(|m| m.get(&p))
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "-".into());
+            format!("{p:?}:deg{deg},s{ds},t{dt}")
+        };
+        let pipes: Vec<String> = built
+            .pipe_pairs
+            .iter()
+            .map(|&(a, b)| format!("[{} <-> {}]", stat(a), stat(b)))
+            .collect();
+        eprintln!("seed {seed:>4}  routes {n}  cost {}  pipes {}", rc.best_cost, pipes.join(" "));
+    }
+}
+
 /// Per-seed build wall time — the number the WASM app's generate latency
 /// tracks. Serial on purpose (per-seed timing, no thread contention).
 ///   TIME_SEEDS=40 cargo test --release --lib test_build_time -- --ignored --nocapture


### PR DESCRIPTION
Closes #121.

## What

Connectivity pipes bridge otherwise-unreachable islands **before any level exists**. The old scorer picked the island endpoint by pure proximity — the tile *nearest the reachable frontier*, which is usually a corridor tip — so the island joined the map as a one-way **spur** (a spanning tree, the most linear shape possible).

This lands the **island endpoint on a junction** (a high walk-degree branch node) instead, so the region joins as a routable subgraph the later measured passes can fork. Reachability is untouched (still enforced by the reachable/unreachable split, never scored) — this only shapes *how* an island connects.

## Changes

- **`map_walker::walk_degree`** — new helper: how many of the 4 orthogonal directions lead to a real neighbor node. Pure grid topology (pipes/canoes/reachability ignored), mirrors `walk_from`'s expansion. Degree 1 = dead-end tip, 3–4 = junction.
- **Island endpoint** = `walk_degree × junction_weight − bridge_len × bridge_penalty` (a short bridge to a *nearby* junction). **Frontier endpoint** stays nearest-`b` — junction preference there was both worse for choice *and* ~5ms slower (distant central bridges cost the downstream measure passes).
- Replaced the inert `frontier_max_dist`/`frontier_weight` knobs with `junction_weight`/`bridge_penalty`.
- **`test_pipe_probe`** — the diagnostic that found the W4 issue (per-seed endpoint walk-degree + hops-to-start/target).

## The W4 opt-out

W4 keeps the old shortest-bridge endpoint (`PROXIMITY_ENDPOINT_WORLDS`). Its central island tiles sit **next to the airship**, so a junction bridge there builds a near-start→near-goal **express** that dominates every walking route — W4 regressed 20%→39% linear under junction endpoints. The `test_pipe_probe` diff showed junction bridges landing the island mouth at 3–5 hops from the goal vs 8–13 for proximity. No world-agnostic knob (bridge penalty, goal-distance bias) separated W4 from the worlds junction preference *helps* (W5 has the same pipe count and improves) — the split is geometric, so W4 simply opts out. Excluding it isn't just damage control: W4 was dragging the average *up*, so the net nearly doubled.

## Results — route-choice census, 2000 seeds, realistic flag mix

| World | Old linear% | New linear% |
|---|---|---|
| W1 | 39 | 39 |
| W2 | 16 | 16 |
| W3 | 34 | 34 |
| W4 | 20 | 19 |
| W5 | 16 | **10** |
| W6 | 1 | 1 |
| W7 | 29 | **24** |
| W8 | 39 | **17** |
| **overall** | **24.34** | **20.00 (−4.3pp)** |

Every world same-or-better. **Perf-neutral**: 71.6ms vs 70.9ms mean build (within noise), worst-case latency improved (171→148ms); WASM stays under budget. 292 tests pass, clippy clean, `wasm-pack build` clean, native==WASM code path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)