### PR TITLE
Origin-lock check: catch a relocated routine whose absolute references didn't move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,62 @@ stream ending at 0x0D9F6.
   Querying a flag the engine already maintains costs a few bytes; a parallel
   per-slot table costs bytes *and* can drift out of sync.
 
+## Every New 6502 Patch Gets an `asm::check` Test
+
+A patch here is a `&[u8]` no assembler ever checked. The classic failure is a
+miscounted relative branch: it still "assembles", lands mid-instruction, the CPU
+runs an operand as an opcode — and the ROM boots. **Add the check in the same
+commit as the patch**, in an `asm_checks` module at the end of the file:
+
+```rust
+#[cfg(test)]
+mod asm_checks {
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn my_routine_is_well_formed() {
+        asm::check(&MY_ROUTINE)
+            .allocation(FS_MY_ROUTINE)   // fits its row, stays in its bank
+            .origin(MY_ROUTINE_CPU)      // absolute self-references resolve
+            .assert_ok();
+    }
+}
+```
+
+It decodes the bytes with the `mos6502` crate's Ricoh 2A03 table (a
+dev-dependency; it reaches neither the binary nor the WASM bundle) and checks
+that every byte decodes, the routine ends in `RTS`/`RTI`/`JMP` rather than
+running into the `$FF` filler after it, every relative branch lands on an
+instruction boundary, the code fits its `FREE_SPACE_ALLOCATIONS` row without
+crossing its bank, and absolute references back into the routine still resolve.
+
+Four builder methods, each for a real shape:
+
+| Method | Use when |
+|---|---|
+| `.allocation(FS_*)` | the routine claims free space (nearly always) |
+| `.origin(cpu)` | the routine has absolute references to itself or its tables |
+| `.data_from(n)` | the tail is a lookup table, not code |
+| `.fragment()` | it is spliced in place over vanilla, or continues into a sibling write |
+| `.hook(&vanilla, off, &bytes)` | it is reached from a hook — checks whole instructions are displaced, and that a `JSR`/`JMP` hook names the origin |
+
+`.fragment()` narrows the check rather than switching it off; branches landing
+inside the array are still verified. Prefer fixing the array over reaching for
+an opt-out.
+
+**`.origin` is the one to remember**, because relocating is the dangerous
+operation. A relative branch says "12 bytes forward" and survives being moved;
+an absolute `JMP $DEB7` has the address baked in and does not. Several
+allocations are origin-locked this way (`FS_CANOE_SUMMON` says so in its own
+comment), which is why reserving headroom beats relocating.
+
+The check cannot see *meaning* — a well-formed routine can still compute the
+wrong answer. Where a routine is a self-contained calculation with no calls out
+to the engine, execute it too: `stomp_fairness` runs its routine on an emulated
+CPU over all 65,536 inputs. Most patches read mid-level engine state and cannot
+be tested that way; for those the ROM is the instrument (see `testrom`).
+
 ## Changelog
 
 `CHANGELOG.md` (repo root, [Keep a Changelog](https://keepachangelog.com/) format) tracks notable changes. When a change is user-visible or notable (a new flag/option, a behavior change, a fixed bug players would notice), add a one-line entry under the `[Unreleased]` section in the right group (`Added` / `Changed` / `Fixed` / `Removed`) as part of the same change. Skip purely internal refactors, test-only changes, and tooling tweaks. At version-bump time, move the accumulated `[Unreleased]` entries into a new versioned section.

--- a/src/randomize/anchor_visuals.rs
+++ b/src/randomize/anchor_visuals.rs
@@ -193,6 +193,6 @@ mod asm_checks {
 
     #[test]
     fn anchor_item_guard_is_well_formed() {
-        asm::check(&ANCHOR_ITEM_GUARD_BODY).allocation(FS_ANCHOR_ITEM_GUARD).assert_ok();
+        asm::check(&ANCHOR_ITEM_GUARD_BODY).origin(ANCHOR_ITEM_GUARD_CPU_ADDR).allocation(FS_ANCHOR_ITEM_GUARD).assert_ok();
     }
 }

--- a/src/randomize/poison_mushroom.rs
+++ b/src/randomize/poison_mushroom.rs
@@ -275,6 +275,6 @@ mod asm_checks {
 
     #[test]
     fn handler_is_well_formed() {
-        asm::check(&HANDLER).allocation(FS_POISON_MUSHROOM).assert_ok();
+        asm::check(&HANDLER).origin(INIT_CPU).allocation(FS_POISON_MUSHROOM).assert_ok();
     }
 }

--- a/src/randomize/qol/big_q.rs
+++ b/src/randomize/qol/big_q.rs
@@ -180,13 +180,15 @@ mod tests {
         assert_eq!(&r[0x5D..0x6A], &BQ_ROOM);
     }
 
+    /// The hook must name the routine's own origin. The routine's *internal*
+    /// self-references are checked by `lookup_routine_is_well_formed`, which
+    /// resolves them against the decoded instruction boundaries rather than
+    /// against a hand-written byte index.
     #[test]
     fn jsr_target_matches_routine_origin() {
         let base = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET);
         let hook = jsr_into_bank(26, BIG_Q_ROUTINE_OFFSET);
         assert_eq!(u16::from_le_bytes([hook[1], hook[2]]), base);
-        let r = build_lookup_routine();
-        assert_eq!(u16::from_le_bytes([r[13], r[14]]), base + 0x26);
     }
 }
 
