### PR TITLE
fix: hazard-protect the 4F2 ground route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ deploys.
   leaving it unboardable. Its tile check read one map row too low, so a path
   tile below the water could be mistaken for water. It now reads the correct
   cell (World 3's middle island dock was the visible case).
+- The eight Dry Bones and the Roto-Disc in World 4's second fortress are now
+  hazard-protected, so they can't be swapped for a Thwomp/Ptooie/nipper-style
+  hazard sitting on the walking path.
 
 ### Changed
 

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -243,6 +243,22 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
         ],
     },
     LevelProtection {
+        label: "4F2 (fort ground route — a hazard on the walking path is unavoidable)",
+        enemy_ptr: 0xD508,
+        walker_segment: WalkerSegmentRule::Default,
+        entries: &[
+            EntryRule { offset: 0x0D519, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=2 col=10
+            EntryRule { offset: 0x0D51C, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=3 col=9
+            EntryRule { offset: 0x0D51F, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=4 col=9
+            EntryRule { offset: 0x0D522, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=5 col=4
+            EntryRule { offset: 0x0D525, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=5 col=11
+            EntryRule { offset: 0x0D528, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=6 col=2
+            EntryRule { offset: 0x0D52B, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=6 col=3
+            EntryRule { offset: 0x0D52E, rule: EntryProtection::ExcludeHazards }, // DryBones    scr=6 col=12
+            EntryRule { offset: 0x0D531, rule: EntryProtection::ExcludeHazards }, // RotodiscCCW scr=6 col=14
+        ],
+    },
+    LevelProtection {
         label: "4-1 (each troopa sits on a small platform Mario must land on to progress; a hazard here forces an unavoidable hit)",
         enemy_ptr: 0xCE97,
         walker_segment: WalkerSegmentRule::Default,


### PR DESCRIPTION
World 4's second fortress (`enemy_ptr` `$D508`) walks Mario along the ground past eight Dry Bones and a counter-clockwise Roto-Disc. If enemy randomization swaps any of them for a Thwomp/Ptooie/nipper-style hazard, that hazard lands directly on the walking path and the hit is unavoidable — so all nine entries get `ExcludeHazards`.

## Verification

The nine offsets are the segment's first nine 3-byte entries — page byte at `0x0D518` (`enemy_ptr_to_file_offset(0xD508)`), entries `0x0D519`..`0x0D533`:

| offset | id | x | y | |
|---|---|---|---|---|
| 0x0D519 | 3F | 2A | 16 | Dry Bones, scr 2 col 10 |
| 0x0D51C | 3F | 39 | 16 | Dry Bones, scr 3 col 9 |
| 0x0D51F | 3F | 49 | 16 | Dry Bones, scr 4 col 9 |
| 0x0D522 | 3F | 54 | 19 | Dry Bones, scr 5 col 4 |
| 0x0D525 | 3F | 5B | 19 | Dry Bones, scr 5 col 11 |
| 0x0D528 | 3F | 62 | 12 | Dry Bones, scr 6 col 2 |
| 0x0D52B | 3F | 63 | 12 | Dry Bones, scr 6 col 3 |
| 0x0D52E | 3F | 6C | 15 | Dry Bones, scr 6 col 12 |
| 0x0D531 | 5B | 6E | 14 | Rotodisc CCW, scr 6 col 14 |

`$3F` = Dry Bones and `$5B` = OBJ_ROTODISCCCLOCKWISE per the ROM reference, and every screen/column matches its comment. `rom_map.json` confirms `obj_ptr 0xD508` is World 4's fortress at grid (4, 0xE), tileset 2. The segment's tenth entry (`$4B` at `0x0D534`) is left unprotected.

Data-table addition only — no pick-logic change, so the `enemy_invariant_baseline` oracle isn't implicated.

`cargo clippy --all-targets` clean; `cargo test` 313 passed / 0 failed / 19 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)