### PR TITLE
feature: pick which chasers Wild Injections drops, and let Boss Bass be one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,21 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry & build
         uses: Swatinem/rust-cache@v2
 
       - name: Clippy (deny warnings)
         run: cargo clippy --all-targets -- -D warnings
+
+      # The native pass above never evaluates the `cfg(target_arch = "wasm32")`
+      # branch, and `wasm-pack` (in the `build` job) exits 0 on warnings — so
+      # without this, a wasm-only warning is invisible and a wasm-only compile
+      # error first surfaces post-merge, in the job that deploys.
+      # `--lib` is required: the bins pull in clap, which isn't built for wasm.
+      - name: Clippy — wasm target (deny warnings)
+        run: cargo clippy --lib --target wasm32-unknown-unknown -- -D warnings
 
       - name: Build
         run: cargo build --all-targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ deploys.
 
 ### Changed
 
+- "Wild Injections" now lets you pick which chaser gets dropped into levels.
+  The option is three pills — Off, Sun, Lakitu — where Sun and Lakitu toggle
+  independently, so you can ask for only Angry Suns, only Lakitus, or both
+  (which is what the old on/off toggle did). Picking a single chaser also
+  means fewer injections overall: a level whose graphics can't fit the one you
+  chose is skipped rather than handed the other one. Saved web settings carry
+  over (an old "on" becomes both), and the CLI flag takes a value now:
+  `--wild-injections both`. Flag keys bump to v28; older keys are no longer
+  accepted.
+
 - "Poison Mushrooms" is now a per-block trap instead of an all-or-nothing
   swap. Each 1-Up block independently hands out either a real 1-Up or an
   upside-down poison mushroom that hurts you, decided by the seed — so a run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,20 @@ deploys.
 
 ### Changed
 
-- "Wild Injections" now lets you pick which chaser gets dropped into levels.
-  The option is three pills — Off, Sun, Lakitu — where Sun and Lakitu toggle
-  independently, so you can ask for only Angry Suns, only Lakitus, or both
-  (which is what the old on/off toggle did). Picking one doesn't make them
-  rarer — every setting drops about the same number of chasers per seed.
-  Saved web settings carry over (an old "on" becomes both), and the CLI flag
-  takes a value now:
-  `--wild-injections both`. Flag keys bump to v28; older keys are no longer
-  accepted.
+- "Wild Injections" now lets you pick which chasers get dropped into levels,
+  and adds a third one. The option is four pills — Off, Sun, Lakitu, Bass —
+  where the three chasers toggle independently and Off clears them, so you can
+  ask for any combination. Picking fewer doesn't make them rarer; every
+  combination drops about the same number per seed.
+
+  **Boss Bass is new to the pool**: a leaping Big Bertha that follows you
+  through a level that never had one, dry ground included. It was meant to be
+  available when the option first shipped, but with water enemies shuffled it
+  was quietly turned back into an ordinary fish before it ever reached the ROM.
+
+  Saved web settings carry over (an old "on" becomes Sun + Lakitu, the pool as
+  it stood then), and the CLI flag takes a set now: `--wild-injections sun,bass`,
+  or `all`, or `off`. Flag keys bump to v28; older keys are no longer accepted.
 
 - "Poison Mushrooms" is now a per-block trap instead of an all-or-nothing
   swap. Each 1-Up block independently hands out either a real 1-Up or an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ deploys.
 - "Wild Injections" now lets you pick which chaser gets dropped into levels.
   The option is three pills — Off, Sun, Lakitu — where Sun and Lakitu toggle
   independently, so you can ask for only Angry Suns, only Lakitus, or both
-  (which is what the old on/off toggle did). Picking a single chaser also
-  means fewer injections overall: a level whose graphics can't fit the one you
-  chose is skipped rather than handed the other one. Saved web settings carry
-  over (an old "on" becomes both), and the CLI flag takes a value now:
+  (which is what the old on/off toggle did). Picking one doesn't make them
+  rarer — every setting drops about the same number of chasers per seed.
+  Saved web settings carry over (an old "on" becomes both), and the CLI flag
+  takes a value now:
   `--wild-injections both`. Flag keys bump to v28; older keys are no longer
   accepted.
 

--- a/docs/wild_injection_rework.md
+++ b/docs/wild_injection_rework.md
@@ -110,9 +110,13 @@ half stay low, half lift up. X is always inherited.
 - Only the level's **main area** first enemy is targeted (no sub-area injection).
 - **Rate** (`WILD_INJECTION_CHANCE = 102`, ~40%) now applies per candidate
   level; may warrant re-measuring against the (larger, cleaner) pool.
-- **A one-chaser pool is a sparser pool.** `WildInjectionMode::Sun` / `Lakitu`
+- **A one-chaser pool is not, in practice, a sparser pool.** `Sun` / `Lakitu`
   filter the pool *before* the CHR-compatibility and no-doubling checks, and a
   candidate that fails them injects nothing rather than falling back to the
-  other chaser. So the single modes land on fewer levels than `Both` — they
-  don't redistribute the same count. The per-mode counts have not been
-  measured; the rate is deliberately left alone until they are.
+  other chaser — so the single modes ought to land on fewer levels. Measured
+  over 20 seeds they don't: 8.2–9.2 injections per seed in every mode, with the
+  between-mode spread no larger than the spread between two runs of one mode
+  (each mode draws a different RNG stream). Few levels are CHR-restricted to
+  exactly one chaser, so the effect exists but is far below the noise.
+  `WILD_INJECTION_CHANCE` is therefore left alone. Numbers from the
+  `print_injection_counts` diagnostic in `enemies/tests.rs`.

--- a/docs/wild_injection_rework.md
+++ b/docs/wild_injection_rework.md
@@ -50,9 +50,11 @@ inject_wild_chasers:
         require first enemy swappable + unprotected      # don't clobber critical
                                                          # objects / get reverted
         CHR pin-scan the enclosing $FF segment
-        pick a chaser that is CHR-compatible, the level
-          does NOT already have (has_enemy_id), and
-          within the Big-Bertha per-segment cap
+        pick a chaser that is in the player's pool
+          (WildInjectionMode: sun / lakitu / both),
+          CHR-compatible, the level does NOT already
+          have (has_enemy_id), and within the
+          Big-Bertha per-segment cap
         replace first enemy; re-seed suns to screen 0 (0x02, 0x11)
 ```
 
@@ -108,3 +110,9 @@ half stay low, half lift up. X is always inherited.
 - Only the level's **main area** first enemy is targeted (no sub-area injection).
 - **Rate** (`WILD_INJECTION_CHANCE = 102`, ~40%) now applies per candidate
   level; may warrant re-measuring against the (larger, cleaner) pool.
+- **A one-chaser pool is a sparser pool.** `WildInjectionMode::Sun` / `Lakitu`
+  filter the pool *before* the CHR-compatibility and no-doubling checks, and a
+  candidate that fails them injects nothing rather than falling back to the
+  other chaser. So the single modes land on fewer levels than `Both` — they
+  don't redistribute the same count. The per-mode counts have not been
+  measured; the rate is deliberately left alone until they are.

--- a/docs/wild_injection_rework.md
+++ b/docs/wild_injection_rework.md
@@ -5,13 +5,33 @@ replacing the old raw-enemy-pointer approach.
 
 ## What it does
 
-For each seed, injects a level-wide chaser — Lakitu (`0x83`) or Angry Sun
-(`0xAF`) — into a random subset of real action levels, replacing each chosen
-level's first enemy with a CHR-compatible chaser.
+For each seed, injects a level-wide chaser — Lakitu (`0x83`), Angry Sun
+(`0xAF`) or Boss Bass (`0x2D`) — into a random subset of real action levels,
+replacing each chosen level's first enemy with a CHR-compatible chaser. The
+player picks which of the three are allowed (`Vec<WildChaser>`; empty = off).
 
-**Boss Bass (`0x2D`) is excluded** from the pool: it's a `WATER_ENEMIES` member,
-so the later walker pass would reshuffle an injected one into an ordinary water
-enemy. Lakitu and Sun are in no class pool, so the walker leaves them alone.
+**Boss Bass was excluded until injection moved inside the walker.** It's a
+`WATER_ENEMIES` member, so while injection ran as a pass *before* the walker,
+the walker reshuffled an injected Bertha into an ordinary water enemy whenever
+water was Shuffle/Wild — a silent no-op. Deciding the injection in the walker's
+own segment prologue and marking the entry settled closes that: nothing after
+it gets a chance to swap it. Lakitu and the Sun never needed the protection,
+being in no class pool.
+
+## Where it runs
+
+Not a pass. `collect_injection_sites` runs up front (level geography, no RNG,
+no CHR), and `inject_segment_chasers` is called from the walker's segment
+prologue in `randomize_object_data` — after the entries are parsed, before
+anything is committed or picked. An injected chaser is therefore just an enemy
+the segment contains: the Bertha tally counts it, `segment_pins` commits its
+page, and every subsequent pick is chosen around it.
+
+That ordering matters. Injecting *after* the walk would also work and would
+also unblock Boss Bass, but the chaser could then only land where the finished
+level happened to accommodate it, instead of the level being built around the
+chaser. Injecting *before* the walk (the old design) required a second copy of
+the walker's CHR model, which is the drift that hid the Boss Bass bug.
 
 ## Why it was reworked
 
@@ -43,19 +63,19 @@ collect_candidates(rom, data, opts):
         first_idx = enemy_ptr_to_file_offset(obj_ptr) - ENEMY_DATA_START (+page byte)
         de-dupe by first_idx                            # shared enemy set = one candidate
 
-inject_wild_chasers:
-    shuffle(candidates)                                 # per-seed variety
-    for cand in candidates:
+inject_segment_chasers:                                 # in the walker prologue
+    for entry in this segment, in data order:
+        skip unless collect_injection_sites knows it    # = some level's first enemy
         roll WILD_INJECTION_CHANCE
-        require first enemy swappable + unprotected      # don't clobber critical
-                                                         # objects / get reverted
-        CHR pin-scan the enclosing $FF segment
-        pick a chaser that is in the player's pool
-          (WildInjectionMode: sun / lakitu / both),
+        require first enemy swappable + unprotected     # don't clobber critical objects
+        pins = segment_pins(entries, skip=this entry)   # the walker's own model
+        pick a chaser that is in the player's set
+          (Vec<WildChaser>: sun / lakitu / bass),
           CHR-compatible, the level does NOT already
           have (has_enemy_id), and within the
           Big-Bertha per-segment cap
         replace first enemy; re-seed suns to screen 0 (0x02, 0x11)
+        mark the entry settled                          # walker pass 2 skips it
 ```
 
 ### Guards
@@ -64,10 +84,13 @@ inject_wild_chasers:
   already contains (the 2-Quicksand fix).
 - **Shared-pointer de-dup** — one physical enemy set injects at most once.
 - **Swappable + unprotected first enemy** — `find_class_pool` guards against
-  destroying a non-enemy object; `entry_protection_at` avoids walker reverts.
+  destroying a non-enemy object; `entry_protection_at` keeps the protection
+  registry authoritative.
 - **CHR compatibility** — unchanged; the chaser's sprite page must fit the
   segment's committed slots.