@@ -200,5 +202,19 @@ mod asm_checks {
     #[test]
     fn big_q_prg030_is_well_formed() {
         asm::check(&BIG_Q_PRG030_ROUTINE).allocation(BIG_Q_PRG030_OFFSET).assert_ok();
+    }
+
+    /// The PRG026 lookup routine, whose internal operands are derived from
+    /// `base` rather than hardcoded — so `.origin` here proves the derivation
+    /// lands on real instruction boundaries, not merely on the right numbers.
+    /// The last 39 bytes are the three 13-entry tables.
+    #[test]
+    fn lookup_routine_is_well_formed() {
+        let routine = build_lookup_routine();
+        asm::check(&routine)
+            .allocation(BIG_Q_ROUTINE_OFFSET)
+            .origin(prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET))
+            .data_from(routine.len() - 39)
+            .assert_ok();
     }
 }

--- a/src/randomize/qol/canoe.rs
+++ b/src/randomize/qol/canoe.rs
@@ -124,7 +124,7 @@ mod asm_checks {
 
     #[test]
     fn canoe_respawn_is_well_formed() {
-        asm::check(&CANOE_RESPAWN_ROUTINE).allocation(FS_CANOE_RESPAWN).assert_ok();
+        asm::check(&CANOE_RESPAWN_ROUTINE).origin(CANOE_RESPAWN_CPU).allocation(FS_CANOE_RESPAWN).assert_ok();
     }
 
     #[test]

--- a/src/randomize/qol/canoe_summon.rs
+++ b/src/randomize/qol/canoe_summon.rs
@@ -190,6 +190,6 @@ mod asm_checks {
 
     #[test]
     fn canoe_summon_is_well_formed() {
-        asm::check(&CANOE_SUMMON_ROUTINE).allocation(FS_CANOE_SUMMON).data_from(139).assert_ok();
+        asm::check(&CANOE_SUMMON_ROUTINE).origin(CANOE_SUMMON_CPU).allocation(FS_CANOE_SUMMON).data_from(139).assert_ok();
     }
 }

--- a/src/randomize/qol/map_warp.rs
+++ b/src/randomize/qol/map_warp.rs
@@ -201,6 +201,6 @@ mod asm_checks {
 
     #[test]
     fn map_warp_is_well_formed() {
-        asm::check(&MAP_WARP_ROUTINE).allocation(FS_MAP_WARP).assert_ok();
+        asm::check(&MAP_WARP_ROUTINE).origin(MAP_WARP_CPU).allocation(FS_MAP_WARP).assert_ok();
     }
 }

--- a/src/randomize/rom_data/asm.rs
+++ b/src/randomize/rom_data/asm.rs
@@ -47,6 +47,9 @@ struct Decoded {
     instr: Instruction,
     /// `true` for the relative-addressed branches, whose targets get checked.
     relative: bool,
+    /// `true` when the operand is a full 16-bit address, which is what makes a
+    /// routine origin-locked. See [`Routine::origin`].
+    absolute: bool,
 }
 
 /// Walk `code` as a straight-line instruction stream.
@@ -73,17 +76,25 @@ fn decode(code: &[u8]) -> Result<Vec<Decoded>, String> {
             len,
             instr,
             relative: matches!(mode, AddressingMode::Relative),
+            absolute: matches!(
+                mode,
+                AddressingMode::Absolute
+                    | AddressingMode::AbsoluteX
+                    | AddressingMode::AbsoluteY
+                    | AddressingMode::Indirect
+                    | AddressingMode::BuggyIndirect
+            ),
         });
         pc += len;
     }
     Ok(out)
 }
 
-/// The vanilla bytes a hook overwrites, and how many of them it takes.
+/// The vanilla bytes a hook overwrites, and the bytes written over them.
 struct Hook<'a> {
     vanilla: &'a [u8],
     offset: usize,
-    len: usize,
+    patch: &'a [u8],
 }
 
 /// A patch under verification. Build with [`check`], then [`Routine::assert_ok`].
@@ -93,11 +104,19 @@ pub struct Routine<'a> {
     hook: Option<Hook<'a>>,
     data_from: Option<usize>,
     fragment: bool,
+    origin: Option<u16>,
 }
 
 /// Begin checking an assembled routine.
 pub fn check(code: &[u8]) -> Routine<'_> {
-    Routine { code, allocation: None, hook: None, data_from: None, fragment: false }
+    Routine {
+        code,
+        allocation: None,
+        hook: None,
+        data_from: None,
+        fragment: false,
+        origin: None,
+    }
 }
 
 impl<'a> Routine<'a> {
@@ -109,9 +128,31 @@ impl<'a> Routine<'a> {
     }
 
     /// The hook site: the vanilla ROM, the file offset the patch writes over,
-    /// and how many bytes it writes there.
-    pub fn hook(mut self, vanilla: &'a [u8], offset: usize, len: usize) -> Self {
-        self.hook = Some(Hook { vanilla, offset, len });
+    /// and the bytes written there.
+    ///
+    /// With [`Routine::origin`] also set, a hook that opens with `JSR`/`JMP`
+    /// must target the routine's origin — the check that catches a relocated
+    /// allocation whose hook was not moved with it.
+    pub fn hook(mut self, vanilla: &'a [u8], offset: usize, patch: &'a [u8]) -> Self {
+        self.hook = Some(Hook { vanilla, offset, patch });
+        self
+    }
+
+    /// The CPU address this routine is assembled to run at.
+    ///
+    /// A relative branch says "12 bytes forward" and survives being moved. An
+    /// absolute `JMP $DEB7` has the address baked into its bytes and does not:
+    /// relocate the routine and it jumps to whatever now lives at the old
+    /// address. A routine holding absolute references to itself — or to tables
+    /// in its own tail — is *origin-locked*, and several here are
+    /// (`FS_CANOE_SUMMON` says so in its own comment).
+    ///
+    /// Given the origin, every absolute operand pointing back inside the
+    /// routine must land on an instruction boundary, or in the data region
+    /// declared by [`Routine::data_from`]. One that lands anywhere else means
+    /// the routine moved, or the address was typed wrong.
+    pub fn origin(mut self, cpu: u16) -> Self {
+        self.origin = Some(cpu);
         self
     }
 
@@ -191,6 +232,30 @@ impl<'a> Routine<'a> {
                         ));
                     }
                 }
+
+                // Absolute references back into the routine — the origin lock.
+                if let Some(origin) = self.origin {
+                    let end = origin as usize + self.code.len();
+                    let data = self.data_from.unwrap_or(self.code.len());
+                    for i in instrs.iter().filter(|i| i.absolute) {
+                        let addr =
+                            u16::from_le_bytes([code[i.start + 1], code[i.start + 2]]) as usize;
+                        if addr < origin as usize || addr >= end {
+                            continue; // points outside; nothing here can judge it
+                        }
+                        let off = addr - origin as usize;
+                        if off >= data || starts.contains(&off) {
+                            continue; // a table read, or a real instruction
+                        }
+                        problems.push(format!(
+                            "{:?} at byte {} targets ${addr:04X}, which is byte {off} of this \
+                             routine — mid-instruction. The routine is origin-locked to \
+                             ${origin:04X}; moving it invalidates absolute references like \
+                             this one.",
+                            i.instr, i.start
+                        ));
+                    }
+                }
             }
         }
 
@@ -221,10 +286,24 @@ impl<'a> Routine<'a> {
             }
         }
 
-        if let Some(h) = self.hook
-            && let Err(e) = check_displacement(h.vanilla, h.offset, h.len)
-        {
-            problems.push(e);
+        if let Some(h) = &self.hook {
+            if let Err(e) = check_displacement(h.vanilla, h.offset, h.patch.len()) {
+                problems.push(e);
+            }
+            // A hook that calls or jumps into the routine must name its origin.
+            if let Some(origin) = self.origin
+                && h.patch.len() >= 3
+                && matches!(h.patch[0], 0x20 | 0x4C)
+            {
+                let target = u16::from_le_bytes([h.patch[1], h.patch[2]]);
+                if target != origin {
+                    problems.push(format!(
+                        "the hook at 0x{:05X} targets ${target:04X} but the routine is at \
+                         ${origin:04X} — the allocation moved and the hook did not follow",
+                        h.offset
+                    ));
+                }
+            }
         }
 
         assert!(
@@ -315,6 +394,40 @@ mod tests {
         check(&code).data_from(3).assert_ok();
         // Without the opt-out the trailing table is read as code and fails.
         assert!(std::panic::catch_unwind(|| check(&code).assert_ok()).is_err());
+    }
+
+    /// Relocating an origin-locked routine must be caught: the same bytes that
+    /// pass at their real origin fail one byte away, because the absolute
+    /// reference then resolves into the middle of an instruction.
+    #[test]
+    fn origin_check_catches_a_relocated_routine() {
+        //   byte 0: LDA #$00   byte 2: JMP $8005   byte 5: RTS
+        let code = [0xA9, 0x00, 0x4C, 0x05, 0x80, 0x60];
+        check(&code).origin(0x8000).assert_ok();
+        assert!(std::panic::catch_unwind(|| check(&code).origin(0x8001).assert_ok()).is_err());
+    }
+
+    /// An absolute operand pointing *outside* the routine is somebody else's
+    /// address and cannot be judged from here.
+    #[test]
+    fn origin_check_ignores_addresses_outside_the_routine() {
+        // JMP $C123 — a vanilla routine elsewhere in the bank.
+        let code = [0x4C, 0x23, 0xC1];
+        check(&code).origin(0x8000).assert_ok();
+    }
+
+    #[test]
+    fn hook_must_target_the_routine_origin() {
+        let vanilla = [0x84, 0x01, 0xB5, 0xA3];
+        let code = [0x60];
+        // JSR $9FB6 + NOP, against a routine that really is at $9FB6.
+        let good = [0x20, 0xB6, 0x9F, 0xEA];
+        check(&code).origin(0x9FB6).hook(&vanilla, 0, &good).assert_ok();
+        // The same hook after the allocation moved.
+        assert!(std::panic::catch_unwind(|| {
+            check(&code).origin(0x9FC0).hook(&vanilla, 0, &good).assert_ok()
+        })
+        .is_err());
     }
 
     #[test]

--- a/src/randomize/stomp_fairness.rs
+++ b/src/randomize/stomp_fairness.rs
@@ -122,15 +122,21 @@ const STOMP_RISE_CODE: [u8; 26] = [
 /// Always on: it removes a source of unearned damage and has no effect on any
 /// collision that vanilla already resolved correctly, so there is nothing for
 /// a player to opt out of and no flag-key bit is spent on it.
+/// `JSR STOMP_RISE_CPU`, then a `NOP` filling the 4th displaced byte.
+///
+/// The target is derived from [`FS_STOMP_RISE`] rather than written out, so
+/// moving the allocation moves the hook with it.
+const STOMP_HEIGHT_HOOK_BYTES: [u8; 4] = [
+    0x20,
+    STOMP_RISE_CPU as u8,
+    (STOMP_RISE_CPU >> 8) as u8,
+    0xEA,
+];
+
 pub fn apply(rom: &mut Rom) {
     rom.write_byte(OVERLAP_THRESHOLD, OVERLAP_TOLERANT);
     rom.write_range(FS_STOMP_RISE, &STOMP_RISE_CODE);
-    rom.write_range(STOMP_HEIGHT_HOOK, &[
-        0x20,
-        STOMP_RISE_CPU as u8,
-        (STOMP_RISE_CPU >> 8) as u8,
-        0xEA, // NOP, filling the 4th displaced byte
-    ]);
+    rom.write_range(STOMP_HEIGHT_HOOK, &STOMP_HEIGHT_HOOK_BYTES);
 }
 
 #[cfg(test)]
@@ -258,7 +264,10 @@ mod tests {
     /// runs everywhere — including CI, where the ROM is absent.
     #[test]
     fn routine_is_well_formed() {
-        asm::check(&STOMP_RISE_CODE).allocation(FS_STOMP_RISE).assert_ok();
+        asm::check(&STOMP_RISE_CODE)
+            .allocation(FS_STOMP_RISE)
+            .origin(STOMP_RISE_CPU)
+            .assert_ok();
     }
 
     /// The hook must displace *whole* vanilla instructions — `STY Temp_Var2`
@@ -272,7 +281,10 @@ mod tests {
             eprintln!("SKIP: requires the ROM, which is not included in the repo");
             return;
         };
-        asm::check(&STOMP_RISE_CODE).hook(&v, STOMP_HEIGHT_HOOK, 4).assert_ok();
+        asm::check(&STOMP_RISE_CODE)
+            .origin(STOMP_RISE_CPU)
+            .hook(&v, STOMP_HEIGHT_HOOK, &STOMP_HEIGHT_HOOK_BYTES)
+            .assert_ok();
     }
 
     /// Both patch sites, against the bytes the disassembly says are there. A


### PR DESCRIPTION
Test-only. ROM output byte-identical to `beta/next` (seed 42, `--no-palettes`, `cmp` clean).

## The gap

A relative branch says "12 bytes forward" and survives being moved. An absolute `JMP $DEB7` has the address baked into its bytes and does not — relocate the routine and it jumps to whatever now lives at the old address.

`CANOE_SUMMON_ROUTINE` reaches its own exit label both ways:

```asm
byte 4:    D0 0C        BNE csexit      ; relative — survives a move
byte 136:  4C B7 DE     JMP $DEB7       ; absolute — does not
```

Both target byte 18. `CLAUDE.md` tells you to reserve headroom precisely so a routine that grows is extended in place rather than moved — but nothing checked it. You could change one offset, build, and watch every test pass while the canoe jumped into garbage.

## What's added

`.origin(cpu)` resolves every absolute operand pointing back into the routine against the decoded instruction boundaries, skipping the data region declared by `.data_from`. `.hook()` now takes the bytes written rather than a length, so a `JSR`/`JMP` hook is also checked to name the routine's origin — the other half of the same failure, where the allocation moves and the hook doesn't follow.

Wired into the six routines that already derive a CPU origin: `map_warp`, `canoe_respawn`, `canoe_summon`, `anchor_item_guard`, the poison handler, and `stomp_fairness`. The rest have no origin constant, and inventing address literals for them would duplicate offsets belonging to `rom_data` — exactly what `tools/offset_dups.py` exists to catch.

## Verified by mutation

Passing `CANOE_SUMMON_CPU + 1`, as a one-byte relocation would:

```
- JMP at byte 125 targets $DEB7, which is byte 17 of this routine — mid-instruction.
  The routine is origin-locked to $DEA6; moving it invalidates absolute references like this one.
- JMP at byte 136 targets $DEB7, which is byte 17 …
- ADCnd at byte 37 targets $DF30, which is byte 138 …
```

All three self-references named, including the table read. Negative tests pin the origin and hook checks permanently — and one of them caught a mistake in its own fixture before I did.

## Also

**`big_q`'s lookup routine gains a check.** Its operands are derived from `base` rather than hardcoded, so `.origin` proves the derivation lands on real instruction boundaries rather than merely on the right numbers. That retires the hand-rolled `r[13], r[14]` index assertion, leaving `jsr_target_matches_routine_origin` the hook half it uniquely covers without needing the ROM. 67 bytes of code that had never been decoded now are.

**`stomp_fairness`'s hook bytes** moved out of `apply()` into a const, so the test checks what ships rather than a copy of it.

**`CLAUDE.md` now requires an `asm::check` test in the same commit as any new 6502 patch**, with a table of the four opt-outs and why `.origin` is the one to remember. That's the answer to "will we remember to use this" — it's in the file loaded every session, not just in a commit message.

378 tests pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB