### PR TITLE
feature: island-aware pipe placement — W7 49→27% linear, W8 11→4%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ deploys.
 
 ### Changed
 
-- Pipe-fragmented worlds (World 7 especially) are less often a single
-  forced corridor: the builder now wires one extra pipe as a loop between
-  walk pockets and balances level costs across the loop's arms — the same
-  two-parallel-arms structure vanilla World 7 ships. W7 all-linear layouts
-  drop from ~49% to ~39% of seeds.
+- Pipe-fragmented worlds (Worlds 7 and 8 especially) are much less often a
+  single forced corridor: the builder now understands island anatomy —
+  pipe mouths on an island land far apart so routes cross its interior, a
+  loop gets wired between islands, and level costs are balanced across the
+  loop's arms — the same two-tied-arms structure vanilla World 7 ships.
+  All-linear layouts drop from ~49% to ~27% of seeds in W7 and ~11% to
+  ~4% in W8.
 
 - The overworld builder was replaced with the choice-first rebuild: knob-free
   placement (connectivity, levels, forts, locks) plus a diagnosis-driven

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ deploys.
 
 ### Changed
 
+- Pipe-fragmented worlds (World 7 especially) are less often a single
+  forced corridor: the builder now wires one extra pipe as a loop between
+  walk pockets and balances level costs across the loop's arms — the same
+  two-parallel-arms structure vanilla World 7 ships. W7 all-linear layouts
+  drop from ~49% to ~39% of seeds.
+
 - The overworld builder was replaced with the choice-first rebuild: knob-free
   placement (connectivity, levels, forts, locks) plus a diagnosis-driven
   shaping loop with pipe-web redeals. Every world now guarantees a minimum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ deploys.
 
 ## [Unreleased]
 
+### Fixed
+
+- Levels no longer pile up back-to-back in one corner of the map: level
+  placement (and the shaping moves that relocate levels) now avoid putting
+  a level next to another whenever the map allows. Worlds with 4+ levels
+  chained in a row drop from ~1 in 6 to ~1 in 50, and route choice
+  improved as a side effect (spread levels fork more).
+
 ### Changed
 
 - Pipe-fragmented worlds (Worlds 7 and 8 especially) are much less often a

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -1688,6 +1688,10 @@ fn test_builder_w7_probe() {
         pocket_cycles_multi_sum: usize,
         trunk_blanks_sum: usize,
         trunk_levels_sum: usize,
+        noalt_probe: usize,
+        noalt_with_detour: usize,
+        noalt_exclusive: usize,
+        noalt_goldable: usize,
     }
 
     let mut arms: std::collections::BTreeMap<Pos, T> = std::collections::BTreeMap::new();
@@ -1830,6 +1834,35 @@ fn test_builder_w7_probe() {
                 .count();
         }
 
+        // Golden-lock feasibility on NOALT seeds: does a dominated detour
+        // exist within the wide window, and does the cheap route's
+        // exclusive stretch vs that detour contain a LOCKABLE tile? (If
+        // yes, a lock on that edge would split the pair; if the stretch is
+        // empty or unlockable, only new topology can help.)
+        if wide.routes.len() < 2 {
+            t.noalt_probe += 1;
+            if let Some(d) = wide.detours.first() {
+                t.noalt_with_detour += 1;
+                let dpath: HashSet<Pos> = d.path.iter().copied().collect();
+                let exclusive: Vec<Pos> = wide
+                    .routes
+                    .first()
+                    .map(|r| {
+                        r.path.iter().copied().filter(|p| !dpath.contains(p)).collect()
+                    })
+                    .unwrap_or_default();
+                if !exclusive.is_empty() {
+                    t.noalt_exclusive += 1;
+                }
+                if exclusive
+                    .iter()
+                    .any(|&(r, c)| LOCKABLE_TILES.contains(&grid.get(r, c)))
+                {
+                    t.noalt_goldable += 1;
+                }
+            }
+        }
+
         // Render the first couple of NOALT worlds per arm for eyeballing,
         // with their shaping logs.
         if wide.routes.len() < 2 && t.renders < 2 {
@@ -1872,9 +1905,13 @@ fn test_builder_w7_probe() {
             t.blanks_sum as f64 / n,
         );
         println!(
-            "        trunk-blanks {:.2}  trunk-levels {:.2}",
+            "        trunk-blanks {:.2}  trunk-levels {:.2}  noalt breakdown: {} total / {} with detour / {} any-exclusive-tile / {} lockable-exclusive-edge",
             t.trunk_blanks_sum as f64 / n,
             t.trunk_levels_sum as f64 / n,
+            t.noalt_probe,
+            t.noalt_with_detour,
+            t.noalt_exclusive,
+            t.noalt_goldable,
         );
         println!(
             "        pockets {:.2}  max-pocket {:.1}  pipes cross {:.2} intra {:.2}  doubled {:.2}  pocket-cycles {:.2} (linear {:.2} / multi {:.2})",

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -724,6 +724,14 @@ fn test_builder_shaping_census() {
         locks: usize,
         goal_open: usize,
         pipes: usize,
+        // Adjacent-level pairs (orthogonal 2-tile neighbors — visually
+        // stacked levels) — the clustering the playtest flagged.
+        adjacent_levels: usize,
+        // Largest connected chain of adjacent levels: sum (for the mean),
+        // worst seed, and how many seeds have a chain of 4+ levels.
+        chain_sum: usize,
+        chain_worst: usize,
+        chain4: usize,
     }
 
     impl Default for ArmTally {
@@ -744,6 +752,10 @@ fn test_builder_shaping_census() {
                 locks: 0,
                 goal_open: 0,
                 pipes: 0,
+                adjacent_levels: 0,
+                chain_sum: 0,
+                chain_worst: 0,
+                chain4: 0,
             }
         }
     }
@@ -776,6 +788,47 @@ fn test_builder_shaping_census() {
         t.goal_gates += state.goal_gate_locks();
         t.locks += state.locks.len();
         t.pipes += state.pipe_pairs.len();
+        let levels: Vec<Pos> = state
+            .slots
+            .iter()
+            .filter(|s| s.kind == SlotKind::Level)
+            .map(|s| s.pos)
+            .collect();
+        let adjacent = |a: Pos, b: Pos| {
+            let (dr, dc) = (a.0.abs_diff(b.0), a.1.abs_diff(b.1));
+            (dr == 2 && dc == 0) || (dr == 0 && dc == 2)
+        };
+        for (i, &a) in levels.iter().enumerate() {
+            for &b in &levels[i + 1..] {
+                if adjacent(a, b) {
+                    t.adjacent_levels += 1;
+                }
+            }
+        }
+        // Largest connected chain under the same adjacency.
+        let mut comp: Vec<usize> = (0..levels.len()).collect();
+        for i in 0..levels.len() {
+            for j in i + 1..levels.len() {
+                if adjacent(levels[i], levels[j]) {
+                    let (mut ri, mut rj) = (i, j);
+                    while comp[ri] != ri { ri = comp[ri]; }
+                    while comp[rj] != rj { rj = comp[rj]; }
+                    comp[ri] = rj;
+                }
+            }
+        }
+        let mut sizes: HashMap<usize, usize> = HashMap::new();
+        for i in 0..levels.len() {
+            let mut r = i;
+            while comp[r] != r { r = comp[r]; }
+            *sizes.entry(r).or_default() += 1;
+        }
+        let max_chain = sizes.values().copied().max().unwrap_or(0);
+        t.chain_sum += max_chain;
+        t.chain_worst = t.chain_worst.max(max_chain);
+        if max_chain >= 4 {
+            t.chain4 += 1;
+        }
     }
 
     let mut dumb = [ArmTally::default(); 8];
@@ -871,7 +924,7 @@ fn test_builder_shaping_census() {
     for world_idx in 0..8 {
         for (arm, t) in [("dumb", &dumb[world_idx]), ("shaped", &shaped[world_idx])] {
             let base = format!(
-                "  W{}   {arm:<7} {:>7.1} {:>6} {:>6.0}% {:>7.2} {:>7.0}% {:>5.2} {:>6.2} {:>6.0}% {:>9.0}% {:>5.2} {:>9.0}% {:>6.2}",
+                "  W{}   {arm:<7} {:>7.1} {:>6} {:>6.0}% {:>7.2} {:>7.0}% {:>5.2} {:>6.2} {:>6.0}% {:>9.0}% {:>5.2} {:>9.0}% {:>6.2} adjL={:.2}",
                 world_idx + 1,
                 t.c1 as f64 / n,
                 t.c1_min,
@@ -885,6 +938,12 @@ fn test_builder_shaping_census() {
                 t.goal_gates as f64 / n,
                 100.0 * t.goal_open as f64 / n,
                 t.pipes as f64 / n,
+                t.adjacent_levels as f64 / n,
+            ) + &format!(
+                " chain={:.2}/max{}/4+{:.0}%",
+                t.chain_sum as f64 / n,
+                t.chain_worst,
+                100.0 * t.chain4 as f64 / n,
             );
             if arm == "shaped" {
                 println!(

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -1639,6 +1639,74 @@ fn test_builder_bridge_lock_rate() {
     }
 }
 
+/// Pin the island anatomy the role model is calibrated on (user design
+/// review 2026-08-01): vanilla orientation, base QOL map. A map edit or
+/// walker change that silently shifts the decomposition fails here first.
+#[test]
+fn test_builder_island_roles() {
+    let Some(raw) = load_rom() else {
+        eprintln!("ROM not found, skipping");
+        return;
+    };
+    use super::islands::IslandRole::{Corridor, Entry, Final, Routing, Utility};
+    let rom = base_qol(&raw);
+    let catalog = NodeCatalog::build(&rom, false);
+    // Toad-house / hammer-bro shuffle ON: those tiles get picked up as
+    // placeable blanks, which is the anatomy the role model was calibrated
+    // on (the flags-off variant shrinks three W7 islands by one tile each).
+    let pickup = pick_up(
+        &rom,
+        &catalog,
+        PickupFlags {
+            shuffle_spade_games: false,
+            shuffle_toad_houses: true,
+            shuffle_hammer_bros: true,
+        },
+    );
+    let flags = BuildFlags {
+        shuffle_toad_houses: true,
+        eights_are_wild: false,
+        shuffle_hammer_bros: true,
+    };
+    let sizes_roles = |world_idx: usize| {
+        let state = from_pickup(&rom, &catalog, &pickup, world_idx, &flags);
+        let (pocket, count) = super::islands::pocket_map(&state);
+        let islands = super::islands::classify(&state, &pocket, count);
+        let mut v: Vec<(usize, super::islands::IslandRole)> =
+            islands.iter().map(|i| (i.size, i.role)).collect();
+        v.sort_unstable_by_key(|&(n, _)| n);
+        v
+    };
+
+    // W7 — the full taxonomy: troll pipe (1), fort/utility slot (2),
+    // corridor (4), start (6 = start tile + 5 placeable), two routing
+    // hubs (8, 9), final island with space (13).
+    assert_eq!(
+        sizes_roles(6),
+        vec![
+            (1, Utility),
+            (2, Utility),
+            (4, Corridor),
+            (6, Entry),
+            (8, Routing),
+            (9, Routing),
+            (13, Final),
+        ],
+    );
+    // W5 — the spiral-tower split: twin big islands, roles taken by
+    // start/target rather than size.
+    let w5 = sizes_roles(4);
+    assert_eq!(w5.len(), 2);
+    assert!(w5.iter().any(|&(_, r)| r == Entry) && w5.iter().any(|&(_, r)| r == Final));
+    // Single-island worlds: the role machinery has nothing to do.
+    assert_eq!(sizes_roles(0).len(), 1);
+    assert_eq!(sizes_roles(1).len(), 1);
+    // W8 — fragmented but with a single big routing hub.
+    let w8 = sizes_roles(7);
+    assert_eq!(w8.len(), 5);
+    assert_eq!(w8.iter().filter(|&&(_, r)| r == Routing).count(), 2);
+}
+
 /// TEMP DIAGNOSTIC (W7 linearity investigation): shaped-arm results for one
 /// world, split by start position (i.e. SAS orientation), with walk-graph
 /// geometry per seed — cycle rank (independent cycles in the final walk
@@ -1692,6 +1760,9 @@ fn test_builder_w7_probe() {
         noalt_with_detour: usize,
         noalt_exclusive: usize,
         noalt_goldable: usize,
+        start_mouths_sum: usize,
+        start_mouths_linear_sum: usize,
+        start_mouths_multi_sum: usize,
     }
 
     let mut arms: std::collections::BTreeMap<Pos, T> = std::collections::BTreeMap::new();
@@ -1785,7 +1856,29 @@ fn test_builder_w7_probe() {
         // links — cycles that thread 3+ pockets (the rebalanceable kind).
         let pocket_cycles = (pair_edges.len() + 1).saturating_sub(sizes.len());
 
+        // Pipe mouths that landed on the START island — the user's
+        // shortcut-concentration question.
+        let start_root = state
+            .start
+            .and_then(|s| index.get(&s).copied())
+            .map(|i| find(&mut comp, i));
+        let start_mouths = built
+            .pipe_pairs
+            .iter()
+            .flat_map(|&(a, b)| [a, b])
+            .filter(|p| {
+                index.get(p).copied().map(|i| find(&mut comp, i)) == start_root
+                    && start_root.is_some()
+            })
+            .count();
+
         let t = arms.entry(state.start.unwrap_or((0, 0))).or_default();
+        t.start_mouths_sum += start_mouths;
+        if m.routes_in_band < 2 {
+            t.start_mouths_linear_sum += start_mouths;
+        } else {
+            t.start_mouths_multi_sum += start_mouths;
+        }
         t.pockets_sum += pockets;
         t.max_pocket_sum += max_pocket;
         t.cross_sum += cross;
@@ -1923,6 +2016,40 @@ fn test_builder_w7_probe() {
             t.pocket_cycles_sum as f64 / n,
             t.pocket_cycles_linear_sum as f64 / t.linear.max(1) as f64,
             t.pocket_cycles_multi_sum as f64 / t.multi.max(1) as f64,
+        );
+        println!(
+            "        start-island pipe mouths {:.2} (linear {:.2} / multi {:.2})",
+            t.start_mouths_sum as f64 / n,
+            t.start_mouths_linear_sum as f64 / t.linear.max(1) as f64,
+            t.start_mouths_multi_sum as f64 / t.multi.max(1) as f64,
+        );
+    }
+
+    // One-time island inventory of the fresh (pre-placement) map: size,
+    // whether it holds the start / target, and its bridge-tile count.
+    let ctx = census_ctx(&raw, 0);
+    let fresh = ctx.world(world_idx);
+    let (pocket, count) = super::islands::pocket_map(&fresh);
+    println!("fresh W{world} island inventory ({count} islands):");
+    for id in 0..count {
+        let members: Vec<Pos> = pocket
+            .iter()
+            .filter(|&(_, &p)| p == id)
+            .map(|(&pos, _)| pos)
+            .collect();
+        let bridges = members
+            .iter()
+            .filter(|&&(r, c)| [0xB3u8, 0xB1, 0xB2].contains(&fresh.grid.get(r, c)))
+            .count();
+        let mut sorted = members.clone();
+        sorted.sort_unstable();
+        println!(
+            "  island {id}: {} tiles, start={} target={} bridges={} members={:?}",
+            members.len(),
+            fresh.start.is_some_and(|s| pocket.get(&s) == Some(&id)),
+            fresh.target.is_some_and(|t| pocket.get(&t) == Some(&id)),
+            bridges,
+            sorted,
         );
     }
 }

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -1686,6 +1686,8 @@ fn test_builder_w7_probe() {
         pocket_cycles_sum: usize,
         pocket_cycles_linear_sum: usize,
         pocket_cycles_multi_sum: usize,
+        trunk_blanks_sum: usize,
+        trunk_levels_sum: usize,
     }
 
     let mut arms: std::collections::BTreeMap<Pos, T> = std::collections::BTreeMap::new();
@@ -1812,6 +1814,21 @@ fn test_builder_w7_probe() {
         t.nodes_sum += v;
         t.dist_sum += dist;
         t.blanks_sum += state.legal_blanks().len();
+        // Free blanks the cheap route walks THROUGH — the only tiles
+        // arm_balance / level_move can use to discriminate routes.
+        if let Some(r) = m.rc.routes.first() {
+            let path: HashSet<Pos> = r.path.iter().copied().collect();
+            t.trunk_blanks_sum += state
+                .legal_blanks()
+                .iter()
+                .filter(|p| path.contains(*p))
+                .count();
+            t.trunk_levels_sum += state
+                .slots
+                .iter()
+                .filter(|s| s.kind == SlotKind::Level && path.contains(&s.pos))
+                .count();
+        }
 
         // Render the first couple of NOALT worlds per arm for eyeballing,
         // with their shaping logs.
@@ -1853,6 +1870,11 @@ fn test_builder_w7_probe() {
             t.nodes_sum as f64 / n,
             t.dist_sum as f64 / n,
             t.blanks_sum as f64 / n,
+        );
+        println!(
+            "        trunk-blanks {:.2}  trunk-levels {:.2}",
+            t.trunk_blanks_sum as f64 / n,
+            t.trunk_levels_sum as f64 / n,
         );
         println!(
             "        pockets {:.2}  max-pocket {:.1}  pipes cross {:.2} intra {:.2}  doubled {:.2}  pocket-cycles {:.2} (linear {:.2} / multi {:.2})",

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -783,6 +783,8 @@ fn test_builder_shaping_census() {
     let mut touched = [0usize; 8];
     let mut lr_acc = [0usize; 8];
     let mut lr_rej = [0usize; 8];
+    let mut ab_acc = [0usize; 8];
+    let mut ab_rej = [0usize; 8];
     let mut gs_acc = [0usize; 8];
     let mut gs_rej = [0usize; 8];
     let mut fl_acc = [0usize; 8];
@@ -840,12 +842,15 @@ fn test_builder_shaping_census() {
                     .count()
             };
             let la = count("lock_replace ACCEPT");
+            let aa = count("arm_balance ACCEPT");
             let ga = count("gated_shortcut ACCEPT");
             let fa = count("fort_lock ACCEPT");
             let ma = count("level_move ACCEPT");
             let pa = count("pipe_move ACCEPT");
             lr_acc[world_idx] += la;
             lr_rej[world_idx] += count("lock_replace REJECT");
+            ab_acc[world_idx] += aa;
+            ab_rej[world_idx] += count("arm_balance REJECT");
             gs_acc[world_idx] += ga;
             gs_rej[world_idx] += count("gated_shortcut REJECT");
             fl_acc[world_idx] += fa;
@@ -854,14 +859,14 @@ fn test_builder_shaping_census() {
             lm_rej[world_idx] += count("level_move REJECT");
             pm_acc[world_idx] += pa;
             pm_rej[world_idx] += count("pipe_move REJECT");
-            if la + ga + fa + ma + pa > 0 {
+            if la + aa + ga + fa + ma + pa > 0 {
                 touched[world_idx] += 1;
             }
         }
     }
 
     println!("shaping A/B census ({seeds} seeds, dumb skeleton vs diagnosis-driven shaping, flag-mix arms)");
-    println!("world  arm     C1(mean)  C1min  C1<12%  routes  linear%  uniq  C2-C1  noalt%  zero-gate%  gGate  goal-open%  pipes  touched%  lr(acc:rej)  gs(acc:rej)  fl(acc:rej)  lm(acc:rej)  pm(acc:rej)  redeals");
+    println!("world  arm     C1(mean)  C1min  C1<12%  routes  linear%  uniq  C2-C1  noalt%  zero-gate%  gGate  goal-open%  pipes  touched%  lr(acc:rej)  ab(acc:rej)  gs(acc:rej)  fl(acc:rej)  lm(acc:rej)  pm(acc:rej)  redeals");
     let n = seeds as f64;
     for world_idx in 0..8 {
         for (arm, t) in [("dumb", &dumb[world_idx]), ("shaped", &shaped[world_idx])] {
@@ -883,10 +888,12 @@ fn test_builder_shaping_census() {
             );
             if arm == "shaped" {
                 println!(
-                    "{base} {:>7.0}% {:>8}:{:<4} {:>6}:{:<4} {:>6}:{:<4} {:>6}:{:<4} {:>6}:{:<4} {:>6}",
+                    "{base} {:>7.0}% {:>8}:{:<4} {:>6}:{:<4} {:>6}:{:<4} {:>6}:{:<4} {:>6}:{:<4} {:>6}:{:<4} {:>6}",
                     100.0 * touched[world_idx] as f64 / n,
                     lr_acc[world_idx],
                     lr_rej[world_idx],
+                    ab_acc[world_idx],
+                    ab_rej[world_idx],
                     gs_acc[world_idx],
                     gs_rej[world_idx],
                     fl_acc[world_idx],
@@ -898,7 +905,7 @@ fn test_builder_shaping_census() {
                     redeals[world_idx],
                 );
             } else {
-                println!("{base}        -        -         -         -         -         -        -");
+                println!("{base}        -        -         -         -         -         -         -        -");
             }
         }
     }
@@ -1453,6 +1460,7 @@ fn test_builder_probe_vanilla_world() {
     for d in &rc.detours {
         println!("  dominated:  cost={:2} levels={} forts={} rocks={}", d.cost, d.levels.len(), d.forts, d.rocks.len());
     }
+    println!("{}", route_choice::render_route_choice(&state.to_built(), slack));
 }
 
 /// PRODUCTION-OUTPUT invariants, on the real `build()` (post promotions and
@@ -1627,6 +1635,235 @@ fn test_builder_bridge_lock_rate() {
             100.0 * bridge_locks[w] as f64 / total_locks[w].max(1) as f64,
             worlds_with_bridge_tile[w],
             seeds,
+        );
+    }
+}
+
+/// TEMP DIAGNOSTIC (W7 linearity investigation): shaped-arm results for one
+/// world, split by start position (i.e. SAS orientation), with walk-graph
+/// geometry per seed — cycle rank (independent cycles in the final walk
+/// graph; 0 = tree = no parallel routes possible), node count, start→goal
+/// hops, and leftover blanks. `CENSUS_WORLD` (default 7), `CENSUS_SEEDS`
+/// (default 200).
+#[test]
+fn test_builder_w7_probe() {
+    let Some(raw) = load_rom() else {
+        eprintln!("ROM not found, skipping");
+        return;
+    };
+    let seeds: u64 = std::env::var("CENSUS_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(200);
+    let world: usize = std::env::var("CENSUS_WORLD")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(7);
+    let world_idx = world - 1;
+
+    #[derive(Default)]
+    struct T {
+        n: usize,
+        linear: usize,
+        noalt: usize,
+        c1: u64,
+        routes: usize,
+        uniq: f64,
+        multi: usize,
+        beta_sum: usize,
+        beta_linear_sum: usize,
+        beta_multi_sum: usize,
+        beta_zero: usize,
+        nodes_sum: usize,
+        dist_sum: usize,
+        blanks_sum: usize,
+        renders: usize,
+        pockets_sum: usize,
+        max_pocket_sum: usize,
+        cross_sum: usize,
+        intra_sum: usize,
+        doubled_sum: usize,
+        pocket_cycles_sum: usize,
+        pocket_cycles_linear_sum: usize,
+        pocket_cycles_multi_sum: usize,
+    }
+
+    let mut arms: std::collections::BTreeMap<Pos, T> = std::collections::BTreeMap::new();
+
+    for seed in 0..seeds {
+        let ctx = census_ctx(&raw, seed);
+        let mut state = ctx.world(world_idx);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        run_shaped_with_web_retries(&mut state, &mut rng);
+
+        let m = measure_world(&state);
+        let built = state.to_built();
+        let wide = analyze_route_choice(&built, SHAPING_SLACK);
+
+        // Replicate route_choice::stage_grid: open breakable rocks, stamp slots.
+        let mut grid = built.grid.clone();
+        for r in 0..grid.rows() {
+            for c in 0..grid.cols {
+                let t = grid.get(r, c);
+                for (closed, open) in [(0x51u8, 0x45u8), (0x52, 0x46)] {
+                    if t == closed {
+                        grid.set(r, c, open);
+                    }
+                }
+            }
+        }
+        types::stamp_slots(&mut grid, &built.slots);
+        let start = rom_data::find_start(&grid).expect("start");
+        let target = find_target(&grid, world_idx).expect("target");
+        let walk = walk_map(&grid, &built.pipe_pairs, Some(start), world_idx);
+
+        // Undirected edge count: each symmetric edge is recorded once per
+        // endpoint; the target sink never expands, so its edges appear once.
+        let directed: usize = walk.edges.values().map(Vec::len).sum();
+        let v = walk.nodes.len();
+        let e = directed.div_ceil(2);
+        let beta = (e + 1).saturating_sub(v);
+        let dist = walk.distances.get(&target).copied().unwrap_or(999);
+
+        // Pocket structure: connected components over WALK edges only
+        // (path_pos Some — teleport edges excluded). Then classify each pipe
+        // pair: cross-pocket (a mandatory chain link) vs intra-pocket (adds a
+        // cycle the domination filter usually eats).
+        let node_list: Vec<Pos> = walk.nodes.iter().copied().collect();
+        let index: std::collections::HashMap<Pos, usize> =
+            node_list.iter().enumerate().map(|(i, &p)| (p, i)).collect();
+        let mut comp: Vec<usize> = (0..node_list.len()).collect();
+        fn find(comp: &mut Vec<usize>, i: usize) -> usize {
+            if comp[i] != i {
+                let root = find(comp, comp[i]);
+                comp[i] = root;
+            }
+            comp[i]
+        }
+        for (from, edges) in &walk.edges {
+            for edge in edges {
+                if edge.path_pos.is_some()
+                    && let (Some(&a), Some(&b)) = (index.get(from), index.get(&edge.dest))
+                {
+                    let (ra, rb) = (find(&mut comp, a), find(&mut comp, b));
+                    comp[ra] = rb;
+                }
+            }
+        }
+        let mut sizes: std::collections::HashMap<usize, usize> =
+            std::collections::HashMap::new();
+        for i in 0..node_list.len() {
+            *sizes.entry(find(&mut comp, i)).or_default() += 1;
+        }
+        let pockets = sizes.len();
+        let max_pocket = sizes.values().copied().max().unwrap_or(0);
+        let mut cross = 0;
+        let mut intra = 0;
+        let mut pair_edges: std::collections::HashSet<(usize, usize)> =
+            std::collections::HashSet::new();
+        let mut doubled = 0;
+        for &(a, b) in &built.pipe_pairs {
+            if let (Some(&ia), Some(&ib)) = (index.get(&a), index.get(&b)) {
+                let (ra, rb) = (find(&mut comp, ia), find(&mut comp, ib));
+                if ra == rb {
+                    intra += 1;
+                } else {
+                    cross += 1;
+                    if !pair_edges.insert((ra.min(rb), ra.max(rb))) {
+                        doubled += 1;
+                    }
+                }
+            }
+        }
+        // Cycle rank of the pocket graph counting only DISTINCT pocket-pair
+        // links — cycles that thread 3+ pockets (the rebalanceable kind).
+        let pocket_cycles = (pair_edges.len() + 1).saturating_sub(sizes.len());
+
+        let t = arms.entry(state.start.unwrap_or((0, 0))).or_default();
+        t.pockets_sum += pockets;
+        t.max_pocket_sum += max_pocket;
+        t.cross_sum += cross;
+        t.intra_sum += intra;
+        t.doubled_sum += doubled;
+        t.pocket_cycles_sum += pocket_cycles;
+        if m.routes_in_band < 2 {
+            t.pocket_cycles_linear_sum += pocket_cycles;
+        } else {
+            t.pocket_cycles_multi_sum += pocket_cycles;
+        }
+        t.n += 1;
+        t.c1 += u64::from(m.c1);
+        t.routes += m.routes_in_band;
+        if m.routes_in_band < 2 {
+            t.linear += 1;
+            t.beta_linear_sum += beta;
+        } else {
+            t.multi += 1;
+            t.uniq += m.mean_exclusive_levels;
+            t.beta_multi_sum += beta;
+        }
+        if wide.routes.len() < 2 {
+            t.noalt += 1;
+        }
+        if beta == 0 {
+            t.beta_zero += 1;
+        }
+        t.beta_sum += beta;
+        t.nodes_sum += v;
+        t.dist_sum += dist;
+        t.blanks_sum += state.legal_blanks().len();
+
+        // Render the first couple of NOALT worlds per arm for eyeballing,
+        // with their shaping logs.
+        if wide.routes.len() < 2 && t.renders < 2 {
+            t.renders += 1;
+            println!(
+                "--- seed {seed} W{world} start {:?} C1 {} beta {beta} (NOALT) ---",
+                state.start.unwrap_or((0, 0)),
+                m.c1
+            );
+            println!("{}", route_choice::render_route_choice(&built, SHAPING_SLACK));
+            for report in &state.log {
+                if report.phase == "shaping" {
+                    for action in &report.actions {
+                        println!("    [{}] {action}", report.phase);
+                    }
+                }
+            }
+        }
+    }
+
+    println!("W{world} probe ({seeds} seeds, shaped arm, split by start pos):");
+    println!("start      n  linear%  noalt%  C1    routes  uniq  beta  beta(lin)  beta(multi)  beta0%  nodes  dist  blanks  pockets  maxpkt  pipes(cross:intra)");
+    for (start, t) in &arms {
+        let n = t.n as f64;
+        println!(
+            "{:>7?} {:>4} {:>7.0}% {:>6.0}% {:>5.1} {:>6.2} {:>5.2} {:>5.2} {:>9.2} {:>11.2} {:>6.0}% {:>6.1} {:>5.1} {:>6.1}",
+            start,
+            t.n,
+            100.0 * t.linear as f64 / n,
+            100.0 * t.noalt as f64 / n,
+            t.c1 as f64 / n,
+            t.routes as f64 / n,
+            t.uniq / t.multi.max(1) as f64,
+            t.beta_sum as f64 / n,
+            t.beta_linear_sum as f64 / t.linear.max(1) as f64,
+            t.beta_multi_sum as f64 / t.multi.max(1) as f64,
+            100.0 * t.beta_zero as f64 / n,
+            t.nodes_sum as f64 / n,
+            t.dist_sum as f64 / n,
+            t.blanks_sum as f64 / n,
+        );
+        println!(
+            "        pockets {:.2}  max-pocket {:.1}  pipes cross {:.2} intra {:.2}  doubled {:.2}  pocket-cycles {:.2} (linear {:.2} / multi {:.2})",
+            t.pockets_sum as f64 / n,
+            t.max_pocket_sum as f64 / n,
+            t.cross_sum as f64 / n,
+            t.intra_sum as f64 / n,
+            t.doubled_sum as f64 / n,
+            t.pocket_cycles_sum as f64 / n,
+            t.pocket_cycles_linear_sum as f64 / t.linear.max(1) as f64,
+            t.pocket_cycles_multi_sum as f64 / t.multi.max(1) as f64,
         );
     }
 }

--- a/src/randomize/overworld_build/connectivity.rs
+++ b/src/randomize/overworld_build/connectivity.rs
@@ -18,6 +18,17 @@
 //! price back up), with a full-set fallback when an island has no clear
 //! candidate, because bridging outranks the bar.
 //!
+//! One structural addition after bridging: the LOOP CLOSER. Spanning
+//! bridges alone leave the pocket graph a tree — every route threads the
+//! same pocket sequence, so no second route can exist no matter where
+//! later phases put content (W7 census 2026-08-01: ~45% linear, and
+//! choice tracked the cycles spare pipes closed by accident; vanilla W7
+//! wires the same 8 pipes into a loop with two arms tied at cost 35).
+//! When the world had 2+ pockets and budget remains, ONE extra pair goes
+//! between two pockets that aren't already directly linked, turning the
+//! tree into a loop the shaping rungs can price. Endpoints stay
+//! uniform-random over the legal candidates.
+//!
 //! Not hard rules, by design: a world can end this phase with unreachable
 //! blanks (an island whose every blank is `fixed` has no legal endpoint, or
 //! the pipe budget runs out first). The phase reports what it couldn't do;
@@ -85,6 +96,46 @@ impl Phase for Connectivity {
             actions.push(format!("pipe {near:?} <-> {far:?} (island of {} blanks)", island_candidates.len()));
         }
 
+        // Loop closer: one pair between two pockets with no direct link yet
+        // (see module doc). Purely optional — no fallback past the anchor
+        // bar, and single-pocket worlds skip it (their pipes are all free
+        // routing ammo already). A stricter "leave shortcut headroom" rule
+        // was tried and reverted: it only ever throttled W7 (the world the
+        // loop is FOR — census 2026-08-01, linear 40% -> 44%), while the
+        // world it meant to protect (W8) never fires the closer at all
+        // (its extra pockets have no legal endpoints).
+        if state.pipe_pairs.len() < state.pipe_budget {
+            let (pocket, pocket_count) = pocket_map(state);
+            if pocket_count >= 2 {
+                let linked = linked_pocket_pairs(&pocket, &state.pipe_pairs);
+                let legal: Vec<Pos> = state
+                    .legal_blanks()
+                    .into_iter()
+                    .filter(|&p| !state.near_anchor(p))
+                    .collect();
+                let mut cands: Vec<(Pos, Pos)> = Vec::new();
+                for (i, &a) in legal.iter().enumerate() {
+                    let Some(&pa) = pocket.get(&a) else { continue };
+                    for &b in &legal[i + 1..] {
+                        let Some(&pb) = pocket.get(&b) else { continue };
+                        if pa != pb
+                            && !linked.contains(&(pa.min(pb), pa.max(pb)))
+                            && Some(b) != row78_partner(a)
+                        {
+                            cands.push((a, b));
+                        }
+                    }
+                }
+                if let Some(&(a, b)) = cands.choose(rng) {
+                    state.add_pipe_pair(a, b);
+                    actions.push(format!(
+                        "loop pipe {a:?} <-> {b:?} (pockets {} <-> {} of {pocket_count})",
+                        pocket[&a], pocket[&b],
+                    ));
+                }
+            }
+        }
+
         // Count what remains cut off — measured, not enforced. Hammer-gated
         // pockets are deliberately left alone, so they are reported apart
         // from genuine stranding.
@@ -120,6 +171,60 @@ fn blank_positions(state: &WorldState) -> Vec<Pos> {
         }
     }
     blanks
+}
+
+/// Pocket decomposition: connected components of the walk network with NO
+/// pipe edges. Canoe edges still count when the canonical walker says they
+/// do (dock walk-reachable from the seed) — canoes are terrain, not budget.
+/// Covers every position the builder places on: blanks, slots, pipe mouths,
+/// start, target. Returns position -> pocket id and the pocket count.
+/// Start seeds first (the mainland pocket claims its canoe islands before
+/// an island seed can claim itself), then scan order — seed-stable.
+pub(super) fn pocket_map(state: &WorldState) -> (HashMap<Pos, usize>, usize) {
+    let mut seeds: Vec<Pos> = blank_positions(state);
+    seeds.extend(state.slots.iter().map(|s| s.pos));
+    for &(a, b) in &state.pipe_pairs {
+        seeds.push(a);
+        seeds.push(b);
+    }
+    seeds.extend(state.target);
+    seeds.sort_unstable();
+    seeds.dedup();
+    if let Some(start) = state.start {
+        seeds.retain(|&p| p != start);
+        seeds.insert(0, start);
+    }
+    let mut pocket: HashMap<Pos, usize> = HashMap::new();
+    let mut count = 0;
+    for &seed in &seeds {
+        if pocket.contains_key(&seed) {
+            continue;
+        }
+        let reach = walk_reachable(&state.grid, &[], Some(seed), state.world_idx);
+        for &q in &seeds {
+            if !pocket.contains_key(&q) && reach.contains(q) {
+                pocket.insert(q, count);
+            }
+        }
+        count += 1;
+    }
+    (pocket, count)
+}
+
+/// The pocket pairs already joined by a direct pipe, normalized (lo, hi).
+/// Intra-pocket pairs appear as (p, p) — harmless to callers, which only
+/// test cross-pocket candidates.
+pub(super) fn linked_pocket_pairs(
+    pocket: &HashMap<Pos, usize>,
+    pipe_pairs: &[TeleportEdge],
+) -> HashSet<(usize, usize)> {
+    pipe_pairs
+        .iter()
+        .filter_map(|&(a, b)| {
+            let (&pa, &pb) = (pocket.get(&a)?, pocket.get(&b)?);
+            Some((pa.min(pb), pa.max(pb)))
+        })
+        .collect()
 }
 
 /// Where to grow next: the goal's component first (a world you can't finish

--- a/src/randomize/overworld_build/connectivity.rs
+++ b/src/randomize/overworld_build/connectivity.rs
@@ -41,6 +41,7 @@
 
 use super::*;
 
+use super::islands::{blank_positions, classify, linked_pocket_pairs, pocket_map, spread_mouth};
 use rand::seq::IndexedRandom;
 
 pub(crate) struct Connectivity;
@@ -52,6 +53,11 @@ impl Phase for Connectivity {
 
     fn run(&self, state: &mut WorldState, rng: &mut dyn RngCore) -> PhaseReport {
         let mut actions = Vec::new();
+
+        // Islands are pipe-free components — stable across everything this
+        // phase does, so decompose and classify once.
+        let (pocket, pocket_count) = pocket_map(state);
+        let islands = classify(state, &pocket, pocket_count);
 
         while state.pipe_pairs.len() < state.pipe_budget {
             let reach = walk_reachable(&state.grid, &state.pipe_pairs, state.start, state.world_idx);
@@ -92,11 +98,23 @@ impl Phase for Connectivity {
                 break;
             };
 
+            // Spread-mouths refinement (uniform pick keeps the cross-island
+            // distribution; the refinement fixes WHERE on the island): on a
+            // routing/corridor/final island that already has a mouth, land
+            // the new mouth as far from the existing ones as the island's
+            // walk network allows, so traversal crosses the interior
+            // instead of hugging one corner.
+            let rn = spread_mouth(state, &pocket, &islands, &mainland_candidates, near);
+            let rf = spread_mouth(state, &pocket, &islands, &island_candidates, far);
+            // Keep the originals if refinement manufactured a row-7/8
+            // partner pair.
+            let (near, far) = if Some(rf) == row78_partner(rn) { (near, far) } else { (rn, rf) };
+
             state.add_pipe_pair(near, far);
             actions.push(format!("pipe {near:?} <-> {far:?} (island of {} blanks)", island_candidates.len()));
         }
 
-        // Loop closer: one pair between two pockets with no direct link yet
+        // Loop closer: one pair between two islands with no direct link yet
         // (see module doc). Purely optional — no fallback past the anchor
         // bar, and single-pocket worlds skip it (their pipes are all free
         // routing ammo already). A stricter "leave shortcut headroom" rule
@@ -104,35 +122,38 @@ impl Phase for Connectivity {
         // loop is FOR — census 2026-08-01, linear 40% -> 44%), while the
         // world it meant to protect (W8) never fires the closer at all
         // (its extra pockets have no legal endpoints).
-        if state.pipe_pairs.len() < state.pipe_budget {
-            let (pocket, pocket_count) = pocket_map(state);
-            if pocket_count >= 2 {
-                let linked = linked_pocket_pairs(&pocket, &state.pipe_pairs);
-                let legal: Vec<Pos> = state
-                    .legal_blanks()
-                    .into_iter()
-                    .filter(|&p| !state.near_anchor(p))
-                    .collect();
-                let mut cands: Vec<(Pos, Pos)> = Vec::new();
-                for (i, &a) in legal.iter().enumerate() {
-                    let Some(&pa) = pocket.get(&a) else { continue };
-                    for &b in &legal[i + 1..] {
-                        let Some(&pb) = pocket.get(&b) else { continue };
-                        if pa != pb
-                            && !linked.contains(&(pa.min(pb), pa.max(pb)))
-                            && Some(b) != row78_partner(a)
-                        {
-                            cands.push((a, b));
-                        }
+        if state.pipe_pairs.len() < state.pipe_budget && pocket_count >= 2 {
+            let linked = linked_pocket_pairs(&pocket, &state.pipe_pairs);
+            let legal: Vec<Pos> = state
+                .legal_blanks()
+                .into_iter()
+                .filter(|&p| !state.near_anchor(p))
+                .collect();
+            let mut cands: Vec<(Pos, Pos)> = Vec::new();
+            for (i, &a) in legal.iter().enumerate() {
+                let Some(&pa) = pocket.get(&a) else { continue };
+                for &b in &legal[i + 1..] {
+                    let Some(&pb) = pocket.get(&b) else { continue };
+                    if pa != pb
+                        && loop_eligible(&islands, pa, pb)
+                        && !linked.contains(&(pa.min(pb), pa.max(pb)))
+                        && Some(b) != row78_partner(a)
+                    {
+                        cands.push((a, b));
                     }
                 }
-                if let Some(&(a, b)) = cands.choose(rng) {
-                    state.add_pipe_pair(a, b);
-                    actions.push(format!(
-                        "loop pipe {a:?} <-> {b:?} (pockets {} <-> {} of {pocket_count})",
-                        pocket[&a], pocket[&b],
-                    ));
-                }
+            }
+            if let Some(&(a, b)) = cands.choose(rng) {
+                let ra = spread_mouth(state, &pocket, &islands, &legal, a);
+                let rb = spread_mouth(state, &pocket, &islands, &legal, b);
+                // Refinement moves picks within their islands; keep the
+                // originals if it manufactured a row-7/8 partner pair.
+                let (a, b) = if Some(rb) == row78_partner(ra) { (a, b) } else { (ra, rb) };
+                state.add_pipe_pair(a, b);
+                actions.push(format!(
+                    "loop pipe {a:?} <-> {b:?} (pockets {} <-> {} of {pocket_count})",
+                    pocket[&a], pocket[&b],
+                ));
             }
         }
 
@@ -158,73 +179,15 @@ impl Phase for Connectivity {
     }
 }
 
-/// All placeable blank tiles on the grid (pickup's blank-tile contract),
-/// including fixed ones — coverage is judged over all of them; only
-/// ENDPOINT candidacy excludes `fixed`.
-fn blank_positions(state: &WorldState) -> Vec<Pos> {
-    let mut blanks = Vec::new();
-    for r in 0..state.grid.rows() {
-        for c in 0..state.grid.cols {
-            if rom_data::VALID_BLANK_TILES.contains(&state.grid.get(r, c)) {
-                blanks.push((r, c));
-            }
-        }
-    }
-    blanks
-}
-
-/// Pocket decomposition: connected components of the walk network with NO
-/// pipe edges. Canoe edges still count when the canonical walker says they
-/// do (dock walk-reachable from the seed) — canoes are terrain, not budget.
-/// Covers every position the builder places on: blanks, slots, pipe mouths,
-/// start, target. Returns position -> pocket id and the pocket count.
-/// Start seeds first (the mainland pocket claims its canoe islands before
-/// an island seed can claim itself), then scan order — seed-stable.
-pub(super) fn pocket_map(state: &WorldState) -> (HashMap<Pos, usize>, usize) {
-    let mut seeds: Vec<Pos> = blank_positions(state);
-    seeds.extend(state.slots.iter().map(|s| s.pos));
-    for &(a, b) in &state.pipe_pairs {
-        seeds.push(a);
-        seeds.push(b);
-    }
-    seeds.extend(state.target);
-    seeds.sort_unstable();
-    seeds.dedup();
-    if let Some(start) = state.start {
-        seeds.retain(|&p| p != start);
-        seeds.insert(0, start);
-    }
-    let mut pocket: HashMap<Pos, usize> = HashMap::new();
-    let mut count = 0;
-    for &seed in &seeds {
-        if pocket.contains_key(&seed) {
-            continue;
-        }
-        let reach = walk_reachable(&state.grid, &[], Some(seed), state.world_idx);
-        for &q in &seeds {
-            if !pocket.contains_key(&q) && reach.contains(q) {
-                pocket.insert(q, count);
-            }
-        }
-        count += 1;
-    }
-    (pocket, count)
-}
-
-/// The pocket pairs already joined by a direct pipe, normalized (lo, hi).
-/// Intra-pocket pairs appear as (p, p) — harmless to callers, which only
-/// test cross-pocket candidates.
-pub(super) fn linked_pocket_pairs(
-    pocket: &HashMap<Pos, usize>,
-    pipe_pairs: &[TeleportEdge],
-) -> HashSet<(usize, usize)> {
-    pipe_pairs
-        .iter()
-        .filter_map(|&(a, b)| {
-            let (&pa, &pb) = (pocket.get(&a)?, pocket.get(&b)?);
-            Some((pa.min(pb), pa.max(pb)))
-        })
-        .collect()
+/// Which island pairs the loop closer may join: any two distinct islands.
+/// A routing/final-only restriction was tried and REJECTED (census
+/// 2026-08-01: W7 linear 25% -> 32%): the pair only picks where the new
+/// EDGE lands — the cycle it closes runs through the existing tree path
+/// between the two islands, which crosses the big islands regardless, and
+/// under spread mouths even a small island's arc can carry a level. The
+/// restriction just shrank candidate diversity.
+fn loop_eligible(_islands: &[super::islands::Island], _pa: usize, _pb: usize) -> bool {
+    true
 }
 
 /// Where to grow next: the goal's component first (a world you can't finish

--- a/src/randomize/overworld_build/islands.rs
+++ b/src/randomize/overworld_build/islands.rs
@@ -1,0 +1,217 @@
+//! Island decomposition and roles.
+//!
+//! An "island" is a connected component of the walk network with NO pipe
+//! edges — the fixed terrain pockets the pipe web stitches together. The
+//! decomposition is computed fresh from the state whenever needed, so SAS
+//! swaps and map-editing QOL flags come out right for free.
+//!
+//! Roles (user design, 2026-08-01, from the W7 anatomy review): the start
+//! and target islands have inherent roles; the rest classify by size —
+//! tiny islands are utility flavor (a troll pipe, a fort/toad-house slot),
+//! mid islands are corridors (a level or two, then pipe out), and big
+//! islands are where ROUTING belongs: mouths spread far apart so traversal
+//! crosses the interior, forks with room for level-bearing arms. W7 is the
+//! richest customer (islands of 1/2/4/6/8/9/13 nodes — pinned in
+//! `test_builder_island_roles`), but the rule is generic: W5's twin
+//! 19/20 islands, W8's 17-node hub, W4's mainland all classify sensibly,
+//! and single-island worlds no-op.
+
+use super::*;
+
+/// What an island is FOR. Size thresholds are structural classification
+/// (not tuning weights): <= 2 utility, 3-5 corridor, >= 6 routing.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum IslandRole {
+    /// Holds the start. Mouth placement stays uniform (the anchor bar
+    /// already keeps pipes off the player's doorstep).
+    Entry,
+    /// Holds the target. Big enough to want spread mouths (vanilla W7's
+    /// final island has two entry doors).
+    Final,
+    /// 1-2 nodes: troll pipe, fort / toad-house / hammer-bro slot.
+    Utility,
+    /// 3-5 nodes: push the player through a level or two, then pipe out.
+    Corridor,
+    /// 6+ nodes: the choice real estate — spread mouths, fork material.
+    Routing,
+}
+
+pub(super) struct Island {
+    // Reason: only the anatomy pinning test (cfg(test)) reads the size
+    // today; it stays on the struct as the island's defining datum.
+    #[allow(dead_code)]
+    pub size: usize,
+    pub role: IslandRole,
+}
+
+impl Island {
+    /// Spread-mouths preference applies: traversal should cross the
+    /// island instead of entering and leaving through the same corner.
+    pub(super) fn wants_spread_mouths(&self) -> bool {
+        matches!(
+            self.role,
+            IslandRole::Routing | IslandRole::Corridor | IslandRole::Final
+        )
+    }
+}
+
+/// Pocket decomposition: connected components of the walk network with NO
+/// pipe edges. Canoe edges still count when the canonical walker says they
+/// do (dock walk-reachable from the seed) — canoes are terrain, not budget.
+/// Covers every position the builder places on: blanks, slots, pipe mouths,
+/// start, target. Returns position -> island id and the island count.
+/// Start seeds first (the mainland pocket claims its canoe islands before
+/// an island seed can claim itself), then scan order — seed-stable.
+pub(super) fn pocket_map(state: &WorldState) -> (HashMap<Pos, usize>, usize) {
+    let mut seeds: Vec<Pos> = blank_positions(state);
+    seeds.extend(state.slots.iter().map(|s| s.pos));
+    for &(a, b) in &state.pipe_pairs {
+        seeds.push(a);
+        seeds.push(b);
+    }
+    seeds.extend(state.target);
+    seeds.sort_unstable();
+    seeds.dedup();
+    if let Some(start) = state.start {
+        seeds.retain(|&p| p != start);
+        seeds.insert(0, start);
+    }
+    let mut pocket: HashMap<Pos, usize> = HashMap::new();
+    let mut count = 0;
+    for &seed in &seeds {
+        if pocket.contains_key(&seed) {
+            continue;
+        }
+        let reach = walk_reachable(&state.grid, &[], Some(seed), state.world_idx);
+        for &q in &seeds {
+            if !pocket.contains_key(&q) && reach.contains(q) {
+                pocket.insert(q, count);
+            }
+        }
+        count += 1;
+    }
+    (pocket, count)
+}
+
+/// All placeable blank tiles on the grid (pickup's blank-tile contract),
+/// including fixed ones.
+pub(super) fn blank_positions(state: &WorldState) -> Vec<Pos> {
+    let mut blanks = Vec::new();
+    for r in 0..state.grid.rows() {
+        for c in 0..state.grid.cols {
+            if rom_data::VALID_BLANK_TILES.contains(&state.grid.get(r, c)) {
+                blanks.push((r, c));
+            }
+        }
+    }
+    blanks
+}
+
+/// The pocket pairs already joined by a direct pipe, normalized (lo, hi).
+/// Intra-pocket pairs appear as (p, p) — harmless to callers, which only
+/// test cross-pocket candidates.
+pub(super) fn linked_pocket_pairs(
+    pocket: &HashMap<Pos, usize>,
+    pipe_pairs: &[TeleportEdge],
+) -> HashSet<(usize, usize)> {
+    pipe_pairs
+        .iter()
+        .filter_map(|&(a, b)| {
+            let (&pa, &pb) = (pocket.get(&a)?, pocket.get(&b)?);
+            Some((pa.min(pb), pa.max(pb)))
+        })
+        .collect()
+}
+
+/// Classify every island. Start precedence over target for the (single
+/// island) world where one component holds both — nothing consumes roles
+/// there anyway.
+pub(super) fn classify(
+    state: &WorldState,
+    pocket: &HashMap<Pos, usize>,
+    count: usize,
+) -> Vec<Island> {
+    let mut sizes: Vec<usize> = vec![0; count];
+    for &id in pocket.values() {
+        sizes[id] += 1;
+    }
+    sizes
+        .into_iter()
+        .enumerate()
+        .map(|(id, size)| {
+            let has = |p: Option<Pos>| p.is_some_and(|p| pocket.get(&p) == Some(&id));
+            let role = if has(state.start) {
+                IslandRole::Entry
+            } else if has(state.target) {
+                IslandRole::Final
+            } else if size <= 2 {
+                IslandRole::Utility
+            } else if size <= 5 {
+                IslandRole::Corridor
+            } else {
+                IslandRole::Routing
+            };
+            Island { size, role }
+        })
+        .collect()
+}
+
+/// Existing pipe mouths on island `id`.
+pub(super) fn island_mouths(
+    pocket: &HashMap<Pos, usize>,
+    pipe_pairs: &[TeleportEdge],
+    id: usize,
+) -> Vec<Pos> {
+    pipe_pairs
+        .iter()
+        .flat_map(|&(a, b)| [a, b])
+        .filter(|p| pocket.get(p) == Some(&id))
+        .collect()
+}
+
+/// Spread-mouths refinement: `picked` was chosen uniformly (that keeps the
+/// cross-island distribution as-is); if its island wants spread mouths and
+/// already has some, move the pick to the candidate ON THE SAME ISLAND
+/// farthest (in-island walk distance, no pipes) from the nearest existing
+/// mouth. Ties keep `picked` when it is among the best, else resolve by
+/// candidate order (the caller's list is deterministic). Everything else —
+/// mouthless islands, Entry/Utility roles, foreign candidates — returns
+/// `picked` unchanged.
+pub(super) fn spread_mouth(
+    state: &WorldState,
+    pocket: &HashMap<Pos, usize>,
+    islands: &[Island],
+    candidates: &[Pos],
+    picked: Pos,
+) -> Pos {
+    let Some(&id) = pocket.get(&picked) else { return picked };
+    if !islands[id].wants_spread_mouths() {
+        return picked;
+    }
+    let mouths = island_mouths(pocket, &state.pipe_pairs, id);
+    if mouths.is_empty() {
+        return picked;
+    }
+    // In-island distance: BFS from each mouth with no pipe edges; a
+    // candidate's score is the distance to its NEAREST mouth.
+    let dist_maps: Vec<HashMap<Pos, usize>> = mouths
+        .iter()
+        .map(|&m| walk_map(&state.grid, &[], Some(m), state.world_idx).distances)
+        .collect();
+    let score = |p: Pos| -> usize {
+        dist_maps
+            .iter()
+            .map(|d| d.get(&p).copied().unwrap_or(0))
+            .min()
+            .unwrap_or(0)
+    };
+    let mut best = picked;
+    let mut best_score = score(picked);
+    for &c in candidates {
+        if pocket.get(&c) == Some(&id) && score(c) > best_score {
+            best = c;
+            best_score = score(c);
+        }
+    }
+    best
+}

--- a/src/randomize/overworld_build/levels.rs
+++ b/src/randomize/overworld_build/levels.rs
@@ -68,7 +68,11 @@ impl Phase for Levels {
             candidates.retain(|&c| c != pos && Some(c) != row78_partner(pos));
         }
 
-        actions.push(format!("done: {placed}/{} levels placed", state.level_budget));
+        actions.push(format!(
+            "done: {placed}/{} levels placed (pool was {} blanks)",
+            state.level_budget,
+            state.legal_blanks().len() + placed,
+        ));
         PhaseReport { phase: self.name(), actions }
     }
 }

--- a/src/randomize/overworld_build/levels.rs
+++ b/src/randomize/overworld_build/levels.rs
@@ -1,10 +1,15 @@
 //! Levels phase — place the world's action levels on the connected map.
 //!
-//! Deliberately KNOB-FREE: every level lands on a uniform-random legal
-//! blank. None of the shipping builder's placement scoring (spread, path
-//! relevance, dead-end preference) exists here — the census measures what
-//! uniform placement produces (clustering, screen balance, route effects),
-//! and any future preference has to beat those numbers to justify itself.
+//! Placement is uniform-random over legal blanks with ONE earned rule —
+//! avoid-adjacency-when-avoidable: if the uniform pick would sit
+//! orthogonally next to an already-placed level and non-adjacent blanks
+//! remain, re-pick uniformly among the non-adjacent ones. Pure uniform
+//! measured terrible (playtest + census 2026-08-01: 14-21% of worlds put
+//! 4+ levels in one connected chain, worst 7 — the whole budget in a
+//! snake and the rest of the map empty; the old builder's spread scorer
+//! had prevented this and was deleted with it). No weights: adjacency is
+//! avoided exactly when the map allows, so small forced corridors (W7)
+//! still chain like vanilla does.
 //!
 //! What binds anyway (facts, not preferences):
 //! - levels go on blank tiles only, never on `fixed` positions;
@@ -37,7 +42,13 @@ impl Phase for Levels {
         let mut placed = 0usize;
 
         while placed < state.level_budget {
-            let Some(&pos) = candidates.choose(rng) else {
+            let clear: Vec<Pos> = candidates
+                .iter()
+                .copied()
+                .filter(|&c| !next_to_level(state, c))
+                .collect();
+            let pool = if clear.is_empty() { &candidates } else { &clear };
+            let Some(&pos) = pool.choose(rng) else {
                 actions.push(format!(
                     "stuck: {placed}/{} levels placed, no legal blanks left",
                     state.level_budget,
@@ -60,4 +71,14 @@ impl Phase for Levels {
         actions.push(format!("done: {placed}/{} levels placed", state.level_budget));
         PhaseReport { phase: self.name(), actions }
     }
+}
+
+/// Orthogonally adjacent (2-tile walk neighbor) to an already-placed level.
+pub(super) fn next_to_level(state: &WorldState, pos: Pos) -> bool {
+    state.slots.iter().any(|s| {
+        s.kind == SlotKind::Level && {
+            let (dr, dc) = (s.pos.0.abs_diff(pos.0), s.pos.1.abs_diff(pos.1));
+            (dr == 2 && dc == 0) || (dr == 0 && dc == 2)
+        }
+    })
 }

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -60,6 +60,7 @@ mod capacity;
 mod connectivity;
 mod forts;
 mod hammer_bros;
+mod islands;
 mod levels;
 mod locks;
 mod metrics;

--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -403,6 +403,11 @@ fn try_gated_shortcut(
 
     let wide_before = analyze_route_choice(&state.to_built(), SHAPING_SLACK).routes.len();
 
+    // NOTE: the connectivity spread-mouths refinement was tried on these
+    // trial pairs too and REJECTED (census 2026-08-01): the argmax is
+    // deterministic, so it collapsed the 4 tries onto one tile per island
+    // — W4's shortcut accepts fell 43 -> 9 (2-island world, no diversity
+    // left) while W7 didn't move. Uniform trials stay.
     for _ in 0..SHORTCUT_TRIES {
         // Anchor-adjacent blanks are barred for pipe endpoints — same rule
         // as connectivity and spare pipes (an ungateable express).

--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -298,11 +298,14 @@ fn try_arm_balance(
     };
     let usable = alt_candidates.iter().find_map(|r| {
         let alt: HashSet<Pos> = r.path.iter().copied().collect();
-        let targets: Vec<Pos> = blanks
-            .iter()
-            .copied()
-            .filter(|p| cheap.contains(p) && !alt.contains(p))
-            .collect();
+        let targets: Vec<Pos> = prefer_spaced(
+            state,
+            blanks
+                .iter()
+                .copied()
+                .filter(|p| cheap.contains(p) && !alt.contains(p))
+                .collect(),
+        );
         (!targets.is_empty()).then_some((r, targets))
     });
     let Some((alt_route, targets)) = usable else {
@@ -563,11 +566,14 @@ fn try_level_move(
         .filter(|(_, s)| s.kind == SlotKind::Level && !trunk.contains(&s.pos))
         .map(|(i, _)| i)
         .collect();
-    let targets: Vec<Pos> = state
-        .legal_blanks()
-        .into_iter()
-        .filter(|p| trunk.contains(p))
-        .collect();
+    let targets: Vec<Pos> = prefer_spaced(
+        state,
+        state
+            .legal_blanks()
+            .into_iter()
+            .filter(|p| trunk.contains(p))
+            .collect(),
+    );
     if sources.is_empty() || targets.is_empty() {
         return Err(format!(
             "level_move REJECT: {} off-route levels, {} on-route blanks — nothing to work with",
@@ -706,6 +712,19 @@ fn try_pipe_move(
         "pipe_move REJECT: no relocation lifts C1 {} ({evals} full evals)",
         before.c1,
     ))
+}
+
+/// Level-relocation targets, spaced when possible: drop targets that would
+/// sit orthogonally next to an existing level unless that would empty the
+/// list — the same avoid-adjacency-when-avoidable rule as level placement
+/// (the trunk must not become a level train; playtest 2026-08-01).
+fn prefer_spaced(state: &WorldState, targets: Vec<Pos>) -> Vec<Pos> {
+    let clear: Vec<Pos> = targets
+        .iter()
+        .copied()
+        .filter(|&p| !super::levels::next_to_level(state, p))
+        .collect();
+    if clear.is_empty() { targets } else { clear }
 }
 
 /// Every slot and the goal walk-reachable from start on the all-open world

--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -298,7 +298,7 @@ fn try_arm_balance(
     };
     let usable = alt_candidates.iter().find_map(|r| {
         let alt: HashSet<Pos> = r.path.iter().copied().collect();
-        let targets: Vec<Pos> = prefer_spaced(
+        let targets: Vec<Pos> = spaced(
             state,
             blanks
                 .iter()
@@ -335,12 +335,6 @@ fn try_arm_balance(
         let Some(&target) = targets.choose(rng) else { break };
         let old_pos = state.slots[si].pos;
         state.slots[si].pos = target;
-        // Chain cap: arm balance is a choice-mode move — never build a
-        // level train for parity.
-        if level_chain_len(state, target) >= 3 {
-            state.slots = saved_slots.clone();
-            continue;
-        }
         let after = measure_world(state);
         let wide_after = analyze_route_choice(&state.to_built(), SHAPING_SLACK);
         let gap_after = if wide_after.routes.len() >= 2 {
@@ -572,7 +566,7 @@ fn try_level_move(
         .filter(|(_, s)| s.kind == SlotKind::Level && !trunk.contains(&s.pos))
         .map(|(i, _)| i)
         .collect();
-    let targets: Vec<Pos> = prefer_spaced(
+    let targets: Vec<Pos> = spaced(
         state,
         state
             .legal_blanks()
@@ -598,11 +592,6 @@ fn try_level_move(
             continue;
         }
         state.slots[si].pos = target;
-        // Chain cap (choice mode): the move must not build a level train.
-        if before.c1 >= C1_FLOOR && level_chain_len(state, target) >= 3 {
-            state.slots = saved_slots.clone();
-            continue;
-        }
         evals += 1;
         let after = measure_world(state);
         // Below the floor: C1 progress (routes may be spent). Above: routes
@@ -725,49 +714,19 @@ fn try_pipe_move(
     ))
 }
 
-/// Level-relocation targets, spaced when possible: drop targets that would
-/// sit orthogonally next to an existing level unless that would empty the
-/// list — the same avoid-adjacency-when-avoidable rule as level placement
-/// (the trunk must not become a level train; playtest 2026-08-01).
-fn prefer_spaced(state: &WorldState, targets: Vec<Pos>) -> Vec<Pos> {
-    let clear: Vec<Pos> = targets
-        .iter()
-        .copied()
+/// The level-spacing invariant, mover side: a RELOCATION never lands a
+/// level next to another level, full stop — a move is optional (unlike
+/// placement, which must spend its budget and may be forced), so when no
+/// spaced target exists the move simply isn't available. This is the
+/// root-cause fix for the playtest's level trains: the movers relocate
+/// levels onto the cheapest route one accept at a time, and with adjacent
+/// tiles as valid targets that process assembles the whole budget into a
+/// snake along the trunk.
+fn spaced(state: &WorldState, targets: Vec<Pos>) -> Vec<Pos> {
+    targets
+        .into_iter()
         .filter(|&p| !super::levels::next_to_level(state, p))
-        .collect();
-    if clear.is_empty() { targets } else { clear }
-}
-
-/// Size of the connected chain of levels containing `pos` (orthogonal
-/// 2-tile adjacency), on the CURRENT slots. The chain cap: a choice-mode
-/// relocation must not leave its level in a chain of 3+ — the spaced
-/// fallback alone still built trains move-by-move on pipe-less W1, where
-/// every repair is a level move onto a short trunk (playtest 2026-08-01,
-/// round two). Pairs stay allowed (vanilla has plenty); cost mode is
-/// exempt (the C1 floor guarantee outranks aesthetics).
-fn level_chain_len(state: &WorldState, pos: Pos) -> usize {
-    let levels: Vec<Pos> = state
-        .slots
-        .iter()
-        .filter(|s| s.kind == SlotKind::Level)
-        .map(|s| s.pos)
-        .collect();
-    let adjacent = |a: Pos, b: Pos| {
-        let (dr, dc) = (a.0.abs_diff(b.0), a.1.abs_diff(b.1));
-        (dr == 2 && dc == 0) || (dr == 0 && dc == 2)
-    };
-    let mut seen: HashSet<Pos> = HashSet::new();
-    let mut queue = vec![pos];
-    seen.insert(pos);
-    while let Some(p) = queue.pop() {
-        for &l in &levels {
-            if !seen.contains(&l) && adjacent(p, l) {
-                seen.insert(l);
-                queue.push(l);
-            }
-        }
-    }
-    seen.len()
+        .collect()
 }
 
 /// Every slot and the goal walk-reachable from start on the all-open world

--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -31,6 +31,15 @@
 //!   topology can help — walk edges are local, so a pipe is the one move
 //!   that creates a route that doesn't exist yet. **Gated shortcut**: add a
 //!   pipe pair, re-place ALL locks on the new topology, judge the bundle.
+//! - **Linear with a wide runner-up or detour** (a second route exists
+//!   within [`SHAPING_SLACK`] but outside the band, or dominated): **arm
+//!   balance** — move a level onto the cheap route's EXCLUSIVE stretch,
+//!   closing the cost gap from the C1 side without touching the runner-up
+//!   (and breaking a detour's superset relation, which un-dominates it).
+//!   The generic level move can't do this: it targets the whole trunk, and
+//!   a level on a SHARED stretch raises both routes alike, leaving the gap
+//!   fixed. Vanilla W7 is the precedent — two pocket arms tied at cost 35.
+//!   After the shortcut: creation first, then trimming what it created.
 //! - **Both cheaper rungs spent** (exhausted or unavailable): **fort+lock
 //!   move** — relocate one fort and re-place all locks as one bundle. The
 //!   trunk-fort symptom: a fort ON the cheapest route makes every lock
@@ -67,8 +76,9 @@
 //! the floor.
 //!
 //! The loop's knobs (the ONLY knobs in the builder): [`MOVE_BUDGET`],
-//! [`TARGET_ROUTES`], [`SHORTCUT_TRIES`], [`FORTLOCK_TRIES`],
-//! [`LEVELMOVE_TRIES`], [`PIPEMOVE_TRIES`], [`ESCALATE_AFTER`].
+//! [`TARGET_ROUTES`], [`SHORTCUT_TRIES`], [`ARM_BALANCE_TRIES`],
+//! [`FORTLOCK_TRIES`], [`LEVELMOVE_TRIES`], [`PIPEMOVE_TRIES`],
+//! [`ESCALATE_AFTER`].
 
 use super::*;
 
@@ -83,6 +93,8 @@ const MOVE_BUDGET: usize = 24;
 const TARGET_ROUTES: usize = 2;
 /// Candidate pipe pairs tried inside ONE gated-shortcut move.
 const SHORTCUT_TRIES: usize = 4;
+/// Level relocations tried inside ONE arm-balance move.
+const ARM_BALANCE_TRIES: usize = 4;
 /// Full fort-relocation evaluations paid inside ONE fort+lock move.
 const FORTLOCK_TRIES: usize = 4;
 /// Level relocations tried inside ONE level move (cheap: no lock re-place).
@@ -104,8 +116,11 @@ impl Phase for Shaping {
         let mut moves = 0usize;
         let mut accepted = 0usize;
         // Per-rung consecutive-rejection counters, indexed by ladder order:
-        // lock re-place, gated shortcut, fort+lock, level move, pipe move.
-        let mut rejects = [0usize; 5];
+        // lock re-place, gated shortcut, arm balance, fort+lock, level move,
+        // pipe move. The shortcut CREATES wide routes, arm balance prices
+        // them into the band — creation before trimming (measured: balance
+        // first displaced W8's shortcut accepts, linear 8% -> 11%).
+        let mut rejects = [0usize; 6];
 
         let status = loop {
             let before = measure_world(state);
@@ -129,9 +144,11 @@ impl Phase for Shaping {
             let available = if cheap {
                 // The pipe move is the final cost rung: when no lock cuts
                 // the goal and levels run out of trunk targets, the express
-                // itself (a pipe mouth) is what must move.
+                // itself (a pipe mouth) is what must move. Arm balance is a
+                // choice tool only — cost mode has its own level rung.
                 [
                     !state.locks.is_empty(),
+                    false,
                     false,
                     state.fort_count() > 0,
                     true,
@@ -143,12 +160,13 @@ impl Phase for Shaping {
                         && !state.locks.is_empty()
                         && (zero_gate > 0 || before.dominated_detours > 0),
                     routes_needy && state.pipe_pairs.len() < state.pipe_budget,
+                    routes_needy, // arm balance finds its own wide runner-up
                     routes_needy && state.fort_count() > 0,
                     true, // level move checks its own sources/targets
                     false, // pipe move is a cost tool only
                 ]
             };
-            let Some(rung) = (0..5)
+            let Some(rung) = (0..6)
                 .find(|&r| available[r] && rejects[r] < ESCALATE_AFTER)
             else {
                 break "stuck: no move available";
@@ -158,14 +176,15 @@ impl Phase for Shaping {
             let outcome = match rung {
                 0 => try_lock_replace(state, rng, &before, zero_gate),
                 1 => try_gated_shortcut(state, rng, &before),
-                2 => try_fort_lock(state, rng, &before),
-                3 => try_level_move(state, rng, &before),
+                2 => try_arm_balance(state, rng, &before),
+                3 => try_fort_lock(state, rng, &before),
+                4 => try_level_move(state, rng, &before),
                 _ => try_pipe_move(state, rng, &before),
             };
             match outcome {
                 Ok(line) => {
                     // The world changed — every rung's ammunition is fresh.
-                    rejects = [0; 5];
+                    rejects = [0; 6];
                     accepted += 1;
                     actions.push(line);
                 }
@@ -229,6 +248,123 @@ fn try_lock_replace(
         state.locks = saved;
         Err(format!("lock_replace REJECT: {line}"))
     }
+}
+
+/// The parity rung: when a runner-up route exists in the WIDE window
+/// ([`SHAPING_SLACK`]) but outside the choice band, close the cost gap
+/// surgically — move a level that is NOT on the cheap route onto a blank on
+/// the cheap route's EXCLUSIVE stretch (on the cheap path, off the
+/// runner-up's). Each move raises C1 by 3 while leaving the runner-up
+/// priced as it was (and cheapens it by 3 when the source level sat on it),
+/// so the gap closes without the whole world re-pricing. The generic level
+/// move can't do this: its targets are the whole trunk, and a level landing
+/// on a stretch SHARED with the runner-up raises both costs alike — gap
+/// unchanged, noalt stays noalt. Locks untouched, so an evaluation is
+/// relocate + measure, same as the level move.
+///
+/// The runner-up can be a DOMINATED detour: on tree-ish maps the loop's
+/// second arm usually plays a superset of the cheap route's levels (its
+/// exclusive stretch holds none of its own), so it sits in `detours`, not
+/// `routes` — invisible to the band. The same move fixes that too: a level
+/// on the cheap route's exclusive stretch is a level the detour does NOT
+/// play, so the superset relation breaks and the detour becomes a real
+/// alternative. Accept iff routes rise, a wide route materialized (the
+/// detour split off), or the wide gap shrank at flat routes (floor held) —
+/// a 9-point gap takes multiple moves, and the early ones buy no route
+/// yet. Vanilla W7 is the design precedent: two pocket arms tied at cost
+/// 35 (the loop closer in connectivity builds the arms; this rung prices
+/// them).
+fn try_arm_balance(
+    state: &mut WorldState,
+    rng: &mut dyn RngCore,
+    before: &WorldMeasure,
+) -> Result<String, String> {
+    let wide_before = analyze_route_choice(&state.to_built(), SHAPING_SLACK);
+    let cheap: HashSet<Pos> = match wide_before.routes.first() {
+        Some(r) => r.path.iter().copied().collect(),
+        None => return Err("arm_balance REJECT: no route at all".into()),
+    };
+    let blanks = state.legal_blanks();
+
+    // Runner-up material: the kept wide route, else the cheapest dominated
+    // detour this move can actually work with — one whose cheap-exclusive
+    // stretch holds a legal blank. Detours that differ by a path-tile-only
+    // bypass (no node on the stretch) are lock material, not level
+    // material; skip them.
+    let alt_candidates = if wide_before.routes.len() >= 2 {
+        std::slice::from_ref(&wide_before.routes[1])
+    } else {
+        &wide_before.detours[..]
+    };
+    let usable = alt_candidates.iter().find_map(|r| {
+        let alt: HashSet<Pos> = r.path.iter().copied().collect();
+        let targets: Vec<Pos> = blanks
+            .iter()
+            .copied()
+            .filter(|p| cheap.contains(p) && !alt.contains(p))
+            .collect();
+        (!targets.is_empty()).then_some((r, targets))
+    });
+    let Some((alt_route, targets)) = usable else {
+        return Err(format!(
+            "arm_balance REJECT: no runner-up/detour with an exclusive blank ({} candidates)",
+            alt_candidates.len(),
+        ));
+    };
+    let gap_before = alt_route.cost - wide_before.routes[0].cost;
+
+    let sources: Vec<usize> = state
+        .slots
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| s.kind == SlotKind::Level && !cheap.contains(&s.pos))
+        .map(|(i, _)| i)
+        .collect();
+    if sources.is_empty() {
+        return Err(format!(
+            "arm_balance REJECT: gap {gap_before}, no off-cheap levels to move",
+        ));
+    }
+
+    let saved_slots = state.slots.clone();
+    for _ in 0..ARM_BALANCE_TRIES {
+        let Some(&si) = sources.choose(rng) else { break };
+        let Some(&target) = targets.choose(rng) else { break };
+        let old_pos = state.slots[si].pos;
+        state.slots[si].pos = target;
+        let after = measure_world(state);
+        let wide_after = analyze_route_choice(&state.to_built(), SHAPING_SLACK);
+        let gap_after = if wide_after.routes.len() >= 2 {
+            wide_after.routes[1].cost - wide_after.routes[0].cost
+        } else {
+            u32::MAX
+        };
+        // The gap-shrink tier only applies when the alt was a KEPT
+        // runner-up — after a detour-splitting move the before/after gaps
+        // would describe different detours.
+        let had_runner_up = wide_before.routes.len() >= 2;
+        let improved = after.c1 >= C1_FLOOR
+            && (after.routes_in_band > before.routes_in_band
+                || (after.routes_in_band == before.routes_in_band
+                    && (wide_after.routes.len() > wide_before.routes.len()
+                        || (had_runner_up && gap_after < gap_before))));
+        if improved {
+            return Ok(format!(
+                "arm_balance ACCEPT: level {old_pos:?} -> {target:?} (cheap-exclusive), routes {} -> {}, wide {} -> {}, gap {gap_before} -> {}, C1 {} -> {}",
+                before.routes_in_band,
+                after.routes_in_band,
+                wide_before.routes.len(),
+                wide_after.routes.len(),
+                if gap_after == u32::MAX { "-".into() } else { gap_after.to_string() },
+                before.c1,
+                after.c1,
+            ));
+        }
+        state.slots = saved_slots.clone();
+    }
+    Err(format!(
+        "arm_balance REJECT: no exclusive-stretch move closes gap {gap_before} ({ARM_BALANCE_TRIES} tries)",
+    ))
 }
 
 /// The topology rung: spend one pipe pair AND re-place all locks as a single

--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -335,6 +335,12 @@ fn try_arm_balance(
         let Some(&target) = targets.choose(rng) else { break };
         let old_pos = state.slots[si].pos;
         state.slots[si].pos = target;
+        // Chain cap: arm balance is a choice-mode move — never build a
+        // level train for parity.
+        if level_chain_len(state, target) >= 3 {
+            state.slots = saved_slots.clone();
+            continue;
+        }
         let after = measure_world(state);
         let wide_after = analyze_route_choice(&state.to_built(), SHAPING_SLACK);
         let gap_after = if wide_after.routes.len() >= 2 {
@@ -592,6 +598,11 @@ fn try_level_move(
             continue;
         }
         state.slots[si].pos = target;
+        // Chain cap (choice mode): the move must not build a level train.
+        if before.c1 >= C1_FLOOR && level_chain_len(state, target) >= 3 {
+            state.slots = saved_slots.clone();
+            continue;
+        }
         evals += 1;
         let after = measure_world(state);
         // Below the floor: C1 progress (routes may be spent). Above: routes
@@ -725,6 +736,38 @@ fn prefer_spaced(state: &WorldState, targets: Vec<Pos>) -> Vec<Pos> {
         .filter(|&p| !super::levels::next_to_level(state, p))
         .collect();
     if clear.is_empty() { targets } else { clear }
+}
+
+/// Size of the connected chain of levels containing `pos` (orthogonal
+/// 2-tile adjacency), on the CURRENT slots. The chain cap: a choice-mode
+/// relocation must not leave its level in a chain of 3+ — the spaced
+/// fallback alone still built trains move-by-move on pipe-less W1, where
+/// every repair is a level move onto a short trunk (playtest 2026-08-01,
+/// round two). Pairs stay allowed (vanilla has plenty); cost mode is
+/// exempt (the C1 floor guarantee outranks aesthetics).
+fn level_chain_len(state: &WorldState, pos: Pos) -> usize {
+    let levels: Vec<Pos> = state
+        .slots
+        .iter()
+        .filter(|s| s.kind == SlotKind::Level)
+        .map(|s| s.pos)
+        .collect();
+    let adjacent = |a: Pos, b: Pos| {
+        let (dr, dc) = (a.0.abs_diff(b.0), a.1.abs_diff(b.1));
+        (dr == 2 && dc == 0) || (dr == 0 && dc == 2)
+    };
+    let mut seen: HashSet<Pos> = HashSet::new();
+    let mut queue = vec![pos];
+    seen.insert(pos);
+    while let Some(p) = queue.pop() {
+        for &l in &levels {
+            if !seen.contains(&l) && adjacent(p, l) {
+                seen.insert(l);
+                queue.push(l);
+            }
+        }
+    }
+    seen.len()
 }
 
 /// Every slot and the goal walk-reachable from start on the all-open world

--- a/src/randomize/overworld_build/spare_pipes.rs
+++ b/src/randomize/overworld_build/spare_pipes.rs
@@ -20,18 +20,29 @@
 //! Runs LAST in the shaped pipeline (after shaping): spares must not eat
 //! the budget headroom the gated-shortcut rung draws on, and the guard
 //! needs the finished structure to measure against.
+//!
+//! Pocket-doubling pairs (a second direct link between two pockets that
+//! already have one) are DEMOTED, not banned: same pocket pair = usually
+//! the same level set both ways, which the domination filter deletes —
+//! measured dead weight (~0.5 pairs/seed on W7, census 2026-08-01). The
+//! creator tier still judges every pair by measurement (a doubled link
+//! with a different forced level on its approach CAN create a route —
+//! vanilla W7's micro-theta), so only the harmless tier and the fallback
+//! ranking prefer non-doubling pairs.
 
 use super::*;
 
+use super::connectivity::{linked_pocket_pairs, pocket_map};
 use super::locks::recompute_safety_flags;
 use rand::seq::IndexedRandom;
 
 /// Candidate pairs measured per spare pipe before settling.
 const SPARE_TRIES: usize = 8;
 
-/// Fallback ranking key for a trial placement: (floor-clamped C1, routes in
-/// band, raw C1) — reach the floor first, then keep routes, then cost.
-type TrialKey = (u32, usize, u32);
+/// Fallback ranking key for a trial placement: (non-doubling, floor-clamped
+/// C1, routes in band, raw C1) — avoid dead pocket-doubles first, reach the
+/// floor, then keep routes, then cost.
+type TrialKey = (bool, u32, usize, u32);
 
 pub(crate) struct SparePipes;
 
@@ -43,6 +54,10 @@ impl Phase for SparePipes {
     fn run(&self, state: &mut WorldState, rng: &mut dyn RngCore) -> PhaseReport {
         let mut actions = Vec::new();
         let mut placed_any = false;
+
+        // Pipe-free pocket ids are stable across spare placement (a new
+        // mouth was a blank in some pocket already), so compute once.
+        let (pocket, _) = pocket_map(state);
 
         while state.pipe_pairs.len() < state.pipe_budget {
             // Anchor-adjacent blanks are barred for pipe endpoints (an
@@ -63,10 +78,11 @@ impl Phase for SparePipes {
                 break;
             }
 
+            let linked = linked_pocket_pairs(&pocket, &state.pipe_pairs);
             let before = measure_world(state);
             let mut creator: Option<(Pos, Pos)> = None;
             let mut harmless: Option<(Pos, Pos)> = None;
-            // Fallback ranking: reach the floor first, then routes, then C1.
+            // Fallback ranking: non-doubling, then floor, routes, C1.
             let mut best: Option<(TrialKey, (Pos, Pos))> = None;
             for _ in 0..SPARE_TRIES {
                 let picked: Vec<Pos> = candidates.choose_multiple(rng, 2).copied().collect();
@@ -74,6 +90,12 @@ impl Phase for SparePipes {
                 if Some(b) == row78_partner(a) {
                     continue;
                 }
+                let doubling = match (pocket.get(&a), pocket.get(&b)) {
+                    (Some(&pa), Some(&pb)) if pa != pb => {
+                        linked.contains(&(pa.min(pb), pa.max(pb)))
+                    }
+                    _ => false,
+                };
                 state.add_pipe_pair(a, b);
                 let m = measure_world(state);
                 state.pop_pipe_pair();
@@ -82,11 +104,11 @@ impl Phase for SparePipes {
                         creator = Some((a, b));
                         break;
                     }
-                    if harmless.is_none() {
+                    if !doubling && harmless.is_none() {
                         harmless = Some((a, b));
                     }
                 }
-                let key = (m.c1.min(C1_FLOOR), m.routes_in_band, m.c1);
+                let key = (!doubling, m.c1.min(C1_FLOOR), m.routes_in_band, m.c1);
                 if best.as_ref().is_none_or(|(k, _)| key > *k) {
                     best = Some((key, (a, b)));
                 }

--- a/src/randomize/overworld_build/spare_pipes.rs
+++ b/src/randomize/overworld_build/spare_pipes.rs
@@ -32,7 +32,7 @@
 
 use super::*;
 
-use super::connectivity::{linked_pocket_pairs, pocket_map};
+use super::islands::{linked_pocket_pairs, pocket_map};
 use super::locks::recompute_safety_flags;
 use rand::seq::IndexedRandom;
 


### PR DESCRIPTION
## Problem

W7 was the builder's worst world at ~49% all-linear seeds (next worst: W1 at 20%). Diagnosis (400–1000 seed probes, committed as `test_builder_w7_probe`):

- W7's map is 46 nodes shattered into **7 walk-islands**; bridging them consumes ~7.5 of the 8-pair pipe budget as a spanning **tree** — and on a tree of islands a second route cannot exist, no matter where levels/forts/locks go.
- The shaping loop was grinding hardest there for the least return (2,000+ rejects per 400 seeds).
- Vanilla W7 proves the map isn't the ceiling: same 8 pipes, wired into a loop with **two arms tied at cost 35**.
- Tested false along the way: "SAS double-arm entry makes it worse" (swapped is *less* linear), "the trunk lacks blanks" (it has more than swapped), and "golden locks would fix the residue" (0 of 111 noalt seeds have a lockable exclusive edge — the residue detours were lollipops and pipe-hops, which no lock can split).

## Changes (each measured separately; rejected experiments documented in code comments)

1. **Loop closer** (`connectivity.rs`): after bridging, one pipe pair between two islands with no direct link — the island tree becomes a loop shaping can price.
2. **Arm balance** (`shaping.rs`, new rung after the gated shortcut): move a level onto the cheap route's exclusive stretch to pull a wide runner-up into the choice band; also breaks a dominated superset detour's subset relation (un-dominates it). Vanilla W7's tied twin arms are the design precedent.
3. **Spare demotion** (`spare_pipes.rs`): pocket-doubling pairs (2nd direct link between the same islands = same level set both ways = domination fodder) demoted from the harmless tier and fallback ranking; the creator tier still measures every pair.
4. **Island roles** (`islands.rs`, new): islands from the pipe-free walk decomposition; start/target islands are Entry/Final, the rest classify by size (≤2 utility, 3–5 corridor, ≥6 routing). Derived at build time, so SAS and QOL map edits come out right for free. W7's full anatomy (1/2/4/6/8/9/13) is pinned in `test_builder_island_roles`.
5. **Spread mouths** (the big win): when a routing/corridor/final island receives a second-or-later pipe mouth, the uniform pick is refined to the same-island tile farthest (in-island walk distance) from the existing mouths — traversal must cross the island interior, which prevents lollipop detour geometry at the source. Zero knobs (argmax); cross-island distribution stays uniform.

Measured and **rejected** (reverted, reasons in comments): loop-closer headroom rule, arm-balance-before-shortcut ladder order, loop closer restricted to routing/final pairs, spread-mouths on gated-shortcut trial pairs.

## Results (1000 seeds, realistic flag mix)

| | before | after |
|---|---|---|
| W7 linear | 49% | **27%** (uniq 0.80 → 1.00, redeals 96 → 60/1000) |
| W8 linear | 11% | **4%** (uniq 1.12) |
| overall linear | 12.75% | **8.5%** |
| build time | 69 ms/seed | **57 ms/seed** |

Every other world same-or-better; C1 floor intact (min 14, sub-12 = 0%); pipes column = full vanilla budget everywhere. 310 tests pass, clippy clean, changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ftbcx3jsSCouGj9YaWEB1z