-- **Bertha cap** — `MAX_BERTHA_PER_SEGMENT`.
+- **Bertha cap** — `MAX_BERTHA_PER_SEGMENT`, counted by the injection itself.
+  The walker enforces it across swaps but can't see an injection that already
+  happened, so an injected Boss Bass checks the budget on its own.
 
 ### Frame
 Everything uses `obj_ptr` + `enemy_ptr_to_file_offset` (the same frame as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use rom::Rom;
 pub use ips::apply_ips_patch;
 pub use randomizer::{
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
-    ITEMS, STARTING_LIVES_VALUES,
+    WildInjectionMode, ITEMS, STARTING_LIVES_VALUES,
     ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use rom::Rom;
 pub use ips::apply_ips_patch;
 pub use randomizer::{
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
-    WildInjectionMode, ITEMS, STARTING_LIVES_VALUES,
+    WildChaser, ITEMS, STARTING_LIVES_VALUES,
     ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::process;
 
 use smb3_rs::{
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
-    WildInjectionMode, ITEMS,
+    WildChaser, ITEMS,
     STARTING_LIVES_VALUES,
 };
 
@@ -83,15 +83,38 @@ fn parse_piranha(s: &str) -> Result<PiranhaMode, String> {
     }
 }
 
-/// clap value parser for `--wild-injections` (off/sun/lakitu/both).
-fn parse_wild_injections(s: &str) -> Result<WildInjectionMode, String> {
-    match s {
-        "off" => Ok(WildInjectionMode::Off),
-        "sun" => Ok(WildInjectionMode::Sun),
-        "lakitu" => Ok(WildInjectionMode::Lakitu),
-        "both" => Ok(WildInjectionMode::Both),
-        _ => Err("valid values: off, sun, lakitu, both".to_string()),
+/// A whole `--wild-injections` value. Newtype rather than a bare
+/// `Vec<WildChaser>` because clap's derive reads a `Vec` field as a repeatable
+/// single-value arg, and would then expect the parser below to return one
+/// `WildChaser` per occurrence — a mismatch that panics at runtime rather than
+/// failing to compile (see `cli_parses_a_chaser_set`). Wrapping keeps the
+/// whole set in one parser, which is what makes `off` and `all` expressible.
+#[derive(Clone, Debug)]
+struct ChaserSet(Vec<WildChaser>);
+
+/// clap value parser for `--wild-injections`: a comma-separated set of chasers
+/// (`sun`, `lakitu`, `bass`), `all` for every one, or `off` for none. Returned
+/// in `WildChaser::ALL` order, which is the order the flag key stores.
+fn parse_wild_injections(s: &str) -> Result<ChaserSet, String> {
+    const VALID: &str = "valid values: off, all, or a comma-separated set of sun, lakitu, bass";
+    if s == "off" || s.is_empty() {
+        return Ok(ChaserSet(Vec::new()));
     }
+    if s == "all" {
+        return Ok(ChaserSet(WildChaser::ALL.to_vec()));
+    }
+    let mut out = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        let Some(&c) = WildChaser::ALL.iter().find(|c| c.name() == part) else {
+            return Err(format!("unknown chaser {part:?} -- {VALID}"));
+        };
+        if !out.contains(&c) {
+            out.push(c);
+        }
+    }
+    out.sort();
+    Ok(ChaserSet(out))
 }
 
 /// clap value parser for the tri-state flags (off/on/maybe).
@@ -372,12 +395,12 @@ struct Cli {
     #[arg(long, default_value = "off", value_parser = parse_enemy_mode)]
     hb_encounters: EnemyMode,
 
-    /// Seed a level-wide chaser into a fraction of levels: off, sun, lakitu,
-    /// or both (default: off). A single-chaser pool injects into fewer levels
-    /// than `both` — a level whose CHR can't fit it is skipped, not given the
-    /// other one.
+    /// Seed a level-wide chaser into a fraction of levels. A comma-separated
+    /// set of `sun`, `lakitu`, `bass`; or `all`; or `off` (default). A level
+    /// whose CHR can't fit an allowed chaser is skipped rather than given one
+    /// you didn't ask for.
     #[arg(long, default_value = "off", value_parser = parse_wild_injections)]
-    wild_injections: WildInjectionMode,
+    wild_injections: ChaserSet,
 
     /// Set starting lives. Must be one of 1, 5, 20, 99 (default: 5).
     #[arg(long, default_value_t = 5, value_parser = parse_starting_lives)]
@@ -527,7 +550,7 @@ fn build_options(cli: &Cli) -> Options {
             water: cli.water,
             bros: cli.bros,
             hb_encounters: cli.hb_encounters,
-            wild_injections: cli.wild_injections,
+            wild_injections: cli.wild_injections.0.clone(),
             starting_lives: cli.starting_lives,
             starting_items,
             skip_rom_validation: cli.skip_rom_validation,
@@ -573,11 +596,10 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
         PiranhaMode::On => "on",
         PiranhaMode::Wild => "wild",
     });
-    eprintln!("  Wild injections: {}", match options.wild_injections {
-        WildInjectionMode::Off => "off",
-        WildInjectionMode::Sun => "sun",
-        WildInjectionMode::Lakitu => "lakitu",
-        WildInjectionMode::Both => "sun + lakitu",
+    eprintln!("  Wild injections: {}", if options.wild_injections.is_empty() {
+        "off".to_string()
+    } else {
+        options.wild_injections.iter().map(|c| c.name()).collect::<Vec<_>>().join(" + ")
     });
     if !options.starting_items.is_empty() {
         let item_names: Vec<&str> =
@@ -716,4 +738,44 @@ fn main() {
         process::exit(1);
     }
     eprintln!("Done! Wrote {} bytes to {}", output_data.len(), output_path.display());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse a real argv, which is the only place this mistake shows up.
+    ///
+    /// clap's derive reads a `Vec` field as a repeatable single-value arg, so a
+    /// `value_parser` returning the whole set downcasts to the wrong type and
+    /// panics during argument parsing — before any of this crate runs. There is
+    /// no compile error, and `Cli::command().debug_assert()` passes (checked:
+    /// it did, while the binary panicked on every invocation). Only converting
+    /// matches back into the struct reaches the downcast, so only a test that
+    /// parses an argv catches it.
+    #[test]
+    fn cli_parses_a_chaser_set() {
+        let cli = Cli::try_parse_from(["smb3-rs", "rom.nes", "--wild-injections", "sun,bass"])
+            .expect("argv should parse");
+        assert_eq!(cli.wild_injections.0, vec![WildChaser::Sun, WildChaser::Bass]);
+
+        let off = Cli::try_parse_from(["smb3-rs", "rom.nes"]).expect("argv should parse");
+        assert!(off.wild_injections.0.is_empty(), "default must be off");
+    }
+
+    #[test]
+    fn wild_injection_sets_parse() {
+        let set = |s: &str| parse_wild_injections(s).map(|c| c.0);
+        assert_eq!(set("off").unwrap(), vec![]);
+        assert_eq!(set("all").unwrap(), WildChaser::ALL.to_vec());
+        assert_eq!(set("bass").unwrap(), vec![WildChaser::Bass]);
+        // Canonical order regardless of how they were typed, so two spellings
+        // of one set produce the same flag key.
+        assert_eq!(set("bass,sun").unwrap(), vec![WildChaser::Sun, WildChaser::Bass]);
+        assert_eq!(set("sun, bass").unwrap(), set("bass,sun").unwrap());
+        // Duplicates collapse rather than double-weighting anything.
+        assert_eq!(set("sun,sun").unwrap(), vec![WildChaser::Sun]);
+        assert!(set("eel").is_err());
+        assert!(set("sun,eel").is_err());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 use std::process;
 
 use smb3_rs::{
-    item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri, ITEMS,
+    item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
+    WildInjectionMode, ITEMS,
     STARTING_LIVES_VALUES,
 };
 
@@ -79,6 +80,17 @@ fn parse_piranha(s: &str) -> Result<PiranhaMode, String> {
         "on" => Ok(PiranhaMode::On),
         "wild" => Ok(PiranhaMode::Wild),
         _ => Err("valid values: off, on, wild".to_string()),
+    }
+}
+
+/// clap value parser for `--wild-injections` (off/sun/lakitu/both).
+fn parse_wild_injections(s: &str) -> Result<WildInjectionMode, String> {
+    match s {
+        "off" => Ok(WildInjectionMode::Off),
+        "sun" => Ok(WildInjectionMode::Sun),
+        "lakitu" => Ok(WildInjectionMode::Lakitu),
+        "both" => Ok(WildInjectionMode::Both),
+        _ => Err("valid values: off, sun, lakitu, both".to_string()),
     }
 }
 
@@ -360,9 +372,12 @@ struct Cli {
     #[arg(long, default_value = "off", value_parser = parse_enemy_mode)]
     hb_encounters: EnemyMode,
 
-    /// Inject Lakitu/Angry Sun/Boss Bass into ~15% of segments
-    #[arg(long)]
-    wild_injections: bool,
+    /// Seed a level-wide chaser into a fraction of levels: off, sun, lakitu,
+    /// or both (default: off). A single-chaser pool injects into fewer levels
+    /// than `both` — a level whose CHR can't fit it is skipped, not given the
+    /// other one.
+    #[arg(long, default_value = "off", value_parser = parse_wild_injections)]
+    wild_injections: WildInjectionMode,
 
     /// Set starting lives. Must be one of 1, 5, 20, 99 (default: 5).
     #[arg(long, default_value_t = 5, value_parser = parse_starting_lives)]
@@ -557,6 +572,12 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
         PiranhaMode::Off => "off",
         PiranhaMode::On => "on",
         PiranhaMode::Wild => "wild",
+    });
+    eprintln!("  Wild injections: {}", match options.wild_injections {
+        WildInjectionMode::Off => "off",
+        WildInjectionMode::Sun => "sun",
+        WildInjectionMode::Lakitu => "lakitu",
+        WildInjectionMode::Both => "sun + lakitu",
     });
     if !options.starting_items.is_empty() {
         let item_names: Vec<&str> =

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -9,7 +9,9 @@
 //! level does not already have. Suns are re-seeded to the vanilla screen-0
 //! spawn so they engage (deep suns idle in the background).
 //!
-//! The pool is Lakitu + Angry Sun only. Boss Bass is deliberately excluded: it's
+//! The pool is Lakitu + Angry Sun, narrowed to one of them when the player
+//! picks a single chaser (see [`WildInjectionMode`] — narrowing also thins the
+//! injections out, it doesn't redistribute them). Boss Bass is excluded: it's
 //! a `WATER_ENEMIES` member, so the later walker pass would reshuffle an injected
 //! one into an ordinary water enemy. Lakitu and Sun belong to no class pool, so
 //! the walker leaves them untouched.
@@ -111,6 +113,19 @@ fn collect_candidates(rom: &Rom, data: &[u8], opts: &Options) -> Vec<Candidate> 
     out
 }
 
+/// True when `id` is in the pool the player asked for. `Sun` / `Lakitu` narrow
+/// the pool to one enemy; a level that can't take that one injects nothing
+/// rather than falling back to the other, so a narrowed pool is also a sparser
+/// one (see [`WildInjectionMode`]).
+fn in_pool(mode: WildInjectionMode, id: u8) -> bool {
+    match mode {
+        WildInjectionMode::Off => false,
+        WildInjectionMode::Sun => id == ANGRY_SUN_ID,
+        WildInjectionMode::Lakitu => id == LAKITU_ID,
+        WildInjectionMode::Both => true,
+    }
+}
+
 /// Pick a CHR-compatible chaser this level doesn't already have. Returns `None`
 /// if nothing fits.
 fn pick_injection<R: Rng>(
@@ -118,15 +133,17 @@ fn pick_injection<R: Rng>(
     obj_ptr: u16,
     slot4: ChrSlot,
     slot5: ChrSlot,
+    mode: WildInjectionMode,
     rng: &mut R,
 ) -> Option<u8> {
     let eligible: Vec<u8> = WILD_INJECTION_IDS
         .iter()
         .copied()
         .filter(|&id| {
-            // CHR-compatible with the segment's pinned pages, and not a chaser
-            // the level already has (no doubling — e.g. 2-Quicksand's sun).
-            is_chr_compatible(id, slot4, slot5) && !has_enemy_id(rom, obj_ptr, id)
+            // In the player's chosen pool, CHR-compatible with the segment's
+            // pinned pages, and not a chaser the level already has (no
+            // doubling — e.g. 2-Quicksand's sun).
+            in_pool(mode, id) && is_chr_compatible(id, slot4, slot5) && !has_enemy_id(rom, obj_ptr, id)
         })
         .collect();
     // Favor the sun over the (harder) Lakitu when both fit.
@@ -192,7 +209,7 @@ pub(super) fn inject_wild_chasers<R: Rng>(
             }
         }
 
-        let Some(chosen) = pick_injection(rom, obj_ptr, s4, s5, rng) else {
+        let Some(chosen) = pick_injection(rom, obj_ptr, s4, s5, opts.wild_injections, rng) else {
             continue;
         };
 

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -1,6 +1,5 @@
-//! Wild-injection pass: seed a level-wide chaser (Lakitu or Angry Sun) into a
-//! fraction of real action levels, selected via the `node_catalog` (not raw
-//! enemy pointers).
+//! Wild injection: seed a level-wide chaser into a fraction of real action
+//! levels, selected via the `node_catalog` (not raw enemy pointers).
 //!
 //! Level-centric design (replaces the old entry-point / `enemy_entry_points`
 //! approach). Each candidate is a `NodeKind::Level` — fortresses, airships and
@@ -9,23 +8,25 @@
 //! level does not already have. Suns are re-seeded to the vanilla screen-0
 //! spawn so they engage (deep suns idle in the background).
 //!
-//! The pool is Lakitu + Angry Sun, narrowed to one of them when the player
-//! picks a single chaser (see [`WildInjectionMode`] — narrowing also thins the
-//! injections out, it doesn't redistribute them). Boss Bass is excluded: it's
-//! a `WATER_ENEMIES` member, so the later walker pass would reshuffle an injected
-//! one into an ordinary water enemy. Lakitu and Sun belong to no class pool, so
-//! the walker leaves them untouched.
+//! **This is not a pass.** It used to be one, running before the walker, which
+//! meant re-deriving the CHR state the walker was about to compute — a second
+//! copy of a model that had to stay in step with the first. It now happens
+//! inside the walker's segment prologue ([`inject_segment_chasers`], called
+//! from `randomize_object_data`), reading the same [`segment_pins`] the walker
+//! seeds itself from. `collect_candidates` still runs up front, because *where*
+//! a level's first enemy lives has nothing to do with the shuffle.
+//!
+//! Injecting during the prologue rather than after the walk keeps the property
+//! that made the old ordering worth its cost: the chaser is fixed before any
+//! pick is made, so every other enemy in the segment is chosen around it.
 //!
 //! Guards: boss-type exclusion, shared-enemy-set de-dup (one physical enemy set
 //! injects at most once), no-double (`has_enemy_id`), first-enemy must be a
-//! real swappable/unprotected enemy (don't clobber a critical object or get
-//! reverted by the walker), and CHR compatibility. All offsets use the
-//! `enemy_ptr_to_file_offset` frame — the same one `has_enemy_id` and the rest
-//! of the codebase use.
+//! real swappable/unprotected enemy (don't clobber a critical object), and CHR
+//! compatibility. All offsets use the `enemy_ptr_to_file_offset` frame — the
+//! same one `has_enemy_id` and the rest of the codebase use.
 
 use std::collections::HashSet;
-
-use rand::seq::SliceRandom;
 
 use crate::randomize::node_catalog::{NodeCatalog, NodeKind};
 use crate::randomize::rom_data::{enemy_ptr_to_file_offset, has_enemy_id};
@@ -62,6 +63,24 @@ pub fn enemy_entry_points(rom: &Rom) -> Vec<u16> {
         }
     }
     pts
+}
+
+/// Where a level's first enemy sits in the `data` buffer, mapped to the level's
+/// `obj_ptr`. The walker consults this by entry index to learn "this byte is
+/// some level's first enemy, and here is the level it belongs to" — which it
+/// cannot work out itself, because one `$FF` segment routinely spans several
+/// levels' enemy pointers.
+pub(super) type InjectionSites = std::collections::HashMap<usize, u16>;
+
+/// Build the injectable-level map from the node catalog: real action levels
+/// only (`NodeKind::Level`), de-duped by enemy-data location so a shared enemy
+/// set is a single candidate. Consumes no RNG and reads no CHR state — it is
+/// pure level geography, which is why it can run before the walk.
+pub(super) fn collect_injection_sites(rom: &Rom, data: &[u8], opts: &Options) -> InjectionSites {
+    collect_candidates(rom, data, opts)
+        .into_iter()
+        .map(|c| (c.first_idx, c.obj_ptr))
+        .collect()
 }
 
 /// One candidate level for injection: its enemy-data location as an index into
@@ -114,9 +133,8 @@ fn collect_candidates(rom: &Rom, data: &[u8], opts: &Options) -> Vec<Candidate> 
 }
 
 /// True when `id` is in the pool the player asked for. `Sun` / `Lakitu` narrow
-/// the pool to one enemy; a level that can't take that one injects nothing
-/// rather than falling back to the other, so a narrowed pool is also a sparser
-/// one (see [`WildInjectionMode`]).
+/// the pool to one enemy; a level whose CHR cannot fit that one injects nothing
+/// rather than falling back to the other (see [`WildInjectionMode`]).
 fn in_pool(mode: WildInjectionMode, id: u8) -> bool {
     match mode {
         WildInjectionMode::Off => false,
@@ -155,78 +173,74 @@ fn pick_injection<R: Rng>(
         .copied()
 }
 
-/// Wild-injection pass. Shuffles the candidate levels for per-seed variety,
-/// then rolls each independently at [`WILD_INJECTION_CHANCE`].
-pub(super) fn inject_wild_chasers<R: Rng>(
+/// Inject chasers into any of this segment's entries that a level points at as
+/// its first enemy. Called from the walker's segment prologue, before the pin
+/// scan and before any pick, so a chaser that lands here constrains every pick
+/// that follows it.
+///
+/// Rolls each site independently at [`WILD_INJECTION_CHANCE`] in data order.
+/// Returns the `data_index` of every entry it wrote, which the walker treats as
+/// fixed for the rest of the segment (see [`is_fixed`]).
+///
+/// `entries` is updated in step with `data` so the caller's later reads — the
+/// Bertha tally, the pin scan, the picks — see the injected enemy.
+pub(super) fn inject_segment_chasers<R: Rng>(
     data: &mut [u8],
     rom: &Rom,
-    bounds: &[segment_writer::SegmentBounds],
+    entries: &mut [SegmentEntry],
+    sites: &InjectionSites,
+    modes: &ClassModes,
     opts: &Options,
     rng: &mut R,
-) {
-    let normal_modes = ClassModes::from_options(opts);
-    let mut candidates = collect_candidates(rom, data, opts);
-    candidates.shuffle(rng);
-
-    for Candidate { obj_ptr, first_idx } in candidates {
+) -> Vec<usize> {
+    let mut injected: Vec<usize> = Vec::new();
+    for k in 0..entries.len() {
+        let first_idx = entries[k].data_index;
+        let Some(&obj_ptr) = sites.get(&first_idx) else {
+            continue; // not a level's first enemy
+        };
         let roll: u8 = rng.random_range(..=255);
         if roll >= WILD_INJECTION_CHANCE {
             continue;
         }
 
-        // The entry we'd replace must be a real, swappable, unprotected enemy:
-        // don't clobber a critical object (find_class_pool guards that it is a
-        // shuffleable enemy) and don't get reverted by the walker's protection
-        // handlers (SkipSwap / forced-pool / ExcludeHazards).
-        let first_id = data[first_idx];
-        let fo = ENEMY_DATA_START + first_idx;
-        if entry_protection_at(fo).is_some() {
+        // The entry we'd replace must be a real, swappable, unprotected enemy —
+        // don't clobber a critical object. `find_class_pool` is the test for
+        // "the shuffle would have been allowed to touch this anyway".
+        if entry_protection_at(ENEMY_DATA_START + first_idx).is_some() {
             continue;
         }
-        if find_class_pool(first_id, &normal_modes).is_none() {
+        if find_class_pool(entries[k].obj_id, modes).is_none() {
             continue;
         }
 
-        // Enclosing $FF segment for CHR pinning (chasers are level-wide, so the
-        // whole segment's pins constrain the pick).
-        let Some(seg) = bounds.iter().find(|b| {
-            let s = b.file_offset + 1;
-            let end = s + b.entry_count * 3;
-            (s..end).contains(&first_idx)
-        }) else {
-            continue;
-        };
-        let mut s4 = ChrSlot::Free;
-        let mut s5 = ChrSlot::Free;
-        for k in 0..seg.entry_count {
-            let off = seg.file_offset + 1 + k * 3;
-            if off == first_idx {
-                continue; // slot being replaced — its enemy goes away
-            }
-            let fo2 = ENEMY_DATA_START + off;
-            if is_pinned(data[off], fo2, &normal_modes) {
-                commit_chr_page(data[off], &mut s4, &mut s5);
-            }
-        }
-
-        let Some(chosen) = pick_injection(rom, obj_ptr, s4, s5, opts.wild_injections, rng) else {
+        // Pages the segment has already committed. Chasers are level-wide, so
+        // the whole segment constrains the pick — and the entry being replaced
+        // is skipped, since its enemy is on its way out.
+        let pins = segment_pins(entries, modes, &injected, Some(first_idx));
+        let Some(chosen) =
+            pick_injection(rom, obj_ptr, pins.all.0, pins.all.1, opts.wild_injections, rng)
+        else {
             continue;
         };
 
         swap_enemy(data, first_idx, chosen);
+        entries[k].obj_id = chosen;
         // The Angry Sun idles in the background unless it spawns on the first
         // screen (with Early Sun on). Injection would otherwise leave it at the
         // replaced enemy's usually-deep position, so re-seed it to the vanilla
-        // 2-Quicksand spawn (screen 0, Y=0x11). The sun becomes the lowest-X
-        // entry, keeping the run X-sorted for the writeback.
+        // 2-Quicksand spawn (screen 0, Y=0x11).
         if chosen == ANGRY_SUN_ID {
             data[first_idx + 1] = SUN_SPAWN_X;
             data[first_idx + 2] = SUN_SPAWN_Y;
+            entries[k].x_pos = SUN_SPAWN_X;
         } else if chosen == LAKITU_ID && rng.random_range(..2u8) == 0 {
             // Lakitu works at any height, but the inherited Y is usually a low
             // ground-enemy spot (harder). Coin-flip half of them up to the
             // common vanilla Lakitu height; the other half keep the low Y.
             data[first_idx + 2] = LAKITU_ALT_Y;
         }
+        injected.push(first_idx);
     }
+    injected
 }

--- a/src/randomize/enemies/injection.rs
+++ b/src/randomize/enemies/injection.rs
@@ -132,39 +132,44 @@ fn collect_candidates(rom: &Rom, data: &[u8], opts: &Options) -> Vec<Candidate> 
     out
 }
 
-/// True when `id` is in the pool the player asked for. `Sun` / `Lakitu` narrow
-/// the pool to one enemy; a level whose CHR cannot fit that one injects nothing
-/// rather than falling back to the other (see [`WildInjectionMode`]).
-fn in_pool(mode: WildInjectionMode, id: u8) -> bool {
-    match mode {
-        WildInjectionMode::Off => false,
-        WildInjectionMode::Sun => id == ANGRY_SUN_ID,
-        WildInjectionMode::Lakitu => id == LAKITU_ID,
-        WildInjectionMode::Both => true,
+/// Which chaser an obj_id is, for matching against the player's allowed set.
+fn chaser_of(id: u8) -> Option<WildChaser> {
+    match id {
+        ANGRY_SUN_ID => Some(WildChaser::Sun),
+        LAKITU_ID => Some(WildChaser::Lakitu),
+        BOSS_BASS_ID => Some(WildChaser::Bass),
+        _ => None,
     }
 }
 
-/// Pick a CHR-compatible chaser this level doesn't already have. Returns `None`
-/// if nothing fits.
+/// Pick a CHR-compatible chaser this level doesn't already have, from the set
+/// the player allowed. Returns `None` if nothing fits — a level that can't take
+/// an allowed chaser gets none, rather than one the player didn't ask for.
 fn pick_injection<R: Rng>(
     rom: &Rom,
     obj_ptr: u16,
     slot4: ChrSlot,
     slot5: ChrSlot,
-    mode: WildInjectionMode,
+    allowed: &[WildChaser],
+    bertha_full: bool,
     rng: &mut R,
 ) -> Option<u8> {
     let eligible: Vec<u8> = WILD_INJECTION_IDS
         .iter()
         .copied()
         .filter(|&id| {
-            // In the player's chosen pool, CHR-compatible with the segment's
-            // pinned pages, and not a chaser the level already has (no
-            // doubling — e.g. 2-Quicksand's sun).
-            in_pool(mode, id) && is_chr_compatible(id, slot4, slot5) && !has_enemy_id(rom, obj_ptr, id)
+            // Allowed by the player, CHR-compatible with the segment's pinned
+            // pages, not a chaser the level already has (no doubling — e.g.
+            // 2-Quicksand's sun), and within the segment's Bertha budget: a
+            // Boss Bass is sprite-heavy enough that stacking them starves other
+            // objects of slots (see MAX_BERTHA_PER_SEGMENT).
+            chaser_of(id).is_some_and(|c| allowed.contains(&c))
+                && !(bertha_full && BERTHA_IDS.contains(&id))
+                && is_chr_compatible(id, slot4, slot5)
+                && !has_enemy_id(rom, obj_ptr, id)
         })
         .collect();
-    // Favor the sun over the (harder) Lakitu when both fit.
+    // Favor the sun over the harder two when more than one fits.
     eligible
         .choose_weighted(rng, |&id| {
             if id == ANGRY_SUN_ID { SUN_INJECTION_WEIGHT } else { 1 }
@@ -218,9 +223,23 @@ pub(super) fn inject_segment_chasers<R: Rng>(
         // the whole segment constrains the pick — and the entry being replaced
         // is skipped, since its enemy is on its way out.
         let pins = segment_pins(entries, modes, &injected, Some(first_idx));
-        let Some(chosen) =
-            pick_injection(rom, obj_ptr, pins.all.0, pins.all.1, opts.wild_injections, rng)
-        else {
+        // Same exclusion for the Bertha tally: the enemy leaving doesn't count,
+        // whatever it was. The walker's own cap can only see swaps, so an
+        // injected Bass has to check the budget here.
+        let bertha_full = entries
+            .iter()
+            .filter(|e| e.data_index != first_idx && BERTHA_IDS.contains(&e.obj_id))
+            .count() as u8
+            >= MAX_BERTHA_PER_SEGMENT;
+        let Some(chosen) = pick_injection(
+            rom,
+            obj_ptr,
+            pins.all.0,
+            pins.all.1,
+            &opts.wild_injections,
+            bertha_full,
+            rng,
+        ) else {
             continue;
         };
 
@@ -240,6 +259,10 @@ pub(super) fn inject_segment_chasers<R: Rng>(
             // common vanilla Lakitu height; the other half keep the low Y.
             data[first_idx + 2] = LAKITU_ALT_Y;
         }
+        // Boss Bass keeps the replaced enemy's position: it homes in on the
+        // player from wherever it starts, so unlike the sun there is no spawn
+        // that makes it work and no height that makes it fair. Whether it wants
+        // a rule of its own is a playtest question.
         injected.push(first_idx);
     }
     injected

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -94,17 +94,16 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
     let hb_modes = hb_class_modes(opts.hb_encounters);
     let hb_wild_pool = hb_modes.build_wild_pool();
 
-    // Wild injection runs in its own pass driven by *level entry points*
-    // (header-pointed enemy_ptr values), not by walker-segments. This
-    // guarantees every injection lands on a byte the SMB3 level loader
-    // actually reads. See inject_at_entry_points doc for details. Segment
-    // bounds are passed so the injection's CHR pin-scan can cover the whole
-    // $FF-bounded segment, not just the ep's own run (runs nest, and outer
-    // levels see the injected enemy too).
-    if opts.wild_injections.is_on() && !big_q_only {
-        let bounds = segment_writer::walk_segments(&data, 0, data.len(), &skip_ranges);
-        inject_wild_chasers(&mut data, rom, &bounds, opts, rng);
-    }
+    // Wild injection happens inside the segment loop below, not as a pass
+    // around it — the walker is what knows a segment's real CHR pin set, and a
+    // pass on either side of it can only re-derive that. All it needs up front
+    // is where each level's first enemy lives (header-pointed enemy_ptr values,
+    // via node_catalog), which no shuffle can move.
+    let injection_sites = if opts.wild_injections.is_on() && !big_q_only {
+        collect_injection_sites(rom, &data, opts)
+    } else {
+        InjectionSites::new()
+    };
 
     let mut i = 0;
     while i < data.len() {
@@ -158,10 +157,23 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
             continue;
         }
 
+        // Wild injection. Runs here — after the entries are parsed, before
+        // anything is committed or picked — so an injected chaser is just an
+        // enemy the segment contains as far as everything below is concerned:
+        // the Bertha tally counts it, the pin scan commits its page, and the
+        // picks route around it. HB segments are excluded; their enemies are
+        // the overworld mini-battle, not a level's.
+        let injected = if injection_sites.is_empty() || is_hb_segment {
+            Vec::new()
+        } else {
+            inject_segment_chasers(
+                &mut data, rom, &mut entries, &injection_sites, modes, opts, rng,
+            )
+        };
+
         // Track Boss Bass count for this segment so the per-segment cap is
-        // enforced during class swaps. If a wild injection (run earlier in
-        // its own pass) added a Bertha to this segment, that's already
-        // reflected here because we re-read obj_ids from `data`.
+        // enforced during class swaps. An injected Bertha is already reflected
+        // here — `entries` was updated in step with `data` above.
         let mut bertha_count: u8 = entries.iter()
             .filter(|e| BERTHA_IDS.contains(&e.obj_id))
             .count() as u8;
@@ -183,21 +195,13 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         //    (pinned now, or picked as we go); it seeds every group's local
         //    slots so ordinary picks stay compatible with a chaser that will
         //    follow the player to them.
-        let mut seg_all4 = ChrSlot::Free;
-        let mut seg_all5 = ChrSlot::Free;
-        let mut seg_chaser4 = ChrSlot::Free;
-        let mut seg_chaser5 = ChrSlot::Free;
-        if !big_q_only {
-            for entry in &entries {
-                let fo = ENEMY_DATA_START + entry.data_index;
-                if is_pinned(entry.obj_id, fo, modes) {
-                    commit_chr_page(entry.obj_id, &mut seg_all4, &mut seg_all5);
-                    if CHASER_IDS.contains(&entry.obj_id) {
-                        commit_chr_page(entry.obj_id, &mut seg_chaser4, &mut seg_chaser5);
-                    }
-                }
-            }
-        }
+        let seg = if big_q_only {
+            SegmentPins::none()
+        } else {
+            segment_pins(&entries, modes, &injected, None)
+        };
+        let (mut seg_all4, mut seg_all5) = seg.all;
+        let (mut seg_chaser4, mut seg_chaser5) = seg.chaser;
 
         for group in &groups {
             // Two-pass approach per CHR group:
@@ -210,8 +214,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
             if !big_q_only {
                 for &idx in group {
                     let entry = &entries[idx];
-                    let fo = ENEMY_DATA_START + entry.data_index;
-                    if is_pinned(entry.obj_id, fo, modes) {
+                    if is_fixed(entry, modes, &injected) {
                         commit_chr_page(entry.obj_id, &mut committed_slot4, &mut committed_slot5);
                     }
                 }
@@ -241,6 +244,14 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                 // SkipSwap keeps its enemy; its CHR page was already pinned
                 // in Pass 1 (is_pinned covers SkipSwap protections).
                 if protection == Some(EntryProtection::SkipSwap) {
+                    continue;
+                }
+                // A wild injection settled this entry. Not covered by the
+                // SkipSwap check above, and not covered by is_pinned either:
+                // `should_precommit` is false for anything in a Wild pool, so
+                // without this an injected Boss Bass would be swapped straight
+                // back out whenever water is Wild.
+                if injected.contains(&entry.data_index) {
                     continue;
                 }
 

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -20,7 +20,7 @@ use crate::randomize::rom_data::{
     TANK_BRO_POOL,
 };
 use crate::randomize::segment_writer::{self, SegmentEntry as WriterEntry, SortMode};
-use crate::randomizer::{EnemyMode, Options, WildInjectionMode};
+use crate::randomizer::{EnemyMode, Options, WildChaser};
 use crate::rom::Rom;
 
 mod class_modes;
@@ -63,7 +63,7 @@ pub fn randomize_big_q_blocks<R: Rng>(rom: &mut Rom, rng: &mut R) {
         piranhas: EnemyMode::Off, ghosts: EnemyMode::Off,
         thwomps: EnemyMode::Off, rotodiscs: EnemyMode::Off,
         cannons: EnemyMode::Off, water: EnemyMode::Off, bros: EnemyMode::Off,
-        hb_encounters: EnemyMode::Off, wild_injections: WildInjectionMode::Off,
+        hb_encounters: EnemyMode::Off, wild_injections: Vec::new(),
         ..Options::default()
     };
     randomize_object_data(rom, rng, true, &no_flags);
@@ -99,7 +99,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
     // pass on either side of it can only re-derive that. All it needs up front
     // is where each level's first enemy lives (header-pointed enemy_ptr values,
     // via node_catalog), which no shuffle can move.
-    let injection_sites = if opts.wild_injections.is_on() && !big_q_only {
+    let injection_sites = if !opts.wild_injections.is_empty() && !big_q_only {
         collect_injection_sites(rom, &data, opts)
     } else {
         InjectionSites::new()

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -20,7 +20,7 @@ use crate::randomize::rom_data::{
     TANK_BRO_POOL,
 };
 use crate::randomize::segment_writer::{self, SegmentEntry as WriterEntry, SortMode};
-use crate::randomizer::{EnemyMode, Options};
+use crate::randomizer::{EnemyMode, Options, WildInjectionMode};
 use crate::rom::Rom;
 
 mod class_modes;
@@ -63,7 +63,7 @@ pub fn randomize_big_q_blocks<R: Rng>(rom: &mut Rom, rng: &mut R) {
         piranhas: EnemyMode::Off, ghosts: EnemyMode::Off,
         thwomps: EnemyMode::Off, rotodiscs: EnemyMode::Off,
         cannons: EnemyMode::Off, water: EnemyMode::Off, bros: EnemyMode::Off,
-        hb_encounters: EnemyMode::Off, wild_injections: false,
+        hb_encounters: EnemyMode::Off, wild_injections: WildInjectionMode::Off,
         ..Options::default()
     };
     randomize_object_data(rom, rng, true, &no_flags);
@@ -101,7 +101,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
     // bounds are passed so the injection's CHR pin-scan can cover the whole
     // $FF-bounded segment, not just the ep's own run (runs nest, and outer
     // levels see the injected enemy too).
-    if opts.wild_injections && !big_q_only {
+    if opts.wild_injections.is_on() && !big_q_only {
         let bounds = segment_writer::walk_segments(&data, 0, data.len(), &skip_ranges);
         inject_wild_chasers(&mut data, rom, &bounds, opts, rng);
     }

--- a/src/randomize/enemies/segments.rs
+++ b/src/randomize/enemies/segments.rs
@@ -12,6 +12,66 @@ pub(super) struct SegmentEntry {
     pub(super) x_pos: u8,
 }
 
+/// CHR pages a segment has already spoken for before any pick is made.
+/// `all` is every fixed entry; `chaser` is the subset that follows the player
+/// across proximity groups (see `CHASER_IDS`).
+#[derive(Clone, Copy)]
+pub(super) struct SegmentPins {
+    pub(super) all: (ChrSlot, ChrSlot),
+    pub(super) chaser: (ChrSlot, ChrSlot),
+}
+
+impl SegmentPins {
+    /// Nothing committed — the Big-?-block pass, which skips the CHR model.
+    pub(super) fn none() -> Self {
+        SegmentPins {
+            all: (ChrSlot::Free, ChrSlot::Free),
+            chaser: (ChrSlot::Free, ChrSlot::Free),
+        }
+    }
+}
+
+/// Whether an entry's obj_id is settled before the picks run: pinned by class
+/// or protection, or a chaser wild injection just wrote here.
+///
+/// The injected case is not redundant with `is_pinned`: `should_precommit`
+/// returns false for anything in a Wild pool, so an injected Boss Bass with
+/// water Wild would otherwise be swapped straight back out — the exact
+/// reshuffle that kept Bertha out of the injection pool to begin with.
+pub(super) fn is_fixed(entry: &SegmentEntry, modes: &ClassModes, injected: &[usize]) -> bool {
+    injected.contains(&entry.data_index)
+        || is_pinned(entry.obj_id, ENEMY_DATA_START + entry.data_index, modes)
+}
+
+/// Accumulate the segment's fixed CHR pages. `skip` drops one entry from the
+/// tally — the wild-injection decision uses it to ignore the enemy it is about
+/// to replace, whose page is on its way out.
+///
+/// Single definition on purpose: the injection decision and the walker's own
+/// seeding must agree about what "already pinned" means, and a second copy of
+/// this loop is what let the old pre-walk injection pass drift.
+pub(super) fn segment_pins(
+    entries: &[SegmentEntry],
+    modes: &ClassModes,
+    injected: &[usize],
+    skip: Option<usize>,
+) -> SegmentPins {
+    let mut pins = SegmentPins {
+        all: (ChrSlot::Free, ChrSlot::Free),
+        chaser: (ChrSlot::Free, ChrSlot::Free),
+    };
+    for entry in entries {
+        if Some(entry.data_index) == skip || !is_fixed(entry, modes, injected) {
+            continue;
+        }
+        commit_chr_page(entry.obj_id, &mut pins.all.0, &mut pins.all.1);
+        if CHASER_IDS.contains(&entry.obj_id) {
+            commit_chr_page(entry.obj_id, &mut pins.chaser.0, &mut pins.chaser.1);
+        }
+    }
+    pins
+}
+
 /// Split entries into proximity groups based on X-position gaps.
 /// Entries within `CHR_GROUP_GAP` tiles of their neighbors stay in the same group.
 /// Returns groups of entry indices (sorted by X within each group).

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -338,12 +338,18 @@ pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
 /// Injection candidates for wild_injections mode: level-wide chasers seeded into
 /// a level's first enemy. CHR compatibility checked via `sprite_bank()` at filter
-/// time. Both are in NO class pool, so the walker leaves an injected one alone.
-/// (Boss Bass 0x2D is deliberately excluded: it's a `WATER_ENEMIES` member, so
-/// the walker would reshuffle an injected one into an ordinary water enemy.)
+/// time.
+///
+/// Boss Bass was excluded until injection moved inside the walker. It is a
+/// `WATER_ENEMIES` member, so with water Wild the walker used to reshuffle an
+/// injected one into an ordinary water enemy — a silent no-op. Deciding the
+/// injection inside the segment prologue and marking the entry settled closes
+/// that hole (Lakitu and the sun never needed it: they belong to no class pool,
+/// so nothing could pick them out).
 pub(super) const WILD_INJECTION_IDS: &[u8] = &[
     LAKITU_ID,    // Lakitu (enemy-spawning variant, CHR $0B/+4)
     ANGRY_SUN_ID, // Angry Sun
+    BOSS_BASS_ID, // Big Bertha, the leaping eater
 ];
 
 /// Angry Sun object id.
@@ -351,6 +357,10 @@ pub(super) const ANGRY_SUN_ID: u8 = 0xAF;
 
 /// Lakitu (enemy-spawning variant) object id.
 pub(super) const LAKITU_ID: u8 = 0x83;
+
+/// Big Bertha, the leaping eater — the "Boss Bass". Also `BERTHA_IDS[0]`, so an
+/// injected one counts against `MAX_BERTHA_PER_SEGMENT` like any other.
+pub(super) const BOSS_BASS_ID: u8 = 0x2D;
 
 /// Weight of the Angry Sun relative to Lakitu (weight 1) when both are eligible
 /// for an injection. Lakitu is much harder to deal with, so the sun is favored:

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1032,7 +1032,7 @@
             piranhas: EnemyMode::Wild, ghosts: EnemyMode::Wild, water: EnemyMode::Wild,
             cannons: EnemyMode::Wild, hb_encounters: EnemyMode::Wild,
             rotodiscs: EnemyMode::Shuffle,
-            wild_injections: true, early_sun: true,
+            wild_injections: WildInjectionMode::Both, early_sun: true,
             ..Options::default()
         }
     }
@@ -1044,7 +1044,7 @@
             piranhas: EnemyMode::Wild, ghosts: EnemyMode::Wild, thwomps: EnemyMode::Wild,
             rotodiscs: EnemyMode::Wild, cannons: EnemyMode::Wild, water: EnemyMode::Wild,
             bros: EnemyMode::Wild, hb_encounters: EnemyMode::Wild,
-            wild_injections: true, early_sun: true,
+            wild_injections: WildInjectionMode::Both, early_sun: true,
             ..Options::default()
         }
     }
@@ -1302,7 +1302,7 @@
         let mut stats = PlacementStats::default();
         let mut violations = Vec::new();
         let modes = ClassModes::from_options(opts);
-        let injectable = if opts.wild_injections {
+        let injectable = if opts.wild_injections.is_on() {
             injectable_offsets(base, vanilla, &modes)
         } else {
             std::collections::HashSet::new()
@@ -1487,7 +1487,6 @@
     #[test]
     fn wild_injection_rework_guarantees() {
         use crate::randomize::node_catalog::{NodeCatalog, NodeKind};
-        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
         const INJ: [u8; 2] = [0x83, 0xAF]; // Lakitu + Angry Sun (Boss Bass dropped)
 
         let Some(base) = load_reference_rom() else {
@@ -1498,28 +1497,9 @@
         let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
         let catalog = NodeCatalog::build(&base, false);
 
-        // First-enemy data index for a level's obj_ptr (after any page byte).
-        let first_idx = |obj_ptr: u16, data: &[u8]| -> Option<usize> {
-            if obj_ptr < 0xC000 {
-                return None;
-            }
-            let fo = enemy_ptr_to_file_offset(obj_ptr);
-            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&fo) {
-                return None;
-            }
-            let p = fo - ENEMY_DATA_START;
-            if p >= data.len() {
-                return None;
-            }
-            let first = if matches!(data[p], 0x00 | 0x01) { p + 1 } else { p };
-            if first >= data.len() || data[first] == 0xFF {
-                return None;
-            }
-            Some(first)
-        };
         // Count occurrences of `id` across a level's first $FF run.
         let run_count = |obj_ptr: u16, data: &[u8], id: u8| -> usize {
-            let Some(mut i) = first_idx(obj_ptr, data) else {
+            let Some(mut i) = first_enemy_idx(obj_ptr, data) else {
                 return 0;
             };
             let mut n = 0;
@@ -1532,7 +1512,7 @@
             n
         };
 
-        let opts = Options { wild_injections: true, ..preset_recommended() };
+        let opts = Options { wild_injections: WildInjectionMode::Both, ..preset_recommended() };
         let mut saw_injection = false;
         for seed in 0..30u64 {
             let mut rom = base.clone();
@@ -1543,9 +1523,9 @@
             for e in &catalog.entries {
                 let Some(le) = &e.level_entry else { continue };
                 let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
-                let Some(fi) = first_idx(obj_ptr, &patched) else { continue };
+                let Some(fi) = first_enemy_idx(obj_ptr, &patched) else { continue };
                 let pid = patched[fi];
-                let van_first = first_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
+                let van_first = first_enemy_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
 
                 // Boss levels are excluded by type — a chaser at their first
                 // enemy can only be a vanilla-native one, never injected.
@@ -1598,13 +1578,104 @@
         assert!(saw_injection, "30 seeds and never saw a chaser injected into a level");
     }
 
+    /// Buffer index of a level's first enemy byte, or `None` when `obj_ptr`
+    /// isn't a real enemy set (out of range, or an empty level). Mirrors the
+    /// frame `inject_wild_chasers` uses — shared by the injection tests, which
+    /// all compare a patched first enemy against vanilla's.
+    fn first_enemy_idx(obj_ptr: u16, data: &[u8]) -> Option<usize> {
+        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
+        if obj_ptr < 0xC000 {
+            return None;
+        }
+        let fo = enemy_ptr_to_file_offset(obj_ptr);
+        if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&fo) {
+            return None;
+        }
+        let p = fo - ENEMY_DATA_START;
+        if p >= data.len() {
+            return None;
+        }
+        let first = if matches!(data[p], 0x00 | 0x01) { p + 1 } else { p };
+        if first >= data.len() || data[first] == 0xFF {
+            return None;
+        }
+        Some(first)
+    }
+
+    /// Count the chasers injected into level main areas over `seeds` seeds,
+    /// as (Angry Sun, Lakitu). A first enemy that already matched vanilla is
+    /// skipped — neither chaser is in any class pool, so anything that changed
+    /// into one came from the injection pass.
+    fn injected_chaser_counts(base: &Rom, opts: &Options, seeds: u64) -> (u32, u32) {
+        use crate::randomize::node_catalog::NodeCatalog;
+
+        let len = ENEMY_DATA_END - ENEMY_DATA_START;
+        let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
+        let catalog = NodeCatalog::build(base, false);
+        let (mut suns, mut lakitus) = (0u32, 0u32);
+        for seed in 0..seeds {
+            let mut rom = base.clone();
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom, &mut rng, opts);
+            let patched = rom.read_range(ENEMY_DATA_START, len).to_vec();
+            for e in &catalog.entries {
+                let Some(le) = &e.level_entry else { continue };
+                let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
+                let Some(fi) = first_enemy_idx(obj_ptr, &patched) else { continue };
+                let pid = patched[fi];
+                if first_enemy_idx(obj_ptr, &vanilla).map(|v| vanilla[v]) == Some(pid) {
+                    continue; // unchanged — vanilla-native, not injected
+                }
+                match pid {
+                    ANGRY_SUN_ID => suns += 1,
+                    LAKITU_ID => lakitus += 1,
+                    _ => {}
+                }
+            }
+        }
+        (suns, lakitus)
+    }
+
+    /// A one-chaser pool injects that chaser and only that one. The narrowed
+    /// modes also inject into *fewer* levels than `Both` (a level whose CHR
+    /// can't fit the pick is skipped, not handed the other chaser), so this
+    /// asserts pool contents, not counts.
+    #[test]
+    fn wild_injection_pool_honors_mode() {
+        let Some(base) = load_reference_rom() else {
+            eprintln!("reference ROM not present — skipping wild_injection_pool_honors_mode");
+            return;
+        };
+
+        let sun_only = Options {
+            wild_injections: WildInjectionMode::Sun,
+            ..preset_recommended()
+        };
+        let (suns, lakitus) = injected_chaser_counts(&base, &sun_only, 20);
+        assert_eq!(lakitus, 0, "sun-only mode injected {lakitus} Lakitu");
+        assert!(suns > 0, "sun-only mode injected no suns at all across 20 seeds");
+
+        let lakitu_only = Options {
+            wild_injections: WildInjectionMode::Lakitu,
+            ..preset_recommended()
+        };
+        let (suns, lakitus) = injected_chaser_counts(&base, &lakitu_only, 20);
+        assert_eq!(suns, 0, "lakitu-only mode injected {suns} Angry Sun");
+        assert!(lakitus > 0, "lakitu-only mode injected no Lakitu at all across 20 seeds");
+
+        let off = Options {
+            wild_injections: WildInjectionMode::Off,
+            ..preset_recommended()
+        };
+        assert_eq!(injected_chaser_counts(&base, &off, 5), (0, 0), "off mode injected a chaser");
+    }
+
     /// An injected Lakitu's height coin-flips between the replaced enemy's Y and
     /// LAKITU_ALT_Y (0x12): across many seeds we must see both outcomes, so it's
     /// not always stuck at the (harder) low inherited height.
     #[test]
     fn wild_injected_lakitu_height_varies() {
         use crate::randomize::node_catalog::NodeCatalog;
-        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
         const LAKITU: u8 = 0x83;
 
         let Some(base) = load_reference_rom() else {
@@ -1615,26 +1686,7 @@
         let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
         let catalog = NodeCatalog::build(&base, false);
 
-        let first_idx = |obj_ptr: u16, data: &[u8]| -> Option<usize> {
-            if obj_ptr < 0xC000 {
-                return None;
-            }
-            let fo = enemy_ptr_to_file_offset(obj_ptr);
-            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&fo) {
-                return None;
-            }
-            let p = fo - ENEMY_DATA_START;
-            if p >= data.len() {
-                return None;
-            }
-            let first = if matches!(data[p], 0x00 | 0x01) { p + 1 } else { p };
-            if first >= data.len() || data[first] == 0xFF {
-                return None;
-            }
-            Some(first)
-        };
-
-        let opts = Options { wild_injections: true, ..preset_recommended() };
+        let opts = Options { wild_injections: WildInjectionMode::Both, ..preset_recommended() };
         let mut saw_alt = false; // lifted to LAKITU_ALT_Y (0x12)
         let mut saw_kept = false; // kept a non-0x12 inherited height
         'seeds: for seed in 0..60u64 {
@@ -1645,11 +1697,11 @@
             for e in &catalog.entries {
                 let Some(le) = &e.level_entry else { continue };
                 let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
-                let Some(fi) = first_idx(obj_ptr, &patched) else { continue };
+                let Some(fi) = first_enemy_idx(obj_ptr, &patched) else { continue };
                 if patched[fi] != LAKITU {
                     continue;
                 }
-                let van_first = first_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
+                let van_first = first_enemy_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
                 if van_first == Some(LAKITU) {
                     continue; // vanilla-native Lakitu, not injected
                 }
@@ -1673,7 +1725,6 @@
     #[test]
     fn wild_injection_favors_sun() {
         use crate::randomize::node_catalog::NodeCatalog;
-        use crate::randomize::rom_data::enemy_ptr_to_file_offset;
 
         let Some(base) = load_reference_rom() else {
             eprintln!("reference ROM not present — skipping wild_injection_favors_sun");
@@ -1683,26 +1734,7 @@
         let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
         let catalog = NodeCatalog::build(&base, false);
 
-        let first_idx = |obj_ptr: u16, data: &[u8]| -> Option<usize> {
-            if obj_ptr < 0xC000 {
-                return None;
-            }
-            let fo = enemy_ptr_to_file_offset(obj_ptr);
-            if !(ENEMY_DATA_START..ENEMY_DATA_END).contains(&fo) {
-                return None;
-            }
-            let p = fo - ENEMY_DATA_START;
-            if p >= data.len() {
-                return None;
-            }
-            let first = if matches!(data[p], 0x00 | 0x01) { p + 1 } else { p };
-            if first >= data.len() || data[first] == 0xFF {
-                return None;
-            }
-            Some(first)
-        };
-
-        let opts = Options { wild_injections: true, ..preset_recommended() };
+        let opts = Options { wild_injections: WildInjectionMode::Both, ..preset_recommended() };
         let (mut suns, mut lakitus) = (0u32, 0u32);
         for seed in 0..40u64 {
             let mut rom = base.clone();
@@ -1712,9 +1744,9 @@
             for e in &catalog.entries {
                 let Some(le) = &e.level_entry else { continue };
                 let obj_ptr = ((le.obj_hi as u16) << 8) | le.obj_lo as u16;
-                let Some(fi) = first_idx(obj_ptr, &patched) else { continue };
+                let Some(fi) = first_enemy_idx(obj_ptr, &patched) else { continue };
                 let pid = patched[fi];
-                let van_first = first_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
+                let van_first = first_enemy_idx(obj_ptr, &vanilla).map(|v| vanilla[v]);
                 if van_first == Some(pid) {
                     continue; // unchanged — vanilla-native, not injected
                 }

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1032,7 +1032,7 @@
             piranhas: EnemyMode::Wild, ghosts: EnemyMode::Wild, water: EnemyMode::Wild,
             cannons: EnemyMode::Wild, hb_encounters: EnemyMode::Wild,
             rotodiscs: EnemyMode::Shuffle,
-            wild_injections: WildInjectionMode::Both, early_sun: true,
+            wild_injections: vec![WildChaser::Sun, WildChaser::Lakitu], early_sun: true,
             ..Options::default()
         }
     }
@@ -1044,7 +1044,7 @@
             piranhas: EnemyMode::Wild, ghosts: EnemyMode::Wild, thwomps: EnemyMode::Wild,
             rotodiscs: EnemyMode::Wild, cannons: EnemyMode::Wild, water: EnemyMode::Wild,
             bros: EnemyMode::Wild, hb_encounters: EnemyMode::Wild,
-            wild_injections: WildInjectionMode::Both, early_sun: true,
+            wild_injections: vec![WildChaser::Sun, WildChaser::Lakitu], early_sun: true,
             ..Options::default()
         }
     }
@@ -1302,7 +1302,7 @@
         let mut stats = PlacementStats::default();
         let mut violations = Vec::new();
         let modes = ClassModes::from_options(opts);
-        let injectable = if opts.wild_injections.is_on() {
+        let injectable = if !opts.wild_injections.is_empty() {
             injectable_offsets(base, vanilla, &modes)
         } else {
             std::collections::HashSet::new()
@@ -1512,7 +1512,7 @@
             n
         };
 
-        let opts = Options { wild_injections: WildInjectionMode::Both, ..preset_recommended() };
+        let opts = Options { wild_injections: vec![WildChaser::Sun, WildChaser::Lakitu], ..preset_recommended() };
         let mut saw_injection = false;
         for seed in 0..30u64 {
             let mut rom = base.clone();
@@ -1602,17 +1602,22 @@
         Some(first)
     }
 
-    /// Count the chasers injected into level main areas over `seeds` seeds,
-    /// as (Angry Sun, Lakitu). A first enemy that already matched vanilla is
-    /// skipped — neither chaser is in any class pool, so anything that changed
-    /// into one came from the injection pass.
-    fn injected_chaser_counts(base: &Rom, opts: &Options, seeds: u64) -> (u32, u32) {
+    /// Count the chasers sitting on level main-area first enemies over `seeds`
+    /// seeds, indexed by `WildChaser::ALL` order (sun, lakitu, bass). Entries
+    /// that still match vanilla are skipped.
+    ///
+    /// Sun and Lakitu counts are exact: neither is in any class pool, so a
+    /// changed entry holding one can only have come from injection. **Bass is
+    /// not** — it is a `WATER_ENEMIES` member, so with water Shuffle/Wild the
+    /// ordinary swap can put one here too. Compare two runs that differ only in
+    /// the injection pool to isolate it.
+    fn injected_chaser_counts(base: &Rom, opts: &Options, seeds: u64) -> [u32; 3] {
         use crate::randomize::node_catalog::NodeCatalog;
 
         let len = ENEMY_DATA_END - ENEMY_DATA_START;
         let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
         let catalog = NodeCatalog::build(base, false);
-        let (mut suns, mut lakitus) = (0u32, 0u32);
+        let mut counts = [0u32; 3];
         for seed in 0..seeds {
             let mut rom = base.clone();
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -1627,13 +1632,14 @@
                     continue; // unchanged — vanilla-native, not injected
                 }
                 match pid {
-                    ANGRY_SUN_ID => suns += 1,
-                    LAKITU_ID => lakitus += 1,
+                    ANGRY_SUN_ID => counts[0] += 1,
+                    LAKITU_ID => counts[1] += 1,
+                    BOSS_BASS_ID => counts[2] += 1,
                     _ => {}
                 }
             }
         }
-        (suns, lakitus)
+        counts
     }
 
     /// Prints how many chasers each mode actually injects, so a change to the
@@ -1650,54 +1656,100 @@
             return;
         };
         const SEEDS: u64 = 20;
-        for mode in [
-            WildInjectionMode::Both,
-            WildInjectionMode::Sun,
-            WildInjectionMode::Lakitu,
-        ] {
-            let opts = Options { wild_injections: mode, ..preset_recommended() };
-            let (suns, lakitus) = injected_chaser_counts(&base, &opts, SEEDS);
-            let total = suns + lakitus;
+        let sets: [Vec<WildChaser>; 5] = [
+            WildChaser::ALL.to_vec(),
+            vec![WildChaser::Sun, WildChaser::Lakitu],
+            vec![WildChaser::Sun],
+            vec![WildChaser::Lakitu],
+            vec![WildChaser::Bass],
+        ];
+        for set in sets {
+            let opts = Options { wild_injections: set.clone(), ..preset_recommended() };
+            let c = injected_chaser_counts(&base, &opts, SEEDS);
+            let names: Vec<&str> = set.iter().map(|c| c.name()).collect();
+            let total: u32 = c.iter().sum();
             println!(
-                "{mode:?}: {total} injections over {SEEDS} seeds ({:.1}/seed) — \
-                 {suns} sun, {lakitus} lakitu",
+                "{:<18} {total:>4} over {SEEDS} seeds ({:.1}/seed) — {} sun, {} lakitu, {} bass",
+                names.join("+"),
                 total as f64 / SEEDS as f64,
+                c[0], c[1], c[2],
             );
         }
+        println!("(bass counts include ordinary water swaps — see injected_chaser_counts)");
     }
 
-    /// A one-chaser pool injects that chaser and only that one. The narrowed
-    /// modes also inject into *fewer* levels than `Both` (a level whose CHR
-    /// can't fit the pick is skipped, not handed the other chaser), so this
-    /// asserts pool contents, not counts.
+    /// A one-chaser set injects that chaser and only that one — a level that
+    /// can't take it is skipped, never handed a chaser the player excluded.
+    /// Asserts set membership, not counts (see `print_injection_counts` for the
+    /// rates, which barely move between sets).
     #[test]
-    fn wild_injection_pool_honors_mode() {
+    fn wild_injection_pool_honors_set() {
         let Some(base) = load_reference_rom() else {
-            eprintln!("reference ROM not present — skipping wild_injection_pool_honors_mode");
+            eprintln!("reference ROM not present — skipping wild_injection_pool_honors_set");
             return;
         };
 
         let sun_only = Options {
-            wild_injections: WildInjectionMode::Sun,
+            wild_injections: vec![WildChaser::Sun],
             ..preset_recommended()
         };
-        let (suns, lakitus) = injected_chaser_counts(&base, &sun_only, 20);
-        assert_eq!(lakitus, 0, "sun-only mode injected {lakitus} Lakitu");
-        assert!(suns > 0, "sun-only mode injected no suns at all across 20 seeds");
+        let c = injected_chaser_counts(&base, &sun_only, 20);
+        assert_eq!(c[1], 0, "sun-only injected {} Lakitu", c[1]);
+        assert!(c[0] > 0, "sun-only injected no suns at all across 20 seeds");
 
         let lakitu_only = Options {
-            wild_injections: WildInjectionMode::Lakitu,
+            wild_injections: vec![WildChaser::Lakitu],
             ..preset_recommended()
         };
-        let (suns, lakitus) = injected_chaser_counts(&base, &lakitu_only, 20);
-        assert_eq!(suns, 0, "lakitu-only mode injected {suns} Angry Sun");
-        assert!(lakitus > 0, "lakitu-only mode injected no Lakitu at all across 20 seeds");
+        let c = injected_chaser_counts(&base, &lakitu_only, 20);
+        assert_eq!(c[0], 0, "lakitu-only injected {} Angry Sun", c[0]);
+        assert!(c[1] > 0, "lakitu-only injected no Lakitu at all across 20 seeds");
 
-        let off = Options {
-            wild_injections: WildInjectionMode::Off,
+        // Bass is omitted from the "off" check on purpose: with water Wild the
+        // ordinary shuffle can also land a Bertha on a first enemy, so its
+        // count is not evidence either way (see injected_chaser_counts).
+        let off = Options { wild_injections: Vec::new(), ..preset_recommended() };
+        let c = injected_chaser_counts(&base, &off, 5);
+        assert_eq!((c[0], c[1]), (0, 0), "injections off, but a chaser was injected");
+    }
+
+    /// Boss Bass reaches the ROM with water Wild — the case that kept it out of
+    /// the pool until injection moved inside the walker, where the walker used
+    /// to reshuffle an injected Bertha straight back into an ordinary water
+    /// enemy.
+    ///
+    /// Bass is also an ordinary swap target, so its raw count is ambiguous. Two
+    /// runs differing *only* in whether Bass is in the injection set isolate it:
+    /// the surplus is injection.
+    #[test]
+    fn wild_injection_bass_survives_water_wild() {
+        let Some(base) = load_reference_rom() else {
+            eprintln!("reference ROM not present — skipping wild_injection_bass_survives_water_wild");
+            return;
+        };
+        assert_eq!(
+            preset_recommended().water,
+            EnemyMode::Wild,
+            "this test is specifically about the water-Wild reshuffle",
+        );
+
+        let without = Options {
+            wild_injections: vec![WildChaser::Sun, WildChaser::Lakitu],
             ..preset_recommended()
         };
-        assert_eq!(injected_chaser_counts(&base, &off, 5), (0, 0), "off mode injected a chaser");
+        let with_bass = Options {
+            wild_injections: WildChaser::ALL.to_vec(),
+            ..preset_recommended()
+        };
+        let background = injected_chaser_counts(&base, &without, 20)[2];
+        let injected = injected_chaser_counts(&base, &with_bass, 20)[2];
+        assert!(
+            injected > background + 15,
+            "Boss Bass in the pool added only {} first-enemy Berthas over 20 seeds \
+             ({injected} vs {background} background) — an injected Bass is probably \
+             being reshuffled away again",
+            injected.saturating_sub(background),
+        );
     }
 
     /// An injected Lakitu's height coin-flips between the replaced enemy's Y and
@@ -1716,7 +1768,7 @@
         let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
         let catalog = NodeCatalog::build(&base, false);
 
-        let opts = Options { wild_injections: WildInjectionMode::Both, ..preset_recommended() };
+        let opts = Options { wild_injections: vec![WildChaser::Sun, WildChaser::Lakitu], ..preset_recommended() };
         let mut saw_alt = false; // lifted to LAKITU_ALT_Y (0x12)
         let mut saw_kept = false; // kept a non-0x12 inherited height
         'seeds: for seed in 0..60u64 {
@@ -1764,7 +1816,7 @@
         let vanilla = base.read_range(ENEMY_DATA_START, len).to_vec();
         let catalog = NodeCatalog::build(&base, false);
 
-        let opts = Options { wild_injections: WildInjectionMode::Both, ..preset_recommended() };
+        let opts = Options { wild_injections: vec![WildChaser::Sun, WildChaser::Lakitu], ..preset_recommended() };
         let (mut suns, mut lakitus) = (0u32, 0u32);
         for seed in 0..40u64 {
             let mut rom = base.clone();

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1636,6 +1636,36 @@
         (suns, lakitus)
     }
 
+    /// Prints how many chasers each mode actually injects, so a change to the
+    /// injection machinery can be compared against the run before it. Ignored
+    /// by default (needs the ROM, takes ~20s); same pattern as
+    /// `overworld_baseline::print_baseline`.
+    ///
+    /// `cargo test print_injection_counts -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn print_injection_counts() {
+        let Some(base) = load_reference_rom() else {
+            eprintln!("reference ROM not present — skipping print_injection_counts");
+            return;
+        };
+        const SEEDS: u64 = 20;
+        for mode in [
+            WildInjectionMode::Both,
+            WildInjectionMode::Sun,
+            WildInjectionMode::Lakitu,
+        ] {
+            let opts = Options { wild_injections: mode, ..preset_recommended() };
+            let (suns, lakitus) = injected_chaser_counts(&base, &opts, SEEDS);
+            let total = suns + lakitus;
+            println!(
+                "{mode:?}: {total} injections over {SEEDS} seeds ({:.1}/seed) — \
+                 {suns} sun, {lakitus} lakitu",
+                total as f64 / SEEDS as f64,
+            );
+        }
+    }
+
     /// A one-chaser pool injects that chaser and only that one. The narrowed
     /// modes also inject into *fewer* levels than `Both` (a level whose CHR
     /// can't fit the pick is skipped, not handed the other chaser), so this

--- a/src/randomize/rom_data/tiles.rs
+++ b/src/randomize/rom_data/tiles.rs
@@ -24,6 +24,9 @@
 //! treatment for a table mirror is a test asserting it still matches the bytes
 //! at its ROM offset, not consolidation into these predicates.
 
+// Only `is_fortress` reads this, and that predicate is native-only (see the
+// "Node tiles" section below).
+#[cfg(not(target_arch = "wasm32"))]
 use super::FORTRESS_TILES;
 
 // ---------------------------------------------------------------------------
@@ -129,19 +132,27 @@ pub(crate) fn path_for_gap_tile(tile: u8) -> Option<u8> {
 
 // ---------------------------------------------------------------------------
 // Node tiles
+//
+// Native-only: `testrom` (itself `cfg(not(wasm32))`) is the sole consumer, so
+// on the WASM build these are dead code and warn. Gated rather than
+// `allow(dead_code)`d so that a genuinely unused item still gets caught.
 // ---------------------------------------------------------------------------
 
 /// Lowest numbered-level tile. Level number = `tile - 2`.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const NUMBERED_TILE_LO: u8 = 0x03;
 /// Highest numbered-level tile.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const NUMBERED_TILE_HI: u8 = 0x0F;
 
 /// A numbered action level (`0x03..=0x0F`, level number = `tile - 2`).
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn is_numbered_level(tile: u8) -> bool {
     (NUMBERED_TILE_LO..=NUMBERED_TILE_HI).contains(&tile)
 }
 
 /// A fortress tile (any of the three variants).
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn is_fortress(tile: u8) -> bool {
     FORTRESS_TILES.contains(&tile)
 }

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -76,6 +76,12 @@ impl Options {
     pub fn to_flag_bytes(&self) -> [u8; 13] {
         let b0 = FLAG_KEY_VERSION;
 
+        // The wild-injection chaser set is one bit each, scattered across three
+        // bytes because no byte had three bits free: sun in b4 bit 0 (where the
+        // old bool lived), lakitu in b12 bit 7, bass in b2 bit 5 (the dead
+        // shuffle_pipes slot). Same trick as eights_are_wild in b11.
+        let has = |c: WildChaser| self.wild_injections.contains(&c) as u8;
+
         // b1: non-enemy flags. hammer_breaks_locks is tri-state: its value bit
         // stores On vs (Off/Maybe); the Maybe bit lives in b11.
         // b1 bit 1 = shuffle_hammer_bros (reuses the slot formerly airship_lock,
@@ -89,12 +95,13 @@ impl Options {
             | (self.shuffle_hammer_bros as u8) << 1
             | (self.chest_items as u8);
 
-        // b2 bit 5 is free (formerly shuffle_pipes, a dead flag removed in v26).
+        // b2 bit 5 = wild-injection Bass bit (was free since shuffle_pipes, a dead\n        // flag removed in v26). That was the last free bit outside b12 bit 7.
         // b2 bit 4 = faster_frog (reuses the slot formerly fix_drawbridges,
         // now always-on).
         // b2 bit 3 = boomboom_hits (reuses the slot formerly remove_rocks).
         let b2 = (self.remove_whistles as u8) << 7
             | (self.hands_levels as u8) << 6
+            | has(WildChaser::Bass) << 5
             | (self.faster_frog as u8) << 4
             | (self.boomboom_hits as u8) << 3
             | (self.troll_pipes.is_on() as u8) << 2
@@ -123,19 +130,6 @@ impl Options {
             }
         }
 
-        // Encode WildInjectionMode as 2 bits (off=0, sun=1, lakitu=2, both=3).
-        // The two bits are split: low in b4 bit 0 (where the old bool lived),
-        // high in b12 bit 7 (the last free bit in the key). Same split trick as
-        // eights_are_wild in b11.
-        fn wim(m: WildInjectionMode) -> u8 {
-            match m {
-                WildInjectionMode::Off => 0,
-                WildInjectionMode::Sun => 1,
-                WildInjectionMode::Lakitu => 2,
-                WildInjectionMode::Both => 3,
-            }
-        }
-
         // b4: card_speed_clear(7) remove_n_cards(6) skip_wand_cutscene(5)
         //     adjust_boss_hitboxes(4) shuffle_spade_games(3)
         //     hb_encounters(2-1) wild_injections low bit(0)
@@ -145,7 +139,7 @@ impl Options {
             | (self.adjust_boss_hitboxes as u8) << 4
             | (self.shuffle_spade_games as u8) << 3
             | em(self.hb_encounters) << 1
-            | (wim(self.wild_injections) & 1);
+            | has(WildChaser::Sun);
 
         // b5: ground(7-6) shell(5-4) flying(3-2) hammer_vulnerable_koopalings(1) early_sun(0)
         let b5 = em(self.ground) << 6
@@ -242,7 +236,7 @@ impl Options {
             | (self.anchor_visuals as u8) << 4
             | (self.poison_mushrooms as u8) << 5
             | (self.modern_powerups as u8) << 6
-            | (wim(self.wild_injections) >> 1) << 7;
+            | has(WildChaser::Lakitu) << 7;
 
         [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12]
     }
@@ -323,16 +317,17 @@ impl Options {
             }
         }
 
-        // Decode the 2-bit wild-injection mode (low bit b4 bit 0, high bit
-        // b12 bit 7).
-        fn dwim(bits: u8) -> WildInjectionMode {
-            match bits & 0x03 {
-                1 => WildInjectionMode::Sun,
-                2 => WildInjectionMode::Lakitu,
-                3 => WildInjectionMode::Both,
-                _ => WildInjectionMode::Off,
-            }
-        }
+        // Rebuild the wild-injection chaser set from its three scattered bits,
+        // always in WildChaser::ALL order so a round-trip normalizes.
+        let chasers: Vec<WildChaser> = [
+            (WildChaser::Sun, b4 & 1),
+            (WildChaser::Lakitu, (b12 >> 7) & 1),
+            (WildChaser::Bass, (b2 >> 5) & 1),
+        ]
+        .into_iter()
+        .filter(|&(_, bit)| bit != 0)
+        .map(|(c, _)| c)
+        .collect();
 
         Ok(Options {
             powerups: (b1 >> 7) & 1 != 0,
@@ -388,7 +383,7 @@ impl Options {
             water: dem(b7 >> 2),
             bros: dem(b7),
             hb_encounters: dem(b4 >> 1),
-            wild_injections: dwim((b4 & 1) | ((b12 >> 7) << 1)),
+            wild_injections: chasers,
             starting_items: {
                 // Decode per-slot random mode from b10 bits 5-0
                 fn mode_to_sentinel(mode: u8, nibble: u8) -> u8 {
@@ -427,6 +422,6 @@ impl Options {
             || self.ghosts != EnemyMode::Off || self.thwomps != EnemyMode::Off
             || self.rotodiscs != EnemyMode::Off || self.cannons != EnemyMode::Off
             || self.water != EnemyMode::Off || self.bros != EnemyMode::Off
-            || self.hb_encounters != EnemyMode::Off || self.wild_injections.is_on()
+            || self.hb_encounters != EnemyMode::Off || !self.wild_injections.is_empty()
     }
 }

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 
-pub(super) const FLAG_KEY_VERSION: u8 = 27;
+pub(super) const FLAG_KEY_VERSION: u8 = 28;
 
 pub(super) const FLAG_KEY_PREFIX: &str = "SMB3R-";
 
@@ -123,16 +123,29 @@ impl Options {
             }
         }
 
+        // Encode WildInjectionMode as 2 bits (off=0, sun=1, lakitu=2, both=3).
+        // The two bits are split: low in b4 bit 0 (where the old bool lived),
+        // high in b12 bit 7 (the last free bit in the key). Same split trick as
+        // eights_are_wild in b11.
+        fn wim(m: WildInjectionMode) -> u8 {
+            match m {
+                WildInjectionMode::Off => 0,
+                WildInjectionMode::Sun => 1,
+                WildInjectionMode::Lakitu => 2,
+                WildInjectionMode::Both => 3,
+            }
+        }
+
         // b4: card_speed_clear(7) remove_n_cards(6) skip_wand_cutscene(5)
         //     adjust_boss_hitboxes(4) shuffle_spade_games(3)
-        //     hb_encounters(2-1) wild_injections(0)
+        //     hb_encounters(2-1) wild_injections low bit(0)
         let b4 = (self.card_speed_clear as u8) << 7
             | (self.remove_n_cards as u8) << 6
             | (self.skip_wand_cutscene as u8) << 5
             | (self.adjust_boss_hitboxes as u8) << 4
             | (self.shuffle_spade_games as u8) << 3
             | em(self.hb_encounters) << 1
-            | (self.wild_injections as u8);
+            | (wim(self.wild_injections) & 1);
 
         // b5: ground(7-6) shell(5-4) flying(3-2) hammer_vulnerable_koopalings(1) early_sun(0)
         let b5 = em(self.ground) << 6
@@ -221,13 +234,15 @@ impl Options {
 
         // b12: piranha_shuffle(1-0), antechamber_shuffle ON bit (2) and
         // Maybe bit (3), anchor_visuals(4), poison_mushrooms(5),
-        // modern_powerups(6). Bit 7 free for future flags.
+        // modern_powerups(6), wild_injections high bit (7 — the key is now
+        // full; the next flag needs a 14th byte).
         let b12 = pm(self.piranha_shuffle)
             | (self.antechamber_shuffle.is_on() as u8) << 2
             | (self.antechamber_shuffle.is_maybe() as u8) << 3
             | (self.anchor_visuals as u8) << 4
             | (self.poison_mushrooms as u8) << 5
-            | (self.modern_powerups as u8) << 6;
+            | (self.modern_powerups as u8) << 6
+            | (wim(self.wild_injections) >> 1) << 7;
 
         [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12]
     }
@@ -308,6 +323,17 @@ impl Options {
             }
         }
 
+        // Decode the 2-bit wild-injection mode (low bit b4 bit 0, high bit
+        // b12 bit 7).
+        fn dwim(bits: u8) -> WildInjectionMode {
+            match bits & 0x03 {
+                1 => WildInjectionMode::Sun,
+                2 => WildInjectionMode::Lakitu,
+                3 => WildInjectionMode::Both,
+                _ => WildInjectionMode::Off,
+            }
+        }
+
         Ok(Options {
             powerups: (b1 >> 7) & 1 != 0,
             palettes: true,
@@ -362,7 +388,7 @@ impl Options {
             water: dem(b7 >> 2),
             bros: dem(b7),
             hb_encounters: dem(b4 >> 1),
-            wild_injections: b4 & 1 != 0,
+            wild_injections: dwim((b4 & 1) | ((b12 >> 7) << 1)),
             starting_items: {
                 // Decode per-slot random mode from b10 bits 5-0
                 fn mode_to_sentinel(mode: u8, nibble: u8) -> u8 {
@@ -401,6 +427,6 @@ impl Options {
             || self.ghosts != EnemyMode::Off || self.thwomps != EnemyMode::Off
             || self.rotodiscs != EnemyMode::Off || self.cannons != EnemyMode::Off
             || self.water != EnemyMode::Off || self.bros != EnemyMode::Off
-            || self.hb_encounters != EnemyMode::Off || self.wild_injections
+            || self.hb_encounters != EnemyMode::Off || self.wild_injections.is_on()
     }
 }

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -17,7 +17,7 @@ use options::*;
 // Public API re-exported by the crate root (see lib.rs).
 pub use options::{
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
-    ITEMS, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
+    WildInjectionMode, ITEMS, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
     STARTING_LIVES_VALUES,
 };
 

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -17,7 +17,7 @@ use options::*;
 // Public API re-exported by the crate root (see lib.rs).
 pub use options::{
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
-    WildInjectionMode, ITEMS, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
+    WildChaser, ITEMS, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
     STARTING_LIVES_VALUES,
 };
 

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -124,6 +124,29 @@ pub enum PiranhaMode {
     Wild,
 }
 
+/// Which level-wide chasers the wild-injection pass may seed into a level.
+/// `Both` is the mixed pool, weighted toward the Angry Sun (see
+/// `SUN_INJECTION_WEIGHT`); `Sun` / `Lakitu` narrow it to that one enemy.
+///
+/// A one-enemy pool injects into *fewer* levels than `Both`, it doesn't just
+/// re-skew the same set: a candidate whose segment CHR can't fit the chosen
+/// chaser (or that already has one) is skipped rather than falling back to
+/// the other. How much sparser each mode runs has not been measured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WildInjectionMode {
+    #[default]
+    Off,
+    Sun,
+    Lakitu,
+    Both,
+}
+
+impl WildInjectionMode {
+    /// True whenever the injection pass runs at all.
+    pub fn is_on(self) -> bool { !matches!(self, WildInjectionMode::Off) }
+}
+
 /// Tri-state toggle for player-hidden flags: forced `Off`, forced `On`, or
 /// left to the seed (`Maybe`). A `Maybe` flag is resolved to a concrete
 /// on/off at generation time from a dedicated RNG substream (see
@@ -416,9 +439,10 @@ pub struct Options {
     /// All enemies in Hammer Bro encounter segments
     #[serde(default = "default_off")]
     pub hb_encounters: EnemyMode,
-    /// Inject Lakitu/Angry Sun/Boss Bass into ~15% of segments (CHR-compatible)
+    /// Seed a level-wide chaser into a fraction of real levels (CHR-compatible).
+    /// Picks which chasers are in the pool — see [`WildInjectionMode`].
     #[serde(default)]
-    pub wild_injections: bool,
+    pub wild_injections: WildInjectionMode,
     /// Skip the SMB3 (USA) iNES header / page-count / size checks so that
     /// modded or translated ROMs can be loaded. When true, the title-screen
     /// seed hash is also skipped because its hooks rely on vanilla offsets.
@@ -491,7 +515,7 @@ impl Default for Options {
             water: EnemyMode::Shuffle,
             bros: EnemyMode::Shuffle,
             hb_encounters: EnemyMode::Off,
-            wild_injections: false,
+            wild_injections: WildInjectionMode::Off,
             starting_lives: default_starting_lives(),
             starting_items: Vec::new(),
             skip_rom_validation: false,

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -128,10 +128,13 @@ pub enum PiranhaMode {
 /// `Both` is the mixed pool, weighted toward the Angry Sun (see
 /// `SUN_INJECTION_WEIGHT`); `Sun` / `Lakitu` narrow it to that one enemy.
 ///
-/// A one-enemy pool injects into *fewer* levels than `Both`, it doesn't just
-/// re-skew the same set: a candidate whose segment CHR can't fit the chosen
-/// chaser (or that already has one) is skipped rather than falling back to
-/// the other. How much sparser each mode runs has not been measured.
+/// A candidate whose segment CHR can't fit the chosen chaser (or that already
+/// has one) is skipped rather than falling back to the other, so a one-enemy
+/// pool is in principle sparser than `Both`. Measured, it isn't: all three
+/// modes land 8-9 injections per seed over 20 seeds, and the gap between modes
+/// is the same size as the gap between two runs of the *same* mode, since each
+/// mode draws a different RNG stream. Run the `print_injection_counts`
+/// diagnostic before believing otherwise.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WildInjectionMode {

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -124,30 +124,45 @@ pub enum PiranhaMode {
     Wild,
 }
 
-/// Which level-wide chasers the wild-injection pass may seed into a level.
-/// `Both` is the mixed pool, weighted toward the Angry Sun (see
-/// `SUN_INJECTION_WEIGHT`); `Sun` / `Lakitu` narrow it to that one enemy.
+/// A level-wide chaser the wild-injection pass can seed into a level. The
+/// option is the *set* of these the player allowed — an empty set is off.
 ///
-/// A candidate whose segment CHR can't fit the chosen chaser (or that already
-/// has one) is skipped rather than falling back to the other, so a one-enemy
-/// pool is in principle sparser than `Both`. Measured, it isn't: all three
-/// modes land 8-9 injections per seed over 20 seeds, and the gap between modes
-/// is the same size as the gap between two runs of the *same* mode, since each
-/// mode draws a different RNG stream. Run the `print_injection_counts`
-/// diagnostic before believing otherwise.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+/// When more than one is allowed the pick is weighted toward the Angry Sun
+/// (see `SUN_INJECTION_WEIGHT`), the gentlest of the three.
+///
+/// Narrowing the set ought to inject into fewer levels — a candidate whose
+/// segment CHR can't fit the allowed chaser (or that already has one) is
+/// skipped rather than handed a different one. Measured, it doesn't: every
+/// combination lands 8-9 injections per seed over 20 seeds, and the gap
+/// between combinations is the same size as the gap between two runs of the
+/// *same* one, since each draws a different RNG stream. Run the
+/// `print_injection_counts` diagnostic before believing otherwise.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "snake_case")]
-pub enum WildInjectionMode {
-    #[default]
-    Off,
+pub enum WildChaser {
+    /// Angry Sun.
     Sun,
+    /// Lakitu, the enemy-spawning variant.
     Lakitu,
-    Both,
+    /// Big Bertha, the leaping eater — the "Boss Bass".
+    Bass,
 }
 
-impl WildInjectionMode {
-    /// True whenever the injection pass runs at all.
-    pub fn is_on(self) -> bool { !matches!(self, WildInjectionMode::Off) }
+impl WildChaser {
+    /// Every chaser, in the canonical order the flag key, the CLI and the web
+    /// pill all use. Decoding produces this order, so a round-trip normalizes.
+    pub const ALL: [WildChaser; 3] = [WildChaser::Sun, WildChaser::Lakitu, WildChaser::Bass];
+
+    /// The lowercase name used by the CLI, the web pill, and serde.
+    pub fn name(self) -> &'static str {
+        match self {
+            WildChaser::Sun => "sun",
+            WildChaser::Lakitu => "lakitu",
+            WildChaser::Bass => "bass",
+        }
+    }
 }
 
 /// Tri-state toggle for player-hidden flags: forced `Off`, forced `On`, or
@@ -442,10 +457,10 @@ pub struct Options {
     /// All enemies in Hammer Bro encounter segments
     #[serde(default = "default_off")]
     pub hb_encounters: EnemyMode,
-    /// Seed a level-wide chaser into a fraction of real levels (CHR-compatible).
-    /// Picks which chasers are in the pool — see [`WildInjectionMode`].
+    /// Which level-wide chasers may be seeded into a fraction of real levels
+    /// (CHR-compatible). Empty = off. See [`WildChaser`].
     #[serde(default)]
-    pub wild_injections: WildInjectionMode,
+    pub wild_injections: Vec<WildChaser>,
     /// Skip the SMB3 (USA) iNES header / page-count / size checks so that
     /// modded or translated ROMs can be loaded. When true, the title-screen
     /// seed hash is also skipped because its hooks rely on vanilla offsets.
@@ -518,7 +533,7 @@ impl Default for Options {
             water: EnemyMode::Shuffle,
             bros: EnemyMode::Shuffle,
             hb_encounters: EnemyMode::Off,
-            wild_injections: WildInjectionMode::Off,
+            wild_injections: Vec::new(),
             starting_lives: default_starting_lives(),
             starting_items: Vec::new(),
             skip_rom_validation: false,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -172,21 +172,23 @@ fn write_log_populated_after_randomize() {
     }
 }
 
-/// The web layer posts `wild_injections` as one of these strings (the pill
-/// values in `web/options.js`). Deserialization is the only contract between
+/// The web layer posts `wild_injections` as an array of these strings (the lit
+/// pills in `web/options.js`). Deserialization is the only contract between
 /// them, so pin the spelling here — a rename on either side breaks generation
 /// at runtime with no compile error.
 #[test]
-fn wild_injection_mode_parses_web_values() {
+fn wild_chasers_parse_web_values() {
     for (json, want) in [
-        ("off", WildInjectionMode::Off),
-        ("sun", WildInjectionMode::Sun),
-        ("lakitu", WildInjectionMode::Lakitu),
-        ("both", WildInjectionMode::Both),
+        ("[]", vec![]),
+        (r#"["sun"]"#, vec![WildChaser::Sun]),
+        (r#"["lakitu"]"#, vec![WildChaser::Lakitu]),
+        (r#"["bass"]"#, vec![WildChaser::Bass]),
+        (r#"["sun","bass"]"#, vec![WildChaser::Sun, WildChaser::Bass]),
+        (r#"["sun","lakitu","bass"]"#, WildChaser::ALL.to_vec()),
     ] {
         let opts: Options =
-            serde_json::from_str(&format!(r#"{{"wild_injections":"{json}"}}"#)).unwrap();
-        assert_eq!(opts.wild_injections, want, "web value {json:?} did not parse");
+            serde_json::from_str(&format!(r#"{{"wild_injections":{json}}}"#)).unwrap();
+        assert_eq!(opts.wild_injections, want, "web value {json} did not parse");
     }
 }
 
@@ -265,7 +267,7 @@ fn flag_key_round_trip_all_wild() {
         water: EnemyMode::Wild,
         bros: EnemyMode::Wild,
         hb_encounters: EnemyMode::Wild,
-        wild_injections: WildInjectionMode::Both,
+        wild_injections: WildChaser::ALL.to_vec(),
         starting_items: vec![0x05, 0x09, 0x03],
         ..all_off_options()
     };
@@ -305,7 +307,7 @@ fn flag_key_round_trip_all_off() {
     assert_eq!(decoded.ground, EnemyMode::Off);
     assert_eq!(decoded.thwomps, EnemyMode::Off);
     assert_eq!(decoded.hb_encounters, EnemyMode::Off);
-    assert_eq!(decoded.wild_injections, WildInjectionMode::Off);
+    assert!(decoded.wild_injections.is_empty());
     assert_eq!(decoded.starting_lives, 1);
 }
 
@@ -510,32 +512,34 @@ fn flag_key_per_option_round_trip() {
         }
     }
 
-    // Wild injections (Off/Sun/Lakitu/Both): the two bits are split across
-    // b4 bit 0 and b12 bit 7, so every state must round-trip and each of the
-    // three on-states must produce a distinct key.
+    // Wild injections: one bit per chaser, scattered across b4 bit 0, b12 bit 7
+    // and b2 bit 5 (no byte had three free). Every one of the 8 subsets must
+    // round-trip, and all 8 must produce distinct keys — a bit landing on top
+    // of a neighbour would otherwise show up as two subsets sharing a key.
     {
         let default_key = Options::default().to_flag_key();
         let mut keys = Vec::new();
-        for &mode in &[
-            WildInjectionMode::Off,
-            WildInjectionMode::Sun,
-            WildInjectionMode::Lakitu,
-            WildInjectionMode::Both,
-        ] {
-            let mutated = Options { wild_injections: mode, ..Default::default() };
+        for bits in 0u8..8 {
+            let set: Vec<WildChaser> = WildChaser::ALL
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| bits & (1 << i) != 0)
+                .map(|(_, &c)| c)
+                .collect();
+            let mutated = Options { wild_injections: set.clone(), ..Default::default() };
             let mutated_key = mutated.to_flag_key();
             let expected = normalized(mutated.clone());
             let recovered = Options::from_flag_key(&mutated_key).unwrap();
-            assert_eq!(recovered, expected, "wild_injections={mode:?}: round-trip mismatch");
-            if mode != WildInjectionMode::Off {
-                assert_ne!(default_key, mutated_key, "wild_injections={mode:?}: key must change");
+            assert_eq!(recovered, expected, "wild_injections={set:?}: round-trip mismatch");
+            if !set.is_empty() {
+                assert_ne!(default_key, mutated_key, "wild_injections={set:?}: key must change");
             }
             keys.push(mutated_key);
         }
         keys.sort();
         let distinct = keys.len();
         keys.dedup();
-        assert_eq!(keys.len(), distinct, "wild_injections: two modes share a key");
+        assert_eq!(keys.len(), distinct, "wild_injections: two chaser sets share a key");
     }
 
     // starting_lives is 2 bits indexing {1, 5, 20, 99} — only the four
@@ -598,7 +602,7 @@ fn flag_key_per_option_round_trip() {
     everything.troll_pipes = Tri::Maybe;
     everything.shuffle_spade_games = !everything.shuffle_spade_games;
     everything.shuffle_toad_houses = !everything.shuffle_toad_houses;
-    everything.wild_injections = WildInjectionMode::Both;
+    everything.wild_injections = WildChaser::ALL.to_vec();
     everything.ground = EnemyMode::Wild;
     everything.shell = EnemyMode::Wild;
     everything.flying = EnemyMode::Wild;
@@ -780,7 +784,7 @@ fn all_off_options() -> Options {
         water: EnemyMode::Off,
         bros: EnemyMode::Off,
         hb_encounters: EnemyMode::Off,
-        wild_injections: WildInjectionMode::Off,
+        wild_injections: Vec::new(),
         starting_items: vec![],
         skip_rom_validation: false,
         anchor_visuals: false,
@@ -847,7 +851,7 @@ fn all_on_options() -> Options {
         water: EnemyMode::Wild,
         bros: EnemyMode::Wild,
         hb_encounters: EnemyMode::Wild,
-        wild_injections: WildInjectionMode::Both,
+        wild_injections: WildChaser::ALL.to_vec(),
         starting_items: vec![0x05, 0x09, 0x03],
         skip_rom_validation: false,
         anchor_visuals: true,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -172,6 +172,24 @@ fn write_log_populated_after_randomize() {
     }
 }
 
+/// The web layer posts `wild_injections` as one of these strings (the pill
+/// values in `web/options.js`). Deserialization is the only contract between
+/// them, so pin the spelling here — a rename on either side breaks generation
+/// at runtime with no compile error.
+#[test]
+fn wild_injection_mode_parses_web_values() {
+    for (json, want) in [
+        ("off", WildInjectionMode::Off),
+        ("sun", WildInjectionMode::Sun),
+        ("lakitu", WildInjectionMode::Lakitu),
+        ("both", WildInjectionMode::Both),
+    ] {
+        let opts: Options =
+            serde_json::from_str(&format!(r#"{{"wild_injections":"{json}"}}"#)).unwrap();
+        assert_eq!(opts.wild_injections, want, "web value {json:?} did not parse");
+    }
+}
+
 #[test]
 fn default_matches_serde_empty_object() {
     // Guard against drift between the manual Default impl and the
@@ -247,7 +265,7 @@ fn flag_key_round_trip_all_wild() {
         water: EnemyMode::Wild,
         bros: EnemyMode::Wild,
         hb_encounters: EnemyMode::Wild,
-        wild_injections: true,
+        wild_injections: WildInjectionMode::Both,
         starting_items: vec![0x05, 0x09, 0x03],
         ..all_off_options()
     };
@@ -287,7 +305,7 @@ fn flag_key_round_trip_all_off() {
     assert_eq!(decoded.ground, EnemyMode::Off);
     assert_eq!(decoded.thwomps, EnemyMode::Off);
     assert_eq!(decoded.hb_encounters, EnemyMode::Off);
-    assert!(!decoded.wild_injections);
+    assert_eq!(decoded.wild_injections, WildInjectionMode::Off);
     assert_eq!(decoded.starting_lives, 1);
 }
 
@@ -412,7 +430,6 @@ fn flag_key_per_option_round_trip() {
         ("include_beta_stages",          Box::new(|o| o.include_beta_stages = !o.include_beta_stages)),
         ("shuffle_spade_games",           Box::new(|o| o.shuffle_spade_games = !o.shuffle_spade_games)),
         ("shuffle_toad_houses",          Box::new(|o| o.shuffle_toad_houses = !o.shuffle_toad_houses)),
-        ("wild_injections",              Box::new(|o| o.wild_injections = !o.wild_injections)),
         ("anchor_visuals",               Box::new(|o| o.anchor_visuals = !o.anchor_visuals)),
     ];
     for (label, mutate) in bools {
@@ -493,6 +510,34 @@ fn flag_key_per_option_round_trip() {
         }
     }
 
+    // Wild injections (Off/Sun/Lakitu/Both): the two bits are split across
+    // b4 bit 0 and b12 bit 7, so every state must round-trip and each of the
+    // three on-states must produce a distinct key.
+    {
+        let default_key = Options::default().to_flag_key();
+        let mut keys = Vec::new();
+        for &mode in &[
+            WildInjectionMode::Off,
+            WildInjectionMode::Sun,
+            WildInjectionMode::Lakitu,
+            WildInjectionMode::Both,
+        ] {
+            let mutated = Options { wild_injections: mode, ..Default::default() };
+            let mutated_key = mutated.to_flag_key();
+            let expected = normalized(mutated.clone());
+            let recovered = Options::from_flag_key(&mutated_key).unwrap();
+            assert_eq!(recovered, expected, "wild_injections={mode:?}: round-trip mismatch");
+            if mode != WildInjectionMode::Off {
+                assert_ne!(default_key, mutated_key, "wild_injections={mode:?}: key must change");
+            }
+            keys.push(mutated_key);
+        }
+        keys.sort();
+        let distinct = keys.len();
+        keys.dedup();
+        assert_eq!(keys.len(), distinct, "wild_injections: two modes share a key");
+    }
+
     // starting_lives is 2 bits indexing {1, 5, 20, 99} — only the four
     // canonical values round-trip exactly.
     for lives in STARTING_LIVES_VALUES {
@@ -553,7 +598,7 @@ fn flag_key_per_option_round_trip() {
     everything.troll_pipes = Tri::Maybe;
     everything.shuffle_spade_games = !everything.shuffle_spade_games;
     everything.shuffle_toad_houses = !everything.shuffle_toad_houses;
-    everything.wild_injections = true;
+    everything.wild_injections = WildInjectionMode::Both;
     everything.ground = EnemyMode::Wild;
     everything.shell = EnemyMode::Wild;
     everything.flying = EnemyMode::Wild;
@@ -735,7 +780,7 @@ fn all_off_options() -> Options {
         water: EnemyMode::Off,
         bros: EnemyMode::Off,
         hb_encounters: EnemyMode::Off,
-        wild_injections: false,
+        wild_injections: WildInjectionMode::Off,
         starting_items: vec![],
         skip_rom_validation: false,
         anchor_visuals: false,
@@ -802,7 +847,7 @@ fn all_on_options() -> Options {
         water: EnemyMode::Wild,
         bros: EnemyMode::Wild,
         hb_encounters: EnemyMode::Wild,
-        wild_injections: true,
+        wild_injections: WildInjectionMode::Both,
         starting_items: vec![0x05, 0x09, 0x03],
         skip_rom_validation: false,
         anchor_visuals: true,

--- a/tests/chr_stats.rs
+++ b/tests/chr_stats.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, HashSet};
 use smb3_rs::randomize::autoscroll::SPOILED_SEGMENT_RANGES;
 use smb3_rs::randomize::enemies::{enemy_entry_points, sprite_bank, wild_pool_for};
 use smb3_rs::randomize::rom_data::{ENEMY_DATA_END, ENEMY_DATA_START};
-use smb3_rs::randomizer::{self, EnemyMode, Options};
+use smb3_rs::randomizer::{self, EnemyMode, Options, WildInjectionMode};
 use smb3_rs::rom::Rom;
 
 /// Wild_injection-only obj_ids. Neither is a member of any class swap pool,
@@ -128,7 +128,7 @@ fn max_enemy_opts() -> Options {
         water: EnemyMode::Wild,
         bros: EnemyMode::Wild,
         hb_encounters: EnemyMode::Wild,
-        wild_injections: true,
+        wild_injections: WildInjectionMode::Both,
         ..Options::default()
     }
 }

--- a/tests/chr_stats.rs
+++ b/tests/chr_stats.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, HashSet};
 use smb3_rs::randomize::autoscroll::SPOILED_SEGMENT_RANGES;
 use smb3_rs::randomize::enemies::{enemy_entry_points, sprite_bank, wild_pool_for};
 use smb3_rs::randomize::rom_data::{ENEMY_DATA_END, ENEMY_DATA_START};
-use smb3_rs::randomizer::{self, EnemyMode, Options, WildInjectionMode};
+use smb3_rs::randomizer::{self, EnemyMode, Options, WildChaser};
 use smb3_rs::rom::Rom;
 
 /// Wild_injection-only obj_ids. Neither is a member of any class swap pool,
@@ -128,7 +128,7 @@ fn max_enemy_opts() -> Options {
         water: EnemyMode::Wild,
         bros: EnemyMode::Wild,
         hb_encounters: EnemyMode::Wild,
-        wild_injections: WildInjectionMode::Both,
+        wild_injections: WildChaser::ALL.to_vec(),
         ..Options::default()
     }
 }

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -70,12 +70,19 @@ fn sweep_is_deterministic() {
 /// into every ROM (`stomp_fairness::apply`). These hashes cover the whole
 /// output, so all 20 seeds moved. Overworld topology is untouched by that
 /// change — the ROM bytes differ, the maps do not.
+///
+/// Re-captured again 2026-08-05 for the Wild Injections sun/lakitu pool
+/// (`FLAG_KEY_VERSION` 27 → 28). The version byte is stamped into every ROM,
+/// so all 20 seeds moved for that reason alone: pinning the constant back to
+/// 27 reproduced the previous hashes exactly, which is the check that this
+/// regeneration hides no real change. Default options leave the injection
+/// mode Off, so no gameplay byte differs.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x155EB975967C4ACB, 0x2DF4A1430D34B093, 0x322575642AA955A6, 0xDEC206CE9041867D,
-    0x15161E783EA3EE9C, 0xF17D4FA051D5EFF4, 0x166EFDF30A772D68, 0x25AD61FEE292102B,
-    0x84F587DBEB2C4E87, 0x75E73651FABAF77B, 0x6EE09335C4E431EA, 0x3CFE80C049E1A927,
-    0xC94F13DA4DD0B4F6, 0xB2734D41553967FD, 0x9A69302D9136071F, 0xEDC915F4FF8C9761,
-    0x6D86BC8A599AFF69, 0x9DD7B9A808BD3134, 0x04EE05C950E8DACB, 0xDBD8F12889EAA542,
+    0xE80654E3D012604F, 0x56BC4E0B2651799F, 0x3DA9EB46E38D6B30, 0xDA3EE41D061EDA7B,
+    0xF5D11330921CE33E, 0xAAB1BDBF548B48CE, 0xE0BD2457DB734B68, 0x069292D8922CB143,
+    0x41ADD63B96205A6D, 0x0970C782159DAE35, 0x07203DE4BD1FD154, 0x6E2B6C6D38620047,
+    0x18C631FC4138325E, 0x52F7FC872DBED52D, 0x229493E5CDAC9103, 0x1551C153BAF84493,
+    0x857B1E9A03988D07, 0xFD9E64C758FBB39C, 0xFA1393CD8EB2D7A5, 0xC61841B9C6000A34,
 ];
 
 #[test]

--- a/web/options.js
+++ b/web/options.js
@@ -58,13 +58,14 @@ const ON_OFF_MAYBE = [
 	{ value: "maybe", label: "Maybe" },
 ];
 
-// Wild Injections is a `toggles` pill: "Off" is exclusive, Sun and Lakitu
-// toggle independently, and lighting both encodes as the entry's `combined`
-// value ("both"). Values match the Rust `WildInjectionMode` enum.
+// Wild Injections is a `toggles` pill: "Off" is exclusive and the chasers
+// toggle independently, so the value is the list of lit ones (empty = off).
+// Values match the Rust `WildChaser` enum.
 const WILD_INJECTION_TOGGLES = [
 	{ value: "off", label: "Off" },
 	{ value: "sun", label: "Sun" },
 	{ value: "lakitu", label: "Lakitu" },
+	{ value: "bass", label: "Bass" },
 ];
 
 // Off / On / Wild pill for Random Fire Flower. "Wild" widens the pool to also
@@ -245,9 +246,9 @@ export const SCHEMA = [
 		tip: "All enemies in overworld Hammer Bro mini-battles",
 		group: "enemies", inFlagKey: true },
 	{ id: "wild_injections", type: "toggles", options: WILD_INJECTION_TOGGLES,
-		combined: "both", default: "off",
+		default: [],
 		label: "Wild Injections",
-		tip: "Drop an Angry Sun or a Lakitu into some levels that never had one. Pick either, or both.",
+		tip: "Drop a chaser into some levels that never had one — an Angry Sun, a Lakitu, or a leaping Big Bertha. Pick any combination.",
 		group: "enemies", inFlagKey: true },
 	{ id: "early_sun", type: "bool", default: false,
 		label: "Early Sun",
@@ -424,7 +425,7 @@ export const PRESETS = [
 			ground: "wild", shell: "wild", flying: "wild", piranhas: "wild",
 			ghosts: "wild", water: "wild", cannons: "wild", hb_encounters: "wild",
 			rotodiscs: "shuffle",
-			wild_injections: "both", early_sun: true,
+			wild_injections: ["sun", "lakitu"], early_sun: true,
 			include_beta_stages: true, swap_start_airship: true,
 			big_q_blocks: true, starting_items: [15],
 			fast_mushroom_house: true, faster_frog: true, faster_tail_speed: true,
@@ -466,7 +467,7 @@ export const PRESETS = [
 		overrides: {
 			ground: "wild", shell: "wild", flying: "wild",
 			hb_encounters: "shuffle", rotodiscs: "shuffle",
-			wild_injections: "both", early_sun: true,
+			wild_injections: ["sun", "lakitu"], early_sun: true,
 			include_beta_stages: true,
 			shuffle_spade_games: false, shuffle_toad_houses: false,
 			hands_levels: false, troll_pipes: "off",
@@ -481,7 +482,7 @@ export const PRESETS = [
 			ground: "wild", shell: "wild", flying: "wild", piranhas: "wild",
 			ghosts: "wild", thwomps: "wild", rotodiscs: "wild", cannons: "wild",
 			water: "wild", bros: "wild", hb_encounters: "wild",
-			wild_injections: "both", early_sun: true,
+			wild_injections: ["sun", "lakitu"], early_sun: true,
 			include_beta_stages: true, swap_start_airship: true,
 			big_q_blocks: true, starting_items: [15, 15, 15],
 			faster_tail_speed: true, faster_frog: true,
@@ -497,7 +498,7 @@ export const PRESETS = [
 			ground: "wild", shell: "wild", flying: "wild", piranhas: "wild",
 			ghosts: "wild", thwomps: "wild", rotodiscs: "wild", cannons: "wild",
 			water: "wild", bros: "wild", hb_encounters: "wild",
-			wild_injections: "both", early_sun: true,
+			wild_injections: ["sun", "lakitu"], early_sun: true,
 			include_beta_stages: true, swap_start_airship: true,
 			big_q_blocks: true, poison_mushrooms: true,
 			world_order: true, random_koopalings: true,
@@ -685,9 +686,8 @@ function renderTri(entry) {
 }
 
 // A pill group where the non-"off" pills toggle independently: check Sun,
-// check Lakitu, check both. The value stays a single string so the flag key
-// and the Rust enum see one field — "off", a lone option's value, or the
-// entry's `combined` value when more than one pill is lit.
+// check Bass, check both. The value is the array of lit pill values, in
+// schema order; empty means off, which is what the exclusive "Off" pill sets.
 function togglePills(entry) {
 	return entry.options.filter(o => o.value !== "off");
 }
@@ -720,8 +720,8 @@ function renderToggles(entry) {
 	for (const opt of entry.options) {
 		const inputId = `${domId(entry.id)}-${opt.value}`;
 		const lit = opt.value === "off"
-			? entry.default === "off"
-			: entry.default === opt.value || entry.default === entry.combined;
+			? entry.default.length === 0
+			: entry.default.includes(opt.value);
 		const input = el("input", {
 			type: "checkbox", name: radioName(entry.id), id: inputId,
 			value: opt.value, checked: lit,
@@ -915,9 +915,9 @@ export function readValue(entry) {
 		case "toggles": {
 			const pills = togglePills(entry).map(o => toggleNode(entry, o.value));
 			if (pills.every(node => !node)) return entry.default; // not rendered yet
-			const lit = togglePills(entry).filter(o => toggleNode(entry, o.value)?.checked);
-			if (lit.length === 0) return "off";
-			return lit.length === 1 ? lit[0].value : entry.combined;
+			return togglePills(entry)
+				.filter(o => toggleNode(entry, o.value)?.checked)
+				.map(o => o.value);
 		}
 		case "select": {
 			const v = document.getElementById(domId(entry.id))?.value ?? entry.default;
@@ -955,12 +955,14 @@ export function writeValue(entry, value) {
 			break;
 		}
 		case "toggles": {
-			const want = value === entry.combined
-				? togglePills(entry).map(o => o.value)
-				: [value];
+			// Tolerates a bare string as well as a list so a hand-edited or
+			// older payload ("sun") still applies.
+			const want = Array.isArray(value) ? value : [value];
 			for (const opt of entry.options) {
 				const node = toggleNode(entry, opt.value);
-				if (node) node.checked = want.includes(opt.value);
+				if (node) node.checked = opt.value === "off"
+					? want.length === 0
+					: want.includes(opt.value);
 			}
 			break;
 		}
@@ -1025,12 +1027,10 @@ export function formatValue(entry, value) {
 			return opt ? opt.label : String(value);
 		}
 		case "toggles": {
-			// The combined value has no option of its own — name both pills.
-			if (value === entry.combined) {
-				return togglePills(entry).map(o => o.label).join(" + ");
-			}
-			const opt = entry.options.find(o => o.value === value);
-			return opt ? opt.label : String(value);
+			if (!Array.isArray(value) || value.length === 0) return "OFF";
+			return value
+				.map(v => entry.options.find(o => o.value === v)?.label ?? v)
+				.join(" + ");
 		}
 		case "items": {
 			if (!Array.isArray(value) || value.length === 0) return "(none)";
@@ -1128,6 +1128,8 @@ export function applyRowStates() {
 		let on = false, maybe = false;
 		if (entry.type === "bool") {
 			on = value === true;
+		} else if (entry.type === "toggles") {
+			on = Array.isArray(value) && value.length > 0;
 		} else if (value === "maybe" || value === "wild") {
 			// "wild" and "maybe" share the cool violet — both mean "the seed picks
 			// something spicier than the plain shuffle / on baseline".
@@ -1171,9 +1173,9 @@ export function saveSettings() {
 			if (entry.type === "bool") {
 				settings[`radio:${radioName(entry.id)}`] = v ? "on" : "off";
 			} else if (entry.type === "toggles") {
-				// Own key prefix: the value can name a pill combination
-				// ("both"), which no single input carries.
-				settings[`toggles:${radioName(entry.id)}`] = v;
+				// Own key prefix: the value is a list, which no single input
+				// carries. Stored as JSON so restore gets an array back.
+				settings[`toggles:${radioName(entry.id)}`] = JSON.stringify(v);
 			} else if (entry.type === "tri" || entry.type === "radio") {
 				settings[`radio:${radioName(entry.id)}`] = v;
 			} else if (entry.type === "nescolor") {
@@ -1205,16 +1207,22 @@ export function restoreSettings() {
 			if (key.startsWith("toggles:")) {
 				const name = key.slice(8);
 				const entry = SCHEMA.find(e => e.type === "toggles" && radioName(e.id) === name);
-				if (entry) writeValue(entry, val);
+				if (!entry) continue;
+				let parsed;
+				try { parsed = JSON.parse(val); } catch (_) { parsed = val; }
+				// Pre-Bass settings stored the combined value as "both".
+				if (parsed === "both") parsed = ["sun", "lakitu"];
+				writeValue(entry, parsed);
 			} else if (key.startsWith("radio:")) {
 				const name = key.slice(6);
 				const elNode = document.querySelector(`input[name="${name}"][value="${val}"]`);
 				if (elNode) elNode.checked = true;
 				if (elNode) continue;
 				// Legacy: a field that used to be a bool and is now a toggle
-				// group (wild_injections). "on" meant the whole pool.
+				// group (wild_injections). "on" meant the pool as it stood
+				// then — sun and lakitu, before Boss Bass joined.
 				const promoted = SCHEMA.find(e => e.type === "toggles" && radioName(e.id) === name);
-				if (promoted) writeValue(promoted, val === "on" ? promoted.combined : "off");
+				if (promoted) writeValue(promoted, val === "on" ? ["sun", "lakitu"] : []);
 			} else {
 				const elNode = document.getElementById(key);
 				if (elNode) {

--- a/web/options.js
+++ b/web/options.js
@@ -58,6 +58,15 @@ const ON_OFF_MAYBE = [
 	{ value: "maybe", label: "Maybe" },
 ];
 
+// Wild Injections is a `toggles` pill: "Off" is exclusive, Sun and Lakitu
+// toggle independently, and lighting both encodes as the entry's `combined`
+// value ("both"). Values match the Rust `WildInjectionMode` enum.
+const WILD_INJECTION_TOGGLES = [
+	{ value: "off", label: "Off" },
+	{ value: "sun", label: "Sun" },
+	{ value: "lakitu", label: "Lakitu" },
+];
+
 // Off / On / Wild pill for Random Fire Flower. "Wild" widens the pool to also
 // include the Small/Big downgrade outcomes. Values match the Rust
 // `FireFlowerMode` enum's serde representation.
@@ -235,9 +244,10 @@ export const SCHEMA = [
 		label: "HB Encounters",
 		tip: "All enemies in overworld Hammer Bro mini-battles",
 		group: "enemies", inFlagKey: true },
-	{ id: "wild_injections", type: "bool", default: false,
+	{ id: "wild_injections", type: "toggles", options: WILD_INJECTION_TOGGLES,
+		combined: "both", default: "off",
 		label: "Wild Injections",
-		tip: "Spawn Lakitu, Angry Sun, or Boss Bass in ~15% of levels",
+		tip: "Drop an Angry Sun or a Lakitu into some levels that never had one. Pick either, or both.",
 		group: "enemies", inFlagKey: true },
 	{ id: "early_sun", type: "bool", default: false,
 		label: "Early Sun",
@@ -414,7 +424,7 @@ export const PRESETS = [
 			ground: "wild", shell: "wild", flying: "wild", piranhas: "wild",
 			ghosts: "wild", water: "wild", cannons: "wild", hb_encounters: "wild",
 			rotodiscs: "shuffle",
-			wild_injections: true, early_sun: true,
+			wild_injections: "both", early_sun: true,
 			include_beta_stages: true, swap_start_airship: true,
 			big_q_blocks: true, starting_items: [15],
 			fast_mushroom_house: true, faster_frog: true, faster_tail_speed: true,
@@ -456,7 +466,7 @@ export const PRESETS = [
 		overrides: {
 			ground: "wild", shell: "wild", flying: "wild",
 			hb_encounters: "shuffle", rotodiscs: "shuffle",
-			wild_injections: true, early_sun: true,
+			wild_injections: "both", early_sun: true,
 			include_beta_stages: true,
 			shuffle_spade_games: false, shuffle_toad_houses: false,
 			hands_levels: false, troll_pipes: "off",
@@ -471,7 +481,7 @@ export const PRESETS = [
 			ground: "wild", shell: "wild", flying: "wild", piranhas: "wild",
 			ghosts: "wild", thwomps: "wild", rotodiscs: "wild", cannons: "wild",
 			water: "wild", bros: "wild", hb_encounters: "wild",
-			wild_injections: true, early_sun: true,
+			wild_injections: "both", early_sun: true,
 			include_beta_stages: true, swap_start_airship: true,
 			big_q_blocks: true, starting_items: [15, 15, 15],
 			faster_tail_speed: true, faster_frog: true,
@@ -487,7 +497,7 @@ export const PRESETS = [
 			ground: "wild", shell: "wild", flying: "wild", piranhas: "wild",
 			ghosts: "wild", thwomps: "wild", rotodiscs: "wild", cannons: "wild",
 			water: "wild", bros: "wild", hb_encounters: "wild",
-			wild_injections: true, early_sun: true,
+			wild_injections: "both", early_sun: true,
 			include_beta_stages: true, swap_start_airship: true,
 			big_q_blocks: true, poison_mushrooms: true,
 			world_order: true, random_koopalings: true,
@@ -674,6 +684,58 @@ function renderTri(entry) {
 	return wrap;
 }
 
+// A pill group where the non-"off" pills toggle independently: check Sun,
+// check Lakitu, check both. The value stays a single string so the flag key
+// and the Rust enum see one field — "off", a lone option's value, or the
+// entry's `combined` value when more than one pill is lit.
+function togglePills(entry) {
+	return entry.options.filter(o => o.value !== "off");
+}
+
+function toggleNode(entry, value) {
+	return document.getElementById(`${domId(entry.id)}-${value}`);
+}
+
+// Keep the group coherent after any click: "off" is exclusive, and clearing
+// the last lit pill falls back to "off" so the row is never blank.
+function syncToggles(entry, clicked) {
+	const off = toggleNode(entry, "off");
+	const pills = togglePills(entry).map(o => toggleNode(entry, o.value)).filter(Boolean);
+	if (clicked === "off") {
+		for (const node of pills) node.checked = false;
+		if (off) off.checked = true; // clicking "off" while off keeps it off
+		return;
+	}
+	if (off) off.checked = !pills.some(node => node.checked);
+}
+
+function renderToggles(entry) {
+	const wrap = el("label", { class: "select-label" });
+	const icon = iconCanvas(entry);
+	if (icon) wrap.appendChild(icon);
+	wrap.appendChild(document.createTextNode(entry.label));
+	const btn = tipBtn(entry);
+	if (btn) wrap.appendChild(btn);
+	const group = el("div", { class: "pill-group" });
+	for (const opt of entry.options) {
+		const inputId = `${domId(entry.id)}-${opt.value}`;
+		const lit = opt.value === "off"
+			? entry.default === "off"
+			: entry.default === opt.value || entry.default === entry.combined;
+		const input = el("input", {
+			type: "checkbox", name: radioName(entry.id), id: inputId,
+			value: opt.value, checked: lit,
+		});
+		// Registered before wireListeners' listener on the same node, so the
+		// group is already coherent by the time readValue runs.
+		input.addEventListener("change", () => syncToggles(entry, opt.value));
+		group.appendChild(input);
+		group.appendChild(el("label", { for: inputId }, opt.label));
+	}
+	wrap.appendChild(group);
+	return wrap;
+}
+
 function renderSelect(entry) {
 	const wrap = el("label", {
 		class: "select-label" + (entry.indent ? " sub-options" : ""),
@@ -793,6 +855,7 @@ function renderNesColor(entry) {
 const RENDERERS = {
 	bool: renderBool,
 	tri: renderTri,
+	toggles: renderToggles,
 	select: renderSelect,
 	radio: renderRadio,
 	items: renderItems,
@@ -849,6 +912,13 @@ export function readValue(entry) {
 			const v = checked?.value ?? entry.default;
 			return entry.numeric ? Number(v) : v;
 		}
+		case "toggles": {
+			const pills = togglePills(entry).map(o => toggleNode(entry, o.value));
+			if (pills.every(node => !node)) return entry.default; // not rendered yet
+			const lit = togglePills(entry).filter(o => toggleNode(entry, o.value)?.checked);
+			if (lit.length === 0) return "off";
+			return lit.length === 1 ? lit[0].value : entry.combined;
+		}
 		case "select": {
 			const v = document.getElementById(domId(entry.id))?.value ?? entry.default;
 			return entry.numeric ? Number(v) : v;
@@ -882,6 +952,16 @@ export function writeValue(entry, value) {
 		case "radio": {
 			const e = document.querySelector(`input[name="${radioName(entry.id)}"][value="${value}"]`);
 			if (e) e.checked = true;
+			break;
+		}
+		case "toggles": {
+			const want = value === entry.combined
+				? togglePills(entry).map(o => o.value)
+				: [value];
+			for (const opt of entry.options) {
+				const node = toggleNode(entry, opt.value);
+				if (node) node.checked = want.includes(opt.value);
+			}
 			break;
 		}
 		case "select": {
@@ -941,6 +1021,14 @@ export function formatValue(entry, value) {
 		case "tri":
 		case "radio":
 		case "select": {
+			const opt = entry.options.find(o => o.value === value);
+			return opt ? opt.label : String(value);
+		}
+		case "toggles": {
+			// The combined value has no option of its own — name both pills.
+			if (value === entry.combined) {
+				return togglePills(entry).map(o => o.label).join(" + ");
+			}
 			const opt = entry.options.find(o => o.value === value);
 			return opt ? opt.label : String(value);
 		}
@@ -1006,6 +1094,7 @@ function entryDomIds(entry) {
 			return BOOL_OPTIONS.map(o => `${domId(entry.id)}-${o.value}`);
 		case "tri":
 		case "radio":
+		case "toggles":
 			return entry.options.map(o => `${domId(entry.id)}-${o.value}`);
 		case "items":
 			return Array.from({ length: entry.slots }, (_, i) => `${domId(entry.id)}-${i}`);
@@ -1029,7 +1118,7 @@ function entryDomIds(entry) {
 // every other state is `opt-on` except for "maybe" which gets its own variant.
 export function applyRowStates() {
 	for (const entry of SCHEMA) {
-		if (entry.type !== "bool" && entry.type !== "tri") continue;
+		if (!["bool", "tri", "toggles"].includes(entry.type)) continue;
 		const ids = entryDomIds(entry);
 		const first = document.getElementById(ids[0]);
 		if (!first) continue;
@@ -1081,6 +1170,10 @@ export function saveSettings() {
 			const v = readValue(entry);
 			if (entry.type === "bool") {
 				settings[`radio:${radioName(entry.id)}`] = v ? "on" : "off";
+			} else if (entry.type === "toggles") {
+				// Own key prefix: the value can name a pill combination
+				// ("both"), which no single input carries.
+				settings[`toggles:${radioName(entry.id)}`] = v;
 			} else if (entry.type === "tri" || entry.type === "radio") {
 				settings[`radio:${radioName(entry.id)}`] = v;
 			} else if (entry.type === "nescolor") {
@@ -1109,10 +1202,19 @@ export function restoreSettings() {
 		if (!raw) return;
 		const settings = JSON.parse(raw);
 		for (const [key, val] of Object.entries(settings)) {
-			if (key.startsWith("radio:")) {
+			if (key.startsWith("toggles:")) {
+				const name = key.slice(8);
+				const entry = SCHEMA.find(e => e.type === "toggles" && radioName(e.id) === name);
+				if (entry) writeValue(entry, val);
+			} else if (key.startsWith("radio:")) {
 				const name = key.slice(6);
 				const elNode = document.querySelector(`input[name="${name}"][value="${val}"]`);
 				if (elNode) elNode.checked = true;
+				if (elNode) continue;
+				// Legacy: a field that used to be a bool and is now a toggle
+				// group (wild_injections). "on" meant the whole pool.
+				const promoted = SCHEMA.find(e => e.type === "toggles" && radioName(e.id) === name);
+				if (promoted) writeValue(promoted, val === "on" ? promoted.combined : "off");
 			} else {
 				const elNode = document.getElementById(key);
 				if (elNode) {

--- a/web/style.css
+++ b/web/style.css
@@ -315,7 +315,10 @@ input[type="radio"] {
     margin-left: auto;
 }
 
-.pill-group input[type="radio"] {
+/* Pill groups are radios (pick one) or checkboxes (toggle several, as in
+   Wild Injections). Both hide the input and style the adjacent label. */
+.pill-group input[type="radio"],
+.pill-group input[type="checkbox"] {
     display: none;
 }
 
@@ -339,21 +342,21 @@ input[type="radio"] {
     color: #e0e0e0;
 }
 
-.pill-group input[type="radio"]:checked + label {
+.pill-group input:checked + label {
     background: var(--pill-active, #4a8a4f);
     color: var(--pill-active-text, #fff);
 }
 
 /* "Off" selected: muted gray so an explicit off doesn't read as a hot accent. */
-.pill-group input[type="radio"][value="off"]:checked + label {
+.pill-group input[value="off"]:checked + label {
     background: #3a3a60;
     color: #b8b8d0;
 }
 
 /* "Maybe" and "Wild" share a cool violet to mark "the seed picks something
    spicier than a plain shuffle". Visually distinct from the green on/shuffle accent. */
-.pill-group input[type="radio"][value="maybe"]:checked + label,
-.pill-group input[type="radio"][value="wild"]:checked + label {
+.pill-group input[value="maybe"]:checked + label,
+.pill-group input[value="wild"]:checked + label {
     background: #6f5fb8;
     color: #fff;
 }


### PR DESCRIPTION
Wild Injections was one bool over a two-enemy pool. This makes it a *set* the player picks — and fixes the reason Boss Bass was never in it.

## The option

Four pills — **Off**, **Sun**, **Lakitu**, **Bass**. The three chasers toggle independently, Off is exclusive and clears them, and clearing the last lit pill falls back to Off so the row is never blank. The value is the list of lit pills (empty = off), which is what the Rust side, the flag key and the presets all see.

CLI takes a set: `--wild-injections sun,bass`, or `all`, or `off`.

## Boss Bass

It was meant to be injectable when the option first shipped and **never once reached a ROM**. Boss Bass is a `WATER_ENEMIES` member, so while injection ran as a pass *before* the walker, the walker reshuffled every injected Bertha back into an ordinary water enemy whenever water was Shuffle/Wild. Silent no-op, no test could see it, and the exclusion got written down as a fact about Boss Bass rather than about the ordering.

## Why the ordering was the real problem

Injection was a pass beside the walker, which meant **two copies of the CHR model**. It had to predict what the walker was about to compute: hunt the enclosing `$FF` segment in a `bounds` list built by an extra `walk_segments` call, run `is_pinned` over every entry with a `ClassModes` built for the purpose, commit pages by hand — and twenty lines later the walker computed the same thing for real. The Boss Bass hole is exactly what a second copy of a model buys you.

Injection now happens **inside the walker's segment prologue**, after the entries are parsed and before anything is committed or picked. An injected chaser is just an enemy the segment contains: the Bertha tally counts it, `segment_pins` commits its page, the picks route around it.

Injecting *before the picks* rather than *after the whole walk* is deliberate — both would unblock Boss Bass, but only this one keeps the level being built around the chaser instead of merely tested against it.

`segment_pins` is now the single definition of "what has this segment committed", called by the injection decision (skipping the entry it's about to replace) and by the walker's own seeding.

Not a line-count win, and the commit says so: ~50 lines of shared helper replace ~23 lines of duplicated scan. What goes away is the second copy.

## A claim I had to withdraw

The first version of this PR documented that narrowing the pool would inject into fewer levels, reasoned from the code. Measured, it's false — the effect is real but far below the noise:

```
sun+lakitu+bass  182 over 20 seeds (9.1/seed) — 97 sun,  44 lakitu,  41 bass
sun+lakitu       190 over 20 seeds (9.5/seed) — 127 sun, 57 lakitu,   6 bass
sun              180 over 20 seeds (9.0/seed) — 174 sun,  0 lakitu,   6 bass
lakitu           167 over 20 seeds (8.3/seed) —   0 sun, 164 lakitu,  3 bass
bass             165 over 20 seeds (8.2/seed) —   0 sun,  0 lakitu, 165 bass
```

Lakitu-only injected *more* than the pair, which the mechanism can't explain — the sets draw different RNG streams and that noise is bigger than the effect. Corrected in the enum doc, the rework doc and the changelog, and `print_injection_counts` (ignored, needs the ROM) is now the diagnostic those numbers come from, so the next change to this machinery gets compared rather than argued about.

The 6-bass background in row two is why every Bass test compares two runs differing *only* in the pool: Bass is an ordinary swap target too, so a Bertha on a first enemy isn't proof of injection.

## Flag key

One bit per chaser, scattered because no byte had three free: sun in `b4` bit 0 (where the old bool lived), lakitu in `b12` bit 7, bass in `b2` bit 5 — free since `shuffle_pipes` died in v26, and the last bit outside `b12` bit 7. Still 13 bytes. Version 27 → 28, so older keys no longer load.

All 20 `overworld_baseline` hashes moved when the version bumped. Pinning `FLAG_KEY_VERSION` back to 27 reproduced the previous hashes exactly — that's the check that the regeneration hides no real change, recorded above the new array.

## Also here

Two commits independent of the feature, from the same session:

- **`fix:`** the four `dead_code` warnings on every `wasm-pack build` — `is_numbered_level` / `is_fortress` and their constants are read only by `testrom.rs`, which `lib.rs` already gates as native-only.
- **`feature:`** a wasm clippy pass in CI. The existing gate runs `--all-targets` natively and never evaluates the wasm `cfg` branch; the `build` job's wasm compile exits 0 on warnings and runs against `ref: main` / `ref: beta/next`, never the PR head. That's why those warnings survived. Confirmed working on this PR's run — it pulls `js-sys`, which the native pass never touches.

## Verification

- **388 tests pass.** New: `wild_injection_bass_survives_water_wild` (the case that was broken), `wild_injection_pool_honors_set`, an 8-subset flag-key round-trip asserting all 8 produce distinct keys, and a serde test pinning the strings the web posts.
- **A bug the tests found only by running the binary:** `Vec<WildChaser>` on a clap field is read by the derive as a repeatable single-value arg, so a `value_parser` returning the whole set downcast to the wrong type and panicked on *every* invocation. No compile error — and `Cli::command().debug_assert()` passes, which I checked while the binary was panicking. `cli_parses_a_chaser_set` parses a real argv, which is the only thing that reaches the downcast.
- The web pill went through the DOM stub again — 28 checks covering three-way toggling, `writeValue`, presets, and both legacy-settings upgrade paths (the original bool `"on"`, and this branch's own earlier `"both"`).
- `cargo clippy --all-targets`, the wasm clippy pass, and `wasm-pack build` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB