### PR TITLE
feature: coin-flip W5 spiral-castle pipe endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ deploys.
 
 ### Changed
 
+- The World 5 spiral-castle pipe no longer always draws the castle on the far
+  endpoint — the castle and the pipe mouth are now coin-flipped between the
+  pair's two cells, so the castle can appear on either side.
 - Connectivity pipes (the ones that bridge otherwise-cut-off parts of a map)
   now land their island end on a **junction** instead of the nearest dead-end
   tip, so a bridged-in region joins the map as something you can route

--- a/src/randomize/overworld_writer/assign.rs
+++ b/src/randomize/overworld_writer/assign.rs
@@ -306,7 +306,7 @@ pub(super) fn assign_pool<R: Rng>(
                 if pair_idx >= built.pipe_pairs.len() || group.len() < 2 {
                     break;
                 }
-                let (pos_a, pos_b) = built.pipe_pairs[pair_idx];
+                let (mut pos_a, mut pos_b) = built.pipe_pairs[pair_idx];
 
                 // Use the is_a_side flag precomputed during catalog building.
                 let (idx_a, idx_b) = if group[0].1 {
@@ -314,6 +314,19 @@ pub(super) fn assign_pool<R: Rng>(
                 } else {
                     (group[1].0, group[0].0)
                 };
+
+                // Mixed pairs (one endpoint is the $5F spiral-castle tile, the
+                // other a plain pipe — only the W5 spiral) always drew the
+                // castle on the B-side cell in vanilla. Coin-flip the two
+                // positions so the castle can appear on either endpoint.
+                // pos_a/pos_b feed the tile grid, dest table, and pointer table
+                // consistently, so swapping them keeps the pipe internally
+                // coherent (the A-side entry stays at the A-nibble position).
+                let tile_a = catalog.entries[pickup.pool[idx_a].catalog_idx].tile;
+                let tile_b = catalog.entries[pickup.pool[idx_b].catalog_idx].tile;
+                if tile_a != tile_b && rng.random_bool(0.5) {
+                    std::mem::swap(&mut pos_a, &mut pos_b);
+                }
                 pipes.push(PipeAssignment {
                     pool_idx_a: idx_a,
                     pool_idx_b: idx_b,


### PR DESCRIPTION
## What

The World 5 spiral-castle pipe always drew the castle icon on the far endpoint every seed. The castle entry is always classified as the B-side, so it always landed at `pos_b`; the pipe mouth (PipeWayController entry) is always the A-side at `pos_a`.

This coin-flips `pos_a`/`pos_b` in `overworld_writer/assign.rs` for **mixed pairs** — pairs whose two endpoints have different tiles, which is only the W5 spiral (castle `$5F` vs. plain pipe) — so the castle can appear on either cell.

## Why it's safe

`pos_a`/`pos_b` flow consistently into all three downstream writers:
- tile grid (`grid.rs`)
- pipe dest table (`pipe_helpers.rs`)
- pointer table (`pointers.rs`)

Swapping the tuple moves the castle and pipe mouth to opposite cells *together*, so the A-side entry still sits at the A-nibble position and the pipe stays internally coherent. Regular pipe pairs have equal tiles, so the `tile_a != tile_b` guard skips them and their ROM output is byte-identical.

## Testing

- `cargo build` / `cargo clippy --all-targets` clean
- `cargo test` — 292 passed, 0 failed
- CHANGELOG updated under `[Unreleased] → Changed`

Worth a quick in-game glance on a swapped seed, since the reversed layout wasn't emulator-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ftbcx3jsSCouGj9YaWEB1z