### PR TITLE
fix: a rising enemy no longer turns a stomp into damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ deploys.
 
 ### Fixed
 
+- Landing on an enemy that is jumping up at you now counts as a stomp instead
+  of hurting you. Vanilla decides "stomp or damage" once per frame, so an enemy
+  rising into you could close the gap faster than the check could resolve and
+  the hit landed on you — most visibly with hopping Cheep Cheeps and with
+  Koopalings at their higher jump speeds. The stompable range now cancels out
+  the enemy's own upward speed, so the verdict no longer depends on how fast it
+  was moving. Collisions vanilla already judged correctly are unaffected.
+
 - Breaking a fortress lock in World 8's dark area no longer lights up the tile.
   The lock-break effect used to paint the replacement tile over the darkness,
   leaving it permanently visible. Now the poof plays where the lock was, and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ is the one to read:
 | Bank | Mapped at | Free left | Largest single gap |
 |------|-----------|-----------|--------------------|
 | PRG031 | `$E000–$FFFF`, always | 81 | **30** |
-| PRG030 | `$8000–$9FFF`, always | 120 | 74 |
+| PRG030 | `$8000–$9FFF`, always | 88 | 42 |
 | PRG001 | swapped, in-level (object AI) | 60 | 38 |
 | PRG003 | swapped, in-level (object AI) | 5 | 5 |
 | PRG004 | swapped, in-level (object AI, group 3) | 426 | 426 |
@@ -90,7 +90,7 @@ is the one to read:
 PRG000 and PRG002 have no `$FF` filler left at all.
 
 The always-mapped banks are effectively full. A patch that must run regardless of
-the current bank has one 74-byte gap in PRG030 and nothing over 30 bytes in
+the current bank has one 42-byte gap in PRG030 and nothing over 30 bytes in
 PRG031, so past that a trampoline into a swapped bank is the only option — and
 that costs bytes too.
 

--- a/src/randomize/mod.rs
+++ b/src/randomize/mod.rs
@@ -31,6 +31,7 @@ pub mod qol;
 pub mod rom_data;
 pub mod segment_writer;
 pub mod start_airship_swap;
+pub mod stomp_fairness;
 pub mod title_screen;
 pub mod troll_pipes;
 pub mod world_order;

--- a/src/randomize/rom_data/access.rs
+++ b/src/randomize/rom_data/access.rs
@@ -73,6 +73,17 @@ pub(crate) const fn prg031_file_to_cpu(file_offset: usize) -> u16 {
     (0xE000 + (file_offset - 0x3E010)) as u16
 }
 
+/// Convert a file offset in PRG030 (always mapped at $8000-$9FFF, file
+/// 0x3C010) to its CPU address.
+///
+/// [`prg_bank_file_to_cpu`] hardcodes the $A000 window and is wrong here, so
+/// PRG030 needs its own converter the way PRG031 does. Deriving beats writing
+/// the address out by hand: dropping the 0x10 iNES header was the issue #14
+/// root cause, and a transcribed operand cannot drift back into agreement.
+pub(crate) const fn prg030_file_to_cpu(file_offset: usize) -> u16 {
+    (0x8000 + (file_offset - 0x3C010)) as u16
+}
+
 /// Build a 3-byte `JSR <target>` where `target` is given as a *file offset*
 /// inside `bank` (the $A000-window bank live when the hook runs). The operand
 /// is computed from [`prg_bank_file_to_cpu`], so it can never drift from where

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -12,8 +12,8 @@
 //! The aggregate free-space number is misleading: space is per-bank, and a
 //! routine must live in a bank mapped when it runs. The always-mapped banks
 //! are effectively full — PRG031 (`$E000–$FFFF`) has 81 bytes left but a
-//! largest contiguous gap of only 30, and PRG030 (`$8000–$9FFF`) has 120 with
-//! a largest gap of 74. Swapped banks are roomier (PRG010 896, PRG026 2603,
+//! largest contiguous gap of only 30, and PRG030 (`$8000–$9FFF`) has 88 with
+//! a largest gap of 42. Swapped banks are roomier (PRG010 896, PRG026 2603,
 //! and the in-level banks PRG004 426 / PRG006 1392 in one run each).
 //!
 //! Reserving some headroom in an allocation is fine and encouraged — a routine
@@ -104,6 +104,7 @@ pub const FREE_SPACE_ALLOCATIONS: &[FreeSpaceAlloc] = &[
     // PRG030 (fixed bank, always mapped $8000–$9FFF, file 0x3C010)
     fs(0x3DF20, 28, &["world_order"], "routine + tables"),
     fs(0x3DF3C, 20, &["big_q_blocks"], "big_q_block: save obj_ptr trampoline"),
+    fs(0x3DFC6, 32, &["stomp_fairness"], "stomp_rise: rise-aware stomp height (32 reserved, 26 used)"),
     // PRG031 (always mapped $E000–$FFFF, file 0x3E010)
     fs(0x3E924, 25, &["title_screen"], "sprite copy routine"),
     fs(0x3E93D, 40, &["title_screen"], "sprite data table"),
@@ -157,10 +158,10 @@ pub const FREE_SPACE_ALLOCATIONS: &[FreeSpaceAlloc] = &[
 // PRG030
 pub(crate) const FS_WORLD_ORDER: usize       = 0x3DF20; // 28 bytes
 
-/// CPU address of the world-order routine: $8000 + (0x3DF20 - 0x3C010) = $9F10.
-/// PRG030 is the MMC3 fixed bank at $8000-$9FFF (file 0x3C010), so
-/// `prg_bank_file_to_cpu` (which assumes the $A000 window) does not apply.
-pub(crate) const WORLD_ORDER_CPU: u16        = 0x9F10;
+/// CPU address of the world-order routine ($9F10). PRG030 is the MMC3 fixed
+/// bank at $8000-$9FFF (file 0x3C010), so `prg_bank_file_to_cpu` (which assumes
+/// the $A000 window) does not apply — `prg030_file_to_cpu` is its counterpart.
+pub(crate) const WORLD_ORDER_CPU: u16        = super::prg030_file_to_cpu(FS_WORLD_ORDER);
 
 pub(crate) const FS_BIG_Q_SAVE: usize        = 0x3DF3C; // 20 bytes
 
@@ -271,6 +272,22 @@ pub(crate) const FS_MYSTERY_ANCHOR: usize    = 0x35572; // 13 bytes
 pub(crate) const FS_HAMMER_LOCKS: usize      = 0x3557F; // 50 bytes
 
 pub(crate) const FS_ANCHOR_ITEM_GUARD: usize = 0x355B1; // 12 bytes (CPU $B5A1)
+
+// Stomp fairness — rise-aware stomp height, hooked from PRG000 at CPU $D22E.
+// PRG030 is mapped at $8000–$9FFF at all times, so a JSR out of PRG000 reaches
+// it whatever the $C000 window holds.
+//
+// The 74-byte run at 0x3DFC6 is the tail of PRG030 and is $FF in vanilla. It is
+// unreferenced: a PRG-wide scan of every absolute-addressing opcode finds no
+// operand in $9FB6-$9FD5. (The same scan reports two `JSR $9FF4` further up the
+// run, at file 0x15D1F and 0x19D1F — those are byte-identical map data in
+// PRG010 and PRG012, disassembled as data by southbird, not code. They sit
+// outside this reservation either way, but anyone taking the remaining 42 bytes
+// should confirm that before trusting the top of the gap.)
+pub(crate) const FS_STOMP_RISE: usize        = 0x3DFC6; // 32 reserved, 26 used
+
+/// CPU address of the rise-aware stomp-height routine ($9FB6).
+pub(crate) const STOMP_RISE_CPU: u16         = super::prg030_file_to_cpu(FS_STOMP_RISE);
 
 // PRG001 (file 0x02010, CPU $A000–$BFFF)
 // Koopaling stomp handler is ObjHit_Koopaling in prg001.asm (southbird disassembly).
@@ -909,6 +926,14 @@ mod free_space_tests {
                 assert_eq!(prg_bank_file_to_cpu(bank, prg_bank_cpu_to_file(bank, cpu)), cpu);
             }
         }
+
+        // The two fixed banks live outside the $A000 window and need their own
+        // converters. These are the values the shipped patches assemble with,
+        // so a regression here would silently retarget every PRG030/031 hook.
+        assert_eq!(prg030_file_to_cpu(0x3C010), 0x8000);
+        assert_eq!(prg030_file_to_cpu(FS_WORLD_ORDER), 0x9F10);
+        assert_eq!(prg030_file_to_cpu(FS_STOMP_RISE), 0x9FB6);
+        assert_eq!(prg031_file_to_cpu(0x3E010), 0xE000);
     }
 
     #[test]

--- a/src/randomize/stomp_fairness.rs
+++ b/src/randomize/stomp_fairness.rs
@@ -1,0 +1,188 @@
+//! Stop a *rising* enemy from turning a stomp into damage.
+//!
+//! Landing on an enemy that is jumping up at you can register as a side hit
+//! instead of a stomp, purely because the enemy closed the gap faster than one
+//! frame of collision testing can resolve. Two independent adjudicators decide
+//! "stomp or hurt", and which one an enemy uses depends on its
+//! `ObjectGroup_CollideJumpTable` entry, so the fix has to land in both:
+//!
+//! * Enemies with their own collide handler (Koopaling → `ObjHit_Koopaling`)
+//!   read `Temp_Var12` bit 0, which `Object_HitTestRespond` may *revoke* at
+//!   CPU $D8E1 when the two boxes overlap too deeply. See [`OVERLAP_THRESHOLD`].
+//! * Enemies with `ObjHit_DoNothing` (most of the roster, reached through
+//!   `Player_HitEnemy`) are resolved by the generic path at CPU $D218, which
+//!   picks a "stompable height" into `Temp_Var2` and requires the Player's top
+//!   to clear the enemy's top by at least that many pixels. See
+//!   [`STOMP_HEIGHT_HOOK`].
+//!
+//! The two paths do not overlap: `Player_HitEnemy` zeroes
+//! `Objects_PlayerHitStat` immediately after the hit test, discarding whatever
+//! the $D8E1 flip decided, so that byte only reaches the first group.
+//!
+//! Derived from MaCobra52's "SMB3 - Koopaling & Cheep Cheep hitbox fix 3.ips",
+//! which supplies the $D8E1 constant verbatim. Its other half — a trampoline
+//! giving the hopping Cheep Cheep a fixed 2-pixel allowance — is replaced here
+//! by a rise-aware height that covers every jumping enemy at its actual speed;
+//! see [`STOMP_RISE_CODE`] for why a constant cannot do that job.
+
+use crate::rom::Rom;
+
+use super::rom_data::{FS_STOMP_RISE, STOMP_RISE_CPU};
+
+/// Operand of `CMP #$08` at CPU $D8E1, inside `Object_HitTestRespond`.
+///
+/// After `ObjectObject_Intersect` reports "Player is above" in `Temp_Var12`
+/// bit 0, vanilla second-guesses it: `Temp_Var1` holds the height of whichever
+/// box is on top and `Temp_Var11` the vertical separation of the two box tops,
+/// so `Temp_Var1 - Temp_Var11` is the *overlap depth*. Eight or more pixels of
+/// overlap flips bit 0 back off and the stomp becomes damage.
+///
+/// The threshold is unreachable unless the pair closes faster than 8 px/frame,
+/// and a stationary enemy contributes nothing to the closing speed, so raising
+/// it cannot affect an ordinary stomp onto an ordinary enemy. Velocities are
+/// 4.4 fixed point (see `Object_ApplyXVel`), so a Koopaling's fastest jump
+/// (`Koopaling_JumpYVels` = -$70) is 7 px/frame; with the Player's
+/// `FALLRATE_MAX` = $40 (4 px/frame) the worst case closes at 11 px/frame.
+/// MaCobra's 11 covers all but the single deepest overlap that can produce.
+const OVERLAP_THRESHOLD: usize = 0x0018F2;
+/// Replacement tolerance: an overlap of 10 or less still counts as a stomp.
+const OVERLAP_TOLERANT: u8 = 0x0B;
+
+/// `STY Temp_Var2; LDA Objects_Y,X` at CPU $D22E — where the selected stomp
+/// height is committed, common to every object on the generic path.
+const STOMP_HEIGHT_HOOK: usize = 0x0123E;
+
+/// Subtract the object's upward speed (in whole pixels) from the stomp height.
+///
+/// The generic path's test is positional:
+///
+/// ```text
+/// stomp  iff  Player_Y  <=  Objects_Y - Temp_Var2
+/// ```
+///
+/// A rising enemy drags that line upward at its own speed, so a Player whose
+/// top is within `rise` pixels of it has a stomp turned into damage purely by
+/// the enemy's motion. Cancelling `rise` out leaves the line where it would
+/// have been had the enemy held still, which restores the margin vanilla
+/// already sizes to absorb the Player's own 4 px/frame fall.
+///
+/// Expressed as a budget — the window is `30 - T - h` pixels wide for a box
+/// with top offset `T`, and a stomp lands when the closing speed fits inside
+/// it — subtracting the rise from `h` adds it back to the budget, so the
+/// enemy's speed cancels from both sides and only the Player's fall is left to
+/// pay for. A per-enemy constant cannot do that: the hopping Cheep Cheep
+/// launches at -$30 (3 px/frame) but -$60 (6 px/frame) when the Player is
+/// close, and the budget also varies with each enemy's bounding box, which was
+/// chosen for drawing rather than for collision feel.
+///
+/// ```asm
+///   LDA Objects_YVel,X   ; 4.4 fixed point
+///   BPL .store           ; not rising -> vanilla height
+///   EOR #$FF             ; |vel| - 1  (the velocities here are multiples of 16)
+///   LSR A ×4             ; -> whole pixels, one short
+///   STA Temp_Var2        ; scratch; the STY below overwrites it
+///   TYA
+///   CLC                  ; borrow makes up the one-short above, exactly
+///   SBC Temp_Var2
+///   BPL .keep
+///   LDA #$00             ; a rise deeper than the height would wrap
+/// .keep:
+///   TAY
+/// .store:
+///   STY Temp_Var2        ; displaced
+///   LDA Objects_Y,X      ; displaced
+///   RTS
+/// ```
+///
+/// The caller re-establishes carry with `SEC` immediately after, so the flags
+/// this returns do not matter.
+#[rustfmt::skip]
+const STOMP_RISE_CODE: [u8; 26] = [
+    0xB5, 0xD0,          // LDA $D0,X      Objects_YVel
+    0x10, 0x11,          // BPL .store
+    0x49, 0xFF,          // EOR #$FF
+    0x4A,                // LSR A
+    0x4A,                // LSR A
+    0x4A,                // LSR A
+    0x4A,                // LSR A
+    0x85, 0x01,          // STA $01        Temp_Var2 (scratch)
+    0x98,                // TYA
+    0x18,                // CLC
+    0xE5, 0x01,          // SBC $01
+    0x10, 0x02,          // BPL .keep
+    0xA9, 0x00,          // LDA #$00
+    0xA8,                // TAY            .keep
+    0x84, 0x01,          // STY $01        .store  (displaced)
+    0xB5, 0xA3,          // LDA $A3,X      Objects_Y (displaced)
+    0x60,                // RTS
+];
+
+/// Apply both halves of the fix.
+///
+/// Always on: it removes a source of unearned damage and has no effect on any
+/// collision that vanilla already resolved correctly, so there is nothing for
+/// a player to opt out of and no flag-key bit is spent on it.
+pub fn apply(rom: &mut Rom) {
+    rom.write_byte(OVERLAP_THRESHOLD, OVERLAP_TOLERANT);
+    rom.write_range(FS_STOMP_RISE, &STOMP_RISE_CODE);
+    rom.write_range(STOMP_HEIGHT_HOOK, &[
+        0x20,
+        STOMP_RISE_CPU as u8,
+        (STOMP_RISE_CPU >> 8) as u8,
+        0xEA, // NOP, filling the 4th displaced byte
+    ]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vanilla() -> Option<Vec<u8>> {
+        std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()
+    }
+
+    /// Both patch sites, against the bytes the disassembly says are there. A
+    /// drifted offset would otherwise sail past the byte-level asserts below.
+    #[test]
+    fn patch_sites_match_vanilla() {
+        let Some(v) = vanilla() else { return };
+        // Operand of CMP #$08 at $D8E1.
+        assert_eq!(v[OVERLAP_THRESHOLD], 0x08);
+        // STY Temp_Var2; LDA Objects_Y,X at $D22E.
+        assert_eq!(
+            &v[STOMP_HEIGHT_HOOK..STOMP_HEIGHT_HOOK + 4],
+            &[0x84, 0x01, 0xB5, 0xA3],
+        );
+        // The PRG030 gap the routine lives in is untouched filler.
+        assert!(v[FS_STOMP_RISE..FS_STOMP_RISE + STOMP_RISE_CODE.len()].iter().all(|&b| b == 0xFF));
+    }
+
+    #[test]
+    fn apply_writes_both_halves() {
+        let Some(v) = vanilla() else { return };
+        let mut rom = Rom::from_bytes_lax(&v, true).expect("valid ROM");
+        apply(&mut rom);
+        assert_eq!(rom.read_byte(OVERLAP_THRESHOLD), OVERLAP_TOLERANT);
+        assert_eq!(rom.read_range(FS_STOMP_RISE, STOMP_RISE_CODE.len()), &STOMP_RISE_CODE);
+        assert_eq!(rom.read_range(STOMP_HEIGHT_HOOK, 3), &[
+            0x20,
+            STOMP_RISE_CPU as u8,
+            (STOMP_RISE_CPU >> 8) as u8,
+        ]);
+        // PRG030 is only mapped at $8000-$9FFF; a routine crossing into the
+        // next bank would execute whatever happens to be paged in.
+        assert!(FS_STOMP_RISE + STOMP_RISE_CODE.len() <= 0x3E010);
+    }
+
+    /// The two `BPL`s are the only relative branches; a miscount lands
+    /// mid-instruction and would still assemble, so pin both targets.
+    #[test]
+    fn routine_branches_land_on_instruction_boundaries() {
+        // BPL at index 2 skips to `.store` (STY $01) at index 21.
+        assert_eq!(STOMP_RISE_CODE[3] as usize + 4, 21);
+        assert_eq!(STOMP_RISE_CODE[21], 0x84);
+        // BPL at index 16 skips the clamp to `.keep` (TAY) at index 20.
+        assert_eq!(STOMP_RISE_CODE[17] as usize + 18, 20);
+        assert_eq!(STOMP_RISE_CODE[20], 0xA8);
+    }
+}

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -414,6 +414,12 @@ fn randomize_inner(
     rom.set_tag("qol/canoe_summon");
     randomize::qol::apply_canoe_summon(rom);
 
+    // Stop an enemy that is jumping up at the player from turning a stomp into
+    // damage. Always applied: it only widens outcomes vanilla already got
+    // wrong, so there is nothing to opt out of.
+    rom.set_tag("stomp_fairness");
+    randomize::stomp_fairness::apply(rom);
+
     // Adjust Bowser and Koopaling hitboxes.
     if options.adjust_boss_hitboxes {
         rom.set_tag("koopalings/adjust_boss_hitboxes");

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -59,15 +59,20 @@ fn sweep_is_deterministic() {
     );
 }
 
-/// Baseline captured 2026-08-03, before any call site was migrated onto
-/// `rom_data::tiles`. Regenerate ONLY for a change intended to alter output,
-/// and say so explicitly in the commit — never to make a red test green.
+/// Regenerate ONLY for a change intended to alter output, and say so
+/// explicitly in the commit — never to make a red test green.
+///
+/// Captured 2026-08-03 before the `rom_data::tiles` migration; re-captured
+/// 2026-08-05 for the always-on stomp-fairness patch, which writes 31 bytes
+/// into every ROM (`stomp_fairness::apply`). These hashes cover the whole
+/// output, so all 20 seeds moved. Overworld topology is untouched by that
+/// change — the ROM bytes differ, the maps do not.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x3CC73D4F8B706AB2, 0x0AEF65A488DCD062, 0x0D056AF8D18E2BFB, 0xB3D5BE313EA37464,
-    0xC7B499E3B7AA3B6D, 0xB5846D1438CE3405, 0x03A24CDEBF64925D, 0x10AA8775674EC492,
-    0xEF8F05273F6202B2, 0x1309B3871D9DD47A, 0x1A760A893B1EA373, 0xB503C9D7095AF6A6,
-    0x43E966B75F3514FF, 0x5968F3BEF7300364, 0x192F85ECF86D75C6, 0x538E5F94D3045FD0,
-    0xB6EDBAACEE372D9C, 0xBC57F481A392D55D, 0x15C89DC8756F6CCA, 0x2F1856871DD3784F,
+    0x155EB975967C4ACB, 0x2DF4A1430D34B093, 0x322575642AA955A6, 0xDEC206CE9041867D,
+    0x15161E783EA3EE9C, 0xF17D4FA051D5EFF4, 0x166EFDF30A772D68, 0x25AD61FEE292102B,
+    0x84F587DBEB2C4E87, 0x75E73651FABAF77B, 0x6EE09335C4E431EA, 0x3CFE80C049E1A927,
+    0xC94F13DA4DD0B4F6, 0xB2734D41553967FD, 0x9A69302D9136071F, 0xEDC915F4FF8C9761,
+    0x6D86BC8A599AFF69, 0x9DD7B9A808BD3134, 0x04EE05C950E8DACB, 0xDBD8F12889EAA542,
 ];
 
 #[test]


### PR DESCRIPTION
Landing on an enemy that is jumping up at you could register as a side hit. The collision test runs once per frame, so an enemy closing the gap faster than the check can resolve lands the hit on the player instead. Reported as Koopaling hitboxes "feeling off".

## Two adjudicators, two fixes

Which one an enemy uses depends on its `ObjectGroup_CollideJumpTable` entry, so a fix on one path does nothing for the other.

| | decided by | change |
|---|---|---|
| Koopaling (own collide handler) | `Temp_Var12` bit 0, revoked at `$D8E1` on 8+ px of box overlap | tolerance 8 → 11 |
| everything via `Player_HitEnemy` | stomp height `Temp_Var2` at `$D218` | height −= the object's rise |

The `$D8E1` constant is MaCobra52's, from `SMB3 - Koopaling & Cheep Cheep hitbox fix 3.ips`. It covers a Koopaling's fastest jump (`-$70` = 7 px/f) plus the player's `FALLRATE_MAX` (4 px/f). The threshold is unreachable below 8 px/f of closing speed and a stationary enemy contributes none, so it cannot affect a collision vanilla already resolved correctly.

For the generic path, a rising enemy drags the stomp line `Objects_Y - Temp_Var2` upward at its own speed. Subtracting the rise leaves the line where it would have been had the enemy held still. As a budget: the window is `30 - T - h` px wide, a stomp lands when the closing speed fits inside it, so subtracting the rise from `h` adds it back to the budget and the enemy's speed cancels from both sides.

## Why not the upstream trampoline

The IPS instead gives one enemy ID a fixed 2-pixel allowance. That is short by 4 px/f exactly when it matters — `ObjNorm_CheepCheepHopper` launches at `-$30` but `-$60` when the player is close — and the budget also varies with each enemy's bounding box, which was chosen for drawing rather than collision feel (the Cheep Cheep hopper and pile driver microgoomba are both 16×16 yet differ by 4 px/f). Cancelling the rise covers every jumping enemy at any speed, so the per-enemy trampoline is dropped and PRG000 keeps its 14 bytes.

Records 4 and 5 of that IPS are also skipped: they re-implement the Koopaling post-stomp guard already shipped as `koopaling_collision_guard`, and would land inside the `FS_KOOPA_VRAM_CLEAR` allocation.

## Free space

26 bytes at `0x3DFC6` (32 reserved) in PRG030, always mapped at `$8000-$9FFF` so a `JSR` out of PRG000 reaches it. Unreferenced check done: `$FF` in vanilla, and a PRG-wide scan of every absolute-addressing opcode finds no operand in `$9FB6-$9FD5`. The registry comment records what the scan reported higher in the run, for whoever takes the remaining 42 bytes.

Also adds `prg030_file_to_cpu`, the counterpart to `prg031_file_to_cpu`. `jsr_into_bank` hardcodes the `$A000` window and is wrong for PRG030 — which is why `WORLD_ORDER_CPU` was a hand-written `0x9F10`. Both it and `STOMP_RISE_CPU` are now derived and pinned in `test_prg_bank_mapping_known_pairs`.

## Always on

No flag, no flag-key bit. It only widens outcomes vanilla got wrong, so there is nothing to opt out of — but a given seed does now produce a different ROM than before.

The output baseline is regenerated for that reason. Verified against seed 4242 that the only bytes differing from the previous build are the 30 this patch writes; it consumes no RNG, so no other module's output moves.

## Verification

- `cargo test` green (350 lib + integration), `cargo clippy --all-targets` clean
- write log: `[stomp_fairness] 31 bytes, 3 writes`, allocation audit `26/32`, zero collisions
- `offset_dups.py` clean
- tests pin the vanilla bytes at both patch sites and both relative-branch targets in the new routine

Caveat worth recording: the pixel-budget reasoning is derived from box geometry and the disassembly, not measured in an emulator. Playtested via `testrom --place 3-2` (9 CheepHoppers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)