### PR TITLE
Audit ROM free space against the write log, and route IPS patches through it

### DIFF
--- a/.claude/commands/review-patch.md
+++ b/.claude/commands/review-patch.md
@@ -8,36 +8,96 @@ Review a new or modified 6502 ROM patch for correctness and safety.
 Perform the following checks and report findings:
 
 ### 1. Free Space Audit
-- Read `src/randomize/rom_data.rs` and find the `FREE_SPACE_ALLOCATIONS` registry (near top of file)
-- List all current allocations grouped by PRG bank
-- For the patch under review, verify:
-  - The file offset is registered in `FREE_SPACE_ALLOCATIONS` with correct size
-  - There is a corresponding `pub(super) const FS_*` constant
-  - The module uses the `FS_*` constant (not a local hardcoded offset)
-  - The size in the registry matches or exceeds the actual bytes written
 
-### 2. Overlap Check
-- Confirm `cargo test free_space` passes (this runs the overlap and constant-match tests)
-- If tests aren't passing, identify which allocations conflict
+Most of this is mechanised — run the tools before reading anything by hand.
+
+```sh
+cargo test --lib free_space          # overlap, FS_* constants, audit, doc table
+smb3-rs <rom> --free-space --fit N   # where a patch of N bytes could go
+smb3-rs <rom> --free-space           # per-bank budget
+```
+
+`cargo test --lib free_space` covers, without you re-deriving any of it:
+
+- no two allocations overlap (`test_free_space_no_overlap`)
+- every `FS_*` constant is a registry row (`test_free_space_constants_match_registry`)
+- **what the randomizer actually wrote** stayed inside its allocation and carried
+  its owner's write-log tag, over a run with every feature on
+  (`free_space_audit_matches_registry`)
+- CLAUDE.md's per-bank table still matches the ROM (`free_space_doc_table_is_current`)
+
+So for the patch under review, check only what the tests cannot:
+
+- The module uses the `FS_*` constant, not a local hardcoded offset
+  (`tools/offset_dups.py` catches the general case)
+- The registry row's `owners` names the write-log tag this patch writes under.
+  If the patch is emitted by a larger pass it needs its own `push_tag` — see
+  `march_veto` / `fx_screen_check` in `overworld_writer/mod.rs` — or its bytes
+  are attributed to the whole pass and the audit cannot tell them apart
+- The reserved size leaves sensible headroom, and any `// N reserved, M used`
+  comment matches. `--write-log` prints measured usage per allocation. It counts
+  bytes *covered by a logged write*, which is exact for a routine emitted as one
+  `write_range`; it under-counts only where a patch writes byte-at-a-time and
+  some bytes already match what was there
+
+The registry lives in `src/randomize/rom_data/free_space.rs`.
+
+### 2. Claiming New Free Space
+
+If the patch claims a region not already registered:
+
+- `--free-space --fit N` lists the candidate gaps. **Candidates, not
+  confirmations** — filler nothing has *claimed* may still be data something
+  *reads*. Verify against the disassembly (`tools/southbird-smb3/PRG/prgNNN.asm`)
+  before taking it, and record what you found in the registry comment, the way
+  the PRG004 and PRG006 tails are
+- The bank must be mapped when the code runs. That is the first filter, not the
+  last: a 2537-byte gap in PRG026 is useless to a routine that runs in-level
 
 ### 3. Patch Site Review
+
 - For hook sites (where existing code is overwritten with JMP/JSR):
-  - Verify the original instruction size matches the replacement (e.g., 3-byte JSR replaced with 3-byte JMP)
+  - Verify the original instruction size matches the replacement (e.g. a 3-byte
+    `JSR` replaced with a 3-byte `JMP`)
   - Check that the hook doesn't clobber adjacent instructions
-  - Verify the bank is correct (CPU address → file offset mapping)
+  - Verify the bank is correct (CPU address ↔ file offset mapping)
 - For subroutines in free space:
-  - Verify the CPU address calculation: `cpu_base + (file_offset - bank_file_base)`
-  - Bank file bases: PRG000=0x00010, PRG001=0x02010, PRG010=0x14010, PRG011=0x16010, PRG012=0x18010, PRG024=0x30010, PRG026=0x34010, PRG027=0x36010, PRG030=0x3C010, PRG031=0x3E010
-  - CPU bases: $8000 for even banks, $A000 for odd banks, $C000 for PRG030, $E000 for PRG031
+  - **Derive operands with `jsr_into_bank(bank, file_offset)` /
+    `prg_bank_cpu_to_file` rather than transcribing address bytes.** Those
+    helpers are pinned by `test_prg_bank_mapping_known_pairs` against
+    known-correct triples from shipped patches, so getting them right protects
+    every hook — dropping the 0x10 iNES header was the issue #14 root cause
+  - `prg_bank_file_to_cpu` assumes the `$A000` window and does **not** apply to
+    banks mapped elsewhere. There is no parity rule: PRG004 (even) maps at
+    `$A000` while PRG000 (even) maps at `$C000`; PRG011 (odd) at `$A000` while
+    PRG029 (odd) at `$C000`. The window is a per-bank fact recorded in the
+    comment above each allocation in `free_space.rs` — read it there
+  - Fixed banks: PRG030 at `$8000–$9FFF`, PRG031 at `$E000–$FFFF`. Hence
+    `WORLD_ORDER_CPU` is `$9F10` for file 0x3DF20
 
 ### 4. Known Danger Zones
+
 Flag if the patch writes to any of these ranges:
-- **0x19100–0x19DCF** (PRG012): active tile lookup + map screen code. Writing here crashes on level entry.
-- **Bank 24 (PRG024)**: avoid JMP-to-free-space — shares code paths with 2P mode, causes switching bugs. Prefer inline patches.
+
+- **0x19100–0x19DCF** (PRG012): active tile lookup + map screen code. Writing
+  here crashes on level entry.
+- **Bank 24 (PRG024)**: avoid JMP-to-free-space — shares code paths with 2P
+  mode, causes switching bugs. Prefer inline patches.
 
 ### 5. Ordering Concerns
-- If the patch touches pointer tables or airship entries, check ordering relative to autoscroll and overworld builder in `randomizer.rs`
-- Autoscroll MUST run before overworld builder (writes to hardcoded vanilla offsets that get displaced by resort_pointer_table)
 
-### 6. Summary
+- If the patch touches pointer tables or airship entries, check ordering
+  relative to autoscroll and overworld builder in `randomizer.rs`
+- Autoscroll MUST run before overworld builder (writes to hardcoded vanilla
+  offsets that get displaced by `resort_pointer_table`)
+
+### 6. Size
+
+Free space is the project's scarcest resource — see "ROM Free Space Is Scarce"
+in CLAUDE.md. Review the *code* for size even when the allocation has room:
+folding constant math into flags, picking the instruction that preserves the
+register you still need, zero-page temps over stack juggling.
+
+### 7. Summary
+
 Report: pass/fail for each check, any warnings, and suggested fixes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,26 +53,65 @@ origin-locked by self-referential absolute addresses. Write the tightest bytes
 you can, then reserve a sensible margin around them and note both numbers
 (e.g. `// 112 reserved, 97 used`).
 
-The total free-space figure is misleading. Free space is **per-bank**, and a
-routine has to live in a bank that is mapped when it runs, so the only number
-that matters is what's left in *the bank you need*. Measured against the current
-allocations (see `FREE_SPACE_ALLOCATIONS` in `rom_data/free_space.rs`):
+**Ask "does a run of N bytes exist", never "how much is free".** Free space is
+per-bank *and* per-gap: a routine needs one contiguous run in a bank that is
+mapped when it runs, so a bank total is worthless on its own — PRG031's 81 free
+bytes are scraps that will not hold a 40-byte routine. Ask the question directly:
+
+```sh
+smb3-rs <rom> --free-space --fit 60   # every unclaimed gap that holds 60 bytes
+smb3-rs <rom> --free-space            # per-bank summary
+```
+
+Two filters the tool cannot apply for you, in this order: the bank must be
+mapped when your code runs, and the gap must be *unreferenced*, not merely
+unclaimed — unclaimed filler can still be data something reads, so check the
+disassembly (`tools/southbird-smb3/PRG/prgNNN.asm`) before taking it. That check
+is once per gap: record it as a `FREE_SPACE_ALLOCATIONS` row and it is settled
+for good.
+
+The per-bank summary, measured against the current allocations (see
+`FREE_SPACE_ALLOCATIONS` in `rom_data/free_space.rs`) — the largest-gap column
+is the one to read:
 
 | Bank | Mapped at | Free left | Largest single gap |
 |------|-----------|-----------|--------------------|
-| PRG031 | `$E000–$FFFF`, always | **68** | **30** |
-| PRG030 | `$8000–$9FFF`, always | **120** | **74** |
-| PRG000–PRG007 | swapped, in-level | 34–58 each (bank 3: **0**) | ≤ 38 |
-| PRG010 | `$C000–$DFFF`, map | 880 | 588 |
+| PRG031 | `$E000–$FFFF`, always | 81 | **30** |
+| PRG030 | `$8000–$9FFF`, always | 120 | 74 |
+| PRG001 | swapped, in-level (object AI) | 60 | 38 |
+| PRG003 | swapped, in-level (object AI) | 5 | 5 |
+| PRG004 | swapped, in-level (object AI, group 3) | 426 | 426 |
+| PRG005 | swapped, in-level (object AI) | 58 | 58 |
+| PRG006 | `$C000–$DFFF`, in-level (enemy data) | 1392 | 1392 |
+| PRG007 | swapped, in-level (object AI) | 27 | 27 |
+| PRG010 | `$C000–$DFFF`, map | 896 | 588 |
 | PRG026 | `$A000–$BFFF`, map/inventory | 2603 | 2537 |
 
-The always-mapped banks are effectively full. Any patch that must run regardless
-of the current bank has under 30 contiguous bytes to work with, so a trampoline
-into a swapped bank is usually the only option — and that costs bytes too.
+PRG000 and PRG002 have no `$FF` filler left at all.
 
-Regenerate these numbers after adding allocations; the script pattern is to sum
-`FREE_SPACE_ALLOCATIONS` and scan the PRG region for `$FF`/`$00` runs not
-covered by one.
+The always-mapped banks are effectively full. A patch that must run regardless of
+the current bank has one 74-byte gap in PRG030 and nothing over 30 bytes in
+PRG031, so past that a trampoline into a swapped bank is the only option — and
+that costs bytes too.
+
+**Do not hand-edit these numbers — regenerate them.** `smb3-rs <rom>
+--free-space` prints the whole per-bank budget without randomizing (the same
+table ends every `--write-log` dump, after the per-allocation audit).
+`free_space_doc_table_is_current` fails when a row here drifts and prints the
+replacement rows, so adding an allocation forces this table to be updated in the
+same commit. That test needs the ROM, so it skips where the ROM is absent — it
+guards the machine the patch is written on, not CI.
+
+The scan counts `$FF` runs of ≥ 8 bytes (the older PRG031=68 / PRG010=880
+figures came from a ≥ 16 scan) and lists `$00` runs in a separate column, which
+is a candidate list rather than space — zeroed data and zero padding look
+identical.
+
+The two largest gaps here have been through the unreferenced check already
+(2026-08-04): `prg004.asm` ends with "Rest of ROM bank was empty" at `$BE56`,
+and PRG006's last assembled data is the dead object stream `_DA60` (file
+0x0DA70..0x0DA74), referenced from nowhere, with the furthest referenced enemy
+stream ending at 0x0D9F6.
 
 ### Size techniques that have actually paid off here
 
@@ -247,6 +286,11 @@ When the overworld builder is active, `levels.rs` intra-world shuffle and airshi
 Read it before scanning the ROM by hand or writing a throwaway script. In
 particular `map_viz.py <rom.nes> --world N` renders any ROM's map as labelled
 ASCII; don't hand-decode tile grids.
+
+Two answers live in the Rust CLI rather than in `tools/`, because they read the
+allocation registry: `--free-space [--fit N]` for where a patch can go, and
+`--write-log` for what a run changed, which module owns each byte, and whether
+any patch overran its allocation. Don't write a script to scan for free space.
 
 Tier 1 (7) is live: `rom_map.py` plus the palette-codegen and visual-preview
 pipelines that regenerate checked-in artifacts. Tier 2 (9) is working general

--- a/docs/seed_report_design.md
+++ b/docs/seed_report_design.md
@@ -1,0 +1,75 @@
+# Seed report / spoiler log — design note
+
+Status: design note. Nothing here is implemented yet.
+
+Two features share one data layer: a human-readable **spoiler log** (a wanted
+user feature) and an **overworld map view** (which would retire
+`tools/map_viz.py`). They need the same facts, so deriving them separately would
+create two producers for things like "which fortress opens which lock".
+
+## Shape
+
+```
+SeedReport                         serializable; serde is already a dependency
+  ├── worlds: Vec<WorldReport>     grid tiles, nodes, locks, pipes
+  ├── items                        where each inventory item comes from
+  └── progression                  world order, SAS, donors
+        ↓
+  render_ascii()   render_text()   render_json()
+```
+
+The ASCII renderer replaces `map_viz.py`. Sharing one glyph table with the rest
+of the report means the `F`-glyph discrepancy noted in `tools/README.md` cannot
+recur.
+
+**Location:** not `src/testrom.rs` — that is native-only and the web app will
+want the spoiler. `src/randomize/report.rs`, compiled for both targets.
+
+## The rule
+
+**No fact has two producers.**
+
+Derive from the **finished ROM** by default. It is the artifact the player
+actually plays, so a writer bug shows up in the spoiler — which is correct,
+because the game has it too. `BuildResult` may *enrich* the report with things
+bytes cannot recover, but must never re-derive a field the ROM already answers.
+
+Concretely: fortress→lock comes from decoding the FX tables, **not** from
+`LockAssignment::fort_section`, even though the latter is easier to read.
+
+## Recoverability of the wanted content
+
+| Content | From ROM? | Notes |
+|---|---|---|
+| Overworld topology, locks, pipes | yes | tiles + pointer tables + FX tables |
+| Fortress → lock it opens | yes | FX tables; layout is documented in `smb3_rom_reference.md` § "Fortress Lock & Bridge FX (PRG010: 0x147CD–0x148B7)" — **read it, do not re-derive from the disassembly.** Doing the latter cost a wrong answer once: `FortressFX_W1–W8` is 32 bytes of slots at `0x14888` *followed* by the 8-byte `FortressFXBase_ByWorld` at `0x148A8`, not the other way round. Validate any decoder against vanilla, where W8 must read `0D 0E 0F 10`. |
+| World order (e.g. `3,5,6`) | yes | `FS_WORLD_ORDER` holds routine + display table |
+| Inventory item sources (HB1 = Fire Flower, 1F secret exit = Hammer) | probably | written to tables; **not yet verified where each source lives** |
+| Antechamber/lobby donor (e.g. "7-5 donated") | **no** | `antechambers::shuffle(rom, rng, beta)` returns nothing; the write destroys provenance |
+
+The donor case is the one that needs a capture hook. The overworld already has
+the pattern — `randomize_with_overworld_capture`, carrying a
+`// WASM hook to follow` comment. Nothing else does. Add hooks **only** where
+the write genuinely destroys provenance; world order and items must not get one,
+because the ROM already answers.
+
+## Staging
+
+1. **`from_rom` + ASCII renderer, overworld only.** Self-contained, retires
+   `map_viz.py`, needs none of the product decisions below settled.
+2. **Item and progression sections.** Requires verifying where item assignments
+   are stored.
+3. **Antechamber capture hook** — its own change, with its own justification.
+4. **WASM hook + web download.**
+
+## Open product questions (not technical)
+
+- Separate file that never ships alongside the ROM? (Accidental spoiling is the
+  classic failure.)
+- Placements only, or solve the progression path? "1F Secret Exit — Hammer"
+  implies annotating *reachability*, which is substantially more than a
+  placement dump.
+- Reproducible from seed + flag key alone, without the ROM? Nearly free given
+  determinism, and makes a spoiler shareable as a one-liner. Caveat: palette
+  randomization is not seed-stable (a handful of NES palette bytes differ
+  between runs of the same seed), though it does not touch topology.

--- a/docs/write_log_design.md
+++ b/docs/write_log_design.md
@@ -1,6 +1,8 @@
 # ROM Write Log — current state and planned enhancements
 
-Status: design note. Nothing here is implemented yet.
+Status: Enhancement 1 (free-space auditor) is implemented — see "Enhancement 1"
+below for what it does and what it found. Enhancements 2 and 3 are still design
+only.
 
 ## What exists today
 
@@ -46,19 +48,21 @@ The two answer different questions:
 
 ## Known gaps
 
-### 1. `apply_ips_patch` bypasses the log
+### 1. `apply_ips_patch` bypasses the log — **fixed for the `Rom` path**
 
-`Rom::apply_ips_patch` writes with a direct slice copy
-(`self.data[HEADER_SIZE..].copy_from_slice(&patched)`), so none of its bytes are
-recorded.
+`Rom::apply_ips_patch` used to write with a direct slice copy
+(`self.data[HEADER_SIZE..].copy_from_slice(&patched)`), recording nothing. It now
+decodes with `ips::parse_ips_records` and applies each record through
+`write_range` under a caller-supplied tag, so patched bytes are logged, audited
+and collision-checked like any other write.
 
-Consequences:
-
-- Visual-patch bytes (Luigi, Peach, Dr. Mario, …) never appear in the log.
-- `testrom --apply-ips` inherits the blind spot: its collision guard compares
-  incoming records against the log, so a *second* applied patch cannot be seen
-  colliding with the first. Patch-vs-randomizer collisions are caught;
-  patch-vs-patch are not.
+Still outstanding: **the CLI does not use that method.** `--toad` and
+`--sprite-patch` apply the free function to the raw bytes before a `Rom` exists
+(`main.rs`), so those two remain invisible to the log — and they are exactly the
+pair most likely to collide, since both replace player graphics. Closing it means
+routing them through `randomize_rom`, whose `visual_patch` parameter takes one
+patch where the CLI layers two, while keeping `pristine_input` intact so the
+emitted IPS still contains the visual bytes.
 
 ### 2. Tags leak between passes
 
@@ -76,73 +80,177 @@ The fix applied was local (drop the stray tag, tag the writer, sub-tag the FX
 patch). The structural problem remains: correctness depends on every one of 83
 call sites being disciplined.
 
-### 3. No dynamic free-space verification
+### 3. No dynamic free-space verification — **fixed, see Enhancement 1**
 
-The existing tests are **static** — they check the registry against itself:
+The tests used to be **static** only — they checked the registry against itself:
 
 - `test_free_space_no_overlap` — allocations don't overlap each other
 - `test_free_space_constants_match_registry` — `FS_*` constants match entries
 
-Nothing checks what is *actually written*. Consequences:
-
-- The `// N reserved, M used` comments on 41 allocations are hand-maintained and
-  can silently go stale. `FS_FX_SCREEN_CHECK` read `112 reserved, 97 used` until
-  it was corrected to `82` by hand in `1fe86fb`; others have not been audited.
-- Nothing detects a patch overrunning its allocation into a neighbour's, or a
-  module writing into free space it does not own.
+Nothing checked what was *actually written*, so the `// N reserved, M used`
+comments could go stale (`FS_FX_SCREEN_CHECK` read `112 reserved, 97 used` until
+it was corrected to `82` by hand in `1fe86fb`), and nothing would have caught a
+patch overrunning its allocation or a module writing into space it does not own.
 
 ---
 
-## Enhancement 1 — free-space auditor (do this first)
+## Enhancement 1 — free-space auditor (implemented)
 
-Cross-reference `FREE_SPACE_ALLOCATIONS` against the write log after a real
+Cross-references `FREE_SPACE_ALLOCATIONS` against the write log after a real
 randomization run.
 
-**Assertions**
+**Where it lives**
 
-1. Every write whose offset falls inside a registered free-space region carries
-   the tag of the module that owns that allocation.
-2. For each allocation, the highest byte actually written is within
-   `offset + size`. (Overrun = failing test.)
-3. Report actual bytes used per allocation, so the `reserved / used` comments
-   can be regenerated rather than remembered.
+- `rom_data::free_space` — `FreeSpaceAlloc` (the registry row, now carrying an
+  `owners` list of write-log tags), `audit_free_space`, `free_space_map`,
+  `format_free_space_report`.
+- `randomizer::tests::free_space_audit_matches_registry` — the CI check.
+- `--write-log` appends the report, so the file that says what changed also says
+  what it cost and what is left.
 
-**Why first**
+**What it asserts**
 
-- It needs no call-site churn — a test plus a small helper.
-- It mechanizes `/review-patch` sections 1–3, currently re-derived by hand for
-  every 6502 patch.
-- It would have caught the stale `97 used` automatically.
-- It tells us whether tags are still lying anywhere else, which is the
-  information needed to decide how urgent Enhancement 3 is.
+1. Every write inside a registered region carries a tag one of that region's
+   `owners` covers. Owners match whole `/`-separated tag components, so
+   `fx_screen_check` covers `overworld_writer/fx_screen_check` and
+   `big_q_blocks` covers both `qol/` and `enemies/` variants.
+2. No write crosses a region boundary, in either direction.
+3. Every allocation is exercised by the audit run. Without this the check is
+   vacuous for anything flag-gated: a patch that never ran writes nothing, and
+   an audit over nothing passes. `audit_options()` is `all_on_options()` with
+   `world_count: 7` and `swap_start_airship: true`; a new gated allocation has
+   to be added there or the test says so by name.
 
-**Prerequisite, already met:** accurate tags. Before `cd5e459` the overworld
-writer's bytes were attributed to `troll_pipes`, which would have made
-assertion 1 fail for reasons unrelated to free space.
+It also reports bytes used per allocation, which is where `// N reserved, M
+used` comments should now come from.
 
-**Gotchas**
+**What it found on the first run**
 
-- Flag-dependent code paths do not run under `Options::default()`. Anything
-  gated off by default (e.g. `hammer_breaks_locks`, `troll_pipes` when off) will
-  simply be absent from the log — the audit must not read "no writes" as
-  "allocation unused". Run the audit over a few option sets, or assert only over
-  allocations whose feature was enabled for that run. This is the same trap that
-  made the overworld baseline sweep vacuous for `hammer_breaks`
-  (see `tests/overworld_baseline.rs`).
+- `march_veto`'s 107 bytes were tagged `overworld_writer`. Not a lie — the
+  writer really does emit them — but too coarse to attribute, and the comment
+  above `fx_screen_check` claimed to be "the one writer patch that claims free
+  space", which had stopped being true. Both are now sub-tagged.
+- The `hand_rooms` and `piranha_rooms` clone blocks are genuinely co-owned:
+  the cloning module builds the enemy stream, then `items` rewrites the
+  `OBJ_TREASURESET` byte inside it via the offsets those modules export. That is
+  why `owners` is a list — a second entry documents intended sharing.
+
+**Limits, by construction**
+
+- `used` is *bytes covered by a logged write* — what the patch occupies, not
+  the narrower "bytes differing from vanilla". `write_range` logs the whole
+  range whenever any byte in it differs, so a routine emitted as one range is
+  measured exactly even where its bytes match the filler underneath. Only a
+  patch built byte-at-a-time with `write_byte` under-counts, since no-op bytes
+  are skipped there. Overrun detection is unaffected either way.
 - A patch may legitimately write fewer bytes than reserved; only *over* is an
   error. Reserved headroom is encouraged (see CLAUDE.md).
 
-## Enhancement 2 — route `apply_ips_patch` through `write_range`
+**Companion: per-bank budget.** `free_space_map` scans the *vanilla* PRG for
+filler runs (≥ 8 bytes) no allocation has claimed, per bank, and reports free
+`$FF`, the largest single gap, and `$00` runs separately — zeroed data looks
+exactly like zero padding, so that column is a candidate list, not space.
 
-Small and self-contained. Volume is not a concern: the largest bundled patch is
-the practice ROM at 193 records.
+Unlike the per-allocation audit this depends on nothing but the vanilla bytes
+and the registry: same answer for every seed and option set, no randomization
+run needed. `smb3-rs <rom> --free-space` prints it on its own.
 
-Two decisions to make when implementing:
+**Which number to decide on.** Three numbers come out of this work and only one
+of them is an input to a decision:
 
-- One record per IPS record (preferred — keeps offsets meaningful) rather than
-  one giant record for the whole ROM.
-- What tag to use. Probably a caller-supplied one, so `--apply-ips` can label
-  the patch by filename and patch-vs-patch collisions become legible.
+| Number | Caveats | Use |
+|---|---|---|
+| bytes used per allocation | flag-dependent; under-counts byte-at-a-time patches | audit output — catches drift, never sites a patch |
+| free bytes per bank | ≥ 8 threshold, `$00` ambiguity, unclaimed ≠ unreferenced | "is this bank roomy", nothing finer |
+| **gap of N contiguous bytes** | **none that bear on the answer** | **where a patch goes** |
+
+A threshold can only hide gaps too small to use, and `$00` ambiguity never
+arises if you claim `$FF` runs — so the question `--free-space --fit N` answers
+is clean, while the aggregate it is derived from is not. The remaining check
+(is this gap *referenced*?) is once per gap, and recording it as a registry row
+retires it permanently. That is why the caveats are not a recurring tax: what
+recurs is arithmetic, and `free_space_doc_table_is_current` does that for you.
+
+CLAUDE.md's per-bank table is that output, and
+`free_space_doc_table_is_current` fails when a row drifts. Reconciling the two
+found: the doc's older figures came from a ≥ 16-byte scan (which is the whole
+of the PRG031 68→81 and PRG010 880→896 difference), and its PRG000–007 row had
+simply missed PRG004 and PRG006, whose bank tails hold 426 and 1392 bytes.
+Both tails were checked against the disassembly before being counted — see the
+note in CLAUDE.md. "Unclaimed filler" is not by itself "unreferenced"; the scan
+finds candidates, the disassembly settles them.
+
+## Enhancement 2 — route `apply_ips_patch` through `write_range` (implemented for the `Rom` path)
+
+Both decisions went the expected way: one write record per IPS record, and a
+caller-supplied tag. `testrom` passes the filename, so a collision report names
+the patch; `randomize_rom` passes `visual_patch`.
+
+Volume is not a problem — the bundled patches run 265–672 records each, and all
+of them end at 0x05FD50, inside the 0x60000 payload.
+
+Two things that came out of doing it:
+
+- **The tag stack had to become `Vec<String>`.** It was `Vec<&'static str>`,
+  which cannot hold a filename. `set_tag`/`push_tag` now take `&str`; all 91
+  existing call sites pass literals and were untouched.
+- **An out-of-range record is now an error, not a panic.** The old path grew a
+  scratch buffer to fit the record and then panicked on the length mismatch when
+  copying it back. Records are validated up front, so a patch that does not fit
+  leaves the ROM untouched instead of half-applied.
+
+**Measured effect on collision reports.** Under default options, visual-patch
+bytes newly collide with `palettes` — 7 bytes for Peach, 1 for Dr. Mario, 0 for
+Toad; with `palette_themed` on, 36 for Peach. The count varies run to run
+because palettes draw on OS entropy rather than the seed. This is real signal:
+the palette randomizer is overwriting colors the visual patch chose. Whether
+that is wanted is a design question (recoloring the swapped sprite may well be
+intended), not a defect in the logging.
+
+## The randomizer-vs-randomizer collisions
+
+A default run used to report ~178 of these. Investigated 2026-08-04: **142 were
+an artifact of the report, and all 36 real ones are intended.**
+
+The artifact: `write_range` logs the *whole* range whenever any byte in it
+differs, so a pass that rewrites a block is credited with every byte in it,
+including the ones it left exactly as it found them. `autoscroll -> powerups`
+(131 bytes, the largest group by far) was entirely this — `powerups` "overwrote"
+those bytes with the identical value autoscroll had put there. `find_collisions`
+now reads `WriteRecord::changes()` instead of the covered range, which drops a
+default seed from 178 to 36–39.
+
+**Not fixed at the source, deliberately.** Narrowing `write_range` to log only
+changed sub-runs would discard the covered/changed distinction, and two
+consumers need *covered*: the free-space audit (a routine byte equal to the
+`$FF` filler under it is still part of the routine, and must stay attributed to
+its owner) and testrom's guard (an incoming patch overwriting such a byte would
+genuinely break that routine). Both facts are recoverable from a record, so the
+fix was to give the distinction a name — `changes()` / `changed_len()` — and
+teach the one consumer that meant "overwrote" to use it.
+
+The per-tag header in `--write-log` now shows both when they differ, which makes
+the shape visible: `[powerups] 52968 bytes (156 changed), 9 writes`. Powerups
+rewrites whole level-data regions to move 156 bytes, which is where essentially
+all of the noise came from. Correct, just coarse — not worth a byte-identity
+risk to narrow.
+
+The 36 that remain, all explained:
+
+| Bytes | Pair | Why |
+|---|---|---|
+| 19 | `autoscroll -> levels/airships` | autoscroll redirects each world's airship ObjSets/LevelLayouts pointers; the airship shuffle then permutes those *post-autoscroll* values between slots. The ordering CLAUDE.md requires, working |
+| 13 | `overworld_writer -> items` | the Hammer Bro reward table at 0x16190: the writer places bros with default rewards, `items` randomizes the reward. Layered by design |
+| 3 | `qol -> overworld_writer` | `gap_tile_for(0xB3) = 0x9D` (the documented bridge→water-gap), the FX slot-16 `replace_tile` handoff after pickup has consumed qol's value, and a level placed on the W1 shortcut stub — which `apply_w1_shortcut` explicitly leaves as a valid blank node |
+| 1 | `hand_rooms -> items` | the co-ownership already recorded in `FREE_SPACE_ALLOCATIONS` |
+
+No defects. Worth re-running after any pass is reordered, since three of the
+four groups are ordering-dependent by construction.
+
+**Known limit of `find_collisions`:** it compares only the *top-level* tag, so
+passes within one family (`koopalings/y_clamp` vs `koopalings/random_hits`) are
+mutually invisible to it. Fine for finding cross-module clobbering, useless for
+intra-module — query full tags via `writes_in_range` for that.
 
 ## Enhancement 3 — make tags un-leakable
 
@@ -158,6 +266,13 @@ This makes leaking structurally impossible rather than a matter of discipline.
 touching every randomization pass. Worth doing *after* Enhancement 1, so the
 audit can confirm whether any other tag is currently wrong — that determines
 whether this is urgent or merely tidy.
+
+**What the audit says about urgency:** the audit run found no *leaked* tag —
+the one attribution problem (`march_veto` under `overworld_writer`) was a
+correct tag that was merely too coarse, not a stale one bleeding across a pass.
+That is weak evidence, though: the audit only sees the 36 free-space regions,
+which is a small share of what a run writes. It lowers the urgency; it does not
+clear the structural problem.
 
 **Verification:** `tests/overworld_baseline.rs` covers it. Tagging is metadata
 and must not move a single ROM byte, so all 20 seeds must stay byte-identical.

--- a/docs/write_log_design.md
+++ b/docs/write_log_design.md
@@ -1,0 +1,176 @@
+# ROM Write Log — current state and planned enhancements
+
+Status: design note. Nothing here is implemented yet.
+
+## What exists today
+
+`Rom` records every mutation that goes through its accessors:
+
+```rust
+pub struct WriteRecord {
+    pub offset: usize,
+    pub len: usize,
+    pub old_bytes: Vec<u8>,
+    pub new_bytes: Vec<u8>,
+    pub tag: String,
+}
+```
+
+- `write_byte` and `write_range` both push a record, **unconditionally** — not
+  gated on `debug_assertions`. They skip the record when the write is a no-op
+  (new bytes equal old), so the log holds only real changes.
+- The tag comes from a stack: `set_tag` replaces it (used by the orchestrator
+  before each pass), `push_tag`/`pop_tag` nest a sub-tag within a pass. There
+  are 83 `set_tag` call sites and 8 `push_tag`.
+- Consumers today: `main.rs`'s write-log dump and `find_collisions()`, and
+  `testrom`'s patch-collision guard (`testrom::collisions`), which checks each
+  incoming IPS record against `rom.writes_in_range`.
+
+## The principle to hold
+
+**The log is about bytes, provenance, and ownership. It does not carry
+meaning.**
+
+It should never grow fields like "placed a vertical lock at W8 (6,40)". A
+semantic description of a seed belongs in the seed report / spoiler log (see
+`docs/seed_report_design.md`), derived from the finished ROM. Encoding the same
+fact in both places makes the log a second producer for something the ROM
+already answers — the exact drift that `rom_data::tiles` was created to remove.
+
+The two answer different questions:
+
+| | Question | Shape |
+|---|---|---|
+| Write log | what did we change, and which pass did it | history |
+| Seed report | what does the player get | final state |
+
+## Known gaps
+
+### 1. `apply_ips_patch` bypasses the log
+
+`Rom::apply_ips_patch` writes with a direct slice copy
+(`self.data[HEADER_SIZE..].copy_from_slice(&patched)`), so none of its bytes are
+recorded.
+
+Consequences:
+
+- Visual-patch bytes (Luigi, Peach, Dr. Mario, …) never appear in the log.
+- `testrom --apply-ips` inherits the blind spot: its collision guard compares
+  incoming records against the log, so a *second* applied patch cannot be seen
+  colliding with the first. Patch-vs-randomizer collisions are caught;
+  patch-vs-patch are not.
+
+### 2. Tags leak between passes
+
+`set_tag` replaces the stack and persists until the next call, so a pass that
+sets a tag but writes nothing leaves its name attached to whatever writes next.
+
+Real instance, fixed in `cd5e459`: `randomize::troll_pipes::mark_troll_pipes`
+mutates the `BuildResult`, not the ROM. Its `set_tag("troll_pipes")` therefore
+labelled nothing of its own and leaked onto every byte the overworld writer
+subsequently emitted. The collision guard reported six overlaps against
+`troll_pipes` when they were really `fx_screen_check`'s, which sent an
+investigation after an optional feature instead of the routine under test.
+
+The fix applied was local (drop the stray tag, tag the writer, sub-tag the FX
+patch). The structural problem remains: correctness depends on every one of 83
+call sites being disciplined.
+
+### 3. No dynamic free-space verification
+
+The existing tests are **static** — they check the registry against itself:
+
+- `test_free_space_no_overlap` — allocations don't overlap each other
+- `test_free_space_constants_match_registry` — `FS_*` constants match entries
+
+Nothing checks what is *actually written*. Consequences:
+
+- The `// N reserved, M used` comments on 41 allocations are hand-maintained and
+  can silently go stale. `FS_FX_SCREEN_CHECK` read `112 reserved, 97 used` until
+  it was corrected to `82` by hand in `1fe86fb`; others have not been audited.
+- Nothing detects a patch overrunning its allocation into a neighbour's, or a
+  module writing into free space it does not own.
+
+---
+
+## Enhancement 1 — free-space auditor (do this first)
+
+Cross-reference `FREE_SPACE_ALLOCATIONS` against the write log after a real
+randomization run.
+
+**Assertions**
+
+1. Every write whose offset falls inside a registered free-space region carries
+   the tag of the module that owns that allocation.
+2. For each allocation, the highest byte actually written is within
+   `offset + size`. (Overrun = failing test.)
+3. Report actual bytes used per allocation, so the `reserved / used` comments
+   can be regenerated rather than remembered.
+
+**Why first**
+
+- It needs no call-site churn — a test plus a small helper.
+- It mechanizes `/review-patch` sections 1–3, currently re-derived by hand for
+  every 6502 patch.
+- It would have caught the stale `97 used` automatically.
+- It tells us whether tags are still lying anywhere else, which is the
+  information needed to decide how urgent Enhancement 3 is.
+
+**Prerequisite, already met:** accurate tags. Before `cd5e459` the overworld
+writer's bytes were attributed to `troll_pipes`, which would have made
+assertion 1 fail for reasons unrelated to free space.
+
+**Gotchas**
+
+- Flag-dependent code paths do not run under `Options::default()`. Anything
+  gated off by default (e.g. `hammer_breaks_locks`, `troll_pipes` when off) will
+  simply be absent from the log — the audit must not read "no writes" as
+  "allocation unused". Run the audit over a few option sets, or assert only over
+  allocations whose feature was enabled for that run. This is the same trap that
+  made the overworld baseline sweep vacuous for `hammer_breaks`
+  (see `tests/overworld_baseline.rs`).
+- A patch may legitimately write fewer bytes than reserved; only *over* is an
+  error. Reserved headroom is encouraged (see CLAUDE.md).
+
+## Enhancement 2 — route `apply_ips_patch` through `write_range`
+
+Small and self-contained. Volume is not a concern: the largest bundled patch is
+the practice ROM at 193 records.
+
+Two decisions to make when implementing:
+
+- One record per IPS record (preferred — keeps offsets meaningful) rather than
+  one giant record for the whole ROM.
+- What tag to use. Probably a caller-supplied one, so `--apply-ips` can label
+  the patch by filename and patch-vs-patch collisions become legible.
+
+## Enhancement 3 — make tags un-leakable
+
+Replace `set_tag` + convention with an RAII scope guard:
+
+```rust
+let _t = rom.tag("qol/starting_items");   // restores the previous tag on drop
+```
+
+This makes leaking structurally impossible rather than a matter of discipline.
+
+**Cost:** 83 `set_tag` call sites plus 8 `push_tag`. Mechanical but wide, and
+touching every randomization pass. Worth doing *after* Enhancement 1, so the
+audit can confirm whether any other tag is currently wrong — that determines
+whether this is urgent or merely tidy.
+
+**Verification:** `tests/overworld_baseline.rs` covers it. Tagging is metadata
+and must not move a single ROM byte, so all 20 seeds must stay byte-identical.
+Note that harness excludes palettes (not seed-stable) and only exercises default
+options, so pair it with the existing pinned-table tests for flag-gated passes.
+
+---
+
+## Explicitly out of scope
+
+- Semantic content in the log (see "The principle to hold").
+- Deriving the spoiler log from the write log. Evaluated and rejected: the log
+  is a change stream requiring the same interpretation layer as reading the
+  finished ROM, plus replay; it does not record decisions that produced no bytes
+  (e.g. which level donated an antechamber); and it would make a player-facing
+  feature depend on tag accuracy.

--- a/src/bin/testrom.rs
+++ b/src/bin/testrom.rs
@@ -277,10 +277,19 @@ fn main() {
         ));
     }
 
-    let extra_patches: Vec<Vec<u8>> = cli
+    // Labelled by filename: the label is what the write log and any collision
+    // report name, so a second patch clashing with the first is legible.
+    let extra_patches: Vec<(String, Vec<u8>)> = cli
         .apply_ips
         .iter()
