### PR TITLE
fix: refuse an unreadable flag key out loud instead of ignoring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ deploys.
 
 ### Fixed
 
+- A flag key the app can't read is now refused out loud instead of being
+  quietly ignored. Previously the key stayed in the box, the options kept
+  whatever they already were, and Generate stayed clickable — so a key from a
+  different version of the randomizer looked accepted while your own leftover
+  settings were used instead. That mattered most in races, where everyone
+  pastes the same key and each person could end up on different settings with
+  nothing on screen to say so. Now the key is marked as rejected, Generate is
+  held until it's sorted out, and the message says whether the key is from an
+  older version, from a newer one, or just isn't valid.
+
 - Landing on an enemy that is jumping up at you now counts as a stomp instead
   of hurting you. Vanilla decides "stomp or damage" once per frame, so an enemy
   rising into you could close the gap faster than the check could resolve and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use rom::Rom;
 
 pub use ips::apply_ips_patch;
 pub use randomizer::{
+    current_flag_key_version, flag_key_version_of,
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
     WildChaser, ITEMS, STARTING_LIVES_VALUES,
     ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -71,6 +71,47 @@ pub(super) fn base32_decode(s: &str, expected_bytes: usize) -> Result<Vec<u8>, S
     Ok(result)
 }
 
+/// Trim surrounding whitespace and strip the "SMB3R-" prefix
+/// case-insensitively if present. Compares as bytes so a non-ASCII key can't
+/// panic on a char-boundary slice.
+///
+/// Shared by `from_flag_key` and `flag_key_version_of` so the two always see
+/// the same string — otherwise a key one accepts and the other rejects would be
+/// classified with the wrong reason.
+fn strip_flag_key_prefix(key: &str) -> &str {
+    let key = key.trim();
+    let prefix_len = FLAG_KEY_PREFIX.len();
+    if key.len() >= prefix_len
+        && key.as_bytes()[..prefix_len].eq_ignore_ascii_case(FLAG_KEY_PREFIX.as_bytes())
+    {
+        &key[prefix_len..]
+    } else {
+        key
+    }
+}
+
+/// The flag-key format version this build reads.
+pub fn current_flag_key_version() -> u8 {
+    FLAG_KEY_VERSION
+}
+
+/// The format version a key claims, read without interpreting the rest of it.
+///
+/// Lets a caller tell "this key is from an older/newer build" apart from "this
+/// isn't a flag key at all" — two failures that need different things from the
+/// user.
+///
+/// Asymmetric about length on purpose. A short key is rejected outright even
+/// though its first byte is readable: a truncated or mistyped paste is not a
+/// version problem, and since a garbled first byte lands above the current
+/// version far more often than not, trusting it would report almost every typo
+/// as "from a newer version" and send the user hunting for a build that doesn't
+/// exist. A *long* key is fine — a future format that grows a 14th byte is
+/// genuinely newer, and saying so is the whole point.
+pub fn flag_key_version_of(key: &str) -> Result<u8, String> {
+    Ok(base32_decode(strip_flag_key_prefix(key), 13)?[0])
+}
+
 impl Options {
     /// Encode options into raw bytes.
     pub fn to_flag_bytes(&self) -> [u8; 13] {
@@ -258,18 +299,7 @@ impl Options {
 
     /// Decode a Crockford Base-32 flag key string into Options.
     pub fn from_flag_key(key: &str) -> Result<Options, String> {
-        // Strip the "SMB3R-" prefix case-insensitively if present. Compare as
-        // bytes so a non-ASCII key can't panic on a char-boundary slice.
-        let prefix_len = FLAG_KEY_PREFIX.len();
-        let encoded = if key.len() >= prefix_len
-            && key.as_bytes()[..prefix_len].eq_ignore_ascii_case(FLAG_KEY_PREFIX.as_bytes())
-        {
-            &key[prefix_len..]
-        } else {
-            key
-        };
-
-        let bytes = base32_decode(encoded, 13)?;
+        let bytes = base32_decode(strip_flag_key_prefix(key), 13)?;
 
         let version = bytes[0];
         if version != FLAG_KEY_VERSION {

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -15,6 +15,7 @@ use flag_key::*;
 use options::*;
 
 // Public API re-exported by the crate root (see lib.rs).
+pub use flag_key::{current_flag_key_version, flag_key_version_of};
 pub use options::{
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
     WildChaser, ITEMS, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -696,6 +696,51 @@ fn flag_key_hammer_vuln_koopalings_distinct_from_hb_encounters() {
     assert_eq!(dec_b.hb_encounters, EnemyMode::Wild);
 }
 
+/// The version probe backs the web app's three-way rejection message (older /
+/// newer / not a flag key). Each case below is one of those branches.
+#[test]
+fn flag_key_version_probe() {
+    let key = Options::default().to_flag_key();
+    let current = current_flag_key_version();
+
+    // A key this build made reports this build's version, with or without the
+    // prefix, in any case, and with the whitespace a paste tends to carry.
+    assert_eq!(flag_key_version_of(&key), Ok(current));
+    assert_eq!(flag_key_version_of(key.trim_start_matches("SMB3R-")), Ok(current));
+    assert_eq!(flag_key_version_of(&key.to_lowercase()), Ok(current));
+    assert_eq!(flag_key_version_of(&format!("  {key}\n")), Ok(current));
+
+    // An older key: same 13-byte layout, earlier version byte. Reads as "older"
+    // even though the full decode rejects it.
+    let mut older = Options::default().to_flag_bytes();
+    older[0] = current - 1;
+    let older_key = base32_encode(&older);
+    assert_eq!(flag_key_version_of(&older_key), Ok(current - 1));
+    assert!(Options::from_flag_key(&older_key).is_err());
+
+    // A key from a future format that grew a 14th byte. The probe must stay
+    // lenient about length or this would read as garbage instead of "newer",
+    // and the app would tell the user to check for typos in a perfectly good
+    // key. This is the direction that bites today: beta runs ahead of the
+    // released app.
+    let mut newer = Options::default().to_flag_bytes().to_vec();
+    newer[0] = current + 1;
+    newer.push(0x00);
+    assert_eq!(flag_key_version_of(&base32_encode(&newer)), Ok(current + 1));
+
+    // Not a flag key at all — the app's third branch.
+    assert!(flag_key_version_of("").is_err());
+    assert!(flag_key_version_of("!!!!").is_err());
+    assert!(flag_key_version_of("SMB3R-").is_err());
+
+    // A truncated paste must NOT be reported as a version mismatch even though
+    // its first byte reads fine. "ZZZZ" decodes to 0xFF, which would otherwise
+    // be announced as "from a newer version of the randomizer" and send the
+    // user looking for a build that was never released. Short is invalid.
+    assert!(flag_key_version_of("SMB3R-ZZZZ").is_err());
+    assert!(flag_key_version_of(&key[..key.len() - 4]).is_err());
+}
+
 #[test]
 fn base32_round_trip() {
     // Test with various byte patterns

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -71,3 +71,19 @@ pub fn decode_flag_key(key: &str) -> Result<String, JsError> {
     let options = Options::from_flag_key(key).map_err(|e| JsError::new(&e))?;
     serde_json::to_string(&options).map_err(|e| JsError::new(&format!("Serialize error: {e}")))
 }
+
+/// The flag-key format version this build reads.
+#[wasm_bindgen]
+pub fn current_flag_key_version() -> u8 {
+    crate::current_flag_key_version()
+}
+
+/// The format version a key claims, without decoding it. The app pairs this
+/// with `current_flag_key_version()` to tell "key from an older build" from
+/// "key from a newer build" from "not a flag key at all" — three rejections
+/// that need different things from the user. Errors only when the key is
+/// garbled beyond reading its first byte.
+#[wasm_bindgen]
+pub fn flag_key_version_of(key: &str) -> Result<u8, JsError> {
+    crate::flag_key_version_of(key).map_err(|e| JsError::new(&e))
+}

--- a/web/app.js
+++ b/web/app.js
@@ -4,6 +4,8 @@ import init, {
 	validate_rom,
 	encode_flag_key,
 	decode_flag_key,
+	current_flag_key_version,
+	flag_key_version_of,
 	default_options_json,
 	version,
 } from "./pkg/smb3_rs.js";
@@ -505,17 +507,81 @@ function renderPresetPills() {
 
 // --- Flag Key ---
 
+// Set while the flag key box holds a key that failed to apply. Generate is
+// gated on this being null.
+//
+// Why it exists: the seed bot passes a racer's typed key into `?flags=`
+// verbatim, and a key that failed to decode used to be swallowed — the options
+// kept whatever was in localStorage, the key sat in the box looking accepted,
+// and Generate stayed live. Every racer in the room then built a ROM from their
+// own leftover settings, with nothing on screen to say so.
+let flagKeyError = null;
+
+function setFlagKeyError(rejection) {
+	flagKeyError = rejection;
+	// The key stays in the box on purpose — a racer may need to re-copy it or
+	// show it to whoever posted it — so the box itself has to carry the "this
+	// did NOT apply" signal.
+	flagKeyInput.classList.toggle("invalid", !!rejection);
+	if (rejection) flagKeyInput.setAttribute("aria-invalid", "true");
+	else flagKeyInput.removeAttribute("aria-invalid");
+	updateGenerateButton();
+}
+
+// Classify a rejected key. "Older" and "newer" mean it was well-formed enough
+// to read its format version but this build doesn't speak it; "invalid" means
+// it isn't a usable flag key at all (typo, truncated paste). The three need
+// different things from the user, so they get different messages.
+//
+// The visible wording avoids version numbers — a player has never heard of a
+// flag-key format version — with the raw detail in a trailing parenthetical for
+// anyone reporting the problem.
+function flagKeyRejection(key, err) {
+	try {
+		const keyVer = flag_key_version_of(key);
+		const appVer = current_flag_key_version();
+		const detail = `key format ${keyVer}, this build reads ${appVer}`;
+		if (keyVer < appVer) {
+			return {
+				kind: "older",
+				message: `This flag key is from an older version of the randomizer. Older versions are listed at the bottom of this page. (${detail})`,
+			};
+		}
+		if (keyVer > appVer) {
+			return {
+				kind: "newer",
+				message: `This flag key is from a newer version of the randomizer. (${detail})`,
+			};
+		}
+		// Right format version, but the rest of the key didn't decode — that's
+		// a damaged key, not a version mismatch. Fall through.
+	} catch (_) {
+		// Not even readable that far.
+	}
+	// `err.message` rather than `err` — stringifying the Error prepends a
+	// redundant "Error: " to a message that already reads as one.
+	return {
+		kind: "invalid",
+		message: `This flag key isn't valid. Check it and try again. (${err?.message ?? err})`,
+	};
+}
+
 function updateFlagKey() {
 	if (!wasmReady) return;
 	try {
 		flagKeyInput.value = encode_flag_key(getOptionsJson());
+		// The box now shows a key built from the options actually loaded, so
+		// whatever was rejected is no longer on screen to be mistaken for
+		// applied.
+		setFlagKeyError(null);
 	} catch (_) {}
 }
 
 function applyFlagKey(key) {
 	if (!wasmReady) return;
+	const trimmed = key.trim();
 	try {
-		const json = decode_flag_key(key.trim());
+		const json = decode_flag_key(trimmed);
 		applyOptions(JSON.parse(json));
 		applyEnabledWhen();
 		applyRowStates();
@@ -523,12 +589,25 @@ function applyFlagKey(key) {
 		updateFlagKey();
 		showStatus("Flag key applied!", "success");
 	} catch (err) {
-		showStatus(`Invalid flag key: ${err}`, "error");
+		const rejection = flagKeyRejection(trimmed, err);
+		setFlagKeyError(rejection);
+		showStatus(rejection.message, "error");
 	}
 }
 
+// Editing the box clears the rejection: the text on screen is now the user's
+// own, not the key that failed, so the invalid marking would be stale. Applying
+// it is still a separate, deliberate click.
+flagKeyInput.addEventListener("input", () => {
+	if (flagKeyError) setFlagKeyError(null);
+});
+
 flagKeyCopyBtn.addEventListener("click", () => {
-	updateFlagKey();
+	// Don't refresh over a rejected key. Copy is how someone hands the key back
+	// to whoever posted it, which is exactly what a rejection asks them to do —
+	// regenerating here would silently swap in a different key. Share below
+	// still refreshes, because a share URL must carry a key that works.
+	if (!flagKeyError) updateFlagKey();
 	navigator.clipboard.writeText(flagKeyInput.value).then(() => {
 		showStatus("Flag key copied!", "success");
 	});
@@ -620,7 +699,7 @@ async function initVersionPicker() {
 // --- Misc ---
 
 function updateGenerateButton() {
-	generateBtn.disabled = !(wasmReady && romBytes && romValid);
+	generateBtn.disabled = !(wasmReady && romBytes && romValid && !flagKeyError);
 }
 
 function showStatus(message, type) {

--- a/web/app.js
+++ b/web/app.js
@@ -703,9 +703,19 @@ function updateGenerateButton() {
 }
 
 function showStatus(message, type) {
+	// Repeating a message writes identical text into an already-visible box, so
+	// nothing on screen changes and the click reads as a no-op. That's the
+	// common case for flag keys in a race: everyone's key comes from the same
+	// older build, so a second paste produces the same rejection word for word.
+	// Re-flash so it still registers as a response.
+	const repeat = !statusDiv.hidden && statusDiv.textContent === message;
 	statusDiv.textContent = message;
 	statusDiv.className = `status ${type}`;
 	statusDiv.hidden = false;
+	if (repeat) {
+		void statusDiv.offsetWidth; // force reflow so the animation restarts
+		statusDiv.classList.add("flash");
+	}
 }
 
 function updateSkipValidationWarning() {

--- a/web/style.css
+++ b/web/style.css
@@ -613,6 +613,23 @@ input[type="radio"] {
     color: #9a9ab0;
 }
 
+/* Applied by showStatus() only when the message repeats verbatim, so the box
+   visibly reacts instead of sitting there unchanged. */
+@keyframes status-flash {
+    from { opacity: 0.2; }
+    to   { opacity: 1; }
+}
+
+.status.flash {
+    animation: status-flash 0.35s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .status.flash {
+        animation: none;
+    }
+}
+
 /* --- Control Panel (sidebar: seed / flag key / generate) --- */
 
 .control-panel {

--- a/web/style.css
+++ b/web/style.css
@@ -660,6 +660,16 @@ input[type="radio"] {
     font-size: 0.8rem;
 }
 
+/* A key that failed to apply stays in the box so it can be re-copied or
+   reported, so the box has to say it didn't take. Same red as .status.error.
+   Wins over :focus, which would otherwise hide the marking as soon as the user
+   clicked back into the field to fix the key. */
+#flag-key-input.invalid,
+#flag-key-input.invalid:focus {
+    border-color: #e44434;
+    background: rgba(228, 68, 52, 0.08);
+}
+
 .preset-pills {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Item 1 of #158 — the race-safety fix. Web-side only; no format change, no version bump.

## The bug

A flag key the app couldn't decode was swallowed. `applyFlagKey`'s catch showed a status line, applied nothing, and returned — so the options kept whatever was in localStorage, the key sat in the input looking accepted, and Generate stayed enabled because the flag key was never part of its gating condition.

That shape is worst in races. `smb3r-seedbot` passes a racer's typed key into `?flags=` verbatim — it can't validate one, since it never loads the wasm — so every racer generated a ROM from their own leftover settings and nothing on screen said so.

## What changes

A rejected key now sets `flagKeyError`, which marks the input (`aria-invalid` + red border) and holds Generate until it's resolved. The key itself stays in the box — it's what a racer needs to re-copy or report. Copy no longer refreshes over a rejected key for the same reason; Share still does, since a share URL must carry a key that works.

The message distinguishes three rejections that need different things from the user:

```
older    This flag key is from an older version of the randomizer. Older versions
         are listed at the bottom of this page. (key format 27, this build reads 28)
newer    This flag key is from a newer version of the randomizer.
         (key format 29, this build reads 28)
invalid  This flag key isn't valid. Check it and try again.
         (Flag key too short (decoded 10 bytes, expected 13))
```

Visible wording carries no version numbers — a player has never heard of a flag-key format version — with the raw detail in a trailing parenthetical for anyone reporting the problem.

Two new wasm exports back the classification, so the app compares numbers instead of parsing error strings:

- `flag_key_version_of(key)` — a key's claimed format version, read without interpreting the rest of it
- `current_flag_key_version()` — what this build reads

`flag_key_version_of` is **asymmetric about length on purpose**. A *long* key is accepted, because a future format that grows a 14th byte is genuinely newer and saying so is the point. A *short* key is rejected even though its first byte is readable: a garbled first byte lands above the current version far more often than not — `SMB3R-ZZZZ` reads as 255 — so trusting it would announce nearly every typo as "from a newer version" and send the user hunting for a build that doesn't exist. That was caught by testing at the wasm boundary, not in Rust.

Second commit fixes a papercut found while tracing a repeated rejection: `showStatus` only set `textContent`, so a second identical message changed nothing on screen and read as a broken button — the common case in a race, where everyone's key comes from the same older build.

## Deliberately not here

Per the design discussion on #158:

- **No version→release link table.** It can't be filled in at bump time: v27 was bumped when `Cargo.toml` said 1.0.4 and never reached main. `origin/main` (1.0.7) still ships v26 while `beta/next` is on v28, so the two deploys can't exchange keys in either direction — and the direction that bites is "newer than this build", which no link can resolve since `/beta/` is never archived. The footer version picker already lists archived builds; the copy points at it in words.
- **No versioned decoders, no length tolerance, no bitfield crate.** Compatibility reaches v28 forward only.
- **No new flag-key test guards** (bit-collision masks, non-bool coverage, `inFlagKey` parity, golden fixtures) — those belong with the versioned-decoder round they're meant to protect.

## Known gap

Editing the box clears the rejection, which re-enables Generate before the new key has been applied or checked. That's the same shape as the pre-existing "type a key, forget to click Apply" hole, and closing it properly wants a stronger invariant — *block Generate whenever the box holds text that isn't the key for the currently loaded options* — which is a behavior change beyond this PR's scope. Left for the follow-up round.

## Testing

- `cargo clippy --all-targets` clean
- Full suite green (382 lib + integration), including a new `flag_key_version_probe` covering all four branches: same-version, older, a 14-byte future key, and truncated/garbled input
- Both wasm targets build; classifier exercised against the real module from Node to confirm each branch's message

**Not browser-verified** — no automation available in this environment. The DOM wiring (input listener, CSS class, Generate gating) is unexercised and worth a manual pass.

Refs #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB