### PR TITLE
release: 1.0.7 — fix lobby-shuffle void in 5-2/6-9 Big ? Block bonus rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ deploys.
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-31
+
 ### Fixed
 
 - Lobby (antechamber) shuffle could drop you into a void when you entered a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ deploys.
 
 ## [Unreleased]
 
+### Fixed
+
+- Lobby (antechamber) shuffle could drop you into a void when you entered a
+  Big ? Block bonus room inside 5-2 or 6-9, in two ways, both fixed:
+  - **5-2's bonus room landed you in a garbage spot.** 5-2's bonus room reads
+    its arrival position from the same pipe the shuffle was rewriting to relink
+    the lobby — so it flung you into the room at a corrupted position. The
+    shuffle now leaves that pipe alone.
+  - **The bonus room itself was the wrong (void) one.** The fix that keeps these
+    rooms working when a level moves worlds keyed on the map tile you entered —
+    which, under lobby shuffle, is a *different* level's tile. It now keys on the
+    room you're actually standing in, so 5-2 and 6-9 open their own bonus rooms
+    even when reached through another level's lobby.
+
 ## [1.0.6] - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "clap",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 
 [lib]

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -3892,36 +3892,59 @@ JMP $894C          ; W8 path: continue with overwrite
 JMP $8964          ; non-W8 path: skip overwrite
 ```
 
-**Part B — Lookup routine replaces World_Num indexing (PRG026)**
+**Part B — Two-pass lookup replaces World_Num indexing (PRG026)**
 
-Hook point: ROM **0x349F9** — replaces `LDY $0727` (3 bytes) with `JSR $B520`.
+Hook point: ROM **0x349F9** — replaces `LDY $0727` (3 bytes) with `JSR $B5AD`.
 
-Lookup routine at ROM **0x35530** (PRG026 free space, CPU $B520), 66 bytes:
+Lookup routine at ROM **0x355BD** (PRG026 free space, CPU $B5AD), 106 bytes. (Moved
+off the old 0x35530/$B520 slot — the 66-byte single-pass version couldn't grow, as
+`mystery_anchor` sits immediately after it.)
 
-The routine reads the saved entry obj_ptr from $7EB4/$7EB5 (not $7EBB/$7EBC which may
-have been overwritten by junctions). It searches an 11-entry table of obj_ptr values.
-On match, it loads the corresponding room index into Y and returns. On no match (levels
-that don't use Big ? Blocks, like W1/W2 levels), it falls back to `LDY $0727`
-(World_Num).
+The room a bonus pipe opens is a property of the *area you're standing in*. The
+routine scans the obj_ptr table against two sources, in order:
 
-**Obj_ptr → room index mapping table (11 levels that use Big ? Blocks):**
+1. **`Level_ObjPtrOrig` ($7EBB/$7EBC)** — the obj_ptr of the current area.
+   `Level_JctInit` writes each area's `Level_AltObjects` here on every junction,
+   so under lobby (antechamber) shuffle — where you reach 5-2/6-9's content
+   through a *foreign lobby* — the bonus pipe still resolves by the room you're
+   actually in, not the entered tile. **This is the lobby-shuffle-aware pass.**
+2. **Frozen map-entry ptr ($7EB4/$7EB5)** — saved by Part A before the W8 code
+   clobbers `Level_ObjPtrOrig` to $C033. Covers 8-1 and any pipe hit in a
+   sub-area whose obj_ptr isn't in the table but whose *entry* is.
+3. **`LDY $0727` (World_Num) fallback** — vanilla default, last resort.
 
-| Level | Obj Hi | Obj Lo | Room Index | Vanilla World |
-|-------|--------|--------|------------|---------------|
+Pass order matters: under lobby shuffle the frozen ptr is the *lobby's*, so
+scanning it first would drop to World_Num and load a garbage room.
+
+**Obj_ptr → room index mapping table (13 entries):**
+
+| Area | Obj Hi | Obj Lo | Room | Notes |
+|------|--------|--------|------|-------|
 | 3-5 | $CD | $EB | 2 | W3 |
 | 3-9 | $C3 | $8F | 2 | W3 |
 | 4-F2 | $D5 | $08 | 3 | W4 |
-| 5-2 | $C8 | $BE | 4 | W5 |
+| 5-2 (entry) | $C8 | $BE | 4 | W5 — its block is here |
 | 5-5 | $CB | $0A | 4 | W5 |
 | 6-3 | $CA | $8E | 5 | W6 |
-| 6-9 | $CD | $2D | 5 | W6 |
+| 6-9 (entry) | $CD | $2D | 5 | W6 |
 | 6-10 | $CC | $E8 | 5 | W6 |
 | 7-F1 | $D4 | $E4 | 6 | W7 |
 | 7-8 | $C3 | $2D | 6 | W7 |
 | 8-1 | $C4 | $24 | 7 | W8 |
+| 5-2 (sub-area) | $CE | $4B | 4 | belt-and-suspenders |
+| **6-9 (interior)** | **$C6** | **$0E** | **5** | 6-9's block lives here, not its entry — needed so lobby-shuffled 6-9 resolves via `ObjPtrOrig` |
 
-Room indices are 0-indexed (matching World_Num values 0–7). W1 and W2 have no levels
-with Big ? Blocks, so they are not in the table and use the World_Num fallback.
+Room indices are 0-indexed (= World_Num 0–7). W1/W2 have no Big ? Block rooms, so
+they use the World_Num fallback. The last two rows are the antechamber levels
+whose content is reachable through a foreign lobby: they must resolve by the
+current area (pass 1), because the frozen entry (pass 2) is the lobby, not them.
+
+**The other half of the lobby-shuffle fix lives in `antechambers.rs`:** the shuffle
+must NOT rewrite a junction command that seeds a bonus room's arrival slot. 5-2's
+slot-4 command `0x1A807` is that slot, so it's excluded from 5-2's rewritten
+junctions (only its front door `0x1A804` is rewritten). Without that, a hosting 5-2
+drops you into its bonus room at a corrupted position (a void), independent of the
+room-*selection* table above.
 
 ### Bonus Room Enemy Data (PRG006)
 

--- a/src/randomize/antechambers.rs
+++ b/src/randomize/antechambers.rs
@@ -37,18 +37,29 @@ struct Antechamber {
     name: &'static str,
     /// File offset of the entry area's 9-byte layout header.
     header: usize,
-    /// File offsets of the entry area's 3-byte junction commands. All of
-    /// them receive the donor's spawn bytes when hosting; the FIRST is
-    /// the canonical front-door command whose bytes serve as this
-    /// level's donor data (matters for 5-2, whose second pipe is a
-    /// mid-level re-entry at different coordinates).
+    /// File offsets of the entry area's front-door junction commands. All of
+    /// them receive the donor's spawn bytes when hosting; the FIRST is the
+    /// canonical front-door command whose bytes serve as this level's donor
+    /// data.
+    ///
+    /// Only list junctions that are genuinely *entrances to the interior*. A
+    /// junction command also seeds a spawn SLOT (`Level_JctXLHStart[slot]`),
+    /// and a Big ? Block bonus room reads its arrival position from that slot.
+    /// If a listed junction happens to be the slot a bonus room uses, hosting
+    /// overwrites it and the bonus room drops you at a corrupted position (a
+    /// void). 5-2 is exactly this case: its slot-4 command `0x1A807` seeds the
+    /// arrival for its Big ? Block room, so it is deliberately NOT listed —
+    /// only the real front door `0x1A804` is. (See the big_q room lookup in
+    /// `qol/big_q.rs` for the matching room-selection half.)
     junctions: &'static [usize],
 }
 
 const ANTECHAMBERS: [Antechamber; 11] = [
     Antechamber { name: "2-Pyr", header: 0x28F36, junctions: &[0x28F6F, 0x28F96] },
     Antechamber { name: "4-3", header: 0x2701F, junctions: &[0x27073] },
-    Antechamber { name: "5-2", header: 0x1A587, junctions: &[0x1A804, 0x1A807] },
+    // 5-2 lists only its front door 0x1A804; 0x1A807 (slot 4) seeds the Big ?
+    // Block bonus-room arrival and must stay vanilla — see the `junctions` doc.
+    Antechamber { name: "5-2", header: 0x1A587, junctions: &[0x1A804] },
     Antechamber { name: "5-3", header: 0x1EC26, junctions: &[0x1EC4A] },
     Antechamber { name: "6-6", header: 0x23941, junctions: &[0x23990] },
     Antechamber { name: "6-9", header: 0x23CFE, junctions: &[0x23D17] },
@@ -393,7 +404,7 @@ mod tests {
         let expected: [(u16, u16, u8, &[u8], [u8; 2]); 11] = [
             (0xA577, 0xC5BC, 3, &[0, 3], [0x68, 0x20]),    // 2-Pyr (door, dir 8)
             (0xB6D5, 0xC863, 3, &[2], [0x52, 0x20]),       // 4-3
-            (0xB481, 0xCE4B, 8, &[0, 4], [0x82, 0x20]),    // 5-2 (vert shaft)
+            (0xB481, 0xCE4B, 8, &[0], [0x82, 0x20]),       // 5-2 (vert shaft; slot-4 0x1A807 excluded, it's the bonus-room slot)
             (0xAC3E, 0xC29E, 1, &[0], [0x02, 0x67]),       // 5-3
             (0xACDC, 0xC64B, 3, &[0], [0x12, 0x20]),       // 6-6
             (0xA9D7, 0xC60E, 3, &[0], [0x02, 0x40]),       // 6-9

--- a/src/randomize/qol/big_q.rs
+++ b/src/randomize/qol/big_q.rs
@@ -4,30 +4,23 @@ use crate::rom::Rom;
 use crate::randomize::rom_data::{
     FS_BIG_Q_LOOKUP as BIG_Q_ROUTINE_OFFSET,
     FS_BIG_Q_SAVE as BIG_Q_PRG030_OFFSET,
+    jsr_into_bank, prg_bank_file_to_cpu,
 };
 
 // Big ? Block bonus room patch: decouple room selection from World_Num.
 //
-// Two-part patch:
-// Part A — PRG030 (fixed bank): During level init, save the entry-point obj_ptr
-//   from $65/$66 to scratch RAM ($7EB4/$7EB5) before the W8-specific code at
-//   $894C can overwrite it with a hardcoded $C033. This hook is in the fixed
-//   bank so it fires for ALL entry paths (normal tile, army sprite, etc.).
-//   The old PRG012 hook was insufficient — it only covered Map_PrepareLevel
-//   (enter state #$03) but W8 army sprites use a different path (state #$08).
-// Part B — PRG026: Replace `LDY World_Num` in LevelJct_BigQuestionBlock with a
-//   JSR to a lookup routine that reads the saved obj_ptr from scratch RAM and
-//   maps it to the correct per-world bonus room index.
+// Entering the bonus-room pipe runs `LevelJct_BigQuestionBlock`, which vanilla
+// selects with `LDY World_Num`. Move a level to another world (world-order /
+// level shuffle) and that opens the wrong world's room — often a void.
+//
+// Part A — PRG030 (fixed bank): save the entry obj_ptr from $65/$66 to scratch
+//   RAM ($7EB4/$7EB5) at level init, before the W8 code clobbers it to $C033.
+// Part B — PRG026: replace `LDY World_Num` with a JSR to a two-pass lookup that
+//   maps the level to its room. See build_lookup_routine.
 
 // Part A: PRG030 (fixed bank) trampoline for level init.
-// Saves the entry-point obj_ptr from $65/$66 to scratch RAM $7EB4/$7EB5.
-// Hooked in PRG030 (always loaded) so it fires for ALL entry paths — normal
-// tile entry, army sprite encounters, and any other mechanism.
-// Replaces `CPY #$07; BNE +$18` (4 bytes) with `JMP $9F2C` + NOP.
 const BIG_Q_PRG030_HOOK: usize = 0x3C958;  // file offset of CPY #$07
 const BIG_Q_PRG030_JMP: [u8; 4] = [0x4C, 0x2C, 0x9F, 0xEA];