-        .map(|p| fs::read(p).unwrap_or_else(|e| die(format!("reading {}: {e}", p.display()))))
+        .map(|p| {
+            let bytes = fs::read(p).unwrap_or_else(|e| die(format!("reading {}: {e}", p.display())));
+            let label = p.file_name().map_or_else(
+                || p.display().to_string(),
+                |n| n.to_string_lossy().into_owned(),
+            );
+            (label, bytes)
+        })
         .collect();
 
     let spec = TestRomSpec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub fn randomize_rom(
     let mut rom = Rom::from_bytes_lax(rom_data, options.skip_rom_validation)
         .map_err(|e| e.to_string())?;
     if let Some(patch) = visual_patch {
-        rom.apply_ips_patch(patch)?;
+        rom.apply_ips_patch(patch, "visual_patch")?;
     }
     randomizer::randomize(&mut rom, seed, options);
     Ok(rom)
@@ -90,7 +90,7 @@ pub(crate) fn randomize_rom_with_overworld_capture(
     let mut rom = Rom::from_bytes_lax(rom_data, options.skip_rom_validation)
         .map_err(|e| e.to_string())?;
     if let Some(patch) = visual_patch {
-        rom.apply_ips_patch(patch)?;
+        rom.apply_ips_patch(patch, "visual_patch")?;
     }
     let mut capture: Option<randomize::overworld_build::BuildResult> = None;
     randomizer::randomize_with_overworld_capture(&mut rom, seed, options, &mut capture);

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,6 +390,18 @@ struct Cli {
     #[arg(long)]
     write_log: Option<PathBuf>,
 
+    /// Print the per-bank free-space budget and exit, without randomizing.
+    /// Derived from the vanilla ROM and the allocation registry, so it is the
+    /// same for every seed and option set.
+    #[arg(long)]
+    free_space: bool,
+
+    /// With --free-space: list every unclaimed gap that would hold N bytes,
+    /// instead of the per-bank summary. This is the question to ask when
+    /// siting a new patch — a bank total can be scraps.
+    #[arg(long, value_name = "N")]
+    fit: Option<usize>,
+
     /// Skip the SMB3 (USA) header / page-count / size checks so modded or
     /// translated ROMs can be loaded. The title-screen seed hash is also
     /// skipped, since its hooks assume the vanilla ROM layout.
@@ -565,6 +577,23 @@ fn main() {
         }
     };
 
+    if cli.free_space {
+        use smb3_rs::randomize::rom_data::{format_bank_budget, format_gaps_fitting};
+        match smb3_rs::rom::Rom::from_bytes_lax(&rom_data, cli.skip_rom_validation) {
+            Ok(rom) => {
+                match cli.fit {
+                    Some(need) => print!("{}", format_gaps_fitting(&rom, need)),
+                    None => print!("{}", format_bank_budget(&rom)),
+                }
+                return;
+            }
+            Err(e) => {
+                eprintln!("Error: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
     let seed = cli.seed.unwrap_or_else(rand::random);
 
     let options = build_options(&cli);
@@ -640,6 +669,10 @@ fn main() {
                 log.push_str(&format!("  0x{off:05X}: {tag1} vs {tag2}\n"));
             }
         }
+
+        // Free space is the scarcest resource here, so the log that says what
+        // was written also says what it cost and what is left.
+        log.push_str(&smb3_rs::randomize::rom_data::format_free_space_report(&rom));
 
         if let Err(e) = fs::write(log_path, &log) {
             eprintln!("Error writing log: {e}");

--- a/src/randomize/overworld_writer/mod.rs
+++ b/src/randomize/overworld_writer/mod.rs
@@ -105,12 +105,15 @@ pub(crate) fn write_overworld<R: Rng>(
     // Keep wandering map objects (Hammer Bros) off plant/army nodes — a bro
     // parked on one would replay the level after it's beaten. Also vetoes
     // hand-trap landings (subsumes the former bros_no_hands patch).
+    // Sub-tagged like fx_screen_check below: it claims free space, so the write
+    // log has to name it for the free-space audit and collision reports.
+    rom.push_tag("march_veto");
     march_veto::write_march_veto(rom, &w8_sprite_positions, &plant_positions);
+    rom.pop_tag();
     if flags.shuffle_hammer_bros {
         write_hb_sprites(rom, build, rng);
     }
-    // Sub-tagged: this is the one writer patch that claims free space, so the
-    // write log has to name it for collision reports to be actionable.
+    // Sub-tagged for the same reason as march_veto above.
     rom.push_tag("fx_screen_check");
     patch_fortress_fx_screen_check(rom);
     rom.pop_tag();

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -1,5 +1,9 @@
 //! Central registry of ROM free-space allocations (assembled code + data
-//! tables). The overlap test guards against collisions.
+//! tables). The overlap test guards against collisions between rows;
+//! `audit_free_space` guards against the registry drifting from what the
+//! randomizer actually writes, and `free_space_map` measures what is left.
+//! Both are printed by `--write-log`, which is where the per-bank numbers
+//! below and the `reserved / used` comments should be regenerated from.
 //!
 //! **Free space is the scarcest resource in this project — size every patch
 //! accordingly.** See the "ROM Free Space Is Scarce" section in `CLAUDE.md`
@@ -7,9 +11,10 @@
 //!
 //! The aggregate free-space number is misleading: space is per-bank, and a
 //! routine must live in a bank mapped when it runs. The always-mapped banks
-//! are effectively full — PRG031 (`$E000–$FFFF`) has ~68 bytes left with a
-//! largest contiguous gap of ~30, and PRG030 (`$8000–$9FFF`) has ~120 with a
-//! largest gap of ~74. Swapped banks are roomier (PRG010 ~880, PRG026 ~2600).
+//! are effectively full — PRG031 (`$E000–$FFFF`) has 81 bytes left but a
+//! largest contiguous gap of only 30, and PRG030 (`$8000–$9FFF`) has 120 with
+//! a largest gap of 74. Swapped banks are roomier (PRG010 896, PRG026 2603,
+//! and the in-level banks PRG004 426 / PRG006 1392 in one run each).
 //!
 //! Reserving some headroom in an allocation is fine and encouraged — a routine
 //! that has to grow later is far safer to extend in place than to relocate
@@ -18,58 +23,135 @@
 //! used". What is *not* fine is letting the code itself be sloppy: reserve
 //! room, but write the bytes as tight as they will go.
 
-/// Free space allocation: (file_offset, size_bytes, label).
-/// The overlap test checks that no two allocations in this list share any bytes.
-#[cfg(test)]
-pub(crate) const FREE_SPACE_ALLOCATIONS: &[(usize, usize, &str)] = &[
+use crate::rom::Rom;
+
+/// One reserved region of ROM free space.
+///
+/// `owners` lists the write-log tags allowed to write here. Each matches as a
+/// run of whole `/`-separated components, so the short name `fx_screen_check`
+/// owns writes tagged `overworld_writer/fx_screen_check`, and `big_q_blocks`
+/// owns both `qol/big_q_blocks` and `enemies/big_q_blocks`. The auditor
+/// (`audit_free_space`) uses this to flag a module writing into free space it
+/// does not own.
+///
+/// Most regions have exactly one owner. A second entry means the region is
+/// shared on purpose — the cloned enemy streams are built by one module and
+/// then have their item byte randomized by another — and is the place to say
+/// so, not a licence to let an unrelated pass wander in.
+pub struct FreeSpaceAlloc {
+    pub offset: usize,
+    pub size: usize,
+    pub owners: &'static [&'static str],
+    pub label: &'static str,
+}
+
+/// Shorthand so registry rows stay one line each.
+const fn fs(
+    offset: usize,
+    size: usize,
+    owners: &'static [&'static str],
+    label: &'static str,
+) -> FreeSpaceAlloc {
+    FreeSpaceAlloc { offset, size, owners, label }
+}
+
+/// Every region of ROM free space this project has claimed.
+///
+/// `test_free_space_no_overlap` checks that no two rows share a byte;
+/// `audit_free_space` checks the rows against what a real run actually wrote.
+///
+/// # Why this is a static map and not an allocator
+///
+/// Evaluated 2026-08-04 and deferred, so it does not get re-proposed blind.
+///
+/// The obvious objection to a static registry is that a flag-gated patch
+/// reserves its bytes whether or not the feature is on — and that is a real
+/// waste in the bank where it hurts most: under default options, 102 of
+/// PRG031's 206 reserved bytes go unwritten (`start_airship_swap` 69,
+/// `starting_items` 33), in a bank whose largest free gap is 30.
+///
+/// It is still the right trade, for two reasons the audit can now quantify:
+///
+/// * **Packing tighter buys almost nothing.** The ROM is generated per seed, so
+///   an unwritten reservation is already `$FF` in the output — nobody pays for
+///   it at runtime. Assigning offsets dynamically would only recover the
+///   *headroom* inside allocations, and `audit_free_space` measures that at
+///   about 39 bytes ROM-wide (`fx_screen_check` 30, `fire_flower` 6, three
+///   others 1 each), an upper bound at that.
+/// * **The only real win is overcommit, and it costs a guarantee.** Letting the
+///   sum of reservations exceed a bank means some flag combinations stop
+///   generating. A static map that fits always works; that property is worth
+///   more than 40 bytes to a randomizer whose users tick arbitrary boxes.
+///
+/// On top of which the routines are not relocatable: hooks already are
+/// (`jsr_into_bank` derives its operand from the allocation), but internal
+/// absolute references are not — `FS_CANOE_SUMMON` is origin-locked by its own
+/// `JMP $DEB7` and `ADC $DF2D` table reads, and the `FS_SAS_*` tables are read
+/// from another bank. Moving patches at generation time means carrying
+/// relocations per patch: a small linker, paid for by all 36 existing patches
+/// and every future one.
+///
+/// **Reach for placement first.** Scarcity here is per-bank, so the cheap fix
+/// when a tight bank fills is to move a flag-gated patch to a roomy one behind
+/// a trampoline — PRG004 (426 bytes) and PRG006 (1392) are both empty.
+///
+/// **Revisit when** an always-mapped bank cannot hold a patch that genuinely
+/// must run there (no trampoline available), *or* two features are provably
+/// never on together. The second case does not need an allocator at all: a
+/// registry row can name both owners, and the audit already knows how to check
+/// that only one of them wrote.
+pub const FREE_SPACE_ALLOCATIONS: &[FreeSpaceAlloc] = &[
     // PRG030 (fixed bank, always mapped $8000–$9FFF, file 0x3C010)
-    (0x3DF20, 28, "world_order: routine + tables"),
-    (0x3DF3C, 20, "big_q_block: save obj_ptr trampoline"),
+    fs(0x3DF20, 28, &["world_order"], "routine + tables"),
+    fs(0x3DF3C, 20, &["big_q_blocks"], "big_q_block: save obj_ptr trampoline"),
     // PRG031 (always mapped $E000–$FFFF, file 0x3E010)
-    (0x3E924, 25, "title_screen: sprite copy routine"),
-    (0x3E93D, 40, "title_screen: sprite data table"),
-    (0x3E260, 33, "starting_items: lives + intro skip + menu music + inventory init trampoline"),
-    (0x3E281, 69, "start_airship_swap: 4 tables (X/XHi/ScrL/ScrH × 8) + Map_Init seed helper"),
-    (0x3E965, 13, "title_screen: intro skip + menu music routine"),
-    (0x3FFF0, 26, "card_speed_clear: XOR trampoline"),
+    fs(0x3E924, 25, &["title_screen"], "sprite copy routine"),
+    fs(0x3E93D, 40, &["title_screen"], "sprite data table"),
+    fs(0x3E260, 33, &["starting_items"], "lives + intro skip + menu music + inventory init trampoline"),
+    fs(0x3E281, 69, &["start_airship_swap"], "4 tables (X/XHi/ScrL/ScrH × 8) + Map_Init seed helper"),
+    fs(0x3E965, 13, &["title_screen"], "intro skip + menu music routine"),
+    fs(0x3FFF0, 26, &["card_speed_clear"], "XOR trampoline"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
-    (0x35572, 13, "mystery_anchor: item redirect trampoline"),
-    (0x3557F, 50, "hammer_locks: tile check subroutine + tables"),
-    (0x355B1, 12, "anchor_visuals: items-vs-cards index guard trampoline"),
-    (0x355BD, 106, "big_q_block: two-pass lookup routine + 13-entry tables (current-area then frozen entry)"),
+    fs(0x35572, 13, &["mystery_anchor"], "item redirect trampoline"),
+    fs(0x3557F, 50, &["hammer_breaks_tiles"], "hammer_locks: tile check subroutine + tables"),
+    fs(0x355B1, 12, &["anchor_visuals"], "items-vs-cards index guard trampoline"),
+    fs(0x355BD, 106, &["big_q_blocks"], "big_q_block: two-pass lookup routine + 13-entry tables (current-area then frozen entry)"),
     // PRG027 (file 0x36010, CPU $A000–$BFFF)
-    (0x379D9, 894, "king_quotes: 7 quotes + hook (7×120 + 54)"),
+    fs(0x379D9, 894, &["king_quotes"], "7 quotes + hook (7×120 + 54)"),
     // PRG010 (file 0x14010, CPU $C000–$DFFF during map)
-    (0x15554, 112, "fx_screen_check: cross-screen lock patch (Fred's algorithm + darkness gate)"),
-    (0x15DF0, 35, "canoe_fix: death respawn position save"),
-    (0x15E13, 162, "map_warp: 2P Start+Select warp-to-partner routine"),
-    (0x15EB5, 151, "canoe_summon: A-on-dock call-the-boat routine + offset tables"),
+    fs(0x15554, 112, &["fx_screen_check"], "cross-screen lock patch (Fred's algorithm + darkness gate)"),
+    fs(0x15DF0, 35, &["fix_canoe_softlock"], "canoe_fix: death respawn position save"),
+    fs(0x15E13, 162, &["map_warp"], "2P Start+Select warp-to-partner routine"),
+    fs(0x15EB5, 151, &["canoe_summon"], "A-on-dock call-the-boat routine + offset tables"),
     // PRG011 (file 0x16010, CPU $A000–$BFFF during map)
-    (0x17C87, 36, "start_airship_swap: game-over twirl finalize helper"),
-    (0x17D00, 66, "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
-    (0x17D50, 26, "no_game_over_penalty: MaCobra NGO routine (macobra.rs NGO_ROUTINE_OFFSET)"),
-    (0x17D70, 107, "march_veto: landing-veto trampoline + per-world coord registry"),
+    fs(0x17C87, 36, &["start_airship_swap"], "game-over twirl finalize helper"),
+    fs(0x17D00, 66, &["fix_canoe_softlock"], "canoe_fix: backup/restore subroutines (CANOE_BACKUP_ROUTINE)"),
+    fs(0x17D50, 26, &["no_game_over_penalty"], "MaCobra NGO routine (macobra.rs NGO_ROUTINE_OFFSET)"),
+    fs(0x17D70, 107, &["march_veto"], "landing-veto trampoline + per-world coord registry"),
     // PRG001 (file 0x02010, CPU $A000–$BFFF)
-    (0x0382A, 23, "koopa_hits: subroutine + defeat JMP + threshold table"),
-    (0x03841, 13, "koopa_collision_guard: skip collision bitmap during invuln"),
-    (0x0384E, 16, "koopa_vram_clear: clear VRAM buffer on defeat"),
-    (0x0385E, 12, "koopa_fire_preset: set stomp counter from threshold table for fireball defeat"),
-    (0x03FD0, 22, "koopa_y_clamp: clamp Koopaling Y position to screen"),
-    (0x03FE6, 36, "fire_flower: position-hash suit routine + pool table"),
-    (0x02713, 17, "poison_mushroom: object $0A init+hit stubs (Norm reuses 1-Up; reclaimed dead Obj0A code)"),
-    (0x02724, 31, "poison_mushroom: 1-up block-spawn hook (position-hash $0B->$0A)"),
+    fs(0x0382A, 23, &["koopalings"], "koopa_hits: subroutine + defeat JMP + threshold table"),
+    fs(0x03841, 13, &["koopalings"], "koopa_collision_guard: skip collision bitmap during invuln"),
+    fs(0x0384E, 16, &["koopalings"], "koopa_vram_clear: clear VRAM buffer on defeat"),
+    fs(0x0385E, 12, &["koopalings"], "koopa_fire_preset: set stomp counter from threshold table for fireball defeat"),
+    fs(0x03FD0, 22, &["koopalings"], "koopa_y_clamp: clamp Koopaling Y position to screen"),
+    fs(0x03FE6, 36, &["fire_flower"], "position-hash suit routine + pool table"),
+    fs(0x02713, 17, &["poison_mushrooms"], "object $0A init+hit stubs (Norm reuses 1-Up; reclaimed dead Obj0A code)"),
+    fs(0x02724, 31, &["poison_mushrooms"], "1-up block-spawn hook (position-hash $0B->$0A)"),
     // PRG003 (file 0x06010, CPU $A000–$BFFF) — object AI bank (Boom-Boom lives here)
-    (0x06609, 8, "tail_stay_dead: MaCobra respawn-suppress routine (CPU $A5F9 gap)"),
-    (0x07FCF, 16, "boomboom_hits: per-fortress threshold table"),
-    (0x07FDF, 44, "boomboom_hits: decoupled stomp-count subroutine"),
+    fs(0x06609, 8, &["macobra"], "tail_stay_dead: MaCobra respawn-suppress routine (CPU $A5F9 gap)"),
+    fs(0x07FCF, 16, &["boomboom"], "boomboom_hits: per-fortress threshold table"),
+    fs(0x07FDF, 44, &["boomboom"], "boomboom_hits: decoupled stomp-count subroutine"),
     // PRG006 (file 0x0C010, CPU $C000–$DFFF) — level enemy data bank
-    (0x0DA74, 22, "hand_rooms: 2 cloned enemy streams for unique 8-Hnd treasure rooms"),
-    (0x0DA8A, 22, "piranha_rooms: 2 cloned chest-room streams with OBJ_TREASURESET for 7-P1/7-P2"),
+    // `items` co-owns both clone blocks: the cloning module builds the stream,
+    // then item randomization rewrites the OBJ_TREASURESET byte inside it
+    // (items.rs reads the offsets from HAND_ROOM_CLONE_*_ITEM / P*_ROOM_ITEM).
+    fs(0x0DA74, 22, &["hand_rooms", "items"], "2 cloned enemy streams for unique 8-Hnd treasure rooms"),
+    fs(0x0DA8A, 22, &["piranha_rooms", "items"], "2 cloned chest-room streams with OBJ_TREASURESET for 7-P1/7-P2"),
     // PRG029 (file 0x3A010, CPU $C000–$DFFF) — swim physics bank
-    (0x3A600, 24, "faster_frog: Frog-Suit swim-speed boost routine"),
+    fs(0x3A600, 24, &["faster_frog"], "Frog-Suit swim-speed boost routine"),
     // PRG000 (file 0x00010) — dead code at CPU $C918 (bytes skipped by the
     // vanilla `JMP $C927` at $C915), reused for MaCobra's hold-left fix helper.
-    (0x00928, 7, "hold_left_fix: scroll-commit helper (STA $FD; STA $0780; RTS)"),
+    fs(0x00928, 7, &["macobra"], "hold_left_fix: scroll-commit helper (STA $FD; STA $0780; RTS)"),
 ];
 
 // PRG030
@@ -276,6 +358,13 @@ pub(crate) const BOOMBOOM_HITS_SUB_CPU: u16    = 0xBFCF;  // $A000 + (0x07FDF - 
 // PRG006 — duplicated enemy streams for the W8 Hand sub-areas. Each clone is
 // 11 bytes (page byte + 3 enemy entries + 0xFF terminator); two clones give
 // the three Hand levels independent OBJ_TREASURESET item bytes.
+//
+// This starts one byte inside vanilla data, not in pure filler: 0x0DA74 is the
+// 0xFF terminator of the object stream southbird labels `_DA60`
+// (0x0DA70..0x0DA74). That stream is dead — nothing in the disassembly
+// references it and no world pointer-table entry reaches past 0x0D9F6 — so
+// overwriting its terminator is safe. It is also why the free-space audit
+// reports this allocation as "sparse".
 pub(crate) const FS_HAND_ROOMS: usize = 0x0DA74; // 22 bytes (2 × 11)
 
 // PRG006 — piranha-shuffle chest-room clones (7-P1/7-P2), each 11 bytes:
@@ -294,20 +383,385 @@ pub(crate) const FS_FASTER_FROG: usize = 0x3A600; // CPU $C5F0
 // PRG008 in-level scroll tail.
 pub(crate) const FS_HOLD_LEFT_HELPER: usize = 0x00928; // 7 bytes (CPU $C918)
 
+// ---------------------------------------------------------------------------
+// Auditor — the registry checked against what a run actually wrote
+// ---------------------------------------------------------------------------
+//
+// The overlap and constants tests above check the registry against *itself*.
+// This checks it against reality: after a randomization run, every byte the
+// write log recorded inside a registered region is matched to the allocation
+// that owns it. That catches a patch overrunning its reservation, a module
+// writing into space it does not own, and `// N reserved, M used` comments
+// that have drifted from the code.
+//
+// `used` counts bytes *covered by a logged write*, which is what a patch
+// occupies — not the narrower "bytes that differ from vanilla". The two come
+// apart because `write_range` logs the whole range whenever any byte in it
+// differs, so a routine emitted as one range is measured exactly even where its
+// bytes happen to match the filler underneath. A patch built byte-at-a-time
+// with `write_byte` is the exception: there, no-op bytes are skipped and `used`
+// under-counts.
+//
+// What the audit cannot see is a feature that was off for the run. Flag-gated
+// code writes nothing, so an allocation showing 0 bytes means "not exercised",
+// not "unused" — never read absence as evidence. (Overrun detection is
+// unaffected by any of this: a write past the end that changes nothing changes
+// nothing.)
+
+/// Size of one PRG bank, and the file offset the PRG region starts at
+/// (after the 16-byte iNES header).
+const PRG_BANK_SIZE: usize = 0x2000;
+const PRG_START: usize = 0x10;
+const PRG_BANKS: usize = 32;
+
+/// PRG bank containing a file offset. Meaningless for CHR offsets.
+pub fn prg_bank_of(offset: usize) -> usize {
+    (offset - PRG_START) / PRG_BANK_SIZE
+}
+
+/// True when write-log tag `tag` is covered by allocation owner `owner`.
+///
+/// Matches whole `/`-separated components, so `koopalings` owns
+/// `koopalings/random_hits` but not `koopalings_extra`, and a full path like
+/// `qol/starting_items` can be used when the short name would be ambiguous.
+fn tag_owns(tag: &str, owner: &str) -> bool {
+    format!("/{tag}/").contains(&format!("/{owner}/"))
+}
+
+/// What one allocation actually received during a run.
+pub struct AllocUsage {
+    pub alloc: &'static FreeSpaceAlloc,
+    /// Bytes inside the region that the run changed.
+    pub changed: usize,
+    /// Region start through the last changed byte — the number that belongs in
+    /// a `// N reserved, M used` comment. Zero when nothing was written.
+    pub used: usize,
+    /// Tags that wrote here without owning the region, and how many bytes each
+    /// wrote. Any entry is a bug: either the owner is wrong or the module is.
+    pub foreign: Vec<(String, usize)>,
+    /// Writes crossing the region boundary: (offset, len, tag). A write
+    /// starting inside and ending past the end is an overrun; one starting
+    /// before is an encroachment from outside.
+    pub overruns: Vec<(usize, usize, String)>,
+}
+
+impl AllocUsage {
+    /// True when this allocation is in a state the registry does not describe.
+    pub fn is_problem(&self) -> bool {
+        !self.foreign.is_empty() || !self.overruns.is_empty()
+    }
+}
+
+/// Cross-reference [`FREE_SPACE_ALLOCATIONS`] against `rom`'s write log.
+/// Returns one entry per allocation, in registry order.
+pub fn audit_free_space(rom: &Rom) -> Vec<AllocUsage> {
+    use std::collections::BTreeMap;
+
+    FREE_SPACE_ALLOCATIONS
+        .iter()
+        .map(|alloc| {
+            let end = alloc.offset + alloc.size;
+            let mut touched = vec![false; alloc.size];
+            let mut foreign: BTreeMap<&str, usize> = BTreeMap::new();
+            let mut overruns = Vec::new();
+
+            for rec in rom.writes_in_range(alloc.offset, end) {
+                if rec.offset < alloc.offset || rec.offset + rec.len > end {
+                    overruns.push((rec.offset, rec.len, rec.tag.clone()));
+                }
+                let lo = rec.offset.max(alloc.offset);
+                let hi = (rec.offset + rec.len).min(end);
+                for b in lo..hi {
+                    touched[b - alloc.offset] = true;
+                }
+                if !alloc.owners.iter().any(|o| tag_owns(&rec.tag, o)) {
+                    *foreign.entry(&rec.tag).or_default() += hi - lo;
+                }
+            }
+
+            AllocUsage {
+                alloc,
+                changed: touched.iter().filter(|t| **t).count(),
+                used: touched.iter().rposition(|t| *t).map_or(0, |i| i + 1),
+                foreign: foreign.into_iter().map(|(t, n)| (t.to_string(), n)).collect(),
+                overruns,
+            }
+        })
+        .collect()
+}
+
+/// Shortest run of identical filler bytes counted as free space. Small enough
+/// to catch the scraps left in the always-mapped banks, large enough that
+/// incidental byte pairs inside real data don't register.
+const MIN_FILLER_RUN: usize = 8;
+
+/// One unclaimed run of `$FF` filler: a place a patch could go.
+#[derive(Clone, Copy)]
+pub struct Gap {
+    pub offset: usize,
+    pub len: usize,
+}
+
+/// Unclaimed filler in one PRG bank, measured against the vanilla ROM.
+///
+/// **`gaps` is the field to make decisions from.** A patch needs one run of N
+/// contiguous bytes in a bank that is mapped when it runs; no total answers
+/// that, and the totals below carry caveats a gap does not (see
+/// [`free_space_map`]).
+pub struct BankFree {
+    pub bank: usize,
+    /// Bytes reserved by [`FREE_SPACE_ALLOCATIONS`] in this bank.
+    pub allocated: usize,
+    /// Unclaimed `$FF` runs, largest first. Candidates, not confirmations:
+    /// filler that nothing has *claimed* may still be data something *reads*.
+    /// Verify a gap against the disassembly once, then record it as a registry
+    /// row and it never needs checking again.
+    pub gaps: Vec<Gap>,
+    /// `$FF` filler outside every allocation. An aggregate — useful for "is
+    /// this bank roomy", never for "does my patch fit".
+    pub free_ff: usize,
+    /// `$00` runs outside every allocation. Reported apart from `free_ff`
+    /// because zeroed *data* looks identical to zero padding — treat this
+    /// column as a candidate list, not as available space.
+    pub free_00: usize,
+}
+
+impl BankFree {
+    /// Largest single unclaimed `$FF` run, or 0.
+    pub fn largest_gap(&self) -> usize {
+        self.gaps.first().map_or(0, |g| g.len)
+    }
+
+    /// Where the largest run starts, or 0 when there is none.
+    pub fn largest_gap_at(&self) -> usize {
+        self.gaps.first().map_or(0, |g| g.offset)
+    }
+}
+
+/// Scan the vanilla PRG for filler runs no allocation has claimed.
+///
+/// Takes the *original* bytes, not the randomized ones: the question is how
+/// much room the ROM has, and a run that this build has already written into
+/// is still owned by whoever wrote it.
+pub fn free_space_map(rom: &Rom) -> Vec<BankFree> {
+    let mut claimed = vec![false; PRG_BANKS * PRG_BANK_SIZE];
+    for a in FREE_SPACE_ALLOCATIONS {
+        for b in a.offset..a.offset + a.size {
+            claimed[b - PRG_START] = true;
+        }
+    }
+
+    let prg = &rom.original[PRG_START..PRG_START + PRG_BANKS * PRG_BANK_SIZE];
+    let mut banks: Vec<BankFree> = (0..PRG_BANKS)
+        .map(|bank| BankFree { bank, allocated: 0, gaps: Vec::new(), free_ff: 0, free_00: 0 })
+        .collect();
+
+    for a in FREE_SPACE_ALLOCATIONS {
+        banks[prg_bank_of(a.offset)].allocated += a.size;
+    }
+
+    // Walk each bank separately: a filler run spanning a bank boundary is two
+    // gaps, not one, since a routine can only live in a bank that is mapped
+    // when it runs.
+    for (bank, entry) in banks.iter_mut().enumerate() {
+        let base = bank * PRG_BANK_SIZE;
+        let mut i = 0;
+        while i < PRG_BANK_SIZE {
+            let val = prg[base + i];
+            if val != 0xFF && val != 0x00 {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < PRG_BANK_SIZE && prg[base + i] == val {
+                i += 1;
+            }
+            if i - start < MIN_FILLER_RUN {
+                continue;
+            }
+            // Subtract the claimed parts, leaving the unclaimed sub-runs.
+            let mut sub = start;
+            while sub < i {
+                if claimed[base + sub] {
+                    sub += 1;
+                    continue;
+                }
+                let sub_start = sub;
+                while sub < i && !claimed[base + sub] {
+                    sub += 1;
+                }
+                let len = sub - sub_start;
+                if val == 0xFF {
+                    entry.free_ff += len;
+                    entry.gaps.push(Gap { offset: PRG_START + base + sub_start, len });
+                } else {
+                    entry.free_00 += len;
+                }
+            }
+        }
+    }
+
+    for b in banks.iter_mut() {
+        b.gaps.sort_by_key(|g| std::cmp::Reverse(g.len));
+    }
+    banks
+}
+
+/// Every unclaimed `$FF` gap of at least `need` bytes, largest first — the
+/// query behind `--free-space --fit N`, and the only free-space question that
+/// bears on where a new patch goes.
+///
+/// Ignore the totals when siting a patch: a bank with 200 free bytes in
+/// ten scraps holds nothing. These are candidates — confirm the one you pick is
+/// unreferenced (the disassembly is the oracle), then record it as a registry
+/// row and the checking is done for good.
+pub fn gaps_fitting(rom: &Rom, need: usize) -> Vec<(usize, Gap)> {
+    let mut out: Vec<(usize, Gap)> = free_space_map(rom)
+        .iter()
+        .flat_map(|b| b.gaps.iter().filter(|g| g.len >= need).map(|g| (b.bank, *g)))
+        .collect();
+    out.sort_by_key(|(_, g)| std::cmp::Reverse(g.len));
+    out
+}
+
+/// Human-readable free-space section for the `--write-log` dump: per-allocation
+/// usage first (problems called out), then the per-bank budget.
+pub fn format_free_space_report(rom: &Rom) -> String {
+    format_alloc_audit(rom) + &format_bank_budget(rom)
+}
+
+/// Per-allocation half of the report. Reads the write log, so it describes the
+/// run that produced `rom` — an allocation whose feature was off reads 0.
+pub fn format_alloc_audit(rom: &Rom) -> String {
+    use std::fmt::Write;
+
+    let usage = audit_free_space(rom);
+    let mut out = String::new();
+
+    let problems: Vec<&AllocUsage> = usage.iter().filter(|u| u.is_problem()).collect();
+    let _ = writeln!(out, "\n--- Free space: {} allocations, {} problem(s) ---", usage.len(), problems.len());
+    for u in &problems {
+        let _ = writeln!(
+            out,
+            "  !! 0x{:05X} {} (owner {})",
+            u.alloc.offset, u.alloc.label, u.alloc.owners.join(" + "),
+        );
+        for (tag, n) in &u.foreign {
+            let _ = writeln!(out, "     foreign write: {n} byte(s) tagged {tag}");
+        }
+        for (off, len, tag) in &u.overruns {
+            let _ = writeln!(out, "     crosses boundary: 0x{off:05X}+{len} tagged {tag}");
+        }
+    }
+
+    let _ = writeln!(out, "\n  bank   offset   used/reserved  owner");
+    for u in &usage {
+        let note = if u.used == 0 {
+            "  (not written this run)"
+        } else if u.changed != u.used {
+            "  (sparse)"
+        } else {
+            ""
+        };
+        let _ = writeln!(
+            out,
+            "  PRG{:03} 0x{:05X}  {:>4}/{:<4}      {}{}",
+            prg_bank_of(u.alloc.offset), u.alloc.offset, u.used, u.alloc.size,
+            u.alloc.owners.join(" + "), note,
+        );
+    }
+    let _ = writeln!(
+        out,
+        "\n  `used` is bytes covered by a logged write. Exact for a routine written as one\n  \
+         write_range; an under-count only where a patch writes byte-at-a-time and some\n  \
+         bytes already match. 0 means the feature was off, not that the space is unused."
+    );
+
+    out
+}
+
+/// Per-bank half of the report: what the ROM has left. Derived from the
+/// *vanilla* bytes and the registry only — no write log, so it is identical for
+/// every seed and every option set, and needs no randomization run to produce.
+pub fn format_bank_budget(rom: &Rom) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "\n  bank   reserved  free($FF)  largest gap        zero runs");
+    for b in free_space_map(rom) {
+        if b.allocated == 0 && b.free_ff == 0 && b.free_00 == 0 {
+            continue;
+        }
+        let gap = if b.gaps.is_empty() {
+            String::from("-")
+        } else {
+            format!("{:>4} @ 0x{:05X}", b.largest_gap(), b.largest_gap_at())
+        };
+        let _ = writeln!(
+            out,
+            "  PRG{:03} {:>9} {:>10}  {:<18} {:>9}",
+            b.bank, b.allocated, b.free_ff, gap, b.free_00,
+        );
+    }
+    let _ = writeln!(
+        out,
+        "\n  Free space is per-bank: a routine must live in a bank mapped when it runs,\n  \
+         so the largest-gap column decides what fits — never the free($FF) total, which\n  \
+         can be ten unusable scraps. `--fit N` lists every gap that would hold N bytes.\n  \
+         Runs shorter than {MIN_FILLER_RUN} bytes are not counted, and the zero-run column may be\n  \
+         live data rather than padding."
+    );
+
+    out
+}
+
+/// Answer to "where can a patch of N bytes go" — the candidate list, printed by
+/// `--free-space --fit N`.
+pub fn format_gaps_fitting(rom: &Rom, need: usize) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    let fits = gaps_fitting(rom, need);
+    if fits.is_empty() {
+        let _ = writeln!(out, "\n  No unclaimed gap holds {need} bytes.");
+        let _ = writeln!(
+            out,
+            "  A trampoline into a roomier bank is the usual answer; see the bank budget.",
+        );
+        return out;
+    }
+
+    let _ = writeln!(out, "\n  {} gap(s) hold {need} bytes:\n", fits.len());
+    let _ = writeln!(out, "  bank    offset     size");
+    for (bank, g) in &fits {
+        let _ = writeln!(out, "  PRG{:03}  0x{:05X}  {:>7}", bank, g.offset, g.len);
+    }
+    let _ = writeln!(
+        out,
+        "\n  These are candidates, not confirmations. Unclaimed filler can still be data\n  \
+         something reads: check the gap you pick against the disassembly\n  \
+         (tools/southbird-smb3/PRG/prgNNN.asm) before claiming it, then add a\n  \
+         FREE_SPACE_ALLOCATIONS row so it never needs checking again.\n  \
+         The bank must also be mapped when your code runs — that is the first filter,\n  \
+         not the last."
+    );
+    out
+}
+
 #[cfg(test)]
 mod free_space_tests {
     use super::super::*;
 
     #[test]
     fn test_free_space_no_overlap() {
-        for (i, &(a_off, a_sz, a_label)) in FREE_SPACE_ALLOCATIONS.iter().enumerate() {
-            let a_end = a_off + a_sz;
-            for &(b_off, b_sz, b_label) in &FREE_SPACE_ALLOCATIONS[i + 1..] {
-                let b_end = b_off + b_sz;
+        for (i, a) in FREE_SPACE_ALLOCATIONS.iter().enumerate() {
+            let a_end = a.offset + a.size;
+            for b in &FREE_SPACE_ALLOCATIONS[i + 1..] {
+                let b_end = b.offset + b.size;
                 assert!(
-                    a_end <= b_off || b_end <= a_off,
+                    a_end <= b.offset || b_end <= a.offset,
                     "free space overlap: '{}' (0x{:05X}..0x{:05X}) vs '{}' (0x{:05X}..0x{:05X})",
-                    a_label, a_off, a_end, b_label, b_off, b_end,
+                    a.label, a.offset, a_end, b.label, b.offset, b_end,
                 );
             }
         }
@@ -315,7 +769,7 @@ mod free_space_tests {
 
     #[test]
     fn test_free_space_constants_match_registry() {
-        let offsets: Vec<usize> = FREE_SPACE_ALLOCATIONS.iter().map(|&(o, _, _)| o).collect();
+        let offsets: Vec<usize> = FREE_SPACE_ALLOCATIONS.iter().map(|a| a.offset).collect();
         // Every FS_* constant that names a whole allocation must be a
         // registry row. This list is exhaustive — add new FS_* consts here.
         for &(off, name) in &[
@@ -362,7 +816,7 @@ mod free_space_tests {
         // Interior offsets (sub-tables inside a parent allocation) must fall
         // within some registry row.
         let covered = |o: usize| {
-            FREE_SPACE_ALLOCATIONS.iter().any(|&(ro, rs, _)| o >= ro && o < ro + rs)
+            FREE_SPACE_ALLOCATIONS.iter().any(|a| o >= a.offset && o < a.offset + a.size)
         };
         for &(off, name) in &[
             (FS_SAS_X_TABLE, "FS_SAS_X_TABLE"),
@@ -377,6 +831,62 @@ mod free_space_tests {
                 "{name} (0x{off:05X}) not covered by any FREE_SPACE_ALLOCATIONS row"
             );
         }
+    }
+
+    /// CLAUDE.md's per-bank budget table is derived data — the same numbers
+    /// `free_space_map` computes — kept in the file because that is what gets
+    /// read when a patch is being sized. This fails the moment a row drifts
+    /// (adding an allocation shrinks whatever bank it lands in) and prints the
+    /// replacement rows, so updating the table is copy-paste rather than
+    /// arithmetic.
+    ///
+    /// Only rows already present are checked: the table lists the banks worth
+    /// caring about, not all 32, and requiring every bank with spare filler to
+    /// appear would bloat it for no gain.
+    ///
+    /// Skips without the ROM, like every other test that needs it.
+    #[test]
+    fn free_space_doc_table_is_current() {
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            return;
+        };
+        let rom = crate::rom::Rom::from_bytes(&bytes).expect("valid ROM");
+        let doc = std::fs::read_to_string("CLAUDE.md").expect("CLAUDE.md");
+        let measured = free_space_map(&rom);
+
+        let mut rows = 0;
+        let mut wrong = Vec::new();
+        for line in doc.lines() {
+            // | PRG010 | `$C000–$DFFF`, map | 896 | 588 |
+            let cells: Vec<&str> = line.split('|').map(|c| c.trim()).collect();
+            if cells.len() < 5 || !cells[1].starts_with("PRG") {
+                continue;
+            }
+            let strip = |c: &str| c.trim_matches('*').to_string();
+            let (Ok(bank), Ok(free), Ok(gap)) = (
+                cells[1][3..].parse::<usize>(),
+                strip(cells[3]).parse::<usize>(),
+                strip(cells[4]).parse::<usize>(),
+            ) else {
+                continue;
+            };
+            rows += 1;
+            let m = &measured[bank];
+            if free != m.free_ff || gap != m.largest_gap() {
+                wrong.push(format!(
+                    "  PRG{bank:03}: table says {free} free / {gap} gap, measured {} / {}",
+                    m.free_ff, m.largest_gap(),
+                ));
+            }
+        }
+
+        assert!(rows >= 8, "parsed only {rows} bank rows from CLAUDE.md — did the table's shape change?");
+        assert!(
+            wrong.is_empty(),
+            "CLAUDE.md's per-bank free-space table is stale:\n{}\n\n\
+             Regenerate with `smb3-rs <rom> --free-space` and replace the rows.",
+            wrong.join("\n"),
+        );
     }
 
     // Ground-truth pins for the PRG bank ↔ file-offset mapping. Each pair is a

--- a/src/randomize/rom_data/mod.rs
+++ b/src/randomize/rom_data/mod.rs
@@ -26,3 +26,11 @@ pub(crate) use tiles::*;
 
 // Part of the lib's public API (consumed by the chr_stats integration test).
 pub use access::{ENEMY_DATA_END, ENEMY_DATA_START};
+
+// Part of the lib's public API: the CLI's `--write-log` dump audits free space
+// against the run it just produced.
+pub use free_space::{
+    audit_free_space, format_alloc_audit, format_bank_budget, format_free_space_report,
+    format_gaps_fitting, free_space_map, gaps_fitting, prg_bank_of, AllocUsage, BankFree, Gap,
+    FreeSpaceAlloc, FREE_SPACE_ALLOCATIONS,
+};

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -73,6 +73,77 @@ fn mystery_anchor_trampoline_written() {
     assert_eq!(rom.read_range(0x345D8, 3), &[0x20, 0x62, 0xB5]);
 }
 
+/// Everything that owns ROM free space, turned on. `all_on_options` is close
+/// but pins `world_count` to 3 and leaves `swap_start_airship` off, and both
+/// gate allocations we want exercised.
+fn audit_options() -> Options {
+    Options {
+        world_count: 7,
+        swap_start_airship: true,
+        ..all_on_options()
+    }
+}
+
+/// Cross-check `FREE_SPACE_ALLOCATIONS` against a real run: every byte written
+/// inside a registered region must come from the module that owns it, and no
+/// write may cross a region boundary.
+///
+/// This is the only check on free space that looks at what the randomizer
+/// *does* rather than at what the registry says about itself. Run with
+/// `--nocapture` to see the usage table — the `used` column is where the
+/// `// N reserved, M used` comments come from.
+#[test]
+fn free_space_audit_matches_registry() {
+    use crate::randomize::rom_data::{audit_free_space, format_free_space_report};
+
+    let Some(mut rom) = make_test_rom() else { return };
+    randomize(&mut rom, 0xA11C0DE, &audit_options());
+
+    let usage = audit_free_space(&rom);
+    println!("{}", format_free_space_report(&rom));
+
+    let problems: Vec<String> = usage
+        .iter()
+        .filter(|u| u.is_problem())
+        .map(|u| {
+            let foreign: Vec<String> = u.foreign.iter()
+                .map(|(tag, n)| format!("{n} byte(s) tagged '{tag}'"))
+                .collect();
+            let over: Vec<String> = u.overruns.iter()
+                .map(|(off, len, tag)| format!("0x{off:05X}+{len} tagged '{tag}' crosses the boundary"))
+                .collect();
+            format!(
+                "0x{:05X} ({}, owner '{}'): {}",
+                u.alloc.offset, u.alloc.label, u.alloc.owners.join(" + "),
+                foreign.into_iter().chain(over).collect::<Vec<_>>().join("; "),
+            )
+        })
+        .collect();
+
+    assert!(
+        problems.is_empty(),
+        "free-space allocations written by a non-owner or overrun:\n  {}",
+        problems.join("\n  "),
+    );
+
+    // A flag-gated patch that never ran writes nothing, and an audit over
+    // nothing passes — the trap that made the overworld baseline vacuous for
+    // hammer_breaks. Every allocation must be exercised for the check above to
+    // mean anything, so assert that rather than trusting it.
+    let untouched: Vec<String> = usage
+        .iter()
+        .filter(|u| u.used == 0)
+        .map(|u| format!("0x{:05X} {} (owner '{}')", u.alloc.offset, u.alloc.label, u.alloc.owners.join(" + ")))
+        .collect();
+    assert!(
+        untouched.is_empty(),
+        "these allocations saw no writes, so the audit above proved nothing about them.\n\
+         Turn the owning feature on in audit_options(), or (if the write is seed-dependent)\n\
+         pick a seed that exercises it:\n  {}",
+        untouched.join("\n  "),
+    );
+}
+
 #[test]
 fn write_log_populated_after_randomize() {
     let Some(mut rom) = make_test_rom() else { return };

--- a/src/rom.rs
+++ b/src/rom.rs
@@ -113,6 +113,20 @@ impl fmt::Display for RomError {
 }
 
 /// A single recorded ROM write operation.
+///
+/// A record carries two distinct facts, and reading the wrong one is the
+/// mistake this type invites:
+///
+/// * **Covered** (`offset`, `len`) — the bytes this pass wrote. `write_range`
+///   logs its whole range whenever *any* byte in it differs, so a pass that
+///   rewrites a block covers every byte in it. This is the ownership question:
+///   what does this pass occupy, and what would an outside patch break?
+/// * **Changed** ([`changes`](Self::changes)) — the subset whose value actually
+///   moved. This is the clobbering question: did a later pass discard an
+///   earlier pass's decision?
+///
+/// Use `changes()` for anything that means "overwrote". Counting covered bytes
+/// as overwrites reported 178 collisions on a default seed where 36 were real.
 #[derive(Clone, Debug)]
 pub struct WriteRecord {
     pub offset: usize,
@@ -120,6 +134,22 @@ pub struct WriteRecord {
     pub old_bytes: Vec<u8>,
     pub new_bytes: Vec<u8>,
     pub tag: String,
+}
+
+impl WriteRecord {
+    /// The bytes this write actually changed, as `(offset, old, new)`.
+    pub fn changes(&self) -> impl Iterator<Item = (usize, u8, u8)> + '_ {
+        (0..self.len)
+            .filter(|&i| self.old_bytes[i] != self.new_bytes[i])
+            .map(move |i| (self.offset + i, self.old_bytes[i], self.new_bytes[i]))
+    }
+
+    /// How many bytes this write changed. Equals `len` for a write that moved
+    /// every byte it touched; less when a range write restated bytes it found
+    /// already correct.
+    pub fn changed_len(&self) -> usize {
+        (0..self.len).filter(|&i| self.old_bytes[i] != self.new_bytes[i]).count()
+    }
 }
 
 /// Parsed iNES header info.
@@ -139,7 +169,7 @@ pub struct Rom {
     pub header: Header,
     /// True when a synthetic iNES header was prepended (unheadered input ROM).
     pub header_synthesized: bool,
-    tag_stack: Vec<&'static str>,
+    tag_stack: Vec<String>,
     write_log: Vec<WriteRecord>,
 }
 
@@ -287,20 +317,39 @@ impl Rom {
     /// Used to layer visual patches before randomization so the final IPS diff
     /// (original → data) captures both visual and randomization changes.
     ///
-    /// The patch is applied against the user-visible bytes (synthetic header
+    /// Patch offsets are relative to the user-visible bytes (synthetic header
     /// stripped if present), matching how external IPS patches are authored.
-    pub fn apply_ips_patch(&mut self, patch: &[u8]) -> Result<(), String> {
-        let view = if self.header_synthesized {
-            &self.data[HEADER_SIZE..]
-        } else {
-            &self.data[..]
-        };
-        let patched = crate::ips::apply_ips_patch(view, patch)?;
-        if self.header_synthesized {
-            self.data[HEADER_SIZE..].copy_from_slice(&patched);
-        } else {
-            self.data.copy_from_slice(&patched);
+    ///
+    /// Each record goes through [`write_range`](Self::write_range), so patched
+    /// bytes appear in the write log under `tag` like any other write. That is
+    /// what lets a *second* patch be seen colliding with the first — while the
+    /// patch was applied as one opaque buffer copy, only patch-vs-randomizer
+    /// collisions were detectable. Pass something that identifies the patch
+    /// (a filename); it is what a collision report will name.
+    pub fn apply_ips_patch(&mut self, patch: &[u8], tag: &str) -> Result<(), String> {
+        let records = crate::ips::parse_ips_records(patch)?;
+        let base = if self.header_synthesized { HEADER_SIZE } else { 0 };
+
+        // Check every record before writing any, so a patch that does not fit
+        // leaves the ROM untouched rather than half-applied. The previous
+        // implementation grew a scratch buffer and then panicked on the
+        // length mismatch when copying it back.
+        for rec in &records {
+            let end = base + rec.offset + rec.payload.len();
+            if end > self.data.len() {
+                return Err(format!(
+                    "IPS record at 0x{:06X} ends at 0x{end:06X}, past the end of the ROM (0x{:06X})",
+                    rec.offset,
+                    self.data.len() - base,
+                ));
+            }
         }
+
+        self.push_tag(tag);
+        for rec in &records {
+            self.write_range(base + rec.offset, &rec.payload);
+        }
+        self.pop_tag();
         Ok(())
     }
 
@@ -346,14 +395,18 @@ impl Rom {
 
     /// Replace the tag stack with a single tag. Used by the orchestrator
     /// before each module call.
-    pub fn set_tag(&mut self, tag: &'static str) {
+    ///
+    /// Takes `&str` rather than `&'static str` so a tag can name something only
+    /// known at runtime — `apply_ips_patch` labels a patch by filename, which is
+    /// what makes a collision between two applied patches legible.
+    pub fn set_tag(&mut self, tag: &str) {
         self.tag_stack.clear();
-        self.tag_stack.push(tag);
+        self.tag_stack.push(tag.to_string());
     }
 
     /// Push a sub-tag onto the stack for hierarchical tagging within a module.
-    pub fn push_tag(&mut self, tag: &'static str) {
-        self.tag_stack.push(tag);
+    pub fn push_tag(&mut self, tag: &str) {
+        self.tag_stack.push(tag.to_string());
     }
 
     /// Pop the most recent sub-tag from the stack.
@@ -407,17 +460,29 @@ impl Rom {
             .any(|r| r.offset < end && r.offset + r.len > start)
     }
 
-    /// Find write collisions: offsets written by more than one top-level tag.
-    /// Returns a list of (offset, tag1, tag2) for each collision.
+    /// Find write collisions: offsets where one top-level tag overwrote a byte
+    /// another had *changed*. Returns (offset, earlier tag, later tag).
+    ///
+    /// Only bytes a pass actually changed count. `write_range` logs the whole
+    /// range whenever any byte in it differs, so a pass that rewrites a block
+    /// is credited with every byte in it — including the ones it left exactly
+    /// as it found them. Counting those produced four noise reports for every
+    /// real one (178 against 36 on a default seed), which is enough to make the
+    /// report not worth reading.
+    ///
+    /// Note this compares only the *top-level* tag, so passes within one family
+    /// (`koopalings/y_clamp` against `koopalings/random_hits`) are invisible to
+    /// each other here. Query full tags with [`writes_in_range`](Self::writes_in_range)
+    /// for that.
     pub fn find_collisions(&self) -> Vec<(usize, String, String)> {
         use std::collections::HashMap;
-        // Map each byte offset to the top-level tag that last wrote it.
+        // Map each byte offset to the top-level tag that last changed it.
         let mut owner: HashMap<usize, &str> = HashMap::new();
         let mut collisions: Vec<(usize, String, String)> = Vec::new();
 
         for rec in &self.write_log {
             let top_tag = rec.tag.split('/').next().unwrap_or(&rec.tag);
-            for off in rec.offset..rec.offset + rec.len {
+            for (off, _, _) in rec.changes() {
                 if let Some(&prev) = owner.get(&off) && prev != top_tag {
                     collisions.push((off, prev.to_string(), top_tag.to_string()));
                 }
@@ -443,7 +508,16 @@ impl Rom {
         let mut out = String::new();
         for (tag, records) in &by_tag {
             let total_bytes: usize = records.iter().map(|r| r.len).sum();
-            let _ = writeln!(out, "[{tag}] {total_bytes} bytes, {} writes", records.len());
+            let changed: usize = records.iter().map(|r| r.changed_len()).sum();
+            // Show both when they differ: the gap is a pass rewriting a block
+            // wider than the bytes it actually moves, which is why counting
+            // covered bytes as overwrites over-reports collisions.
+            let counts = if changed == total_bytes {
+                format!("{total_bytes} bytes")
+            } else {
+                format!("{total_bytes} bytes ({changed} changed)")
+            };
+            let _ = writeln!(out, "[{tag}] {counts}, {} writes", records.len());
             for rec in records {
                 if rec.len <= 4 {
                     let _ = writeln!(
@@ -709,5 +783,108 @@ mod tests {
         assert!(rom.has_writes_in_range(50, 101));
         assert!(!rom.has_writes_in_range(101, 200));
         assert!(!rom.has_writes_in_range(50, 100));
+    }
+
+    // --- IPS application through the write log ---
+
+    /// One raw IPS record: `offset` (3 bytes BE), `len` (2 bytes BE), payload.
+    fn ips_with(offset: usize, payload: &[u8]) -> Vec<u8> {
+        let mut p = b"PATCH".to_vec();
+        p.extend_from_slice(&[(offset >> 16) as u8, (offset >> 8) as u8, offset as u8]);
+        p.extend_from_slice(&[(payload.len() >> 8) as u8, payload.len() as u8]);
+        p.extend_from_slice(payload);
+        p.extend_from_slice(b"EOF");
+        p
+    }
+
+    #[test]
+    fn ips_records_land_in_the_write_log() {
+        let data = make_valid_rom();
+        let mut rom = rom_from(&data);
+        rom.apply_ips_patch(&ips_with(0x100, &[1, 2, 3]), "toad.ips").unwrap();
+
+        let log = rom.write_log();
+        assert_eq!(log.len(), 1, "one record in, one write record out");
+        assert_eq!(log[0].offset, 0x100);
+        assert_eq!(log[0].new_bytes, vec![1, 2, 3]);
+        assert_eq!(log[0].tag, "toad.ips");
+        assert_eq!(rom.read_range(0x100, 3), &[1, 2, 3]);
+    }
+
+    /// Patch offsets are relative to the user-visible bytes, so an unheadered
+    /// input shifts every record by the synthetic header. Getting this wrong
+    /// would corrupt every patch applied to a headerless ROM.
+    #[test]
+    fn ips_offsets_shift_past_a_synthesized_header() {
+        let unheadered = vec![
+            0u8;
+            EXPECTED_PRG_PAGES as usize * PRG_PAGE_SIZE
+                + EXPECTED_CHR_PAGES as usize * CHR_PAGE_SIZE
+        ];
+        let mut rom = rom_from(&unheadered);
+        assert!(rom.header_synthesized);
+
+        rom.apply_ips_patch(&ips_with(0x100, &[9]), "p.ips").unwrap();
+
+        assert_eq!(rom.write_log()[0].offset, HEADER_SIZE + 0x100);
+        assert_eq!(rom.output_bytes()[0x100], 9, "lands at 0x100 of the visible ROM");
+    }
+
+    /// The payoff: while a patch was applied as one opaque buffer copy, a
+    /// second patch overwriting the first was undetectable.
+    #[test]
+    fn second_ips_patch_is_seen_colliding_with_the_first() {
+        let data = make_valid_rom();
+        let mut rom = rom_from(&data);
+        rom.apply_ips_patch(&ips_with(0x100, &[1, 2, 3]), "first.ips").unwrap();
+        rom.apply_ips_patch(&ips_with(0x101, &[4, 5]), "second.ips").unwrap();
+
+        let collisions = rom.find_collisions();
+        assert_eq!(collisions.len(), 2, "two bytes are written by both patches");
+        assert_eq!(collisions[0], (0x101, "first.ips".to_string(), "second.ips".to_string()));
+        assert_eq!(collisions[1], (0x102, "first.ips".to_string(), "second.ips".to_string()));
+    }
+
+    /// A range write logs every byte it covers. A later pass restating a byte
+    /// it did not change is not a collision — counting those buried the real
+    /// ones four to one.
+    #[test]
+    fn a_range_write_restating_a_byte_is_not_a_collision() {
+        let data = make_valid_rom();
+        let mut rom = rom_from(&data);
+
+        rom.set_tag("first");
+        rom.write_range(100, &[0xAA, 0xBB]);
+        // Second pass rewrites the block: 100 is restated, 101 genuinely changed.
+        rom.set_tag("second");
+        rom.write_range(100, &[0xAA, 0xCC]);
+
+        let collisions = rom.find_collisions();
+        assert_eq!(
+            collisions,
+            vec![(101, "first".to_string(), "second".to_string())],
+            "only the byte `second` actually changed should collide",
+        );
+    }
+
+    #[test]
+    fn ips_record_past_the_end_errors_and_writes_nothing() {
+        let data = make_valid_rom();
+        let mut rom = rom_from(&data);
+        let len = rom.data.len();
+
+        // Second record is out of range; the first must not be applied either.
+        let mut patch = b"PATCH".to_vec();
+        patch.extend_from_slice(&[0x00, 0x01, 0x00, 0x00, 0x01, 0xAA]);
+        patch.extend_from_slice(&[
+            ((len >> 16) & 0xFF) as u8, ((len >> 8) & 0xFF) as u8, (len & 0xFF) as u8,
+            0x00, 0x01, 0xBB,
+        ]);
+        patch.extend_from_slice(b"EOF");
+
+        let err = rom.apply_ips_patch(&patch, "too_big.ips").unwrap_err();
+        assert!(err.contains("past the end"), "unexpected error: {err}");
+        assert!(rom.write_log().is_empty(), "a rejected patch must write nothing");
+        assert_eq!(rom.read_byte(0x100), 0, "first record must not be applied");
     }
 }

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -306,13 +306,15 @@ pub struct TestRomSpec {
     pub place_all: Option<String>,
     /// Starting world, 1-based. `None` leaves the ROM's own starting world.
     pub world: Option<u8>,
-    /// Whole IPS patches to apply to the base, in order, before any test edits.
+    /// Whole IPS patches to apply to the base, in order, before any test edits,
+    /// as `(label, bytes)`. The label names the patch in the write log and in
+    /// collision reports — pass the filename.
     ///
     /// Test edits deliberately land *after* these, so `--place`/`--keep-locks`
     /// win over anything a patch writes to the same bytes. Use this for the
     /// full practice ROM (level select + warp whistles) or any patch in
     /// `patches/`; `movement_patch` is the narrow subset instead.
-    pub extra_patches: Vec<Vec<u8>>,
+    pub extra_patches: Vec<(String, Vec<u8>)>,
     /// Keep `extra_patches` from touching the 8 overworld map grids.
     ///
     /// The full practice patch rewrites the maps (49 of its records land in
@@ -537,7 +539,7 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
                 .collect()
         });
 
-        for patch in &spec.extra_patches {
+        for (label, patch) in &spec.extra_patches {
             let clashes = collisions(&rom, patch, None)?;
             if !clashes.is_empty() {
                 return Err(format!(
@@ -550,8 +552,8 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
             }
             let records = ips::parse_ips_records(patch)?;
             let bytes: usize = records.iter().map(|r| r.payload.len()).sum();
-            rom.apply_ips_patch(patch)?;
-            report.push(format!("patch: {} records ({bytes} bytes)", records.len()));
+            rom.apply_ips_patch(patch, label)?;
+            report.push(format!("patch {label}: {} records ({bytes} bytes)", records.len()));
         }
 
         if let Some(grids) = saved_grids {

--- a/tools/README.md
+++ b/tools/README.md
@@ -19,6 +19,13 @@ nix-shell -p python3 --run "python3 tools/<script>.py [args]"
 Two scripts need Pillow — use `nix-shell -p python3 python3Packages.pillow`
 (marked **[PIL]**).
 
+> **Not here: free space.** "Where can this patch go" and "what did this run
+> write" are answered by the Rust CLI, which reads the allocation registry:
+> `smb3-rs <rom> --free-space --fit N` lists unclaimed gaps that hold N bytes,
+> and `--write-log` ends with a per-allocation audit plus the per-bank budget.
+> A Python scanner would duplicate `FREE_SPACE_ALLOCATIONS` and drift from it —
+> exactly what `offset_dups.py` exists to catch.
+
 > **Trust note.** The Rust implementation is the source of truth, not these
 > scripts. When a tool disagrees with Rust, suspect the tool.
 > `validate_shuffleable.py` currently reports 4 discrepancies against

--- a/tools/README.md
+++ b/tools/README.md
@@ -53,7 +53,7 @@ Written once because they were written well.
 
 | Tool | Status | Notes |
 |------|--------|-------|
-| `map_viz.py` | OK | **Renders any ROM's world maps as labelled ASCII**, with screen boundaries. Use this instead of hand-decoding tile grids. `map_viz.py <rom.nes> --world 8`. |
+| `map_viz.py` | OK, but see note | **Renders any ROM's world maps as labelled ASCII**, with screen boundaries. Use this instead of hand-decoding tile grids. `map_viz.py <rom.nes> --world 8`. **Do not trust its `F` glyph for fortress positions** — it drew `F` at seed 10's W8 (5,40) where a byte scan finds no fortress tile (`0x67`/`0xEB`/`0x6A`), and disagreed again on seed 23. Either `F` means something else or the renderer is wrong; unresolved as of 2026-08-04. Slated for replacement by the Rust ASCII renderer in `docs/seed_report_design.md`. |
 | `map_walker.py` | OK | BFS map connectivity + fortress progression. |
 | `level_sim.py` | OK | Level tile simulator, for debugging one level's layout. |
 | `fx_check.py` | needs args | `fx_check.py <rom.nes>` — cross-checks FX slots against actual map tiles. |


### PR DESCRIPTION
Implements Enhancements 1 and 2 from `docs/write_log_design.md` (whose commit rides along here, since it was still unpushed).

## Free-space auditor

`FREE_SPACE_ALLOCATIONS` was only ever checked against itself — no overlaps, `FS_*` constants match rows. Nothing verified what the randomizer *writes*, which is why `FS_FX_SCREEN_CHECK` read "97 used" until it was corrected by hand.

`audit_free_space` cross-references the registry against a real run's write log: every byte written inside a registered region must carry a tag one of that region's `owners` covers, and no write may cross a boundary. The test runs with every feature on and **also asserts every allocation was exercised** — without that the check is vacuous for anything flag-gated, the trap that made the overworld baseline useless for `hammer_breaks`.

Two findings from the first run:

- `march_veto`'s 107 bytes were tagged `overworld_writer` — accurate but unattributable. Now sub-tagged like `fx_screen_check`, whose comment claimed to be the only writer patch claiming free space and had stopped being true.
- The `hand_rooms` / `piranha_rooms` clone blocks are genuinely co-owned: the cloning module builds the enemy stream, `items` rewrites the `OBJ_TREASURESET` byte inside it. Hence `owners` is a list.

## Per-bank budget

`free_space_map` scans the vanilla PRG for unclaimed filler per bank. `smb3-rs <rom> --free-space [--fit N]` prints it without randomizing; `--write-log` ends with both halves.

**The gap list is the number to decide on, not the total** — PRG031's 81 free bytes are scraps that won't hold a 40-byte routine, and `--fit 40` correctly returns nothing there.

The scan found 426 bytes in PRG004 and 1392 in PRG006 that CLAUDE.md's table had missed entirely. Both tails were checked against the disassembly before being counted: `prg004.asm` ends "Rest of ROM bank was empty" at `$BE56`, and PRG006's last assembled data is the dead object stream `_DA60`, referenced from nowhere, with the furthest referenced enemy stream ending at 0x0D9F6. The remaining differences were a threshold — the old figures came from a ≥16-byte scan. The table is now one row per bank and guarded by `free_space_doc_table_is_current`, which prints replacement rows when one drifts.

## IPS through the write log

`Rom::apply_ips_patch` applied a patch as one opaque buffer copy, so visual-patch bytes were invisible and testrom could catch patch-vs-randomizer collisions but never patch-vs-patch. It now applies each record through `write_range` under a caller-supplied tag (testrom passes the filename).

- The tag stack becomes `Vec<String>`; it was `Vec<&'static str>`, which can't hold a filename. All 91 existing call sites pass literals and are untouched.
- A record past the end of the ROM is now an error, not a panic — records are validated up front, so a patch that doesn't fit leaves the ROM untouched instead of half-applied.

The CLI's `--toad` / `--sprite-patch` still bypass this, applying to raw bytes before a `Rom` exists. The design doc records what closing that needs.

## Collision reports: 178 → 36

`find_collisions` was over-reporting four to one. `write_range` logs its whole range whenever any byte in it differs, so a pass that rewrites a block is credited with every byte in it — `powerups` rewrites ~53KB of level data to move 156 bytes, which alone produced 131 of the 178 collisions a default seed reported.

`WriteRecord::changes()` / `changed_len()` name the distinction the type invites you to miss (**covered** vs **changed**), `find_collisions` uses it, and the per-tag header shows both when they differ.

All 36 survivors were investigated and are intended — the airship shuffle permuting autoscroll's redirected pointers, `items` randomizing rewards the writer placed, the co-owned clone block, and three qol tiles the builder legitimately owns afterwards. **No defects found.** Catalogued in the design doc, since three of the four groups are ordering-dependent by construction.

Narrowing `write_range` at the source was rejected: the free-space audit and testrom's guard both need the *covered* fact, since a routine byte equal to the `$FF` filler underneath it is still part of the routine.

## Verification

- 347 lib tests, all four integration binaries (`chr_stats`, `overworld_baseline`, `toad_swap`), `cargo clippy --all-targets` clean, `cargo check --target wasm32-unknown-unknown` clean (its 4 dead-code warnings are pre-existing in `tiles.rs`).
- Output unchanged: `toad_swap` and the 20-seed `overworld_baseline` both pass.
- The doc-drift guard was verified to actually fail — reverting PRG010 to its old 880 produces the stale-table error with the replacement row.

**Caveat:** the two ROM-dependent guards (`free_space_audit_matches_registry`, `free_space_doc_table_is_current`) skip where the ROM is absent, so they protect the machine a patch is written on, not CI. Stated in CLAUDE.md next to the table.

No CHANGELOG entry — this is developer tooling, not player-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB