### PR TITLE
fix: canoe summon reads the map-tile row it places the boat on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ deploys.
   reachability walk more than pays for the extra work (~94 ms in the browser).
   (issue #125)
 
+### Fixed
+
+- The "call the boat" canoe summon (press A on a dock) could drop the canoe on
+  a land tile *inside* an island instead of on the water beside the dock,
+  leaving it unboardable. Its tile check read one map row too low, so a path
+  tile below the water could be mistaken for water. It now reads the correct
+  cell (World 3's middle island dock was the visible case).
+
 ## [1.1.0] - 2026-07-27
 
 ### Changed

--- a/src/randomize/qol/canoe_summon.rs
+++ b/src/randomize/qol/canoe_summon.rs
@@ -24,7 +24,9 @@
 //!
 //! The navigable-water range `$82..=$A9` is the canoe engine's own bound
 //! (`TILE_WATER_INVT $82 <= tile < TILE_VERTPATHWLU $AA` in the in-canoe move
-//! check), so any dock's water neighbor lands in it and no path/blank tile can.
+//! check). The scan must read the tile at the *placement* cell, which requires a
+//! one-row compensation in the tile lookup (see `CANOE_SUMMON_ROUTINE`); without
+//! it the check read one row low and could pick a land/path tile beside a dock.
 //!
 //! **Hook.** A pressed on a dock does nothing in vanilla (`$4B` is a page-1 tile,
 //! below its `$67` gate threshold, and not a special-entry tile), so the summon
@@ -50,8 +52,17 @@ const CANOE_SUMMON_CPU: u16 = (0xC000 + FS_CANOE_SUMMON - 0x14010) as u16;
 /// `tools/_canoe_summon.a65` with `xa`. On entry it is reached only when A was
 /// just pressed; it exits with `A = World_Map_Tile` and `Y = $1A` on every path
 /// so the displaced special-enter-tile scan continues exactly as in vanilla.
+///
+/// The tile check reads the map-tile page **one row up** from the neighbor cell
+/// (the `SEC / SBC #$10` below). The world map's tiles live at `screen_base +
+/// $110`, but the inline lookup only `INC`s the high byte (`+$100`) — so without
+/// the compensation every read lands one row too low. The game's own
+/// `MapTile_Get_By_Offset` avoids this because its `Search_YOff` table bakes in a
+/// matching `-16`. The `-$10` here keeps the tile we *test* aligned with the cell
+/// we actually drop the boat on; the placement coordinate itself is left alone
+/// (it must stay `World_Map_Y`-relative for boarding to find the canoe).
 #[rustfmt::skip]
-const CANOE_SUMMON_ROUTINE: [u8; 148] = [
+const CANOE_SUMMON_ROUTINE: [u8; 151] = [
     0xA5, 0xE5,             // LDA World_Map_Tile
     0xC9, 0x4B,             // CMP #$4B         (TILE_DOCK)
     0xD0, 0x0C,             // BNE csexit       (not a dock -> passthrough)
@@ -75,14 +86,14 @@ const CANOE_SUMMON_ROUTINE: [u8; 148] = [
     0xA4, 0x03,             // LDY Temp_Var4    (direction)
     0xB5, 0x75,             // LDA World_Map_Y,X ($75)
     0x18,                   // CLC
-    0x79, 0x2D, 0xDF,       // ADC csyoff,Y     ($DF2D)
+    0x79, 0x30, 0xDF,       // ADC csyoff,Y     ($DF30)
     0x85, 0x0E,             // STA Temp_Var15   (neighbor Y)
     0xB5, 0x79,             // LDA World_Map_X,X ($79)
     0x18,                   // CLC
-    0x79, 0x31, 0xDF,       // ADC csxoff,Y     ($DF31)
+    0x79, 0x34, 0xDF,       // ADC csxoff,Y     ($DF34)
     0x85, 0x0F,             // STA Temp_Var16   (neighbor X)
     0xB5, 0x77,             // LDA World_Map_XHi,X ($77)
-    0x79, 0x35, 0xDF,       // ADC csxhioff,Y   ($DF35, +carry from X)
+    0x79, 0x38, 0xDF,       // ADC csxhioff,Y   ($DF38, +carry from X)
     0x85, 0x05,             // STA Temp_Var6    (neighbor XHi)
     0x0A,                   // ASL             (screen index * 2)
     0xAA,                   // TAX
@@ -90,11 +101,15 @@ const CANOE_SUMMON_ROUTINE: [u8; 148] = [
     0x85, 0x63,             // STA Map_Tile_AddrL
     0xBD, 0x01, 0x80,       // LDA Tile_Mem_Addr+1,X
     0x85, 0x64,             // STA Map_Tile_AddrH
-    0xE6, 0x64,             // INC Map_Tile_AddrH  (screen tiles at base + $100)
+    0xE6, 0x64,             // INC Map_Tile_AddrH  (reaches base + $100)
     0xA5, 0x0F,             // LDA Temp_Var16   (neighbor X)
     0x4A, 0x4A, 0x4A, 0x4A, // LSR x4           (>> 4 -> column within screen)
     0x85, 0x06,             // STA Temp_Var7
     0xA5, 0x0E,             // LDA Temp_Var15   (neighbor Y)
+    0x38,                   // SEC
+    0xE9, 0x10,             // SBC #$10         (tiles are at base+$110, INC only got
+                            //                   +$100 -> read one row up so the tile
+                            //                   we test matches the placement cell)
     0x29, 0xF0,             // AND #$F0
     0x05, 0x06,             // ORA Temp_Var7
     0xA8,                   // TAY
@@ -119,12 +134,12 @@ const CANOE_SUMMON_ROUTINE: [u8; 148] = [
     0xE6, 0x03,             // INC Temp_Var4    (next direction)
     0xA5, 0x03,             // LDA Temp_Var4
     0xC9, 0x04,             // CMP #$04
-    0xD0, 0x98,             // BNE csloop
+    0xD0, 0x95,             // BNE csloop
     0x4C, 0xB7, 0xDE,       // JMP csexit ($DEB7)  (no water neighbor)
     // csyoff / csxoff / csxhioff — cardinal offsets, dir 0..3 = right,left,down,up:
-    0x00, 0x00, 0x10, 0xF0, // csyoff   ($DF2D)
-    0x10, 0xF0, 0x00, 0x00, // csxoff   ($DF31)
-    0x00, 0xFF, 0x00, 0x00, // csxhioff ($DF35)
+    0x00, 0x00, 0x10, 0xF0, // csyoff   ($DF30)
+    0x10, 0xF0, 0x00, 0x00, // csxoff   ($DF34)
+    0x00, 0xFF, 0x00, 0x00, // csxhioff ($DF38)
 ];
 
 /// Install the "call the boat" summon: A on a dock warps the canoe alongside.

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -26,7 +26,7 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x15554, 80, "fx_screen_check: cross-screen lock patch (Fred's algorithm verbatim)"),
     (0x15DF0, 35, "canoe_fix: death respawn position save"),
     (0x15E13, 162, "map_warp: 2P Start+Select warp-to-partner routine"),
-    (0x15EB5, 148, "canoe_summon: A-on-dock call-the-boat routine + offset tables"),
+    (0x15EB5, 151, "canoe_summon: A-on-dock call-the-boat routine + offset tables"),
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
     (0x17C87, 36, "start_airship_swap: game-over twirl finalize helper"),
     (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
@@ -149,7 +149,7 @@ pub(crate) const FS_MAP_WARP: usize          = 0x15E13; // 162 bytes (CPU $DE03)
 // Canoe "call the boat" routine (CPU $DEA5). ORIGIN-LOCKED: the assembled bytes
 // contain self-referential absolute addresses (JMP $DEB7, and the ADC $DF2D/31/35
 // offset-table reads), so this MUST live at exactly 0x15EB5. See canoe_summon.rs.
-pub(crate) const FS_CANOE_SUMMON: usize      = 0x15EB5; // 148 bytes (CPU $DEA5)
+pub(crate) const FS_CANOE_SUMMON: usize      = 0x15EB5; // 151 bytes (CPU $DEA5)
 
 // PRG011
 pub(crate) const FS_CANOE_BACKUP: usize      = 0x17D00; // 66 bytes

--- a/tools/_canoe_summon.a65
+++ b/tools/_canoe_summon.a65
@@ -1,0 +1,110 @@
+; canoe_summon routine, origin-locked to CPU $DEA5 (FS_CANOE_SUMMON).
+; Assemble and paste bytes into src/randomize/qol/canoe_summon.rs:
+;   xa -o cs.bin tools/_canoe_summon.a65
+; The SEC/SBC #$10 before the tile lookup reads one row up so the checked cell
+; matches the placement cell (map tiles live at screen_base+$110, INC gives +$100).
+
+
+World_Map_Tile   = $E5
+Temp_Var4        = $03
+Temp_Var5        = $04
+Temp_Var6        = $05
+Temp_Var7        = $06
+Temp_Var15       = $0E
+Temp_Var16       = $0F
+Map_Tile_AddrL   = $63
+Map_Tile_AddrH   = $64
+World_Map_Y      = $75
+World_Map_XHi    = $77
+World_Map_X      = $79
+Map_Object_ActY  = $0500
+Map_Object_ActX  = $050F
+Map_Object_ActXH = $051E
+Player_Current   = $0726
+Map_Objects_Y    = $7EEB
+Map_Objects_XLo  = $7EF9
+Map_Objects_XHi  = $7F07
+Map_Objects_IDs  = $7F15
+Tile_Mem_Addr    = $8000
+
+    * = $DEA5
+
+    lda World_Map_Tile
+    cmp #$4B
+    bne csexit
+    ldx #$0D
+csfind:
+    lda Map_Objects_IDs,x
+    cmp #$10
+    beq cshave
+    dex
+    bpl csfind
+csexit:
+    lda World_Map_Tile
+    ldy #$1A
+    rts
+cshave:
+    stx Temp_Var5
+    lda #$00
+    sta Temp_Var4
+csloop:
+    ldx Player_Current
+    ldy Temp_Var4
+    lda World_Map_Y,x
+    clc
+    adc csyoff,y
+    sta Temp_Var15
+    lda World_Map_X,x
+    clc
+    adc csxoff,y
+    sta Temp_Var16
+    lda World_Map_XHi,x
+    adc csxhioff,y
+    sta Temp_Var6
+    asl
+    tax
+    lda Tile_Mem_Addr,x
+    sta Map_Tile_AddrL
+    lda Tile_Mem_Addr+1,x
+    sta Map_Tile_AddrH
+    inc Map_Tile_AddrH
+    lda Temp_Var16
+    lsr
+    lsr
+    lsr
+    lsr
+    sta Temp_Var7
+    lda Temp_Var15
+    sec
+    sbc #$10
+    and #$F0
+    ora Temp_Var7
+    tay
+    lda (Map_Tile_AddrL),y
+    cmp #$82
+    bcc csnext
+    cmp #$AA
+    bcs csnext
+    ldx Temp_Var5
+    lda Temp_Var15
+    sta Map_Objects_Y,x
+    sta Map_Object_ActY,x
+    lda Temp_Var16
+    sta Map_Objects_XLo,x
+    sta Map_Object_ActX,x
+    lda Temp_Var6
+    sta Map_Objects_XHi,x
+    sta Map_Object_ActXH,x
+    jmp csexit
+csnext:
+    inc Temp_Var4
+    lda Temp_Var4
+    cmp #$04
+    bne csloop
+    jmp csexit
+csyoff:
+    .byte $00,$00,$10,$F0
+csxoff:
+    .byte $10,$F0,$00,$00
+csxhioff:
+    .byte $00,$FF,$00,$00


### PR DESCRIPTION
## Problem

The "call the boat" canoe summon (press **A** on a dock) could drop the canoe on a **land tile inside an island** instead of the water beside the dock, leaving it unboardable. World 3's middle island dock (grid `(5,24)`) was the visible case.

## Root cause

The summon's inline map-tile lookup adds `+$100` to reach the tile page, but world-map tiles load at **`screen_base + $110`** — so every tile it checked was read **one row too low**. At `(5,24)` it tested grid `(6,25)=$9B` (water) instead of `(5,25)=$45` (land), false-positived on "water to the right," and placed the boat on the island path tile. The game's own `MapTile_Get_By_Offset` avoids this because its `Search_YOff` table bakes in a matching `-16`.

Confirmed live via BizHawk RAM watch: player `World_Map_Y=$70`, canoe placed at active `Y=$70 X=$90` = grid `(5,25)`, and the map-tile RAM at the checked cell (`$6329`) held `$9B` (grid `(6,25)`, one row down).

## Fix

Insert `SEC / SBC #$10` before the tile index so the **checked** cell matches the **placement** cell. Read-only compensation — the placement coordinate stays `World_Map_Y`-relative so boarding still finds the canoe. This corrects the addressing math, so it applies to **every dock in every world**, not one hardcoded tile. The other two W3 docks only looked correct before (they read the wrong cell too, but luck gave the same choice); they're unchanged after the fix.

## Size / safety

- Routine grows **148 → 151 bytes**; the 3 trailing bytes were `FF` padding, no free-space collision (registry + no-overlap test updated/pass).
- Origin-locked invariants preserved: `csexit=$DEB7`, offset tables shifted to `$DF30/34/38`, loop back-branch recomputed.
- Adds `tools/_canoe_summon.a65` (assembler source of record); `xa` output matches the embedded ROM bytes byte-for-byte.
- Full suite: **292 passed**, clippy clean.

## Testing

Verified in-game (walk-anywhere W3 test ROM): at `(5,24)` the boat now snaps **left to open water** and boards; mainland and top-right docks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ftbcx3jsSCouGj9YaWEB1z