### PR TITLE
fix: builder rebuild regressions — SAS castle-top move + W3 rock-pocket pipe

### DIFF
--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -139,6 +139,7 @@ fn test_builder_schedule_runs_phases_in_order() {
         start: None,
         target: None,
         fixed: HashSet::new(),
+        hammer_gated: HashSet::new(),
         pipe_budget: 0,
         level_budget: 0,
         fort_budget: 0,

--- a/src/randomize/overworld_build/connectivity.rs
+++ b/src/randomize/overworld_build/connectivity.rs
@@ -85,14 +85,23 @@ impl Phase for Connectivity {
             actions.push(format!("pipe {near:?} <-> {far:?} (island of {} blanks)", island_candidates.len()));
         }
 
-        // Count what remains cut off — measured, not enforced.
+        // Count what remains cut off — measured, not enforced. Hammer-gated
+        // pockets are deliberately left alone, so they are reported apart
+        // from genuine stranding.
         let reach = walk_reachable(&state.grid, &state.pipe_pairs, state.start, state.world_idx);
         let stranded = blank_positions(state)
             .iter()
-            .filter(|p| !reach.contains(**p))
+            .filter(|p| !reach.contains(**p) && !state.hammer_gated.contains(p))
             .count();
         let goal_ok = state.target.is_none_or(|t| reach.contains(t));
-        actions.push(format!("done: {stranded} blanks stranded, goal reachable: {goal_ok}"));
+        let gated_note = if state.hammer_gated.is_empty() {
+            String::new()
+        } else {
+            format!(", {} hammer-gated left alone", state.hammer_gated.len())
+        };
+        actions.push(format!(
+            "done: {stranded} blanks stranded{gated_note}, goal reachable: {goal_ok}"
+        ));
 
         PhaseReport { phase: self.name(), actions }
     }
@@ -115,7 +124,9 @@ fn blank_positions(state: &WorldState) -> Vec<Pos> {
 
 /// Where to grow next: the goal's component first (a world you can't finish
 /// is the worst kind of cut off), then the first stranded blank in scan
-/// order. `None` when start is unknown or nothing is stranded.
+/// order — skipping hammer-gated pockets, which are not stranded (and, being
+/// excluded from `legal_blanks`, could never take an endpoint). `None` when
+/// start is unknown or nothing is stranded.
 fn next_island_seed(state: &WorldState, reach: &Reach, blanks: &[Pos]) -> Option<Pos> {
     state.start?;
     if let Some(target) = state.target
@@ -123,6 +134,9 @@ fn next_island_seed(state: &WorldState, reach: &Reach, blanks: &[Pos]) -> Option
     {
         return Some(target);
     }
-    blanks.iter().copied().find(|p| !reach.contains(*p))
+    blanks
+        .iter()
+        .copied()
+        .find(|p| !reach.contains(*p) && !state.hammer_gated.contains(p))
 }
 

--- a/src/randomize/overworld_build/sources.rs
+++ b/src/randomize/overworld_build/sources.rs
@@ -57,6 +57,7 @@ pub(crate) fn from_built(built: &BuiltWorld) -> WorldState {
         start: rom_data::find_start(&built.grid),
         target: find_target(&built.grid, built.world_idx),
         fixed: HashSet::new(),
+        hammer_gated: HashSet::new(),
         pipe_budget: VANILLA_PIPE_PAIRS[built.world_idx],
         level_budget: built
             .slots
@@ -100,6 +101,13 @@ pub(crate) fn from_pickup(
             grid.set(entry.grid_pos.0, entry.grid_pos.1, entry.tile);
         }
     }
+    // SAS-swapped worlds: the castle's top half ($C8) travels with the
+    // relocated airship tile, and the cell above the relocated start gets a
+    // plausible backdrop (W5 skips the castle-top write — the cell above its
+    // vanilla start is the only approach path). Stamping happens here, on
+    // the grid every phase builds on, so the non-blank $C8 also keeps
+    // placement off that cell.
+    crate::randomize::start_airship_swap::swap_tiles_above(&mut grid, world_idx, catalog);
     let start = rom_data::find_start(&grid);
     let target = find_target(&grid, world_idx);
     let fixed = fixed_positions_for_world(
@@ -124,6 +132,11 @@ pub(crate) fn from_pickup(
     } else {
         rom_data::read_hb_sprite_positions(rom, world_idx)
     };
+    let hammer_gated: HashSet<Pos> = HAMMER_GATED_POCKETS
+        .iter()
+        .filter(|(wi, _)| *wi == world_idx)
+        .map(|(_, pos)| *pos)
+        .collect();
     WorldState {
         world_idx,
         grid,
@@ -133,6 +146,7 @@ pub(crate) fn from_pickup(
         start,
         target,
         fixed,
+        hammer_gated,
         pipe_budget: VANILLA_PIPE_PAIRS[world_idx],
         level_budget,
         fort_budget,
@@ -141,6 +155,15 @@ pub(crate) fn from_pickup(
         log: Vec::new(),
     }
 }
+
+/// Lone blanks sealed off by breakable hammer rocks: `(world_idx, position)`.
+/// W3 (8,6) is the vanilla spade between two rocks — once the spade is picked
+/// up, the cell is a one-blank island that connectivity would otherwise
+/// bridge with a pipe every seed. (W6's rock at (2,13) guards a vanilla PIPE
+/// at (2,14) — deliberately NOT listed, bridging it is vanilla-faithful.)
+const HAMMER_GATED_POCKETS: &[(usize, Pos)] = &[
+    (2, (8, 6)), // W3 spade pocket between two rocks near start
+];
 
 /// Read one vanilla world from the ROM: tiles from the map grid, slots and
 /// pipe pairs from the node catalog, locks from the fortress-FX tables.
@@ -173,6 +196,7 @@ pub(crate) fn from_vanilla(rom: &Rom, catalog: &NodeCatalog, world_idx: usize) -
         start,
         target,
         fixed: HashSet::new(),
+        hammer_gated: HashSet::new(),
         pipe_budget: VANILLA_PIPE_PAIRS[world_idx],
         level_budget,
         fort_budget,

--- a/src/randomize/overworld_build/state.rs
+++ b/src/randomize/overworld_build/state.rs
@@ -26,6 +26,11 @@ pub(crate) struct WorldState {
     /// houses, airship/Bowser tiles) — input from the shared pickup/catalog
     /// phases, constant across the build.
     pub fixed: HashSet<Pos>,
+    /// Lone blanks sealed off by breakable hammer rocks (the W3 spade
+    /// pocket, see `HAMMER_GATED_POCKETS`) — terrain, not stranded islands.
+    /// Connectivity never bridges them and no phase claims them; they stay
+    /// empty hammer-gated nooks.
+    pub hammer_gated: HashSet<Pos>,
     /// Hard limit on pipe pairs in this world — currently the vanilla
     /// per-world count, a chosen design budget (not an inherent ROM limit;
     /// it may be raised later). All pipe-placing phases share it: whatever
@@ -82,12 +87,12 @@ impl WorldState {
     }
 
     /// Blanks a phase may claim for new content: blank tile, not `fixed`,
-    /// not already a slot, and not the row-7/8 completion-bit partner of
-    /// existing content OR of a lock (rows 7 and 8 share one completion bit
-    /// per column — a ROM mechanic; stacked completable content marks each
-    /// other beaten, and a lock consumes that shared bit too). The lock
-    /// barring only matters to the shaping moves — the dumb placement
-    /// phases all run before any lock exists.
+    /// not already a slot, not a hammer-gated pocket, and not the row-7/8
+    /// completion-bit partner of existing content OR of a lock (rows 7 and 8
+    /// share one completion bit per column — a ROM mechanic; stacked
+    /// completable content marks each other beaten, and a lock consumes that
+    /// shared bit too). The lock barring only matters to the shaping moves —
+    /// the dumb placement phases all run before any lock exists.
     pub(crate) fn legal_blanks(&self) -> Vec<Pos> {
         let taken: HashSet<Pos> = self.slots.iter().map(|s| s.pos).collect();
         let barred: HashSet<Pos> = self
@@ -104,6 +109,7 @@ impl WorldState {
                     && !self.fixed.contains(&pos)
                     && !taken.contains(&pos)
                     && !barred.contains(&pos)
+                    && !self.hammer_gated.contains(&pos)
                 {
                     out.push(pos);
                 }


### PR DESCRIPTION
Two regressions from the choice-first rebuild (#133), caught in playtest.

## 1. SAS castle-top no longer moved with the airship

`from_pickup` stamps the swapped Start/Airship tiles back onto the grid but never called `swap_tiles_above` — that call only survived inside `prepare_capacities`, whose patched grids the rebuild discards (only the capacity numbers are kept). Result: in every SAS-swapped world the castle entrance moved but the `$C8` top half stayed floating above the new start.

Fix: `from_pickup` calls `swap_tiles_above` on the grid every phase builds on. The W5 exception (its vanilla start is approached from above, so the castle-top write is skipped there) lives inside that function and rides along unchanged.

## 2. W3 spade pocket always got a pipe

The vanilla W3 spade at (8,6) sits between two hammer rocks. Once spade shuffle picks it up, the cell is a one-blank island and the connectivity phase bridged it with a pipe **every seed** — the old builder's `PIPE_EXCLUDED_POSITIONS` list died with `pipes.rs`.

Fix: restored as a hard-coded `HAMMER_GATED_POCKETS` list feeding `WorldState.hammer_gated` — never an island seed, never a legal blank, counted apart from genuine stranding in the connectivity report. W6's rock-guarded cell (2,14) is deliberately **not** listed: vanilla puts a pipe behind that rock, so bridging it is vanilla-faithful (and rock-required progression is impossible regardless — the reachability walker treats rocks as walls, so `completable()` rejects any layout leaning on one).

## Verification

- 10-seed SAS ROM sweep: castle top moved in every swapped world (36/36 checks), W5 exception intact, W3 pocket empty in all seeds, W6 rock-pipe present in all seeds
- Connectivity census and full builder metrics census (C1 / linear% / routes / goal-open) identical to baseline
- `cargo test` (311 tests) green, `cargo clippy --all-targets -- -D warnings` clean
- Note: the builder censuses run spades-off, so the pocket case is only visible in ROM-level seed dumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ftbcx3jsSCouGj9YaWEB1z