### PR TITLE
Structural verification for assembled 6502 patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,10 +191,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mos6502"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41602b70ecb904b5359a3be5d947dacde19b03316284f1fbf804576437546e4d"
+dependencies = [
+ "bitflags",
+ "log",
+]
 
 [[package]]
 name = "once_cell"
@@ -332,6 +354,7 @@ dependencies = [
  "clap",
  "getrandom",
  "js-sys",
+ "mos6502",
  "rand",
  "rand_chacha",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ clap = { version = "4", features = ["derive"] }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 getrandom = { version = "0.3", features = ["wasm_js"] }
+
+[dev-dependencies]
+mos6502 = "0.10.1"

--- a/src/randomize/anchor_visuals.rs
+++ b/src/randomize/anchor_visuals.rs
@@ -183,3 +183,16 @@ mod tests {
         assert_eq!(rom.read_range(TOAD_HOUSE_STORE_OFFSET, 3), &VANILLA_TOAD_LDA);
     }
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn anchor_item_guard_is_well_formed() {
+        asm::check(&ANCHOR_ITEM_GUARD_BODY).allocation(FS_ANCHOR_ITEM_GUARD).assert_ok();
+    }
+}

--- a/src/randomize/antechambers.rs
+++ b/src/randomize/antechambers.rs
@@ -452,6 +452,7 @@ mod tests {
     #[test]
     fn vanilla_offsets_match_real_rom() {
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
             return;
         };
         let rom = Rom::from_bytes(&bytes).unwrap();

--- a/src/randomize/koopalings.rs
+++ b/src/randomize/koopalings.rs
@@ -703,3 +703,16 @@ mod tests {
         assert_eq!(rom.read_range(SKIP_WAND_CUTSCENE_OFFSET, 2), &[0x16, 0xB5]);
     }
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn koopa_hits_is_well_formed() {
+        asm::check(&KOOPA_HITS_CODE).allocation(crate::randomize::rom_data::FS_KOOPA_HITS_SUB).fragment().assert_ok();
+    }
+}

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -175,7 +175,7 @@ fn test_builder_schedule_runs_phases_in_order() {
 #[test]
 fn test_w1_shortcut_is_walkable() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let off = rom_data::read_tile_grid(&base_qol(&raw), 0);
@@ -214,7 +214,7 @@ fn test_w1_shortcut_is_walkable() {
 #[test]
 fn test_builder_vanilla_worlds() {
     let Some(rom) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let catalog = NodeCatalog::build(&rom, false);
@@ -266,7 +266,7 @@ fn test_builder_vanilla_worlds() {
 #[test]
 fn test_builder_current_builder_worlds() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -365,7 +365,7 @@ fn test_builder_current_builder_worlds() {
 #[test]
 fn test_builder_connectivity_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -435,7 +435,7 @@ fn test_builder_connectivity_census() {
 #[test]
 fn test_builder_levels_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -547,7 +547,7 @@ fn test_builder_levels_census() {
 #[test]
 fn test_builder_forts_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -622,7 +622,7 @@ fn test_builder_forts_census() {
 #[test]
 fn test_builder_locks_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -743,7 +743,7 @@ fn test_builder_locks_census() {
 #[test]
 fn test_builder_shaping_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -1059,7 +1059,7 @@ fn test_builder_shaping_census() {
 #[test]
 fn test_builder_progression_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -1174,7 +1174,7 @@ fn test_builder_progression_census() {
 #[test]
 fn test_builder_secret_exit_safety() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -1362,7 +1362,7 @@ fn diversity_row(shapes: &[SeedShape]) -> (f64, f64, f64, f64, f64) {
 #[test]
 fn test_builder_diversity_census() {
     let Some(rom) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let rom = base_qol(&rom);
@@ -1466,7 +1466,7 @@ fn parse_pipe_delta(line: &str) -> Option<(usize, usize, u32, u32)> {
 #[test]
 fn test_builder_spare_pipes_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")
@@ -1556,7 +1556,7 @@ fn test_builder_spare_pipes_census() {
 #[test]
 fn test_builder_probe_vanilla_world() {
     let Some(rom) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let world: usize = std::env::var("CENSUS_WORLD").ok().and_then(|s| s.parse().ok()).unwrap_or(2);
@@ -1590,7 +1590,7 @@ fn test_builder_probe_vanilla_world() {
 #[test]
 fn test_builder_output_completable() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(25);
@@ -1663,7 +1663,7 @@ fn test_builder_output_completable() {
 #[test]
 fn test_builder_fort_removal_census() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(200);
@@ -1708,7 +1708,7 @@ fn test_builder_fort_removal_census() {
 #[test]
 fn test_builder_bridge_lock_rate() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(300);
@@ -1756,7 +1756,7 @@ fn test_builder_bridge_lock_rate() {
 #[test]
 fn test_builder_island_roles() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     use super::islands::IslandRole::{Corridor, Entry, Final, Routing, Utility};
@@ -1827,7 +1827,7 @@ fn test_builder_island_roles() {
 #[test]
 fn test_builder_w7_probe() {
     let Some(raw) = load_rom() else {
-        eprintln!("ROM not found, skipping");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let seeds: u64 = std::env::var("CENSUS_SEEDS")

--- a/src/randomize/poison_mushroom.rs
+++ b/src/randomize/poison_mushroom.rs
@@ -265,3 +265,16 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn handler_is_well_formed() {
+        asm::check(&HANDLER).allocation(FS_POISON_MUSHROOM).assert_ok();
+    }
+}

--- a/src/randomize/qol/big_q.rs
+++ b/src/randomize/qol/big_q.rs
@@ -189,3 +189,16 @@ mod tests {
         assert_eq!(u16::from_le_bytes([r[13], r[14]]), base + 0x26);
     }
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn big_q_prg030_is_well_formed() {
+        asm::check(&BIG_Q_PRG030_ROUTINE).allocation(BIG_Q_PRG030_OFFSET).assert_ok();
+    }
+}

--- a/src/randomize/qol/canoe.rs
+++ b/src/randomize/qol/canoe.rs
@@ -114,3 +114,21 @@ pub fn fix_canoe_softlock(rom: &mut Rom) {
     // Record 5: backup/restore subroutines
     rom.write_range(FS_CANOE_BACKUP, &CANOE_BACKUP_ROUTINE);
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn canoe_respawn_is_well_formed() {
+        asm::check(&CANOE_RESPAWN_ROUTINE).allocation(FS_CANOE_RESPAWN).assert_ok();
+    }
+
+    #[test]
+    fn canoe_backup_is_well_formed() {
+        asm::check(&CANOE_BACKUP_ROUTINE).allocation(FS_CANOE_BACKUP).assert_ok();
+    }
+}

--- a/src/randomize/qol/canoe_summon.rs
+++ b/src/randomize/qol/canoe_summon.rs
@@ -180,3 +180,16 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn canoe_summon_is_well_formed() {
+        asm::check(&CANOE_SUMMON_ROUTINE).allocation(FS_CANOE_SUMMON).data_from(139).assert_ok();
+    }
+}

--- a/src/randomize/qol/hammer_breaks.rs
+++ b/src/randomize/qol/hammer_breaks.rs
@@ -143,6 +143,7 @@ mod tests {
     /// the literals this function used before that change.
     fn tables(locks: bool, bridges: bool) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
             return (vec![], vec![], vec![]);
         };
         let mut rom = crate::rom::Rom::from_bytes_lax(&bytes, true).unwrap();

--- a/src/randomize/qol/macobra.rs
+++ b/src/randomize/qol/macobra.rs
@@ -667,3 +667,41 @@ mod tests {
         assert_eq!(rom.read_range(NGO_NOP_OFFSET, NGO_NOP_BYTES.len()), &NGO_NOP_BYTES);
     }
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn faster_frog_is_well_formed() {
+        asm::check(&FASTER_FROG_ROUTINE).allocation(FS_FASTER_FROG).assert_ok();
+    }
+
+    #[test]
+    fn tail_stay_dead_is_well_formed() {
+        asm::check(&TAIL_STAY_DEAD_ROUTINE).allocation(FS_TAIL_STAY_DEAD).assert_ok();
+    }
+
+    #[test]
+    fn hold_left_helper_is_well_formed() {
+        asm::check(&HOLD_LEFT_HELPER_BYTES).allocation(FS_HOLD_LEFT_HELPER).assert_ok();
+    }
+
+    #[test]
+    fn no_game_over_is_well_formed() {
+        asm::check(&NGO_ROUTINE).allocation(NGO_ROUTINE_OFFSET).assert_ok();
+    }
+
+    #[test]
+    fn limit_bro_is_well_formed() {
+        asm::check(&LIMIT_BRO_CODE).fragment().assert_ok();
+    }
+
+    #[test]
+    fn tail_swim_is_well_formed() {
+        asm::check(&TAIL_SWIM_ROUTINE).fragment().assert_ok();
+    }
+}

--- a/src/randomize/qol/map_warp.rs
+++ b/src/randomize/qol/map_warp.rs
@@ -191,3 +191,16 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod asm_checks {
+    //! Decode each assembled routine and check the structural properties no
+    //! assembler was around to enforce. See [`crate::randomize::rom_data::asm`].
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn map_warp_is_well_formed() {
+        asm::check(&MAP_WARP_ROUTINE).allocation(FS_MAP_WARP).assert_ok();
+    }
+}

--- a/src/randomize/rom_data/asm.rs
+++ b/src/randomize/rom_data/asm.rs
@@ -1,0 +1,270 @@
+//! Structural verification of hand-assembled 6502 patches.
+//!
+//! Every patch in this crate is a `&[u8]` of opcodes that no assembler ever
+//! checked. The classic failure is a miscounted relative branch: it still
+//! "assembles", lands mid-instruction, and the CPU executes an operand as an
+//! opcode. Nothing about the byte array looks wrong, and the ROM boots.
+//!
+//! This module decodes those bytes with the `mos6502` crate's Ricoh 2A03
+//! opcode table — the NES's CPU, so no decimal mode — and checks the
+//! properties that hold for *any* routine, without knowing what it is for:
+//!
+//! * every byte decodes as part of a well-formed instruction, and the routine
+//!   does not end mid-instruction
+//! * it ends in `RTS`/`RTI`/`JMP` rather than running off its own end into the
+//!   `$FF` filler that follows
+//! * every relative branch lands on an instruction boundary, inside the routine
+//! * the code fits its [`FREE_SPACE_ALLOCATIONS`] row and does not cross the
+//!   end of its bank
+//! * a hook displaces *whole* vanilla instructions, leaving no dangling operand
+//!   behind for the CPU to run as an opcode
+//!
+//! What it cannot check is semantics — a well-formed routine can compute the
+//! wrong answer. Executing one to settle that is a separate exercise; see the
+//! arithmetic tests in `stomp_fairness` for the pattern.
+//!
+//! Test-only: `mos6502` is a dev-dependency and never reaches the CLI binary
+//! or the WASM bundle.
+//!
+//! # Routines containing data
+//!
+//! The sweep is linear, so a routine carrying an inline data table would be
+//! misdecoded — and would fail loudly here rather than pass quietly, which is
+//! the intent. Every routine checked so far is pure code. The first one that
+//! is not should grow a `.data(range)` opt-out rather than skip the check.
+
+use std::collections::BTreeSet;
+
+use mos6502::instruction::{AddressingMode, Instruction, Ricoh2a03};
+use mos6502::Variant;
+
+use super::free_space::{prg_bank_end, FREE_SPACE_ALLOCATIONS};
+
+/// One instruction located by the linear sweep.
+struct Decoded {
+    start: usize,
+    len: usize,
+    instr: Instruction,
+    /// `true` for the relative-addressed branches, whose targets get checked.
+    relative: bool,
+}
+
+/// Walk `code` as a straight-line instruction stream.
+fn decode(code: &[u8]) -> Result<Vec<Decoded>, String> {
+    let mut out = Vec::new();
+    let mut pc = 0;
+    while pc < code.len() {
+        let byte = code[pc];
+        let Some((instr, mode)) = Ricoh2a03::decode(byte) else {
+            return Err(format!(
+                "byte {pc} (0x{byte:02X}) is not a valid Ricoh 2A03 opcode"
+            ));
+        };
+        let len = mode.extra_bytes() as usize + 1;
+        if pc + len > code.len() {
+            return Err(format!(
+                "{instr:?} at byte {pc} needs {len} bytes but only {} remain — \
+                 the routine ends mid-instruction",
+                code.len() - pc
+            ));
+        }
+        out.push(Decoded {
+            start: pc,
+            len,
+            instr,
+            relative: matches!(mode, AddressingMode::Relative),
+        });
+        pc += len;
+    }
+    Ok(out)
+}
+
+/// The vanilla bytes a hook overwrites, and how many of them it takes.
+struct Hook<'a> {
+    vanilla: &'a [u8],
+    offset: usize,
+    len: usize,
+}
+
+/// A patch under verification. Build with [`check`], then [`Routine::assert_ok`].
+pub struct Routine<'a> {
+    code: &'a [u8],
+    allocation: Option<usize>,
+    hook: Option<Hook<'a>>,
+}
+
+/// Begin checking an assembled routine.
+pub fn check(code: &[u8]) -> Routine<'_> {
+    Routine { code, allocation: None, hook: None }
+}
+
+impl<'a> Routine<'a> {
+    /// The [`FREE_SPACE_ALLOCATIONS`] row this routine is written to, named by
+    /// its file offset so that owners holding several rows stay unambiguous.
+    pub fn allocation(mut self, file_offset: usize) -> Self {
+        self.allocation = Some(file_offset);
+        self
+    }
+
+    /// The hook site: the vanilla ROM, the file offset the patch writes over,
+    /// and how many bytes it writes there.
+    pub fn hook(mut self, vanilla: &'a [u8], offset: usize, len: usize) -> Self {
+        self.hook = Some(Hook { vanilla, offset, len });
+        self
+    }
+
+    /// Run every configured check, panicking with all failures at once.
+    pub fn assert_ok(self) {
+        let mut problems: Vec<String> = Vec::new();
+
+        match decode(self.code) {
+            Err(e) => problems.push(e),
+            Ok(instrs) => {
+                match instrs.last() {
+                    None => problems.push("routine is empty".to_string()),
+                    Some(last) if !matches!(
+                        last.instr,
+                        Instruction::RTS | Instruction::RTI | Instruction::JMP
+                    ) =>
+                    {
+                        problems.push(format!(
+                            "routine ends in {:?} at byte {}; execution would run past the \
+                             end of the routine into whatever follows it",
+                            last.instr, last.start
+                        ));
+                    }
+                    Some(_) => {}
+                }
+
+                let starts: BTreeSet<usize> = instrs.iter().map(|i| i.start).collect();
+                for i in instrs.iter().filter(|i| i.relative) {
+                    let rel = self.code[i.start + 1] as i8 as isize;
+                    let target = i.start as isize + i.len as isize + rel;
+                    if target < 0 || target as usize >= self.code.len() {
+                        problems.push(format!(
+                            "{:?} at byte {} branches to {target}, outside the routine \
+                             (0..{})",
+                            i.instr,
+                            i.start,
+                            self.code.len()
+                        ));
+                    } else if !starts.contains(&(target as usize)) {
+                        problems.push(format!(
+                            "{:?} at byte {} branches to byte {target}, which is \
+                             mid-instruction",
+                            i.instr, i.start
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(offset) = self.allocation {
+            match FREE_SPACE_ALLOCATIONS.iter().find(|a| a.offset == offset) {
+                None => problems.push(format!(
+                    "no FREE_SPACE_ALLOCATIONS row starts at 0x{offset:05X}"
+                )),
+                Some(a) => {
+                    if self.code.len() > a.size {
+                        problems.push(format!(
+                            "routine is {} bytes but `{}` reserves only {}",
+                            self.code.len(),
+                            a.label,
+                            a.size
+                        ));
+                    }
+                    let bank_end = prg_bank_end(a.offset);
+                    if a.offset + self.code.len() > bank_end {
+                        problems.push(format!(
+                            "routine runs to 0x{:05X}, past the end of its bank \
+                             (0x{bank_end:05X}) — the tail would execute whatever is \
+                             paged in next",
+                            a.offset + self.code.len()
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(h) = self.hook
+            && let Err(e) = check_displacement(h.vanilla, h.offset, h.len)
+        {
+            problems.push(e);
+        }
+
+        assert!(
+            problems.is_empty(),
+            "assembled routine is malformed:\n  - {}",
+            problems.join("\n  - ")
+        );
+    }
+}
+
+/// A hook must overwrite a whole number of vanilla instructions.
+///
+/// Take one byte too few and the tail of the last displaced instruction is
+/// left behind, where the CPU will run its operand as an opcode.
+fn check_displacement(vanilla: &[u8], offset: usize, patch_len: usize) -> Result<(), String> {
+    let mut covered = 0;
+    let mut displaced = Vec::new();
+    while covered < patch_len {
+        let byte = vanilla[offset + covered];
+        let Some((instr, mode)) = Ricoh2a03::decode(byte) else {
+            return Err(format!(
+                "vanilla byte at 0x{:05X} (0x{byte:02X}) is not a valid opcode, so the \
+                 hook site cannot be checked",
+                offset + covered
+            ));
+        };
+        displaced.push(instr);
+        covered += mode.extra_bytes() as usize + 1;
+    }
+    if covered != patch_len {
+        return Err(format!(
+            "the {patch_len}-byte hook at 0x{offset:05X} displaces {displaced:?}, which is \
+             {covered} bytes — {} operand byte(s) would be left dangling for the CPU to \
+             execute as an opcode",
+            covered - patch_len
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The decoder is the foundation every other check stands on, so pin it
+    /// against instructions whose lengths are not in dispute.
+    #[test]
+    fn decode_lengths_match_the_addressing_modes() {
+        //     LDA $D0,X   BPL +2   EOR #$FF  LSR A  JMP $1234  RTS
+        let code = [0xB5, 0xD0, 0x10, 0x02, 0x49, 0xFF, 0x4A, 0x4C, 0x34, 0x12, 0x60];
+        let got: Vec<(usize, usize)> =
+            decode(&code).unwrap().iter().map(|i| (i.start, i.len)).collect();
+        assert_eq!(got, [(0, 2), (2, 2), (4, 2), (6, 1), (7, 3), (10, 1)]);
+    }
+
+    #[test]
+    fn rejects_a_branch_into_the_middle_of_an_instruction() {
+        // BPL +1 lands on the $FF operand of EOR #$FF rather than on the EOR.
+        let code = [0x10, 0x01, 0x49, 0xFF, 0x60];
+        let problems = std::panic::catch_unwind(|| check(&code).assert_ok());
+        assert!(problems.is_err());
+    }
+
+    #[test]
+    fn rejects_a_routine_that_falls_off_its_end() {
+        let code = [0xA9, 0x00]; // LDA #$00, no terminator
+        assert!(std::panic::catch_unwind(|| check(&code).assert_ok()).is_err());
+    }
+
+    #[test]
+    fn rejects_a_hook_that_leaves_a_dangling_operand() {
+        // STY $01 (2 bytes) then LDA $A3,X (2 bytes); a 3-byte hook splits the
+        // second one and strands its $A3 operand.
+        let vanilla = [0x84, 0x01, 0xB5, 0xA3];
+        assert!(check_displacement(&vanilla, 0, 3).is_err());
+        assert!(check_displacement(&vanilla, 0, 4).is_ok());
+    }
+}

--- a/src/randomize/rom_data/asm.rs
+++ b/src/randomize/rom_data/asm.rs
@@ -91,11 +91,13 @@ pub struct Routine<'a> {
     code: &'a [u8],
     allocation: Option<usize>,
     hook: Option<Hook<'a>>,
+    data_from: Option<usize>,
+    fragment: bool,
 }
 
 /// Begin checking an assembled routine.
 pub fn check(code: &[u8]) -> Routine<'_> {
-    Routine { code, allocation: None, hook: None }
+    Routine { code, allocation: None, hook: None, data_from: None, fragment: false }
 }
 
 impl<'a> Routine<'a> {
@@ -113,19 +115,50 @@ impl<'a> Routine<'a> {
         self
     }
 
+    /// Bytes from here to the end are a data table, not code.
+    ///
+    /// A routine carrying its own lookup tables would otherwise be decoded as
+    /// instructions past its last `RTS`/`JMP`, desynchronising everything after
+    /// and reporting failures that say nothing about the code.
+    pub fn data_from(mut self, offset: usize) -> Self {
+        self.data_from = Some(offset);
+        self
+    }
+
+    /// This array is one piece of a larger routine, not a self-contained one.
+    ///
+    /// Two shapes need it: a patch spliced *in place* over vanilla code, whose
+    /// branches legitimately target the vanilla around it, and a fragment
+    /// written next to further pieces in the same allocation, which it falls
+    /// through into. Both drop the terminator requirement and allow branches to
+    /// leave the array — branches landing *inside* it are still checked.
+    pub fn fragment(mut self) -> Self {
+        self.fragment = true;
+        self
+    }
+
     /// Run every configured check, panicking with all failures at once.
     pub fn assert_ok(self) {
         let mut problems: Vec<String> = Vec::new();
 
-        match decode(self.code) {
+        let code = &self.code[..self.data_from.unwrap_or(self.code.len())];
+        match decode(code) {
             Err(e) => problems.push(e),
             Ok(instrs) => {
-                match instrs.last() {
-                    None => problems.push("routine is empty".to_string()),
-                    Some(last) if !matches!(
-                        last.instr,
-                        Instruction::RTS | Instruction::RTI | Instruction::JMP
-                    ) =>
+                // Trailing NOPs are padding — several routines are NOP-filled out
+                // to the length of the vanilla bytes they replace — so the
+                // terminator is the last instruction that actually does something.
+                let last = instrs
+                    .iter()
+                    .rfind(|i| !matches!(i.instr, Instruction::NOP));
+                match last {
+                    None => problems.push("routine is empty or all NOPs".to_string()),
+                    Some(last)
+                        if !self.fragment
+                            && !matches!(
+                                last.instr,
+                                Instruction::RTS | Instruction::RTI | Instruction::JMP
+                            ) =>
                     {
                         problems.push(format!(
                             "routine ends in {:?} at byte {}; execution would run past the \
@@ -138,16 +171,18 @@ impl<'a> Routine<'a> {
 
                 let starts: BTreeSet<usize> = instrs.iter().map(|i| i.start).collect();
                 for i in instrs.iter().filter(|i| i.relative) {
-                    let rel = self.code[i.start + 1] as i8 as isize;
+                    let rel = code[i.start + 1] as i8 as isize;
                     let target = i.start as isize + i.len as isize + rel;
-                    if target < 0 || target as usize >= self.code.len() {
-                        problems.push(format!(
-                            "{:?} at byte {} branches to {target}, outside the routine \
-                             (0..{})",
-                            i.instr,
-                            i.start,
-                            self.code.len()
-                        ));
+                    if target < 0 || target as usize >= code.len() {
+                        if !self.fragment {
+                            problems.push(format!(
+                                "{:?} at byte {} branches to {target}, outside the routine \
+                                 (0..{})",
+                                i.instr,
+                                i.start,
+                                code.len()
+                            ));
+                        }
                     } else if !starts.contains(&(target as usize)) {
                         problems.push(format!(
                             "{:?} at byte {} branches to byte {target}, which is \
@@ -256,6 +291,29 @@ mod tests {
     #[test]
     fn rejects_a_routine_that_falls_off_its_end() {
         let code = [0xA9, 0x00]; // LDA #$00, no terminator
+        assert!(std::panic::catch_unwind(|| check(&code).assert_ok()).is_err());
+    }
+
+    /// `.fragment()` allows branches to *leave* the array, but a branch landing
+    /// inside it must still be on a boundary — otherwise the opt-out would turn
+    /// the check off rather than narrow it.
+    #[test]
+    fn fragment_still_rejects_an_internal_mid_instruction_branch() {
+        // BPL +1 lands on the $FF operand of EOR #$FF, inside the array.
+        let code = [0x10, 0x01, 0x49, 0xFF, 0xCA];
+        assert!(std::panic::catch_unwind(|| check(&code).fragment().assert_ok()).is_err());
+        // ...while a branch past the end is what `.fragment()` is for.
+        let out = [0x10, 0x20, 0x49, 0xFF, 0xCA];
+        check(&out).fragment().assert_ok();
+    }
+
+    /// `.data_from` must exclude the table from decoding, not merely tolerate it.
+    #[test]
+    fn data_from_excludes_the_table_but_still_checks_the_code() {
+        // LDA #$00, RTS, then bytes that do not decode as valid instructions.
+        let code = [0xA9, 0x00, 0x60, 0xFF, 0xFF, 0xFF];
+        check(&code).data_from(3).assert_ok();
+        // Without the opt-out the trailing table is read as code and fails.
         assert!(std::panic::catch_unwind(|| check(&code).assert_ok()).is_err());
     }
 

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -436,6 +436,15 @@ pub fn prg_bank_of(offset: usize) -> usize {
     (offset - PRG_START) / PRG_BANK_SIZE
 }
 
+/// One past the last file offset of the PRG bank containing `offset`.
+///
+/// A routine that runs past this executes whatever is paged in next, so it is
+/// the hard bound on how far an allocation near the end of a bank may grow.
+#[cfg(test)]
+pub(crate) fn prg_bank_end(offset: usize) -> usize {
+    PRG_START + (prg_bank_of(offset) + 1) * PRG_BANK_SIZE
+}
+
 /// True when write-log tag `tag` is covered by allocation owner `owner`.
 ///
 /// Matches whole `/`-separated components, so `koopalings` owns

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -874,6 +874,7 @@ mod free_space_tests {
     #[test]
     fn free_space_doc_table_is_current() {
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
             return;
         };
         let rom = crate::rom::Rom::from_bytes(&bytes).expect("valid ROM");

--- a/src/randomize/rom_data/mod.rs
+++ b/src/randomize/rom_data/mod.rs
@@ -14,6 +14,9 @@ use crate::rom::Rom;
 
 mod access;
 mod free_space;
+/// Structural checks for hand-assembled 6502 patches (test-only).
+#[cfg(test)]
+pub(crate) mod asm;
 mod grid;
 mod tables;
 mod tiles;

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -682,6 +682,7 @@ mod fortress_table_tests {
         // VANILLA_FORTRESS_OBJ_PTRS[i], and BOOMBOOM_Y_OFFSETS[i] must point
         // at the Y byte of a Boom-Boom enemy entry ([id, x, y]).
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
             return; // Base ROM not present (e.g. CI) — skip.
         };
         let rom = Rom::from_bytes(&bytes).unwrap();

--- a/src/randomize/stomp_fairness.rs
+++ b/src/randomize/stomp_fairness.rs
@@ -268,7 +268,10 @@ mod tests {
     /// structural check on that would keep it out of CI.
     #[test]
     fn hook_displaces_whole_instructions() {
-        let Some(v) = vanilla() else { return };
+        let Some(v) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         asm::check(&STOMP_RISE_CODE).hook(&v, STOMP_HEIGHT_HOOK, 4).assert_ok();
     }
 
@@ -276,7 +279,10 @@ mod tests {
     /// drifted offset would otherwise sail past the byte-level asserts below.
     #[test]
     fn patch_sites_match_vanilla() {
-        let Some(v) = vanilla() else { return };
+        let Some(v) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         // Operand of CMP #$08 at $D8E1.
         assert_eq!(v[OVERLAP_THRESHOLD], 0x08);
         // STY Temp_Var2; LDA Objects_Y,X at $D22E.
@@ -290,7 +296,10 @@ mod tests {
 
     #[test]
     fn apply_writes_both_halves() {
-        let Some(v) = vanilla() else { return };
+        let Some(v) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         let mut rom = Rom::from_bytes_lax(&v, true).expect("valid ROM");
         apply(&mut rom);
         assert_eq!(rom.read_byte(OVERLAP_THRESHOLD), OVERLAP_TOLERANT);

--- a/src/randomize/stomp_fairness.rs
+++ b/src/randomize/stomp_fairness.rs
@@ -253,13 +253,23 @@ mod tests {
     /// Decode the assembled bytes and check the structural properties no
     /// assembler was around to check. Supersedes the hand-derived branch-index
     /// assertions this test used to carry.
+    ///
+    /// Reads only the byte array, so unlike the ROM-dependent tests above it
+    /// runs everywhere — including CI, where the ROM is absent.
     #[test]
     fn routine_is_well_formed() {
+        asm::check(&STOMP_RISE_CODE).allocation(FS_STOMP_RISE).assert_ok();
+    }
+
+    /// The hook must displace *whole* vanilla instructions — `STY Temp_Var2`
+    /// (2 bytes) plus `LDA Objects_Y,X` (2) — or the tail of the second would
+    /// be left for the CPU to run as an opcode. Split from the check above
+    /// because comparing against vanilla needs the ROM, and gating the whole
+    /// structural check on that would keep it out of CI.
+    #[test]
+    fn hook_displaces_whole_instructions() {
         let Some(v) = vanilla() else { return };
-        asm::check(&STOMP_RISE_CODE)
-            .allocation(FS_STOMP_RISE)
-            .hook(&v, STOMP_HEIGHT_HOOK, 4)
-            .assert_ok();
+        asm::check(&STOMP_RISE_CODE).hook(&v, STOMP_HEIGHT_HOOK, 4).assert_ok();
     }
 
     /// Both patch sites, against the bytes the disassembly says are there. A

--- a/src/randomize/stomp_fairness.rs
+++ b/src/randomize/stomp_fairness.rs
@@ -135,10 +135,131 @@ pub fn apply(rom: &mut Rom) {
 
 #[cfg(test)]
 mod tests {
+    use mos6502::cpu::CPU;
+    use mos6502::instruction::{Instruction, Ricoh2a03};
+    use mos6502::memory::{Bus, Memory};
+    use mos6502::Variant;
+
     use super::*;
+    use crate::randomize::rom_data::asm;
 
     fn vanilla() -> Option<Vec<u8>> {
         std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()
+    }
+
+    /// Object slot the routine is exercised on; `LDA Objects_YVel,X` reads
+    /// `$D0 + X`, and any slot exercises the same code.
+    const SLOT: u8 = 3;
+    const OBJECTS_YVEL: u16 = 0x00D0;
+    const TEMP_VAR2: u16 = 0x0001;
+
+    /// A CPU with the routine loaded at its real origin. Reused across cases:
+    /// the routine does not modify itself, so only the inputs need resetting.
+    fn cpu_with_routine() -> CPU<Memory, Ricoh2a03> {
+        let mut mem = Memory::new();
+        mem.set_bytes(STOMP_RISE_CPU, &STOMP_RISE_CODE);
+        CPU::new(mem, Ricoh2a03)
+    }
+
+    /// Run the routine for one `(velocity, height)` pair and return the stomp
+    /// height it commits to `Temp_Var2`.
+    ///
+    /// Entry state mirrors the hook site: `Y` holds the height `$D218` selected
+    /// and `X` the object slot, which is exactly what the displaced
+    /// `STY Temp_Var2` was about to act on.
+    fn stomp_height(cpu: &mut CPU<Memory, Ricoh2a03>, vel: u8, height: u8) -> u8 {
+        cpu.memory.set_byte(OBJECTS_YVEL + u16::from(SLOT), vel);
+        cpu.memory.set_byte(TEMP_VAR2, 0xAA); // poison: a missing store stays visible
+        cpu.registers.program_counter = STOMP_RISE_CPU;
+        cpu.registers.index_x = SLOT;
+        cpu.registers.index_y = height;
+
+        for _ in 0..STOMP_RISE_CODE.len() {
+            let op = cpu.memory.get_byte(cpu.registers.program_counter);
+            if matches!(Ricoh2a03::decode(op), Some((Instruction::RTS, _))) {
+                return cpu.memory.get_byte(TEMP_VAR2);
+            }
+            cpu.single_step();
+        }
+        panic!("routine ran past {} instructions without reaching RTS", STOMP_RISE_CODE.len());
+    }
+
+    /// The whole point of the routine, over every input it can ever see.
+    ///
+    /// A non-negative velocity must leave the vanilla height alone; a rising
+    /// one must lose its whole-pixel rise, floored at zero. 65,536 cases, which
+    /// is the entire state space — the routine reads nothing else.
+    #[test]
+    fn rise_is_subtracted_from_the_stomp_height() {
+        let mut cpu = cpu_with_routine();
+        for height in 0..=u8::MAX {
+            for vel in 0..=u8::MAX {
+                let want = if vel < 0x80 {
+                    height // falling or stationary: untouched
+                } else {
+                    let rise = (vel ^ 0xFF) >> 4; // |vel| - 1, in whole pixels
+                    let t = height.wrapping_sub(rise).wrapping_sub(1); // CLC borrows the 1 back
+                    if t & 0x80 == 0 { t } else { 0 } // clamp rather than wrap
+                };
+                assert_eq!(
+                    stomp_height(&mut cpu, vel, height),
+                    want,
+                    "vel=0x{vel:02X} height={height}"
+                );
+            }
+        }
+    }
+
+    /// The claim [`STOMP_RISE_CODE`]'s comment makes: for the whole-pixel
+    /// velocities the engine actually produces, the height loses *exactly* the
+    /// rise — the `EOR`'s off-by-one and the `CLC`'s borrow cancel. This is the
+    /// property the size trick is only worth having if it preserves.
+    #[test]
+    fn whole_pixel_rises_are_cancelled_exactly() {
+        let mut cpu = cpu_with_routine();
+        for px in 1..=8u8 {
+            let vel = 0u8.wrapping_sub(px * 16); // -$10 ..= -$80
+            for height in px..=64 {
+                // heights where the clamp cannot bite
+                assert_eq!(
+                    stomp_height(&mut cpu, vel, height),
+                    height - px,
+                    "{px} px/frame at height {height}"
+                );
+            }
+        }
+    }
+
+    /// The velocities and heights that actually occur in the game, spelled out.
+    /// Heights are the three `$D218` picks (`prg000.asm:3800`); velocities come
+    /// from `ObjNorm_CheepCheepHopper` and `Koopaling_JumpYVels`.
+    #[test]
+    fn vanilla_cases() {
+        let mut cpu = cpu_with_routine();
+        // Cheep Cheep Hopper, height 17: launches at -$30, or -$60 close in.
+        assert_eq!(stomp_height(&mut cpu, 0xD0, 17), 14); // 3 px/frame
+        assert_eq!(stomp_height(&mut cpu, 0xA0, 17), 11); // 6 px/frame
+        // Koopaling's fastest jump against the generic height.
+        assert_eq!(stomp_height(&mut cpu, 0x90, 19), 12); // 7 px/frame
+        // Falling or stationary leaves vanilla behaviour untouched — including
+        // the Player's own FALLRATE_MAX, which is downward and so not a rise.
+        assert_eq!(stomp_height(&mut cpu, 0x00, 19), 19);
+        assert_eq!(stomp_height(&mut cpu, 0x40, 19), 19);
+        // A giant (height 8) at the fastest representable rise clamps to zero
+        // instead of wrapping to 255, which would invert the comparison.
+        assert_eq!(stomp_height(&mut cpu, 0x80, 8), 0);
+    }
+
+    /// Decode the assembled bytes and check the structural properties no
+    /// assembler was around to check. Supersedes the hand-derived branch-index
+    /// assertions this test used to carry.
+    #[test]
+    fn routine_is_well_formed() {
+        let Some(v) = vanilla() else { return };
+        asm::check(&STOMP_RISE_CODE)
+            .allocation(FS_STOMP_RISE)
+            .hook(&v, STOMP_HEIGHT_HOOK, 4)
+            .assert_ok();
     }
 
     /// Both patch sites, against the bytes the disassembly says are there. A
@@ -169,20 +290,7 @@ mod tests {
             STOMP_RISE_CPU as u8,
             (STOMP_RISE_CPU >> 8) as u8,
         ]);
-        // PRG030 is only mapped at $8000-$9FFF; a routine crossing into the
-        // next bank would execute whatever happens to be paged in.
-        assert!(FS_STOMP_RISE + STOMP_RISE_CODE.len() <= 0x3E010);
-    }
-
-    /// The two `BPL`s are the only relative branches; a miscount lands
-    /// mid-instruction and would still assemble, so pin both targets.
-    #[test]
-    fn routine_branches_land_on_instruction_boundaries() {
-        // BPL at index 2 skips to `.store` (STY $01) at index 21.
-        assert_eq!(STOMP_RISE_CODE[3] as usize + 4, 21);
-        assert_eq!(STOMP_RISE_CODE[21], 0x84);
-        // BPL at index 16 skips the clamp to `.keep` (TAY) at index 20.
-        assert_eq!(STOMP_RISE_CODE[17] as usize + 18, 20);
-        assert_eq!(STOMP_RISE_CODE[20], 0xA8);
+        // Bank containment and allocation fit are checked generically by
+        // `routine_is_well_formed`.
     }
 }

--- a/src/randomize/troll_pipes.rs
+++ b/src/randomize/troll_pipes.rs
@@ -78,6 +78,7 @@ mod tests {
     #[test]
     fn marks_at_most_one_pipe_per_world_w2_w8() {
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
             return; // Base ROM not present (e.g. CI) — skip.
         };
         let rom = Rom::from_bytes(&bytes).unwrap();
@@ -111,6 +112,7 @@ mod tests {
     #[test]
     fn deterministic_per_seed() {
         let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
             return; // Base ROM not present (e.g. CI) — skip.
         };
         let rom = Rom::from_bytes(&bytes).unwrap();

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -38,7 +38,10 @@ fn normalized(mut o: Options) -> Options {
 
 #[test]
 fn mystery_anchor_trampoline_written() {
-    let Some(mut rom) = make_test_rom() else { return };
+    let Some(mut rom) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     // Place anchors in item tables — they should stay as 0x0A
     rom.write_byte(HAMMER_BROS_ITEMS_OFFSET + 2, ANCHOR);
     rom.write_byte(TOAD_HOUSE_ITEMS_OFFSET + 1, ANCHOR);
@@ -96,7 +99,10 @@ fn audit_options() -> Options {
 fn free_space_audit_matches_registry() {
     use crate::randomize::rom_data::{audit_free_space, format_free_space_report};
 
-    let Some(mut rom) = make_test_rom() else { return };
+    let Some(mut rom) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     randomize(&mut rom, 0xA11C0DE, &audit_options());
 
     let usage = audit_free_space(&rom);
@@ -146,7 +152,10 @@ fn free_space_audit_matches_registry() {
 
 #[test]
 fn write_log_populated_after_randomize() {
-    let Some(mut rom) = make_test_rom() else { return };
+    let Some(mut rom) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     let options = test_options();
     randomize(&mut rom, 0x12345678, &options);
 
@@ -820,11 +829,17 @@ fn test_full_determinism() {
     let seed = 42u64;
     for (name, options) in &configs {
         // Run 1
-        let Some(mut rom1) = make_test_rom() else { return };
+        let Some(mut rom1) = make_test_rom() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         randomize(&mut rom1, seed, options);
 
         // Run 2 (same seed, same options)
-        let Some(mut rom2) = make_test_rom() else { return };
+        let Some(mut rom2) = make_test_rom() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         randomize(&mut rom2, seed, options);
 
         // Same-run determinism — find first differing byte for diagnostics
@@ -876,8 +891,14 @@ fn maybe_flags_are_deterministic_and_hidden() {
 
     // (3) determinism across runs (needs the real ROM).
     let seed = 0xC0FFEEu64;
-    let Some(mut rom1) = make_test_rom() else { return };
-    let Some(mut rom2) = make_test_rom() else { return };
+    let Some(mut rom1) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
+    let Some(mut rom2) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     randomize(&mut rom1, seed, &opts);
     randomize(&mut rom2, seed, &opts);
     assert_eq!(
@@ -895,7 +916,10 @@ fn maybe_resolves_both_ways_across_seeds() {
     // each Maybe run's tile bytes to the explicit-On run's bytes, so the
     // flag-key stamp / title hash (which always differ for Maybe) don't
     // confound the comparison.
-    let Some(_) = make_test_rom() else { return };
+    let Some(_) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     let on = Options { more_hammer_rocks: Tri::On, ..test_options() };
     let maybe = Options { more_hammer_rocks: Tri::Maybe, ..test_options() };
 
@@ -926,7 +950,10 @@ fn maybe_resolves_both_ways_across_seeds() {
 
 #[test]
 fn write_log_tags_match_enabled_modules() {
-    let Some(mut rom) = make_test_rom() else { return };
+    let Some(mut rom) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     let mut options = test_options();
     // Disable optional modules we can check for absence
     options.ground = EnemyMode::Off;

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -778,7 +778,10 @@ mod tests {
 
     #[test]
     fn placement_writes_the_source_levels_pointers() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
 
         // 6F1 is W6's first fortress: FORTRESS_ENTRIES lists it at (5, 9).
         let src = Rom::from_bytes_lax(&van, true).unwrap();
@@ -807,7 +810,10 @@ mod tests {
     /// zero lock bytes behind and must not touch anything else.
     #[test]
     fn unlocking_clears_every_lock_and_nothing_else() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
 
         let built = build(&van, &TestRomSpec { remove_locks: true, ..spec() }).unwrap();
         let out = Rom::from_bytes_lax(&built.bytes, true).unwrap();
@@ -839,7 +845,10 @@ mod tests {
 
     #[test]
     fn gaps_and_locks_are_independent_knobs() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
 
         let locks_only = build(&van, &TestRomSpec { remove_locks: true, ..spec() }).unwrap();
         for (i, (before, after)) in van.iter().zip(locks_only.bytes.iter()).enumerate() {
@@ -860,7 +869,10 @@ mod tests {
 
     #[test]
     fn starting_world_is_written() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         let built = build(&van, &TestRomSpec { world: Some(7), ..spec() }).unwrap();
         assert_eq!(built.bytes[WORLD_INIT_OPERAND], 6);
     }
@@ -869,7 +881,10 @@ mod tests {
     /// items must not disturb the map.
     #[test]
     fn starting_items_are_written_and_touch_nothing_on_the_map() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
 
         let built = build(
             &van,
@@ -907,7 +922,10 @@ mod tests {
     /// that combination is the whole point of lock-FX testing.
     #[test]
     fn hammer_breaks_locks_leaves_the_locks_in_place() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
 
         let built = build(
             &van,
@@ -975,7 +993,10 @@ mod tests {
     /// seed it reports must actually satisfy it.
     #[test]
     fn search_returns_a_seed_that_really_matches() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
 
         let req = Requirement::parse("lock@w8:s2").unwrap();
         let hit = search_seed(&van, &Options::default(), &req, 1, 8)
@@ -997,7 +1018,10 @@ mod tests {
 
     #[test]
     fn search_gives_up_cleanly_when_nothing_matches() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         // W1 has no Bowser castle, so this can never be satisfied.
         let req = Requirement::parse("bowser@w1").unwrap();
         assert!(search_seed(&van, &Options::default(), &req, 1, 3).unwrap().is_none());
@@ -1005,7 +1029,10 @@ mod tests {
 
     #[test]
     fn unknown_level_name_is_an_error() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         let err = build(
             &van,
             &TestRomSpec {
@@ -1021,7 +1048,10 @@ mod tests {
     /// should name the kind rather than silently writing garbage pointers.
     #[test]
     fn placing_a_non_level_entry_explains_why() {
-        let Some(van) = vanilla() else { return };
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
         let err = build(
             &van,
             &TestRomSpec {

--- a/tests/chr_stats.rs
+++ b/tests/chr_stats.rs
@@ -222,7 +222,7 @@ fn load_rom() -> Option<Rom> {
 #[test]
 fn chr_page_stats() {
     let Some(rom) = load_rom() else {
-        eprintln!("ROM file not present — skipping chr_page_stats (run locally with the ROM in repo root)");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     let opts = max_enemy_opts();

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -50,7 +50,10 @@ fn hashes(rom: &[u8]) -> Vec<u64> {
 /// Runs the sweep twice in one process and requires agreement.
 #[test]
 fn sweep_is_deterministic() {
-    let Ok(rom) = std::fs::read(ROM_PATH) else { return };
+    let Ok(rom) = std::fs::read(ROM_PATH) else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     assert_eq!(
         hashes(&rom),
         hashes(&rom),
@@ -77,7 +80,10 @@ const BASELINE: [u64; SEEDS as usize] = [
 
 #[test]
 fn output_matches_baseline() {
-    let Ok(rom) = std::fs::read(ROM_PATH) else { return };
+    let Ok(rom) = std::fs::read(ROM_PATH) else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
     if BASELINE.iter().all(|h| *h == 0) {
         panic!("BASELINE is unpopulated — run `cargo test print_baseline -- --ignored --nocapture`");
     }
@@ -97,7 +103,7 @@ fn output_matches_baseline() {
 #[ignore]
 fn print_baseline() {
     let Ok(rom) = std::fs::read(ROM_PATH) else {
-        println!("ROM not found at {ROM_PATH}");
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
     };
     println!("const BASELINE: [u64; SEEDS as usize] = [");


### PR DESCRIPTION
Test-only. ROM output is byte-identical to `beta/next` — verified by generating seed 42 with `--no-palettes` on both branches and comparing (`f7ec91cc…`, `cmp` clean). No patch bytes changed.

## What this adds

Every 6502 patch here is a byte array no assembler ever checked. The classic failure is a miscounted relative branch: it still "assembles", lands mid-instruction, the CPU runs an operand as an opcode, and the ROM boots. Nothing about the array looks wrong.

**`rom_data::asm`** decodes a patch with the `mos6502` crate's Ricoh 2A03 table — the NES's CPU, so no decimal mode — and checks what holds for any routine:

- every byte decodes, and the routine does not end mid-instruction
- it ends in `RTS`/`RTI`/`JMP` rather than running into the `$FF` filler after it
- every relative branch lands on an instruction boundary inside the routine
- the code fits its `FREE_SPACE_ALLOCATIONS` row without crossing its bank
- a hook displaces *whole* vanilla instructions rather than stranding an operand

`Variant::decode` and `AddressingMode::extra_bytes` are public, so there is no hand-written 256-entry opcode table to get wrong — which was the reason to prefer a crate over rolling it here.

**Coverage: 15 routines across 9 modules.** `stomp_fairness` additionally gets arithmetic tests, executing the routine over all 65,536 `(velocity, height)` pairs — the entire state space it can see. Executing rather than re-implementing the arithmetic is the point: correctness turns on `CLC` + `SBC` borrow semantics, and a hand-written interpreter would encode my reading of `SBC`. If that reading were wrong in the same way the patch was, the test would agree with the bug.

## What the sweep found

**No defects.** Every patch was already correct. This is regression insurance, not a discovery tool.

Adoption did surface three legitimate shapes the checker did not model, each needing a real fix rather than a suppression:

| Routine | Reported | Reality |
|---|---|---|
| `CANOE_SUMMON_ROUTINE` | `ends in ISC`, 2 mid-instruction branches | 12 bytes of offset tables at the tail; code ends at 139 |
| `KOOPA_HITS_CODE` | branches outside the routine | allocation is `13 code + 3 JMP + 7 table` — the array is a fragment |
| `LIMIT_BRO_CODE`, `TAIL_SWIM_ROUTINE` | branches to `-3` and past the end | spliced in place over vanilla; branches target surrounding code |

Hence `.data_from(n)` and `.fragment()`. `.fragment()` **narrows** the check rather than switching it off — branches landing inside the array are still verified, with a negative test pinning that. Several routines are also NOP-padded to the length of the vanilla bytes they replace, so the terminator is now the last non-NOP instruction.

## Verified by mutation

| Mutation | Structural | Arithmetic |
|---|---|---|
| `CLC` → `SEC` | passes — `SEC` is valid, just wrong | **3 fail** |
| branch `$11` → `$12` | **fails**, mid-instruction | fails |
| branch `$11` → `$10` | passes — byte 20 is a real boundary, the wrong one | **fails** |
| `MAP_WARP_ROUTINE` first `BNE` ±1 | **fails**, mid-instruction | n/a |

Rows one and three are why both layers exist. All mutations reverted.

## Test skips are now visible

`libtest` has no runtime skip, so the 50 ROM-gated tests returned early and reported `ok` — indistinguishable from having run. In CI, where the ROM is absent, that is a wall of green partly meaning "never executed". They now all print one line before returning. Verified by hiding `roms/`.

`stomp_fairness`'s structural check was also split from its hook check, so the routine this work started from is no longer the one routine whose decode/branch checks skip in CI.

## Not covered

Routines built at runtime rather than as a `const [u8; N]` — the segment composers, `king_quotes` (data, not code), `title_screen`, `fx_screen_check`, `march_veto`. Reaching those means changing how the patches are expressed.

Two follow-ups left open: the origin-lock self-reference check (which `big_q` already hand-rolls, and which `canoe_summon` documents a dependency on), and extracting `poison_mushroom`'s runtime-built hook block so it can be covered too.

`mos6502` is a **dev-dependency** — `cargo tree --edges normal` does not list it, so it reaches neither the CLI binary nor the WASM bundle. First dev-dependency in the project; pinned at 0.10.1.

No CHANGELOG entry: test-only, per the changelog rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB