### PR TITLE
Consolidate overworld tile classification into rom_data::tiles

### DIFF
--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -49,7 +49,8 @@ use crate::rom::Rom;
 
 use super::map_walker::{Reach, walk_map, walk_reachable};
 use super::node_catalog::{NodeCatalog, NodeKind};
-use super::overworld_helpers::{LOCKABLE_TILES, find_target, gap_tile_for};
+use super::overworld_helpers::{LOCKABLE_TILES, find_target};
+use super::rom_data::gap_tile_for;
 use super::overworld_pickup::{PickupResult, blank_tile_for};
 use super::rom_data::{
     self, BACKGROUND_TILES, Grid, Pos, TILE_BONUS_GAME, TILE_FORTRESS, TILE_NODE, TILE_PIPE,

--- a/src/randomize/overworld_helpers.rs
+++ b/src/randomize/overworld_helpers.rs
@@ -3,7 +3,7 @@
 //! These are stateless helpers used by the overworld builder pipeline for tile
 //! classification, gap placement, and FX pattern lookup.
 
-use super::rom_data::{Grid, TILE_AIRSHIP, TILE_BOWSER};
+use super::rom_data::{self, Grid, TILE_AIRSHIP, TILE_BOWSER};
 
 /// All path tiles eligible for lock/water-gap placement.
 /// Locks (0x54, 0x56, 0xE4) are visual variants — all block the path equally.
@@ -40,29 +40,15 @@ pub(super) fn find_target(grid: &Grid, world_idx: usize) -> Option<(usize, usize
     None
 }
 
-/// Vertical path tiles (plain + variants + drawbridge). Both the gap-tile
-/// and FX-pattern lookups key on this — a new vertical variant added here
-/// gets the vertical lock AND its FX pattern together.
-fn is_vertical_path(tile: u8) -> bool {
-    matches!(tile, 0x46 | 0xAA | 0xAB | 0xB0 | 0xB1 | 0xDB | 0xBA)
-}
-
-/// Determine the lock/gap tile for a given path tile.
-/// 0x54 = vertical lock, 0x56 = horizontal lock, 0xE4 = sky lock, 0x9D = water gap.
-pub(super) fn gap_tile_for(tile: u8) -> u8 {
-    match tile {
-        0xB3 => 0x9D,                          // bridge → water gap
-        0xDA => 0xE4,                          // sky path → sky lock
-        t if is_vertical_path(t) => 0x54,      // vertical path → vertical lock
-        _ => 0x56,                             // horizontal path → horizontal lock
-    }
-}
-
 /// Pattern bytes for each FX type (keyed by the original path tile).
+///
+/// Keys on [`rom_data::is_vertical_path`], the same predicate
+/// [`rom_data::gap_tile_for`] uses, so a new vertical variant added there gets
+/// its lock tile and its FX pattern together rather than one of the two.
 pub(super) fn fx_patterns_for(tile: u8) -> [u8; 4] {
     match tile {
-        0xB3 => [0xD4, 0xD6, 0xD5, 0xD7],                    // water bridge
-        t if is_vertical_path(t) => [0xFE, 0xC0, 0xFE, 0xC0], // lock (vertical)
+        rom_data::BRIDGE_TILE => [0xD4, 0xD6, 0xD5, 0xD7],   // water bridge
+        t if rom_data::is_vertical_path(t) => [0xFE, 0xC0, 0xFE, 0xC0], // lock (vertical)
         _ => [0xFE, 0xFE, 0xE1, 0xE1],                        // bridge gap / sky
     }
 }

--- a/src/randomize/overworld_pickup.rs
+++ b/src/randomize/overworld_pickup.rs
@@ -444,7 +444,7 @@ mod tests {
                 if slot.grid_row < grid.rows() && slot.grid_col < grid.cols {
                     let tile = grid.get(slot.grid_row, slot.grid_col);
                     assert!(
-                        tile != 0x54 && tile != 0x56 && tile != 0x9D && tile != 0xE4,
+                        !rom_data::is_gap_tile(tile),
                         "W{} FX slot {si} at ({},{}) still has gap tile ${tile:02X}",
                         wi + 1, slot.grid_row, slot.grid_col,
                     );

--- a/src/randomize/qol/hammer_breaks.rs
+++ b/src/randomize/qol/hammer_breaks.rs
@@ -1,7 +1,7 @@
 //! Hammer item also breaks fortress locks / water-gap bridges.
 
 use crate::rom::Rom;
-use crate::randomize::rom_data::{FS_HAMMER_LOCKS, prg_bank_file_to_cpu};
+use crate::randomize::rom_data::{self, FS_HAMMER_LOCKS, prg_bank_file_to_cpu};
 
 // Make the hammer item also break fortress lock tiles and/or water-gap
 // bridge locks on the overworld map.
@@ -39,14 +39,25 @@ pub fn hammer_breaks_tiles(rom: &mut Rom, locks: bool, bridges: bool) {
     let mut replace:   Vec<u8> = vec![0x45, 0x46];
     let mut tilefix:   Vec<u8> = vec![0x00, 0x01];
 
+    // `replace` is derived from `path_for_gap_tile` rather than written out
+    // again: it is the same lock→path mapping the FX restore uses, and a third
+    // copy of it here could drift from the other two. `tilefix` stays explicit
+    // — it is a hammer-specific orientation fixup, not tile classification.
     if locks {
-        breakable.extend_from_slice(&[0x54, 0x56, 0xE4]);
-        replace.extend_from_slice(&[0x46, 0x45, 0xDA]);
+        for &lock in &rom_data::LOCK_TILES {
+            breakable.push(lock);
+            replace.push(
+                rom_data::path_for_gap_tile(lock).expect("a lock tile always inverts"),
+            );
+        }
         tilefix.extend_from_slice(&[0x01, 0x00, 0x00]);
     }
     if bridges {
-        breakable.push(0x9D);
-        replace.push(0xB3);
+        breakable.push(rom_data::WATER_GAP_TILE);
+        replace.push(
+            rom_data::path_for_gap_tile(rom_data::WATER_GAP_TILE)
+                .expect("the water gap always inverts"),
+        );
         tilefix.push(0x00);
     }
 
@@ -118,4 +129,74 @@ pub fn hammer_breaks_tiles(rom: &mut Rom, locks: bool, bridges: bool) {
     subroutine.extend_from_slice(&replace);
     subroutine.extend_from_slice(&tilefix);
     rom.write_range(FS_HAMMER_LOCKS, &subroutine);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the generated tables byte-for-byte.
+    ///
+    /// `hammer_breaks_locks` is off by default, so the overworld baseline sweep
+    /// never reaches this code — it would pass vacuously and prove nothing about
+    /// deriving `replace` from `path_for_gap_tile`. The expected bytes below are
+    /// the literals this function used before that change.
+    fn tables(locks: bool, bridges: bool) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            return (vec![], vec![], vec![]);
+        };
+        let mut rom = crate::rom::Rom::from_bytes_lax(&bytes, true).unwrap();
+        hammer_breaks_tiles(&mut rom, locks, bridges);
+
+        let n = 2 + if locks { 3 } else { 0 } + usize::from(bridges);
+        let base = FS_HAMMER_LOCKS + 32;
+        let read = |i: usize| rom.read_range(base + i * n, n).to_vec();
+        (read(0), read(1), read(2))
+    }
+
+    #[test]
+    fn rocks_only_tables_are_unchanged() {
+        let (breakable, replace, tilefix) = tables(false, false);
+        if breakable.is_empty() {
+            return; // no ROM available
+        }
+        assert_eq!(breakable, vec![0x51, 0x52]);
+        assert_eq!(replace, vec![0x45, 0x46]);
+        assert_eq!(tilefix, vec![0x00, 0x01]);
+    }
+
+    #[test]
+    fn lock_tables_match_the_literals_they_replaced() {
+        let (breakable, replace, tilefix) = tables(true, false);
+        if breakable.is_empty() {
+            return;
+        }
+        assert_eq!(breakable, vec![0x51, 0x52, 0x54, 0x56, 0xE4]);
+        assert_eq!(replace, vec![0x45, 0x46, 0x46, 0x45, 0xDA]);
+        assert_eq!(tilefix, vec![0x00, 0x01, 0x01, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn bridge_entry_appends_after_locks() {
+        let (breakable, replace, tilefix) = tables(true, true);
+        if breakable.is_empty() {
+            return;
+        }
+        assert_eq!(breakable, vec![0x51, 0x52, 0x54, 0x56, 0xE4, 0x9D]);
+        assert_eq!(replace, vec![0x45, 0x46, 0x46, 0x45, 0xDA, 0xB3]);
+        assert_eq!(tilefix, vec![0x00, 0x01, 0x01, 0x00, 0x00, 0x00]);
+    }
+
+    /// Bridges without locks must not shift the lock entries in — the tables are
+    /// parallel arrays indexed together, so order is load-bearing.
+    #[test]
+    fn bridges_without_locks() {
+        let (breakable, replace, tilefix) = tables(false, true);
+        if breakable.is_empty() {
+            return;
+        }
+        assert_eq!(breakable, vec![0x51, 0x52, 0x9D]);
+        assert_eq!(replace, vec![0x45, 0x46, 0xB3]);
+        assert_eq!(tilefix, vec![0x00, 0x01, 0x00]);
+    }
 }

--- a/src/randomize/rom_data/mod.rs
+++ b/src/randomize/rom_data/mod.rs
@@ -5,8 +5,10 @@
 //! multiple randomization modules. The BFS map walker lives in `map_walker.rs`.
 //!
 //! Split into submodules: `free_space` (allocation registry), `tables` (static
-//! data), `grid` (the overworld grid), `access` (typed read/write helpers). All
-//! items are re-exported flat so callers keep using `rom_data::ITEM`.
+//! data), `grid` (the overworld grid), `access` (typed read/write helpers),
+//! `tiles` (overworld tile classification — the single producer for "which
+//! bytes mean what"). All items are re-exported flat so callers keep using
+//! `rom_data::ITEM`.
 
 use crate::rom::Rom;
 
@@ -14,11 +16,16 @@ mod access;
 mod free_space;
 mod grid;
 mod tables;
+mod tiles;
 
 pub(crate) use access::*;
 pub(crate) use free_space::*;
 pub(crate) use grid::*;
 pub(crate) use tables::*;
+// Reason: re-exported ahead of its callers; the tile-predicate consolidation
+// migrates one call site per commit. Drop this allow with the last one.
+#[allow(unused_imports)]
+pub(crate) use tiles::*;
 
 // Part of the lib's public API (consumed by the chr_stats integration test).
 pub use access::{ENEMY_DATA_END, ENEMY_DATA_START};

--- a/src/randomize/rom_data/mod.rs
+++ b/src/randomize/rom_data/mod.rs
@@ -22,9 +22,6 @@ pub(crate) use access::*;
 pub(crate) use free_space::*;
 pub(crate) use grid::*;
 pub(crate) use tables::*;
-// Reason: re-exported ahead of its callers; the tile-predicate consolidation
-// migrates one call site per commit. Drop this allow with the last one.
-#[allow(unused_imports)]
 pub(crate) use tiles::*;
 
 // Part of the lib's public API (consumed by the chr_stats integration test).

--- a/src/randomize/rom_data/tiles.rs
+++ b/src/randomize/rom_data/tiles.rs
@@ -1,0 +1,226 @@
+//! Overworld tile classification — the single producer for "which bytes mean
+//! what" on the world map.
+//!
+//! # Why this exists
+//!
+//! Before this module, "which bytes are locks" was written out independently in
+//! four places (`overworld_pickup`'s FX-slot assertion, `qol::hammer_breaks`'s
+//! breakable table, `overworld_helpers::gap_tile_for`, and `testrom`'s unlock
+//! table). Each answered a slightly different question inline, so none was
+//! obviously the authority and any of them could drift.
+//!
+//! The rule this module enforces: **no fact about the ROM has two producers.**
+//! Predicates are named after the *question being asked*, not lumped into one
+//! list — the sites genuinely differ (the hammer takes locks but only takes
+//! water gaps when asked to), and a single flat list would paper over
+//! distinctions that matter.
+//!
+//! # What does *not* belong here
+//!
+//! Mirrors of the engine's own lookup tables — `capacity::is_completion_unsafe`
+//! reproduces `Map_Removable_Tiles` from the ROM, which must track the *game's*
+//! bytes rather than our semantics. Those two lists legitimately differ and
+//! merging them would couple concepts that should move independently. The right
+//! treatment for a table mirror is a test asserting it still matches the bytes
+//! at its ROM offset, not consolidation into these predicates.
+
+// Reason: this module is introduced ahead of its callers on purpose — the
+// consolidation migrates one call site per commit, each verified byte-identical
+// against `tests/overworld_baseline.rs`. Every item here is dead until its
+// first migration; remove this allow once the last inlined list is gone.
+#![allow(dead_code)]
+
+use super::FORTRESS_TILES;
+
+// ---------------------------------------------------------------------------
+// Gap tiles (locks and water gaps)
+// ---------------------------------------------------------------------------
+
+/// Lock tiles. Three visual variants — vertical, horizontal, sky — that all
+/// block a path identically; only the graphic differs.
+pub(crate) const LOCK_TILES: [u8; 3] = [
+    0x54, // vertical lock
+    0x56, // horizontal lock
+    0xE4, // sky lock
+];
+
+/// The water-gap tile. Distinct from a lock: it replaces a bridge rather than a
+/// path, is restored to `0xB3` rather than a path tile, and the hammer only
+/// breaks it when explicitly asked (see `qol::hammer_breaks`).
+pub(crate) const WATER_GAP_TILE: u8 = 0x9D;
+
+/// The bridge tile a water gap is cut from and restored to.
+pub(crate) const BRIDGE_TILE: u8 = 0xB3;
+
+/// A lock tile — opened by clearing its fortress, or by the hammer when
+/// `hammer_breaks_locks` is on.
+pub(crate) fn is_lock(tile: u8) -> bool {
+    LOCK_TILES.contains(&tile)
+}
+
+/// The water-gap tile.
+pub(crate) fn is_water_gap(tile: u8) -> bool {
+    tile == WATER_GAP_TILE
+}
+
+/// A "gap tile" in the codebase's existing sense (`LockAssignment::gap_tile`,
+/// the output domain of [`gap_tile_for`]): a tile written over a path to block
+/// it, removed again by a fortress-clear FX. Locks and the water gap both
+/// qualify.
+///
+/// Use this where a site treats all four identically — the FX-slot assertion in
+/// `overworld_pickup` is the motivating case. Use [`is_lock`] where the water
+/// gap must be excluded.
+pub(crate) fn is_gap_tile(tile: u8) -> bool {
+    is_lock(tile) || is_water_gap(tile)
+}
+
+// ---------------------------------------------------------------------------
+// Path <-> gap mapping
+// ---------------------------------------------------------------------------
+
+/// Vertical path tiles (plain + variants + drawbridge). Both the gap-tile and
+/// FX-pattern lookups key on this, so a new vertical variant added here gets
+/// the vertical lock and its FX pattern together.
+///
+/// `0xB1` (vertical drawbridge) is unreachable in practice — the drawbridge
+/// QoL patch removes drawbridges from the game, so no lock is ever placed on
+/// one. Kept for completeness of the classification; do not expect a change to
+/// it to move any output. (Verified: dropping it left all 20 baseline seeds
+/// byte-identical.)
+pub(crate) fn is_vertical_path(tile: u8) -> bool {
+    matches!(tile, 0x46 | 0xAA | 0xAB | 0xB0 | 0xB1 | 0xDB | 0xBA)
+}
+
+/// The gap tile that blocks a given path tile.
+///
+/// **Many-to-one**: every vertical path variant maps onto the single vertical
+/// lock `0x54`, so this cannot be inverted without loss — see
+/// [`path_for_gap_tile`]. Keep the two adjacent so that relationship stays
+/// visible.
+pub(crate) fn gap_tile_for(tile: u8) -> u8 {
+    match tile {
+        BRIDGE_TILE => WATER_GAP_TILE,         // bridge → water gap
+        0xDA => 0xE4,                          // sky path → sky lock
+        t if is_vertical_path(t) => 0x54,      // vertical path → vertical lock
+        _ => 0x56,                             // horizontal path → horizontal lock
+    }
+}
+
+/// The path tile to restore under a gap tile.
+///
+/// **Lossy inverse of [`gap_tile_for`].** Because that mapping is many-to-one,
+/// this can only return the plain path tile of the right orientation, never the
+/// specific variant (drawbridge, path variant) that was originally there. That
+/// is fine for a test ROM walking over the tile, and wrong for anything that
+/// must restore the map faithfully — such callers must keep the original tile
+/// (as `LockAssignment::replace_tile` does) rather than reconstruct it here.
+///
+/// Returns `None` for a tile that is not a gap tile.
+pub(crate) fn path_for_gap_tile(tile: u8) -> Option<u8> {
+    match tile {
+        0x54 => Some(0x46),           // vertical lock   → vertical path
+        0x56 => Some(0x45),           // horizontal lock → horizontal path
+        0xE4 => Some(0xDA),           // sky lock        → sky path
+        WATER_GAP_TILE => Some(BRIDGE_TILE), // water gap → bridge
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Node tiles
+// ---------------------------------------------------------------------------
+
+/// Lowest numbered-level tile. Level number = `tile - 2`.
+pub(crate) const NUMBERED_TILE_LO: u8 = 0x03;
+/// Highest numbered-level tile.
+pub(crate) const NUMBERED_TILE_HI: u8 = 0x0F;
+
+/// A numbered action level (`0x03..=0x0F`, level number = `tile - 2`).
+pub(crate) fn is_numbered_level(tile: u8) -> bool {
+    (NUMBERED_TILE_LO..=NUMBERED_TILE_HI).contains(&tile)
+}
+
+/// A fortress tile (any of the three variants).
+pub(crate) fn is_fortress(tile: u8) -> bool {
+    FORTRESS_TILES.contains(&tile)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_and_gap_membership() {
+        for t in LOCK_TILES {
+            assert!(is_lock(t), "{t:#04X} should be a lock");
+            assert!(is_gap_tile(t));
+            assert!(!is_water_gap(t));
+        }
+        assert!(is_water_gap(WATER_GAP_TILE));
+        assert!(is_gap_tile(WATER_GAP_TILE));
+        assert!(!is_lock(WATER_GAP_TILE), "the water gap is not a lock");
+
+        // Path tiles and the bridge are not gap tiles.
+        for t in [0x45, 0x46, 0xDA, BRIDGE_TILE, 0x00] {
+            assert!(!is_gap_tile(t), "{t:#04X} should not be a gap tile");
+        }
+    }
+
+    /// Every gap tile `gap_tile_for` can produce must be invertible, and the
+    /// round trip must land back on a tile that maps to the same gap.
+    #[test]
+    fn gap_mapping_round_trips_by_orientation() {
+        let paths = [0x45, 0x46, 0xDA, BRIDGE_TILE, 0xAA, 0xAB, 0xB0, 0xB1, 0xDB, 0xBA];
+        for p in paths {
+            let gap = gap_tile_for(p);
+            assert!(is_gap_tile(gap), "{p:#04X} produced non-gap {gap:#04X}");
+
+            let back = path_for_gap_tile(gap).expect("gap tile must invert");
+            assert_eq!(
+                gap_tile_for(back),
+                gap,
+                "{p:#04X} -> {gap:#04X} -> {back:#04X} left the orientation class"
+            );
+        }
+    }
+
+    /// The inverse is documented as lossy; pin that so nobody "fixes" it into a
+    /// silent identity assumption.
+    #[test]
+    fn inverse_is_lossy_for_path_variants() {
+        assert_eq!(gap_tile_for(0xB1), 0x54, "drawbridge is a vertical path");
+        assert_eq!(path_for_gap_tile(0x54), Some(0x46), "inverse yields plain path");
+        assert_ne!(path_for_gap_tile(gap_tile_for(0xB1)), Some(0xB1));
+    }
+
+    #[test]
+    fn non_gap_tiles_do_not_invert() {
+        for t in [0x45, 0x46, BRIDGE_TILE, 0x67, 0x00, 0xFF] {
+            assert_eq!(path_for_gap_tile(t), None, "{t:#04X} is not a gap tile");
+        }
+    }
+
+    #[test]
+    fn node_tile_classification() {
+        assert!(is_numbered_level(0x03) && is_numbered_level(0x0F));
+        assert!(!is_numbered_level(0x02) && !is_numbered_level(0x10));
+        for t in FORTRESS_TILES {
+            assert!(is_fortress(t));
+        }
+        assert!(!is_fortress(0x45));
+    }
+
+    /// A lock is never also a node tile — the classifications must not overlap,
+    /// or a site substituting one predicate for another silently changes sets.
+    #[test]
+    fn classifications_are_disjoint() {
+        for t in 0u8..=0xFF {
+            let n = [is_lock(t), is_water_gap(t), is_numbered_level(t), is_fortress(t)]
+                .iter()
+                .filter(|b| **b)
+                .count();
+            assert!(n <= 1, "{t:#04X} matches {n} classifications");
+        }
+    }
+}

--- a/src/randomize/rom_data/tiles.rs
+++ b/src/randomize/rom_data/tiles.rs
@@ -24,12 +24,6 @@
 //! treatment for a table mirror is a test asserting it still matches the bytes
 //! at its ROM offset, not consolidation into these predicates.
 
-// Reason: this module is introduced ahead of its callers on purpose — the
-// consolidation migrates one call site per commit, each verified byte-identical
-// against `tests/overworld_baseline.rs`. Every item here is dead until its
-// first migration; remove this allow once the last inlined list is gone.
-#![allow(dead_code)]
-
 use super::FORTRESS_TILES;
 
 // ---------------------------------------------------------------------------
@@ -68,9 +62,15 @@ pub(crate) fn is_water_gap(tile: u8) -> bool {
 /// it, removed again by a fortress-clear FX. Locks and the water gap both
 /// qualify.
 ///
-/// Use this where a site treats all four identically — the FX-slot assertion in
-/// `overworld_pickup` is the motivating case. Use [`is_lock`] where the water
-/// gap must be excluded.
+/// Use this where a site treats all four identically — `overworld_pickup`'s
+/// `test_no_fx_gaps_remain` is the current consumer. Use [`is_lock`] where the
+/// water gap must be excluded, as `qol::hammer_breaks` does.
+// Reason: only a test consumes this today, so the lib build sees it as dead.
+// Kept because it names the codebase's existing umbrella concept (the output
+// domain of `gap_tile_for`, stored as `LockAssignment::gap_tile`) and is the
+// correct predicate for any future site treating locks and gaps alike —
+// re-inlining that set is exactly the drift this module exists to stop.
+#[allow(dead_code)]
 pub(crate) fn is_gap_tile(tile: u8) -> bool {
     is_lock(tile) || is_water_gap(tile)
 }

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -21,10 +21,6 @@ use crate::{randomize_rom, Options};
 /// Bytes per map screen: 9 rows × 16 columns, stored screen-major.
 const SCREEN_BYTES: usize = 144;
 
-/// Numbered level tiles: tile `0x03..=0x0F`, level number = tile - 2.
-const NUMBERED_TILE_LO: u8 = 0x03;
-const NUMBERED_TILE_HI: u8 = 0x0F;
-
 /// File-offset window covering PRG010–011 of the ROM.
 ///
 /// Practice-patch records outside this window rewrite PRG006/PRG012 (enemy
@@ -32,24 +28,11 @@ const NUMBERED_TILE_HI: u8 = 0x0F;
 /// produced, so the movement patch is applied as a subset over this range only.
 const MOVEMENT_RECORD_RANGE: (usize, usize) = (0x14010, 0x18010);
 
-/// Path tile to restore for each lock/gap tile.
-///
-/// Locks are a many-to-one encoding — `overworld_helpers::gap_tile_for` maps
-/// every vertical path variant (plain, drawbridge, sky) onto a single lock
-/// byte — so the inverse can only return the plain path tile of the right
-/// orientation, not the original variant. In a test ROM that's a cosmetic
-/// difference on a tile you're about to walk over.
-const UNLOCK_TILES: &[(u8, u8)] = &[
-    (0x54, 0x46), // vertical lock   → vertical path
-    (0x56, 0x45), // horizontal lock → horizontal path
-    (0xE4, 0xDA), // sky lock        → sky path
-];
-
-/// Water gaps are restored separately from locks — testing canoe/bridge
-/// routing usually wants gaps intact even when locks are gone.
-const UNGAP_TILES: &[(u8, u8)] = &[
-    (0x9D, 0xB3), // water gap → bridge
-];
+// Lock/gap classification and the path each restores to come from
+// `rom_data::tiles` — see `is_lock`, `is_water_gap`, `path_for_gap_tile`. The
+// inverse is lossy (a vertical path variant comes back as the plain vertical
+// path), which for a test ROM is a cosmetic difference on a tile you are about
+// to walk over.
 
 // ---------------------------------------------------------------------------
 // Seed requirements
@@ -100,10 +83,10 @@ impl TileClass {
 
     fn matches(&self, tile: u8) -> bool {
         match self {
-            TileClass::Lock => UNLOCK_TILES.iter().any(|(l, _)| *l == tile),
-            TileClass::Gap => UNGAP_TILES.iter().any(|(g, _)| *g == tile),
-            TileClass::Fortress => rom_data::FORTRESS_TILES.contains(&tile),
-            TileClass::Level => (NUMBERED_TILE_LO..=NUMBERED_TILE_HI).contains(&tile),
+            TileClass::Lock => rom_data::is_lock(tile),
+            TileClass::Gap => rom_data::is_water_gap(tile),
+            TileClass::Fortress => rom_data::is_fortress(tile),
+            TileClass::Level => rom_data::is_numbered_level(tile),
             TileClass::Pipe => tile == rom_data::TILE_PIPE,
             TileClass::ToadHouse => tile == rom_data::TILE_TOAD_HOUSE,
             TileClass::Airship => tile == rom_data::TILE_AIRSHIP,
@@ -415,7 +398,7 @@ fn numbered_slots(rom: &Rom, world_idx: usize, include_beta: bool) -> Vec<(u8, u
         .filter(|e| {
             e.world_idx == world_idx
                 && e.is_numbered_level
-                && (NUMBERED_TILE_LO..=NUMBERED_TILE_HI).contains(&e.tile)
+                && rom_data::is_numbered_level(e.tile)
         })
         .map(|e| (e.tile - 2, e.entry_idx))
         .collect();
@@ -427,11 +410,12 @@ fn numbered_slots(rom: &Rom, world_idx: usize, include_beta: bool) -> Vec<(u8, u
 /// Rewrite lock and/or water-gap tiles across all 8 world maps.
 fn open_map(rom: &mut Rom, remove_locks: bool, remove_gaps: bool) -> usize {
     let mut swaps: Vec<(u8, u8)> = Vec::new();
-    if remove_locks {
-        swaps.extend_from_slice(UNLOCK_TILES);
-    }
-    if remove_gaps {
-        swaps.extend_from_slice(UNGAP_TILES);
+    for tile in 0u8..=0xFF {
+        let wanted = (remove_locks && rom_data::is_lock(tile))
+            || (remove_gaps && rom_data::is_water_gap(tile));
+        if let Some(path) = rom_data::path_for_gap_tile(tile).filter(|_| wanted) {
+            swaps.push((tile, path));
+        }
     }
     if swaps.is_empty() {
         return 0;
@@ -826,7 +810,7 @@ mod tests {
         let built = build(&van, &TestRomSpec { remove_locks: true, ..spec() }).unwrap();
         let out = Rom::from_bytes_lax(&built.bytes, true).unwrap();
 
-        let locks: Vec<u8> = UNLOCK_TILES.iter().map(|(l, _)| *l).collect();
+        let locks: Vec<u8> = rom_data::LOCK_TILES.to_vec();
         for world_idx in 0..8 {
             let grid = rom_data::read_tile_grid(&out, world_idx);
             for row in 0..grid.rows() {
@@ -844,7 +828,7 @@ mod tests {
         for (i, (before, after)) in van.iter().zip(built.bytes.iter()).enumerate() {
             if before != after {
                 assert!(
-                    UNLOCK_TILES.contains(&(*before, *after)),
+                    rom_data::path_for_gap_tile(*before) == Some(*after),
                     "unexpected write at 0x{i:05X}: {before:#04X} -> {after:#04X}"
                 );
             }
@@ -930,7 +914,7 @@ mod tests {
         .unwrap();
 
         let out = Rom::from_bytes_lax(&built.bytes, true).unwrap();
-        let locks: Vec<u8> = UNLOCK_TILES.iter().map(|(l, _)| *l).collect();
+        let locks: Vec<u8> = rom_data::LOCK_TILES.to_vec();
         let surviving: usize = (0..8)
             .map(|w| {
                 let grid = rom_data::read_tile_grid(&out, w);

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -1,0 +1,104 @@
+//! Byte-identity baseline for overworld output.
+//!
+//! Guards refactors that are supposed to change nothing — the tile-predicate
+//! consolidation in `rom_data::tiles` being the motivating case. Each migration
+//! of a call site onto a shared predicate must leave these hashes untouched; a
+//! changed hash means the substituted predicate covers a different set than the
+//! inlined list it replaced, which is exactly the kind of silent behaviour
+//! change a "pure refactor" is not allowed to make.
+//!
+//! Palette randomization is excluded: it is not seed-stable (two runs of the
+//! same seed differ in a handful of NES palette bytes), so it would make this
+//! harness flap for reasons unrelated to what it is guarding. Topology is
+//! unaffected.
+//!
+//! Skipped when the ROM is absent, like the other ROM-dependent tests — the
+//! ROM is gitignored and CI has no copy.
+
+use smb3_rs::{generate_patched_rom, Options};
+
+const ROM_PATH: &str = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes";
+const SEEDS: u64 = 20;
+
+/// FNV-1a. Rolled by hand rather than using `DefaultHasher`, whose output is
+/// explicitly not guaranteed stable across Rust releases — a baseline that
+/// changes when the toolchain updates is worse than none.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn options() -> Options {
+    Options { palettes: false, palette_themed: false, ..Options::default() }
+}
+
+fn hashes(rom: &[u8]) -> Vec<u64> {
+    (1..=SEEDS)
+        .map(|seed| {
+            let out = generate_patched_rom(rom, seed, &options(), None)
+                .unwrap_or_else(|e| panic!("seed {seed} failed to generate: {e}"));
+            fnv1a(&out)
+        })
+        .collect()
+}
+
+/// The harness is only worth anything if it is stable in the first place.
+/// Runs the sweep twice in one process and requires agreement.
+#[test]
+fn sweep_is_deterministic() {
+    let Ok(rom) = std::fs::read(ROM_PATH) else { return };
+    assert_eq!(
+        hashes(&rom),
+        hashes(&rom),
+        "same seeds produced different output within one run — the baseline \
+         cannot guard anything until this is stable"
+    );
+}
+
+/// Baseline captured 2026-08-03, before any call site was migrated onto
+/// `rom_data::tiles`. Regenerate ONLY for a change intended to alter output,
+/// and say so explicitly in the commit — never to make a red test green.
+const BASELINE: [u64; SEEDS as usize] = [
+    0x3CC73D4F8B706AB2, 0x0AEF65A488DCD062, 0x0D056AF8D18E2BFB, 0xB3D5BE313EA37464,
+    0xC7B499E3B7AA3B6D, 0xB5846D1438CE3405, 0x03A24CDEBF64925D, 0x10AA8775674EC492,
+    0xEF8F05273F6202B2, 0x1309B3871D9DD47A, 0x1A760A893B1EA373, 0xB503C9D7095AF6A6,
+    0x43E966B75F3514FF, 0x5968F3BEF7300364, 0x192F85ECF86D75C6, 0x538E5F94D3045FD0,
+    0xB6EDBAACEE372D9C, 0xBC57F481A392D55D, 0x15C89DC8756F6CCA, 0x2F1856871DD3784F,
+];
+
+#[test]
+fn output_matches_baseline() {
+    let Ok(rom) = std::fs::read(ROM_PATH) else { return };
+    if BASELINE.iter().all(|h| *h == 0) {
+        panic!("BASELINE is unpopulated — run `cargo test print_baseline -- --ignored --nocapture`");
+    }
+    let got = hashes(&rom);
+    let mismatched: Vec<usize> = (0..SEEDS as usize).filter(|i| got[*i] != BASELINE[*i]).collect();
+    assert!(
+        mismatched.is_empty(),
+        "output changed for seed(s) {:?} — if this was intentional, regenerate \
+         the baseline in the same commit and explain why",
+        mismatched.iter().map(|i| i + 1).collect::<Vec<_>>()
+    );
+}
+
+/// Prints a `BASELINE` array to paste above. Ignored by default so it never
+/// runs as part of the suite.
+#[test]
+#[ignore]
+fn print_baseline() {
+    let Ok(rom) = std::fs::read(ROM_PATH) else {
+        println!("ROM not found at {ROM_PATH}");
+        return;
+    };
+    println!("const BASELINE: [u64; SEEDS as usize] = [");
+    for chunk in hashes(&rom).chunks(4) {
+        let line: Vec<String> = chunk.iter().map(|h| format!("0x{h:016X}")).collect();
+        println!("    {},", line.join(", "));
+    }
+    println!("];");
+}


### PR DESCRIPTION
Single source of truth for "which bytes mean what" on the world map. No output change — verified byte-identical.

## The problem

`0x54` meant "vertical lock" in four different files, each answering a slightly different question inline, so none was the authority and nothing made them agree:

| Site | Form |
|---|---|
| `overworld_pickup` | `tile != 0x54 && tile != 0x56 && tile != 0x9D && tile != 0xE4` |
| `qol::hammer_breaks` | `[0x54, 0x56, 0xE4]` + a literal `replace` table |
| `overworld_helpers` | local `gap_tile_for` / `is_vertical_path` |
| `testrom` | `UNLOCK_TILES` / `UNGAP_TILES` |

## The shape

Predicates named after the *question asked*, not one blob list — the sites genuinely differ. `is_lock` excludes the water gap because `hammer_breaks` deliberately does; `is_gap_tile` includes it because the FX-slot check treats all four alike. A flat list would have forced them together and silently changed one.

`gap_tile_for` and its lossy inverse `path_for_gap_tile` live adjacent so that relationship stays visible — the mapping is many-to-one, so a vertical path variant can't be reconstructed from its lock.

The name "gap tile" is the codebase's existing term (`LockAssignment::gap_tile`), not a new one.

**Deliberately excluded:** `capacity::is_completion_unsafe`'s `REMOVABLE` mirrors the engine's own `Map_Removable_Tiles` and must track the game's bytes, not our semantics. Merging them would couple concepts that move independently. (This also retracts a `0x6A` "discrepancy" I flagged mid-review — it's caught by the explicit fortress check above.)

## Verification

`tests/overworld_baseline.rs` — 20 seeds, whole-ROM FNV-1a hashes, palettes excluded (not seed-stable). Green after every migration step.

The harness was proven sensitive in both directions before being trusted: changing `gap_tile_for`'s horizontal arm turns all 20 red, restoring it turns them green.

**`hammer_breaks` is not covered by that sweep** — `hammer_breaks_locks` is off by default, so those seeds never execute it and a green result would have been vacuous. Verified two other ways: four tests pinning the generated tables against the literals they replaced (including bridges-without-locks, since the three tables are parallel arrays where order is load-bearing), plus a direct before/after ROM diff across the migration commit — **0 bytes differ**, code block and all three tables.

## Note

`overworld_pickup`'s FX-slot assertion is inside a `#[test]`, not production code — so it was three production sites plus one test. Consequently `is_gap_tile` has no production caller yet and carries an explicit `allow(dead_code)`: it names the umbrella concept, and re-inlining that set later is the drift this exists to stop.

340 tests, clippy clean on native and wasm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB