### PR TITLE
fix: W8 dark page — no VRAM tile write on lock-break FX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ deploys.
 
 ### Fixed
 
+- Breaking a fortress lock in World 8's dark area no longer lights up the tile.
+  The lock-break effect used to paint the replacement tile over the darkness,
+  leaving it permanently visible. Now the poof plays where the lock was, and a
+  lock out in the dark stays hidden until your light reaches it, while a lock
+  already inside your light simply disappears as it should. Either way the lock
+  is gone for good. As part of the same fix, beating a fortress whose lock you
+  had already smashed with the hammer no longer redraws that tile — in the dark
+  area that redraw gave away which lock belonged to which fortress, which is
+  meant to be the risk you take when you swing the hammer blind.
 - Map nodes no longer show up in the wrong scenery. An empty node sitting in
   World 5's sky region could be drawn as a green land tile, and nodes on the
   island strips in Worlds 3, 4 and 7 could get land tiles instead of sand —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,65 @@ When clippy flags new code:
 
 Never silence a lint by deleting the warning text or globally disabling — the goal is "every warning was considered," not "no warnings emitted."
 
+## ROM Free Space Is Scarce — Optimize Every Patch for Size
+
+**Treat bytes of ROM free space as the project's scarcest resource.** Every new
+6502 patch must be written as small as it can be made, not merely small enough
+to fit its current allocation. "It fits, ship it" is not the standard — a patch
+that wastes 5 bytes has spent 5 bytes that a future feature will need.
+
+Space is **always** a concern. Never argue from the local gap ("there are 600
+free bytes right after this patch, so size doesn't matter here") — that
+reasoning is wrong even when the gap is real, because the gap belongs to the
+next feature, not to this one. Optimize the code every time.
+
+This applies to the *code*, not to the *allocation*. Reserving headroom in an
+allocation is encouraged: a routine that later needs a few more bytes is far
+safer to extend in place than to relocate, and several allocations here are
+origin-locked by self-referential absolute addresses. Write the tightest bytes
+you can, then reserve a sensible margin around them and note both numbers
+(e.g. `// 112 reserved, 97 used`).
+
+The total free-space figure is misleading. Free space is **per-bank**, and a
+routine has to live in a bank that is mapped when it runs, so the only number
+that matters is what's left in *the bank you need*. Measured against the current
+allocations (see `FREE_SPACE_ALLOCATIONS` in `rom_data/free_space.rs`):
+
+| Bank | Mapped at | Free left | Largest single gap |
+|------|-----------|-----------|--------------------|
+| PRG031 | `$E000–$FFFF`, always | **68** | **30** |
+| PRG030 | `$8000–$9FFF`, always | **120** | **74** |
+| PRG000–PRG007 | swapped, in-level | 34–58 each (bank 3: **0**) | ≤ 38 |
+| PRG010 | `$C000–$DFFF`, map | 880 | 588 |
+| PRG026 | `$A000–$BFFF`, map/inventory | 2603 | 2537 |
+
+The always-mapped banks are effectively full. Any patch that must run regardless
+of the current bank has under 30 contiguous bytes to work with, so a trampoline
+into a swapped bank is usually the only option — and that costs bytes too.
+
+Regenerate these numbers after adding allocations; the script pattern is to sum
+`FREE_SPACE_ALLOCATIONS` and scan the PRG region for `$FF`/`$00` runs not
+covered by one.
+
+### Size techniques that have actually paid off here
+
+- **Fold constant math into flags.** `ASL` leaves the shifted-out bit in carry;
+  `AND` + `ADC #$00` can then combine two extracted fields in 5 bytes where the
+  arithmetic-first version took 11 (see `fortress_fx.rs`, saved 6 bytes).
+- **Pick the instruction that preserves the register you still need.** `LDX abs`
+  to test a flag keeps `A` live for a following `STA`; `LDA` would force a
+  reload.
+- **Stash in a zero-page temp, not on the stack.** `PHA`/`PLA` is 1 byte per
+  half, but every exit path then needs its own discard — two exits and the
+  zero-page version is already smaller *and* removes the stack-balance hazard.
+- **Derive an index from one you already hold.** `TYA`/`ASL`/`TAY` (3) beats
+  re-reading the source and shifting (5).
+- **Reach a shared exit with a conditional branch.** When a flag is known (e.g.
+  `A` is non-zero), `BNE common` is 2 bytes where a second `JMP` is 3.
+- **Reuse the engine's own state and routines** instead of storing your own.
+  Querying a flag the engine already maintains costs a few bytes; a parallel
+  per-slot table costs bytes *and* can drift out of sync.
+
 ## Changelog
 
 `CHANGELOG.md` (repo root, [Keep a Changelog](https://keepachangelog.com/) format) tracks notable changes. When a change is user-visible or notable (a new flag/option, a behavior change, a fixed bug players would notice), add a one-line entry under the `[Unreleased]` section in the right group (`Added` / `Changed` / `Fixed` / `Removed`) as part of the same change. Skip purely internal refactors, test-only changes, and tooling tweaks. At version-bump time, move the accumulated `[Unreleased]` entries into a new versioned section.

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -2245,6 +2245,26 @@ fortress/ship in the game.
 3. Reads the FX slot value from `FortressFX_W1[absolute_index]` (0x00–0x10).
 4. Uses the FX slot to index into all visual/map replacement tables below.
 
+**Routine layout and entry points (CPU addresses, PRG010 = file − 0x8010):**
+
+| Address | What it does |
+|---------|--------------|
+| `$C8E6` | `LDA #$01 / STA $20` — sets `Map_ClearLevelFXCnt`. Randomizer hook site. |
+| `$C8EA`–`$C94F` | Queues the replacement tile into `Graphics_Buffer` (the VRAM write) |
+| `$C952` | `Map_Completions` block: loads `FortressFX_MapCompIdx` into `$0A`/`$0B` |
+| `$C964`–`$C969` | `LDA $7D00,Y / AND $0B / BNE $C9C9` — **already-busted check** |
+| `$C96B`–`$C9A2` | Sets the bits (both players), then writes the tile into map RAM |
+| `$C9A4` | Poof-sprite animation loop, driven by `$20` counting up to 7 |
+| `$C9C9` | Clears `Map_DoFortressFX` / `$20` and ends the effect |
+
+Note the ordering: **the VRAM write is queued before the busted check.** Vanilla
+re-runs the effect for an already-broken lock, repainting a tile that already
+shows the replacement — invisible normally, but a disclosure on a dark page.
+Entering at `$C952` therefore skips only the VRAM write; `$20` chosen at entry
+selects whether the poof plays (`$20=1`) or the effect ends at once (`$20=6`).
+`$C952` is self-contained — it reloads the slot from `$0745` and needs no
+register setup. See `fortress_fx.rs` (issue #131).
+
 **Data tables (all 17 entries, indexed by FX slot 0x00–0x10):**
 
 | File Offset | Size | Label | Description |
@@ -3667,6 +3687,21 @@ this and the `ExcludeHazards` filter over many seeds.
 | $797E–$797F | Death respawn map Y (Mario/Luigi) |
 | $7980–$7981 | Death respawn map X high (Mario/Luigi) |
 | $7982–$7983 | Death respawn map X low (Mario/Luigi) |
+| $0596 | `Map_MarchInit` — marching data initialized this cycle |
+| $0597 | `Map_InCanoe_Flag` — player is in the canoe |
+| $0598 | `World_8_Dark` — W8 darkness active; counts 0–7 while the effect sets up |
+
+**`World_8_Dark` ($0598)** is the engine's single source of truth for "the map
+is dark right now." Set on map load (PRG030, two sites: `STY $0598` at 0x3C5B5
+and 0x3D1E1) from `World_Num == 7 && World_Map_XHi[player] == 2` — i.e. it
+tracks the *player's* page, not any particular tile's. Three consumers gate on
+it: `Map_W8DarknessFill` (blanket-fills the nametable with black tile `$FF`
+starting at VRAM `$2880`, ~608 bytes, leaving map RAM untouched),
+`FX_World_8_Darkness` (PRG011 $BB6D — the reveal-around-Mario animation, which
+paints real tiles back into VRAM), and `Map_W8Dark_IntroCover`. Because the
+darkness is *only* a VRAM overlay, anything that writes a tile to VRAM on that
+page paints it lit over the black and it stays that way until reload — which is
+why the fortress lock-break FX has to gate its VRAM write on this flag.
 
 ### Enemy / Object State
 

--- a/src/randomize/overworld_writer/fortress_fx.rs
+++ b/src/randomize/overworld_writer/fortress_fx.rs
@@ -97,7 +97,7 @@ pub(super) fn patch_fortress_fx_screen_check(rom: &mut Rom) {
     rom.write_byte(HOOK_OFFSET + 1, 0x44); // lo($D544)
     rom.write_byte(HOOK_OFFSET + 2, 0xD5); // hi($D544)
 
-    // --- Custom code at $D544 (file 0x15554), 80 bytes ---
+    // --- Custom code at $D544 (file 0x15554) ---
     //
     // **Algorithm: compare lock's half-screen index to Mario's half-
     // screen index, not the scroll's screen index.** Cross-checked
@@ -126,22 +126,107 @@ pub(super) fn patch_fortress_fx_screen_check(rom: &mut Rom) {
     // tiles where the lock-break animation would clip across screen
     // boundaries even when nominally "visible."
     //
+    // Two further gates suppress the VRAM tile write (issue #131).
+    // Vanilla queues that write into `Graphics_Buffer` at the *top* of
+    // `MO_DoFortressFX` ($C8EA..$C94F), before it checks anything — so
+    // both gates have to be decided here, ahead of the jump.
+    //
+    // **1. Lock already busted → skip the write.** Vanilla itself
+    // branches on this at $C964 (`Map_Completions[col] & bit`), but only
+    // *after* the buffer was already filled. Harmless on a lit page (the
+    // tile it draws is the one that's already there), but on the W8 dark
+    // page it repaints a tile the darkness was hiding — so beating a
+    // fortress whose lock the player had already smashed with the hammer
+    // disclosed which lock belonged to that fortress. Hammer breaks go
+    // through `Map_SetCompletion_By_Poof`, which sets the very same
+    // (column, row-bit) this slot's `FortressFX_MapCompIdx` pair encodes,
+    // so reading `Map_Completions` covers them. Taking the skip exit
+    // matches vanilla's own handling: $C952 re-runs the busted check and
+    // ends the effect at $C9C9, no poof, no map write.
+    //
+    // **2. Darkness active → poof but no write, then replay the reveal.**
+    // `Map_W8DarknessFill` blacks out the nametable with tile $FF and
+    // leaves map RAM alone; Mario carries a 3x3 metatile box of light that
+    // `Map_W8DarknessUpdate` repaints from map RAM as he walks. A tile
+    // written here would therefore stand lit against the black and stay
+    // that way. The poof-only exit ($20=1 → JMP $C952) plays the sprites
+    // at the lock's spot and updates map RAM + `Map_Completions`.
+    //
+    // But skipping the write alone leaves a *stale lock* whenever the lock
+    // sits inside that box — the common case, since a lock is often right
+    // beside the fortress that opens it. So the same path also resets
+    // `World_8_Dark` to 1, which is what the map-load code sets on arrival
+    // (PRG030 `INY; STY $0598`): `FX_World_8_Darkness` replays the arrival
+    // reveal, repainting the light box from the now-updated map RAM.
+    //
+    // The two halves cover disjoint cases and neither needs any geometry:
+    // the skip stops a tile *outside* the light from being painted lit
+    // (nothing could ever black it again — the reveal only paints, and the
+    // only routine that blacks the screen writes 608 bytes straight to the
+    // PPU with rendering off, i.e. map load only), and the replay fixes a
+    // tile *inside* the light whose graphic is now stale. Mario is always
+    // standing still on the fortress tile here — the map has just loaded
+    // and input is locked through the effect — so the lit region is exactly
+    // the arrival box the replay redraws.
+    //
+    // Reset timing takes care of itself: `FX_World_8_Darkness` is reached
+    // only via `MapObjects_UpdateDrawEnter`, which is not on the
+    // `MO_DoFortressFX` path (that ends at `WorldMap_UpdateAndDraw`, which
+    // just draws the player sprite), so the replay runs once the effect
+    // finishes — by which point map RAM has held the replacement tile since
+    // the effect's first frame.
+    //
+    // `World_8_Dark` ($0598) is the engine's own darkness flag — the same
+    // one `Map_W8DarknessFill` and `FX_World_8_Darkness` gate on — set on
+    // map load from `World_Num == 7 && World_Map_XHi[player] == 2`. It is
+    // preferred over deriving `world == 7 && lock_screen == 2` inline
+    // because it is a real source of truth rather than a restatement of
+    // one, and it needs no per-slot flag in the FX tables. (A prior
+    // attempt at this feature, d608bf1, smuggled a poof-only flag into
+    // bit 0 of `FX_MAP_LOC_ROW`; the engine ORs that nibble into the
+    // map-data write column at $C99B, which corrupted the destination
+    // tile and softlocked the lock — reverted in 13ac21e. No per-slot FX
+    // table has a free bit; this reads engine state instead.) Note the
+    // flag tracks *Mario's* page, not the lock's: it is set while the
+    // player stands on the dark page, which is when darkness is on screen.
+    //
     // **What the patch reads:**
     //   $0745    — resolved FX slot (engine stored it at $C8E3)
+    //   $C7DF,Y  — FortressFX_MapCompIdx[slot*2] = (column, row bit)
+    //   $7D00,X  — Map_Completions (Mario's copy, as vanilla's own check)
     //   $C856,Y  — FortressFX_MapLocation[slot] = (col<<4)|screen
     //   $77, $79 — Mario's map_obj X hi/lo (settled position)
     //   $FD      — Map_Scroll_X
+    //   $0598    — World_8_Dark
     //   $0A      — temporary in zero page
     //
     // Exit:
-    //   visible   → JMP $C8EA ($20=1, full animate)
-    //   invisible → JMP $C952 ($20=6, data-only update)
+    //   visible          → JMP $C8EA ($20=1, full animate)
+    //   visible + dark   → JMP $C952 ($20=1, poof + map data, no VRAM,
+    //                      World_8_Dark=1 to replay the reveal)
+    //   invisible/busted → JMP $C952 ($20=6, data-only update)
     //
-    // 80 bytes; matches the FS_FX_SCREEN_CHECK allocation in
-    // rom_data.rs. debug_assert! locks the size.
+    // 102 bytes; fits the FS_FX_SCREEN_CHECK allocation in rom_data.rs.
+    // debug_assert! locks the size.
     const CODE_OFFSET: usize = rom_data::FS_FX_SCREEN_CHECK;
     #[rustfmt::skip]
     let code: &[u8] = &[
+        // ----- Edge-tile filter (skip cols 0/15 at certain scrolls) -----
+        // Same as Fred's: (col<<4) EOR $FD, must be in [$10, $E8). Saves the
+        // lock-break animation from clipping across screen boundaries on
+        // edge tiles. The loc byte is stashed in X rather than re-read from
+        // $C856,Y for the half-index below (TAX+TXA = 2 bytes vs a 3-byte
+        // re-load).
+        0xAC, 0x45, 0x07,    //  0: LDY $0745         ; Y = real FX slot
+        0xB9, 0x56, 0xC8,    //  3: LDA $C856,Y       ; loc = (col<<4)|screen
+        0xAA,                //  6: TAX               ; stash loc
+        0x29, 0xF0,          //  7: AND #$F0          ; A = col<<4
+        0x45, 0xFD,          //  9: EOR $FD           ; A ^= Map_Scroll_X
+        0xC9, 0x10,          // 11: CMP #$10
+        0x90, 0x48,          // 13: BCC +72 → skip
+        0xC9, 0xE8,          // 15: CMP #$E8
+        0xB0, 0x44,          // 17: BCS +68 → skip
+
         // ----- $0A = lock_half_index = 2*screen + (col>=8 ? 1 : 0) -----
         //
         // Fred's version of this block runs `LDA / ASL / LDA / AND #$03 /
@@ -154,33 +239,23 @@ pub(super) fn patch_fortress_fx_screen_check(rom: &mut Rom) {
         // them. Saves 6 bytes vs Fred. Equivalent for all in-use loc
         // values (verified by exhaustive enumeration of the 17 vanilla
         // slots and chr_stats's randomized layouts).
-        0xAC, 0x45, 0x07,    //  0: LDY $0745         ; Y = real FX slot
-        0xB9, 0x56, 0xC8,    //  3: LDA $C856,Y       ; loc byte
-        0x0A,                //  6: ASL A             ; A=(loc<<1)&$FF; C = col>=8
-        0x29, 0x06,          //  7: AND #$06          ; A = (screen<<1)&$06 = 2*(screen&3)
-        0x69, 0x00,          //  9: ADC #$00          ; A += C  → 2*screen + (col>=8)
-        0x85, 0x0A,          // 11: STA $0A           ; lock_half_index (0..7)
-
-        // ----- Edge-tile filter (skip cols 0/15 at certain scrolls) -----
-        // Same as Fred's: (col<<4) EOR $FD, must be in [$10, $E8).
-        // Saves the lock-break animation from clipping across screen
-        // boundaries on edge tiles.
-        0xB9, 0x56, 0xC8,    // 13: LDA $C856,Y       ; reload loc
-        0x29, 0xF0,          // 16: AND #$F0          ; A = col<<4
-        0x45, 0xFD,          // 18: EOR $FD           ; A ^= Map_Scroll_X
-        0xC9, 0x10,          // 20: CMP #$10
-        0x90, 0x23,          // 22: BCC +35 → skip
-        0xC9, 0xE8,          // 24: CMP #$E8
-        0xB0, 0x1F,          // 26: BCS +31 → skip
+        0x8A,                // 19: TXA               ; loc back
+        0x0A,                // 20: ASL A             ; A=(loc<<1)&$FF; C = col>=8
+        0x29, 0x06,          // 21: AND #$06          ; A = (screen<<1)&$06 = 2*(screen&3)
+        0x69, 0x00,          // 23: ADC #$00          ; A += C  → 2*screen + (col>=8)
+        0x85, 0x0A,          // 25: STA $0A           ; lock_half_index (0..7)
 
         // ----- mario_half_index = 2*$77 + bit7($79) ; first compare -----
-        0xA5, 0x79,          // 28: LDA $79           ; Mario X lo
-        0x0A,                // 30: ASL A             ; C = bit 7 of $79
-        0xA5, 0x77,          // 31: LDA $77           ; Mario X hi
-        0x65, 0x77,          // 33: ADC $77           ; A = 2*$77 + C  (= mario_half_index)
-        0x48,                // 35: PHA               ; stash mario_index
+        // Cached in $0B (Temp_Var12) rather than on the stack: every exit
+        // would otherwise need its own PLA discard, which is both bigger and
+        // the reason "skip" used to have two entry points.
+        0xA5, 0x79,          // 27: LDA $79           ; Mario X lo
+        0x0A,                // 29: ASL A             ; C = bit 7 of $79
+        0xA5, 0x77,          // 30: LDA $77           ; Mario X hi
+        0x65, 0x77,          // 32: ADC $77           ; A = 2*$77 + C  (= mario_half_index)
+        0x85, 0x0B,          // 34: STA $0B
         0xC5, 0x0A,          // 36: CMP $0A
-        0xF0, 0x1A,          // 38: BEQ +26 → animate ; same half-screen → visible
+        0xF0, 0x12,          // 38: BEQ +18 → busted  ; same half-screen → visible
 
         // ----- adjacency: adjust $0A by ±1 per scroll/mario alignment -----
         // BMI path (B): $79 and $FD differ on bit 7 → INC $0A (+1)
@@ -191,24 +266,43 @@ pub(super) fn patch_fortress_fx_screen_check(rom: &mut Rom) {
         0xC6, 0x0A,          // 46: DEC $0A           ; path A start
         0xC6, 0x0A,          // 48: DEC $0A
         0xE6, 0x0A,          // 50: INC $0A           ; path B target (fall-through for A)
-        0x68,                // 52: PLA               ; peek mario_index
-        0x48,                // 53: PHA               ; re-push
+        0xA5, 0x0B,          // 52: LDA $0B           ; mario_index
         0xC5, 0x0A,          // 54: CMP $0A
-        0xF0, 0x08,          // 56: BEQ +8 → animate
+        0xD0, 0x1D,          // 56: BNE +29 → skip    ; neither half-screen → invisible
 
-        // ----- skip: data-only update, $20 = 6 -----
-        0x68,                // 58: PLA               ; discard stashed mario_index
-        0xA9, 0x06,          // 59: LDA #$06
-        0x85, 0x20,          // 61: STA $20
-        0x4C, 0x52, 0xC9,    // 63: JMP $C952
+        // ----- Already-busted check: Map_Completions[col] & row_bit -----
+        // Mirrors vanilla's own test at $C964, hoisted ahead of the
+        // graphics-buffer fill so an already-broken lock never reaches VRAM.
+        // $C952 re-runs it and ends the effect. Placed after the visibility
+        // test so the slot*2 index comes from Y (TYA/ASL/TAY) instead of a
+        // second `LDA $0745` — 3 bytes instead of 5.
+        0x98,                // 58: TYA               ; Y still = FX slot
+        0x0A,                // 59: ASL A
+        0xA8,                // 60: TAY               ; Y = slot*2
+        0xBE, 0xDF, 0xC7,    // 61: LDX $C7DF,Y       ; MapCompIdx col
+        0xC8,                // 64: INY
+        0xBD, 0x00, 0x7D,    // 65: LDA $7D00,X       ; Map_Completions[col]
+        0x39, 0xDF, 0xC7,    // 68: AND $C7DF,Y       ; MapCompIdx row bit
+        0xD0, 0x0E,          // 71: BNE +14 → skip    ; busted → no VRAM write
 
         // ----- animate: full FX, $20 = 1 -----
-        0x68,                // 66: PLA               ; discard stashed mario_index
-        0xA9, 0x01,          // 67: LDA #$01
-        0x85, 0x20,          // 69: STA $20
-        0x4C, 0xEA, 0xC8,    // 71: JMP $C8EA
+        0xA9, 0x01,          // 73: LDA #$01
+        0x85, 0x20,          // 75: STA $20
+        // Darkness active → poof + map data only, and restart the reveal so
+        // a lock inside Mario's light gets repainted from the updated map
+        // RAM. LDX (not LDA) so A stays #$01 for the STA below.
+        0xAE, 0x98, 0x05,    // 77: LDX $0598         ; World_8_Dark
+        0xF0, 0x0C,          // 80: BEQ +12 → full animate
+        0x8D, 0x98, 0x05,    // 82: STA $0598         ; A=1 → replay arrival reveal
+        0xD0, 0x04,          // 85: BNE +4 → common   ; A=1, always taken
+
+        // ----- skip: data-only update, $20 = 6 -----
+        0xA9, 0x06,          // 87: LDA #$06
+        0x85, 0x20,          // 89: STA $20
+        0x4C, 0x52, 0xC9,    // 91: JMP $C952         ; common
+        0x4C, 0xEA, 0xC8,    // 94: JMP $C8EA         ; full animate
     ];
-    debug_assert!(code.len() == 74, "FX screen-check patch must be 74 bytes (allocation is 80, 6 reserved free)");
+    debug_assert!(code.len() == 97, "FX screen-check patch must be 97 bytes (allocation is 112, 15 reserved free)");
     for (i, &b) in code.iter().enumerate() {
         rom.write_byte(CODE_OFFSET + i, b);
     }

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -1,5 +1,22 @@
 //! Central registry of ROM free-space allocations (assembled code + data
 //! tables). The overlap test guards against collisions.
+//!
+//! **Free space is the scarcest resource in this project — size every patch
+//! accordingly.** See the "ROM Free Space Is Scarce" section in `CLAUDE.md`
+//! for the per-bank budget and the size techniques that have paid off.
+//!
+//! The aggregate free-space number is misleading: space is per-bank, and a
+//! routine must live in a bank mapped when it runs. The always-mapped banks
+//! are effectively full — PRG031 (`$E000–$FFFF`) has ~68 bytes left with a
+//! largest contiguous gap of ~30, and PRG030 (`$8000–$9FFF`) has ~120 with a
+//! largest gap of ~74. Swapped banks are roomier (PRG010 ~880, PRG026 ~2600).
+//!
+//! Reserving some headroom in an allocation is fine and encouraged — a routine
+//! that has to grow later is far safer to extend in place than to relocate
+//! (several allocations here are origin-locked by self-referential absolute
+//! addresses). Note both numbers when they differ, e.g. "112 reserved, 97
+//! used". What is *not* fine is letting the code itself be sloppy: reserve
+//! room, but write the bytes as tight as they will go.
 
 /// Free space allocation: (file_offset, size_bytes, label).
 /// The overlap test checks that no two allocations in this list share any bytes.
@@ -23,7 +40,7 @@ pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
     // PRG027 (file 0x36010, CPU $A000–$BFFF)
     (0x379D9, 894, "king_quotes: 7 quotes + hook (7×120 + 54)"),
     // PRG010 (file 0x14010, CPU $C000–$DFFF during map)
-    (0x15554, 80, "fx_screen_check: cross-screen lock patch (Fred's algorithm verbatim)"),
+    (0x15554, 112, "fx_screen_check: cross-screen lock patch (Fred's algorithm + busted/darkness gates)"),
     (0x15DF0, 35, "canoe_fix: death respawn position save"),
     (0x15E13, 162, "map_warp: 2P Start+Select warp-to-partner routine"),
     (0x15EB5, 151, "canoe_summon: A-on-dock call-the-boat routine + offset tables"),
@@ -144,7 +161,9 @@ pub(crate) const FS_BIG_Q_LOOKUP: usize      = 0x355BD; // 106 bytes (CPU $B5AD)
 pub(crate) const FS_KING_QUOTES: usize       = 0x379D9; // 894 bytes
 
 // PRG010
-pub(crate) const FS_FX_SCREEN_CHECK: usize   = 0x15554; // 80 bytes (Fred's algorithm)
+// Fred's visibility algorithm plus the busted / darkness gates (issue #131).
+// The $FF run this sits in continues to 0x15810, so there is room to grow.
+pub(crate) const FS_FX_SCREEN_CHECK: usize   = 0x15554; // 112 reserved, 97 used
 
 pub(crate) const FS_CANOE_RESPAWN: usize     = 0x15DF0; // 35 bytes
 pub(crate) const FS_MAP_WARP: usize          = 0x15E13; // 162 bytes (CPU $DE03)


### PR DESCRIPTION
Fixes #131.

## The bug

On World 8's dark page the fortress lock-break FX revealed the map tile that the darkness overlay was hiding, two ways:

1. The replacement tile was painted lit against the black and stayed visible.
2. It fired even when the lock had already been hammer-broken, so beating the associated fortress disclosed the fort→lock pairing — which is meant to be the blind risk you take swinging the hammer.

Both come from ordering: vanilla queues the VRAM tile write at the **top** of `MO_DoFortressFX` (`$C8EA..$C94F`), before it checks anything — including its own already-busted test at `$C964`.

## The fix

Both gates are decided in `patch_fortress_fx_screen_check` before the jump, and neither stores per-slot state:

- **Already busted** → derived from `Map_Completions` via the slot's own `FortressFX_MapCompIdx` pair. Hammer breaks route through `Map_SetCompletion_By_Poof`, which sets the very same (column, row-bit), so they're covered.
- **Darkness active** → `World_8_Dark` (`$0598`), the engine's own flag, the one `Map_W8DarknessFill` and `FX_World_8_Darkness` gate on.

The dark page is **not uniformly dark** — Mario carries a 3×3 metatile box of light that `Map_W8DarknessUpdate` repaints from map RAM. Skipping the write alone therefore left a *stale lock* whenever the lock sat inside that box, which is the common case since a lock is often right beside the fortress that opens it. So the same path also resets `World_8_Dark` to 1 — what the map-load code sets on arrival — replaying the arrival reveal against the updated map RAM.

The two halves cover disjoint cases and neither needs geometry maths:

| | lock inside the light | lock out in the dark |
|---|---|---|
| before | correct | **bug** — painted lit |
| skip only | **bug** — stale lock | correct |
| skip + replay | correct | correct |

The skip stops a tile outside the light being painted lit (nothing could ever black it again — the reveal only paints, and the only routine that blacks the screen writes 608 bytes straight to the PPU with rendering off). The replay fixes a tile inside the light whose graphic is now stale. Mario is always standing still on the fortress tile when this runs, so the lit region is exactly the arrival box the replay redraws.

**No per-slot FX flag.** `d608bf1` tried that and smuggled it into bit 0 of `FX_MAP_LOC_ROW`, which the engine ORs into the map-data write column at `$C99B` — corrupting the destination tile and softlocking the lock (reverted in `13ac21e`). No per-slot FX table has a free bit; reading engine RAM sidesteps the whole class.

## Verification

- 97 bytes (was 74), allocation reserves 112. Disassembly pass: every branch resolves to an intended label, no stack use, clean `$FF` tail.
- Proved equivalent to the unoptimised 102-byte form over **321,632 inputs** with a small 6502 interpreter diffing exit target plus `$20`, `$0598` and stack depth — exhaustive over boundary values for the scroll/Mario/loc bytes, then a 300k random sweep. Zero divergences.
- Playtested on hardware-accurate emulation with purpose-built seeds: seed 17 (lock adjacent to its fort — inside the light) and seed 25 (lock 4 rows away — outside it).
- 319 tests pass, clippy clean.

## Also included

A `docs:` commit recording that ROM free space is the project's scarcest resource and that every patch must be sized accordingly — with the measured **per-bank** budget, since the aggregate figure is misleading. The always-mapped banks are effectively full: PRG031 has ~68 bytes left (largest gap ~30), PRG030 ~120 (largest ~74), PRG003 none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)