-// Trampoline in PRG030 free space — offset from rom_data::FS_BIG_Q_SAVE
-// (imported as BIG_Q_PRG030_OFFSET at the top of the file).
 const BIG_Q_PRG030_ROUTINE: [u8; 20] = [
     0xA5, 0x65,        // LDA $65        (real obj_lo, before W8 overwrite)
     0x8D, 0xB4, 0x7E,  // STA $7EB4
@@ -40,72 +33,108 @@ const BIG_Q_PRG030_ROUTINE: [u8; 20] = [
 ];
 
 // Part B: PRG026 lookup routine.
-// Hook point: replace `LDY $0727` with `JSR $B520` in LevelJct_BigQuestionBlock.
 const BIG_Q_HOOK_OFFSET: usize = 0x349F9;
-const BIG_Q_JSR: [u8; 3] = [0x20, 0x20, 0xB5];
-// Lookup routine in PRG026 free space — offset from rom_data::FS_BIG_Q_LOOKUP
-// (imported as BIG_Q_ROUTINE_OFFSET at the top of the file).
-// Reads saved entry-point obj_ptr from $7EB4/$7EB5 (not ObjPtrOrig which
-// gets overwritten by sub-area junctions). Falls back to World_Num for
-// levels not in the table (W1/W2 levels don't use Big ? Blocks).
-const BIG_Q_ROUTINE: [u8; 66] = [
-    // LDA $7EB5 (saved entry obj_hi)
-    0xAD, 0xB5, 0x7E,
-    // LDX #10
-    0xA2, 0x0A,
-    // .loop: CMP $B541,X (obj_hi table)
-    0xDD, 0x41, 0xB5,
-    // BNE .next (+16)
-    0xD0, 0x10,
-    // PHA
-    0x48,
-    // LDA $7EB4 (saved entry obj_lo)
-    0xAD, 0xB4, 0x7E,
-    // CMP $B54C,X (obj_lo table)
-    0xDD, 0x4C, 0xB5,
-    // BNE .no_match (+6)
-    0xD0, 0x06,
-    // PLA
-    0x68,
-    // LDA $B557,X (room index table)
-    0xBD, 0x57, 0xB5,
-    // TAY
-    0xA8,
-    // RTS
-    0x60,
-    // .no_match: PLA
-    0x68,
-    // .next: DEX
-    0xCA,
-    // BPL .loop (-24)
-    0x10, 0xE8,
-    // fallback: LDY $0727
-    0xAC, 0x27, 0x07,
-    // RTS
-    0x60,
-    // obj_hi table (11 entries): 3-5,3-9,4-F2,5-2,5-5,6-3,6-9,6-10,7-F1,7-8,8-1
-    0xCD, 0xC3, 0xD5, 0xC8, 0xCB, 0xCA, 0xCD, 0xCC, 0xD4, 0xC3, 0xC4,
-    // obj_lo table (11 entries)
-    0xEB, 0x8F, 0x08, 0xBE, 0x0A, 0x8E, 0x2D, 0xE8, 0xE4, 0x2D, 0x24,
-    // room index table (11 entries): vanilla world indices (0-indexed)
-    0x02, 0x02, 0x03, 0x04, 0x04, 0x05, 0x05, 0x05, 0x06, 0x06, 0x07,
-];
+
+// obj_ptr -> vanilla bonus-room index (= World_Num 0-7) for every AREA that can
+// be the "current area" (`Level_ObjPtrOrig`) when a Big ? Block bonus pipe is
+// entered. The 11 base rooms belong to levels 3-5, 3-9, 4-F2, 5-2, 5-5, 6-3,
+// 6-9, 6-10, 7-F1, 7-8, 8-1 (keyed on their ENTRY obj_ptr, which pass 2 catches
+// via the frozen save for levels entered from their own tile).
+//
+// Two extra rows exist for the antechamber (lobby-shuffle) levels, whose content
+// is reachable through a FOREIGN lobby — so their bonus pipe must resolve by the
+// room you're standing in, not the entered tile:
+//   * 5-2 sub-area $CE4B -> room 4 (its block is in the entry $C8BE, already
+//     above; the sub row is a belt-and-suspenders for the sub-area path).
+//   * 6-9 donated interior $C60E -> room 5 (its block lives HERE, not in the
+//     entry $CD2D — so without this row, reaching 6-9 via a lobby falls through
+//     to World_Num and picks the wrong room).
+const BQ_OBJ_HI: [u8; 13] =
+    [0xCD, 0xC3, 0xD5, 0xC8, 0xCB, 0xCA, 0xCD, 0xCC, 0xD4, 0xC3, 0xC4, 0xCE, 0xC6];
+const BQ_OBJ_LO: [u8; 13] =
+    [0xEB, 0x8F, 0x08, 0xBE, 0x0A, 0x8E, 0x2D, 0xE8, 0xE4, 0x2D, 0x24, 0x4B, 0x0E];
+const BQ_ROOM: [u8; 13] =
+    [0x02, 0x02, 0x03, 0x04, 0x04, 0x05, 0x05, 0x05, 0x06, 0x06, 0x07, 0x04, 0x05];
+
+const BIG_Q_ROUTINE_LEN: usize = 106;
+
+/// Build the PRG026 Big ? Block bonus-room lookup routine.
+///
+/// **Two-pass lookup.** The room a bonus pipe opens is a property of the *level
+/// whose area you're standing in*. The routine resolves that by scanning the
+/// obj_ptr table against two sources, in order:
+///
+/// 1. **`Level_ObjPtrOrig` ($7EBB/$7EBC)** — the obj_ptr of the area the player
+///    is *currently in*. `Level_JctInit` writes each area's `Level_AltObjects`
+///    here on every junction, so under lobby (antechamber) shuffle — where you
+///    enter 5-2's content through a *foreign lobby* and its interior loops back
+///    into its entry — this pointer is still 5-2's when you hit the bonus pipe,
+///    not the lobby's. That makes the lookup lobby-shuffle-aware **without any
+///    per-seed table changes**, and it resolves each level (5-2→4, 6-9→5, …)
+///    correctly on its own.
+/// 2. **Frozen map-entry ptr ($7EB4/$7EB5)** — saved by Part A before the W8
+///    code clobbers `Level_ObjPtrOrig` to $C033. Covers 8-1 and any pipe hit in
+///    an area not itself in the table.
+/// 3. **`LDY $0727` (World_Num) fallback** — vanilla default, last resort.
+///
+/// Internal absolute operands are derived from where the routine is written, so
+/// it is not origin-locked to a hardcoded CPU address.
+fn build_lookup_routine() -> Vec<u8> {
+    let base = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET); // routine start (CPU)
+    let scan = (base + 0x26).to_le_bytes(); // bq_scan subroutine
+    let hi = (base + 0x43).to_le_bytes(); // BQ_OBJ_HI table
+    let lo = (base + 0x50).to_le_bytes(); // BQ_OBJ_LO table (13 bytes after hi)
+    let room = (base + 0x5D).to_le_bytes(); // BQ_ROOM table (13 bytes after lo)
+    let mut r: Vec<u8> = vec![
+        // --- pass 1: current area (Level_ObjPtrOrig $7EBB/$7EBC) ---
+        0xAD, 0xBB, 0x7E,       // LDA $7EBB     ; current-area obj_lo
+        0x8D, 0xB2, 0x7E,       // STA $7EB2     ; scratch lo
+        0xAD, 0xBC, 0x7E,       // LDA $7EBC     ; current-area obj_hi
+        0x8D, 0xB3, 0x7E,       // STA $7EB3     ; scratch hi
+        0x20, scan[0], scan[1], // JSR bq_scan
+        0xB0, 0x14,             // BCS .ret      ; matched -> Y = room
+        // --- pass 2: frozen map-entry ptr ($7EB4/$7EB5, saved by Part A) ---
+        0xAD, 0xB4, 0x7E,       // LDA $7EB4     ; frozen obj_lo
+        0x8D, 0xB2, 0x7E,       // STA $7EB2
+        0xAD, 0xB5, 0x7E,       // LDA $7EB5     ; frozen obj_hi
+        0x8D, 0xB3, 0x7E,       // STA $7EB3
+        0x20, scan[0], scan[1], // JSR bq_scan
+        0xB0, 0x03,             // BCS .ret
+        // --- fallback: World_Num ---
+        0xAC, 0x27, 0x07,       // LDY $0727
+        0x60,                   // .ret: RTS
+        // --- bq_scan: scratch $7EB2=lo/$7EB3=hi -> carry set + Y=room on match ---
+        0xA2, 0x0C,             // LDX #12  (13 entries, index 0..12)
+        0xAD, 0xB3, 0x7E,       // .loop: LDA $7EB3
+        0xDD, hi[0], hi[1],     // CMP BQ_OBJ_HI,X
+        0xD0, 0x0E,             // BNE .next
+        0xAD, 0xB2, 0x7E,       // LDA $7EB2
+        0xDD, lo[0], lo[1],     // CMP BQ_OBJ_LO,X
+        0xD0, 0x06,             // BNE .next
+        0xBD, room[0], room[1], // LDA BQ_ROOM,X
+        0xA8,                   // TAY
+        0x38,                   // SEC
+        0x60,                   // RTS
+        0xCA,                   // .next: DEX
+        0x10, 0xE7,             // BPL .loop
+        0x18,                   // CLC
+        0x60,                   // RTS
+    ];
+    r.extend_from_slice(&BQ_OBJ_HI);
+    r.extend_from_slice(&BQ_OBJ_LO);
+    r.extend_from_slice(&BQ_ROOM);
+    debug_assert_eq!(r.len(), BIG_Q_ROUTINE_LEN);
+    r
+}
 
 /// Patch Big ? Block bonus room selection to use level identity instead of World_Num.
-///
-/// Part A: Saves the entry-point obj_ptr to scratch RAM ($7EB4/$7EB5) at the end of
-/// Map_PrepareLevel, before any sub-area junctions can overwrite Level_ObjPtrOrig.
-///
-/// Part B: Installs a lookup routine in PRG026 free space that reads the saved obj_ptr
-/// and maps it to the correct per-world bonus room index. Falls back to World_Num for
-/// levels not in the table (W1/W2 levels don't use Big ? Blocks).
 pub fn fix_big_q_block_rooms(rom: &mut Rom) {
     // Part A: PRG030 save trampoline (saves $65/$66 before W8 overwrite)
     rom.write_range(BIG_Q_PRG030_HOOK, &BIG_Q_PRG030_JMP);
     rom.write_range(BIG_Q_PRG030_OFFSET, &BIG_Q_PRG030_ROUTINE);
-    // Part B: PRG026 lookup routine
-    rom.write_range(BIG_Q_HOOK_OFFSET, &BIG_Q_JSR);
-    rom.write_range(BIG_Q_ROUTINE_OFFSET, &BIG_Q_ROUTINE);
+    // Part B: PRG026 two-pass lookup routine + hook
+    rom.write_range(BIG_Q_HOOK_OFFSET, &jsr_into_bank(26, BIG_Q_ROUTINE_OFFSET));
+    rom.write_range(BIG_Q_ROUTINE_OFFSET, &build_lookup_routine());
 }
 
 #[cfg(test)]
@@ -116,33 +145,47 @@ mod tests {
     #[test]
     fn test_fix_big_q_block_rooms() {
         let mut rom = make_test_rom();
-        // Place original bytes at hook points
         rom.write_range(BIG_Q_HOOK_OFFSET, &[0xAC, 0x27, 0x07]);
         rom.write_range(BIG_Q_PRG030_HOOK, &[0xC0, 0x07, 0xD0, 0x18]);
 
         fix_big_q_block_rooms(&mut rom);
 
-        // Part A: PRG030 save trampoline
         assert_eq!(rom.read_range(BIG_Q_PRG030_HOOK, 4), &BIG_Q_PRG030_JMP);
         assert_eq!(
             rom.read_range(BIG_Q_PRG030_OFFSET, BIG_Q_PRG030_ROUTINE.len()),
             &BIG_Q_PRG030_ROUTINE
         );
-        // Spot-check: trampoline reads $65 (zp obj_lo)
-        assert_eq!(rom.read_byte(BIG_Q_PRG030_OFFSET), 0xA5);
-        assert_eq!(rom.read_byte(BIG_Q_PRG030_OFFSET + 1), 0x65);
-
-        // Part B: PRG026 lookup routine
-        assert_eq!(rom.read_range(BIG_Q_HOOK_OFFSET, 3), &BIG_Q_JSR);
         assert_eq!(
-            rom.read_range(BIG_Q_ROUTINE_OFFSET, BIG_Q_ROUTINE.len()),
-            &BIG_Q_ROUTINE
+            rom.read_range(BIG_Q_HOOK_OFFSET, 3),
+            &jsr_into_bank(26, BIG_Q_ROUTINE_OFFSET)
         );
-        // Spot-check: routine reads $7EB5 (not $7EBC)
-        assert_eq!(rom.read_byte(BIG_Q_ROUTINE_OFFSET + 1), 0xB5);
-        assert_eq!(rom.read_byte(BIG_Q_ROUTINE_OFFSET + 2), 0x7E);
-        // Spot-check: first obj_hi entry is $CD (3-5), last room index is $07 (8-1)
-        assert_eq!(rom.read_byte(BIG_Q_ROUTINE_OFFSET + 33), 0xCD);
-        assert_eq!(rom.read_byte(BIG_Q_ROUTINE_OFFSET + 65), 0x07);
+        let expected = build_lookup_routine();
+        assert_eq!(
+            rom.read_range(BIG_Q_ROUTINE_OFFSET, expected.len()),
+            expected.as_slice()
+        );
+    }
+
+    #[test]
+    fn routine_scans_current_area_before_frozen_entry() {
+        let r = build_lookup_routine();
+        assert_eq!(r.len(), BIG_Q_ROUTINE_LEN);
+        assert_eq!(&r[0..3], &[0xAD, 0xBB, 0x7E], "pass 1 LDA $7EBB");
+        assert_eq!(&r[6..9], &[0xAD, 0xBC, 0x7E], "pass 1 LDA $7EBC");
+        assert_eq!(&r[17..20], &[0xAD, 0xB4, 0x7E], "pass 2 LDA $7EB4");
+        assert_eq!(&r[23..26], &[0xAD, 0xB5, 0x7E], "pass 2 LDA $7EB5");
+        assert_eq!(&r[34..38], &[0xAC, 0x27, 0x07, 0x60], "fallback LDY $0727; RTS");
+        assert_eq!(&r[0x43..0x50], &BQ_OBJ_HI);
+        assert_eq!(&r[0x50..0x5D], &BQ_OBJ_LO);
+        assert_eq!(&r[0x5D..0x6A], &BQ_ROOM);
+    }
+
+    #[test]
+    fn jsr_target_matches_routine_origin() {
+        let base = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET);
+        let hook = jsr_into_bank(26, BIG_Q_ROUTINE_OFFSET);
+        assert_eq!(u16::from_le_bytes([hook[1], hook[2]]), base);
+        let r = build_lookup_routine();
+        assert_eq!(u16::from_le_bytes([r[13], r[14]]), base + 0x26);
     }
 }

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -16,10 +16,10 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     (0x3E965, 13, "title_screen: intro skip + menu music routine"),
     (0x3FFF0, 26, "card_speed_clear: XOR trampoline"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
-    (0x35530, 66, "big_q_block: lookup routine + tables"),
     (0x35572, 13, "mystery_anchor: item redirect trampoline"),
     (0x3557F, 50, "hammer_locks: tile check subroutine + tables"),
     (0x355B1, 12, "anchor_visuals: items-vs-cards index guard trampoline"),
+    (0x355BD, 106, "big_q_block: two-pass lookup routine + 13-entry tables (current-area then frozen entry)"),
     // PRG027 (file 0x36010, CPU $A000–$BFFF)
     (0x379D9, 894, "king_quotes: 7 quotes + hook (7×120 + 54)"),
     // PRG010 (file 0x14010, CPU $C000–$DFFF during map)
@@ -132,8 +132,9 @@ pub(crate) const GAMEOVER_FINALIZE_SITE: usize = 0x166BA;  // 3 bytes — `STA $
 // "NOTE: Assumes Index 1 is the Airship!"
 pub(crate) const AIRSHIP_OBJ_SLOT: usize = 1;
 
-// PRG026
-pub(crate) const FS_BIG_Q_LOOKUP: usize      = 0x35530; // 66 bytes
+// PRG026 — two-pass Big ? Block lookup (qol/big_q.rs), relocated off the old
+// 0x35530 slot into tail free space to hold the two-pass routine + 12 entries.
+pub(crate) const FS_BIG_Q_LOOKUP: usize      = 0x355BD; // 106 bytes (CPU $B5AD)
 
 // PRG027
 pub(crate) const FS_KING_QUOTES: usize       = 0x379D9; // 894 bytes


### PR DESCRIPTION
Cherry-picks the lobby-shuffle bonus-room fix (#132, `33b617f`) from `beta/next` onto `main` and bumps the version to **1.0.7**.

## The fix

Lobby (antechamber) shuffle could drop the player into a void when entering the Big ? Block bonus room in 5-2 or 6-9, from two independent causes:

1. **Junction-slot corruption (5-2).** The bonus room reads its arrival position from a junction slot (`Level_JctXLHStart`), and the shuffle was rewriting the command that seeds it (0x1A807, slot 4) when 5-2 hosts. 5-2 now lists only its front door 0x1A804, so the bonus slot stays vanilla.
2. **Room selection (5-2 and 6-9).** `big_q` keyed on the frozen map-entry pointer, which under lobby shuffle is the lobby's, not the level's, so it fell through to `World_Num` and picked a garbage room. The lookup is now two-pass — `Level_ObjPtrOrig` (the current area) first, then the frozen entry (for 8-1/W8 and sub-area pipes), then `World_Num` — and the table gains 6-9's interior ($C60E → room 5).

Routine grew 66 → 106 bytes; relocated 0x35530 → 0x355BD (CPU $B5AD). Verified in-emulator on both 5-2 (seed 5373658913819566) and 6-9 (seed 1).

## Cherry-pick notes

- The commit applied cleanly except `CHANGELOG.md`, where only the lobby-fix entry was kept (the rest of beta's `[Unreleased]` backlog stays on `beta/next`).
- `free_space.rs` merged cleanly on main: the new 106-byte slot at 0x355BD starts right after `anchor_visuals` (0x355B1+12) with no other claims in range.

## Release

- Version 1.0.6 → 1.0.7 (Cargo.toml/Cargo.lock), CHANGELOG entry moved into a dated [1.0.7] section.
- `cargo clippy --all-targets`: clean. `cargo test`: 291 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ftbcx3jsSCouGj9YaWEB1z