### PR TITLE
feature: rebuild the flag key as v29 — bitfield layout, checksum, reserve bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ deploys.
 
 ### Changed
 
+- **Flag keys have been rebuilt, and keys from earlier versions no longer
+  work.** This is the last time they break: the new format has room to grow, so
+  from here on adding an option leaves existing keys valid — the new option is
+  simply off in a key made before it existed. Two other things come with it:
+
+  - **A mistyped key is now caught.** Previously a single wrong character
+    produced a valid key for *different* settings about nine times out of ten,
+    with nothing on screen to say so. A key now carries a check byte, so a typo
+    or a truncated paste is rejected instead of quietly changing the ruleset —
+    which matters most in a race, where everyone is pasting the same key.
+  - **Keys got a little shorter** (26 characters instead of 27 for the default
+    set), and only carry as much as the settings need.
+
 - "Wild Injections" now lets you pick which chasers get dropped into levels,
   and adds a third one. The option is four pills — Off, Sun, Lakitu, Bass —
   where the three chasers toggle independently and Off clears them, so you can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ deploys.
 
 ### Added
 
+- **Random Boom-Boom Stomps** now has a toggle in the web app, under Bosses. It
+  was already part of the randomizer and already carried in the flag key, but
+  with no control on the page the web app always ran it on — and a shared flag
+  key that turned it off was silently ignored. The setting is on by default, so
+  nothing changes unless you turn it off.
+
 - The beta stage β4 now joins the Antechamber Shuffle pool when beta stages
   are enabled. Like the vanilla antechamber levels, its 8-screen interior can
   be swapped behind another level's entry pipe (and vice versa). With beta

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +378,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 name = "smb3-rs"
 version = "1.1.0"
 dependencies = [
+ "base32",
  "clap",
  "getrandom",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "modular-bitfield"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2956e537fc68236d2aa048f55704f231cc93f1c4de42fe1ecb5bd7938061fc4a"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mos6502"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +375,7 @@ dependencies = [
  "clap",
  "getrandom",
  "js-sys",
+ "modular-bitfield",
  "mos6502",
  "rand",
  "rand_chacha",
@@ -361,6 +383,12 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,5 @@ js-sys = "0.3"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]
+base32 = "0.5"
 mos6502 = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "testrom"
 path = "src/bin/testrom.rs"
 
 [dependencies]
+modular-bitfield = "0.13"
 rand = "0.9"
 rand_chacha = "0.9"
 serde = { version = "1", features = ["derive"] }

--- a/docs/application_flow.md
+++ b/docs/application_flow.md
@@ -229,7 +229,7 @@ flowchart TD
         F3["[always] qol::apply_macobra_patches  · tag qol/macobra"]
         F4{"faster_frog?"}
         F4y["qol::apply_faster_frog (MUST follow macobra patches) · tag qol/faster_frog"]
-        F5["[always] stamp flag-key + seed @ STAMP_OFFSET 0x19DF0 (24 bytes) · tag stamp"]
+        F5["[always] stamp flag-key + seed @ STAMP_OFFSET 0x19DF0 (~22-26 bytes; key length varies) · tag stamp"]
         F1 -- yes --> F1y --> F2
         F1 -- no --> F2
         F2 -- yes --> F2y --> F3

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -2132,14 +2132,19 @@ others get `0x37`. Without it the new ring boss loads `0x37` and the ring render
 
 **0x19103–0x193D9**: Region between overworld tile grid data and the InitIndex master pointer table (starts at 0x193DA). **WARNING:** 0x19103–0x1910F contains a tile lookup table, and 0x19110+ contains active map screen code (level-entry logic: `ROL $07`, `LDA $073C,X`, etc.). This is NOT free space — writing here corrupts the map screen and crashes on level entry.
 
-**0x19DD0–0x19FFF** (560 bytes): Free space after overworld tile/code region. The randomizer stamps a 17-byte identification block at **0x19DF0**:
+**0x19DD0–0x19FFF** (560 bytes): Free space after overworld tile/code region. The randomizer stamps an identification block at **0x19DF0**:
 
 | Offset | Size | Content |
 |--------|------|---------|
 | +0 | 3 | `S3R` magic bytes |
-| +3 | 1 | Version (0x02) |
-| +4 | 5 | Flag key bytes (encoded Options) |
-| +9 | 8 | Seed (little-endian u64) |
+| +3 | 1 | Length of the flag key bytes that follow (`N`) |
+| +4 | N | Flag key bytes (encoded Options; byte 0 is the flag-key format version, byte 1 its checksum) |
+| +4+N | 8 | Seed (little-endian u64) |
+
+`N` varies: since flag-key format v29 the encoder drops trailing zero bytes, so
+a set of options that doesn't reach the tail of the payload produces a shorter
+key. Typical block size is 22–26 bytes; the format's ceiling is 3 + 1 + 32 + 8 =
+44.
 
 **Note:** The Big ? Block trampoline and flag stamp both live in this region.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use rom::Rom;
 
 pub use ips::apply_ips_patch;
 pub use randomizer::{
-    current_flag_key_version, flag_key_version_of,
+    current_flag_key_version, flag_key_fields, flag_key_version_of,
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
     WildChaser, ITEMS, STARTING_LIVES_VALUES,
     ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -59,6 +59,14 @@ const FLAG_PAYLOAD_BYTES: usize = 30;
 /// Version byte + checksum byte.
 const ENVELOPE_BYTES: usize = 2;
 
+/// Every pre-v29 key was exactly this many bytes: a version byte and 12 bytes
+/// of hand-packed flags, with no checksum anywhere.
+const LEGACY_KEY_BYTES: usize = 13;
+
+/// Last format version that used the pre-v29 fixed-width layout. Nothing past
+/// this will ever be added, which is what keeps [`legacy_version_of`] exact.
+const LAST_LEGACY_VERSION: u8 = 28;
+
 /// Crockford Base-32 alphabet (excludes I, L, O, U to avoid ambiguity).
 pub(super) const CROCKFORD: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
@@ -195,7 +203,38 @@ pub fn current_flag_key_version() -> u8 {
 /// reporting a version if its bytes are intact, so a typo is reported as a bad
 /// key rather than sending the user hunting for a build that never existed.
 pub fn flag_key_version_of(key: &str) -> Result<u8, String> {
-    Ok(decode_envelope(strip_flag_key_prefix(key))?[0])
+    let stripped = strip_flag_key_prefix(key);
+    match decode_envelope(stripped) {
+        Ok(bytes) => Ok(bytes[0]),
+        Err(e) => legacy_version_of(stripped).ok_or(e),
+    }
+}
+
+/// Read the version off a pre-v29 key.
+///
+/// Those keys carry no checksum, so [`decode_envelope`] rejects every one of
+/// them as damaged. Without this fallback, everyone still holding a v26 or v28
+/// key — which is everyone, the day v29 ships — would be told their key is
+/// mistyped and sent hunting for a typo that isn't there, instead of "this is
+/// from an older version".
+///
+/// Exact rather than heuristic, and permanently bounded: the old layout was
+/// always 13 bytes with the version in byte 0, and no version past 28 ever used
+/// it. A v29+ key can also be 13 bytes, but its version byte is 29 or higher, so
+/// the two can't be confused.
+fn legacy_version_of(stripped: &str) -> Option<u8> {
+    let bytes = base32_decode(stripped).ok()?;
+    // `first()` rather than `bytes[0]`: an empty key decodes to no bytes, and
+    // `then_some` would evaluate the index either way.
+    let version = *bytes.first()?;
+    let is_legacy =
+        bytes.len() == LEGACY_KEY_BYTES && (1..=LAST_LEGACY_VERSION).contains(&version);
+    is_legacy.then_some(version)
+}
+
+/// The message for a key whose format this build doesn't read.
+fn unsupported_version(version: u8) -> String {
+    format!("Unsupported flag key version {version} (expected {FLAG_KEY_VERSION})")
 }
 
 /// `Options` fields deliberately absent from the flag key, with the reason.
@@ -571,11 +610,20 @@ impl Options {
 
     /// Decode a Crockford Base-32 flag key string into Options.
     pub fn from_flag_key(key: &str) -> Result<Options, String> {
-        let bytes = decode_envelope(strip_flag_key_prefix(key))?;
+        let stripped = strip_flag_key_prefix(key);
+        let bytes = match decode_envelope(stripped) {
+            Ok(bytes) => bytes,
+            // A pre-v29 key fails the envelope check for want of a checksum, not
+            // because it is damaged. Say which it is — the CLI shows this message
+            // verbatim, and "mistyped" would be a lie.
+            Err(checksum_err) => {
+                return Err(legacy_version_of(stripped).map_or(checksum_err, unsupported_version));
+            }
+        };
 
         let version = bytes[0];
         if version != FLAG_KEY_VERSION {
-            return Err(format!("Unsupported flag key version {version} (expected {FLAG_KEY_VERSION})"));
+            return Err(unsupported_version(version));
         }
 
         let body = &bytes[ENVELOPE_BYTES..];

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -374,9 +374,17 @@ mod payload {
         pub(super) starting_item_2: B5,
 
         // --- Reserve ---
-        // 147 bits. Spend these from the top when adding an option: an older key
-        // simply has them zero, which is "off" for a bool and the default for
-        // every enum here, so it stays a correct key for the settings it named.
+        // 147 bits. Adding an option is: declare it immediately above this
+        // block, then take the same number of bits off `B19`. An older key
+        // simply has those bits zero, which is "off" for a bool and the default
+        // for every enum here, so it stays a correct key for the settings it
+        // named — no version bump, and keys already in circulation keep working.
+        //
+        // Forgetting to shrink the reserve is a compile error, but a cryptic
+        // one: the crate reports `OneMod8: TotalSizeIsMultipleOfEightBits is not
+        // satisfied` against the struct. It means the widths no longer add up to
+        // `bytes * 8`, nothing more.
+        //
         // Two fields because the crate's widths stop at B128.
         #[skip] __: B128,
         #[skip] __: B19,

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -1,9 +1,38 @@
 //! Flag-key encode/decode: the shareable base32 string that round-trips an
 //! `Options` set (Crockford alphabet, versioned).
+//!
+//! # Format (v29)
+//!
+//! ```text
+//! byte 0   version
+//! byte 1   checksum over byte 0 and the payload as transmitted
+//! byte 2+  payload — a bitfield, trailing zero bytes stripped
+//! ```
+//!
+//! Three properties fall out of that shape, and each one is load-bearing:
+//!
+//! - **Bit collisions are unrepresentable.** The payload is a
+//!   [`modular_bitfield`] struct, so bit positions are assigned by declaration
+//!   order rather than written out by hand. Two options cannot land on the same
+//!   bit, which is a class of bug this format used to catch one incident at a
+//!   time.
+//! - **Adding an option does not break existing keys.** The payload has spare
+//!   capacity ([`FLAG_PAYLOAD_BYTES`]); a new option spends reserve bits, an
+//!   older key decodes them as zero, and zero is "off" for every bool and the
+//!   default for every enum here. So an addition needs **no version bump** —
+//!   only *repurposing* an allocated bit does.
+//! - **Mistyped keys are rejected instead of silently decoding to a different
+//!   ruleset.** Before the checksum, ~90% of single-character typos produced a
+//!   valid key for different settings with nothing on screen to say so.
+//!
+//! The version and checksum sit in a fixed two-byte envelope at the front on
+//! purpose: both stay readable without knowing the payload layout, so a future
+//! format can still be classified as "older"/"newer" rather than "garbage".
 
 use super::*;
+use modular_bitfield::prelude::*;
 
-pub(super) const FLAG_KEY_VERSION: u8 = 28;
+pub(super) const FLAG_KEY_VERSION: u8 = 29;
 
 pub(super) const FLAG_KEY_PREFIX: &str = "SMB3R-";
 
@@ -12,6 +41,23 @@ pub(super) const FLAG_KEY_PREFIX: &str = "SMB3R-";
 /// never perturbs the main randomization RNG, so a seed with no `Maybe`
 /// flags produces byte-identical output to before this feature existed.
 pub(super) const MAYBE_SALT: u64 = 0x4D41_5942_455F_5631; // "MAYBE_V1"
+
+/// Bytes of payload the format can address, past the two-byte envelope.
+///
+/// 93 bits are spent today, leaving 147 in reserve — years of headroom at the
+/// rate this project has actually added options (the layout was bumped six
+/// times in the 38 days to 2026-08-06). It is deliberately generous rather than
+/// "one more byte than we need": running out of reserve is the one thing that
+/// forces a breaking version bump, and unused capacity is free. Trailing zero
+/// bytes never leave the encoder, so raising this number does not lengthen a
+/// single key.
+///
+/// Must match the `bytes` argument on `FlagBits` — the compiler enforces it,
+/// since `from_bytes` takes the generated array type.
+const FLAG_PAYLOAD_BYTES: usize = 30;
+
+/// Version byte + checksum byte.
+const ENVELOPE_BYTES: usize = 2;
 
 /// Crockford Base-32 alphabet (excludes I, L, O, U to avoid ambiguity).
 pub(super) const CROCKFORD: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
@@ -40,11 +86,19 @@ pub(super) fn base32_encode(data: &[u8]) -> String {
 
 /// Decode a Crockford Base-32 string back into bytes.
 /// Accepts mixed case; normalizes I→1, L→1, O→0 per Crockford spec.
-pub(super) fn base32_decode(s: &str, expected_bytes: usize) -> Result<Vec<u8>, String> {
+///
+/// Length is not fixed — a key carries only as many payload bytes as it needs
+/// — but it is not free either: N bytes always encode to exactly `ceil(N*8/5)`
+/// characters, and anything else is rejected. That catches a character appended
+/// to or lost from the tail, which the checksum on its own can miss, since those
+/// spare bits are padding that never reaches a byte.
+pub(super) fn base32_decode(s: &str) -> Result<Vec<u8>, String> {
     let mut buf: u64 = 0;
     let mut bits: u32 = 0;
-    let mut result = Vec::with_capacity(expected_bytes);
+    let mut result = Vec::new();
+    let mut chars = 0usize;
     for ch in s.chars() {
+        chars += 1;
         let val = match ch.to_ascii_uppercase() {
             '0' | 'O' => 0,
             '1' | 'I' | 'L' => 1,
@@ -64,11 +118,33 @@ pub(super) fn base32_decode(s: &str, expected_bytes: usize) -> Result<Vec<u8>, S
             result.push((buf >> bits) as u8);
         }
     }
-    if result.len() < expected_bytes {
-        return Err(format!("Flag key too short (decoded {} bytes, expected {})", result.len(), expected_bytes));
+    if chars != (result.len() * 8).div_ceil(5) {
+        return Err(format!("Flag key is the wrong length ({chars} characters)"));
     }
-    result.truncate(expected_bytes);
     Ok(result)
+}
+
+/// CRC-8 (polynomial `0x07`, init 0) over the version byte and the payload as
+/// transmitted.
+///
+/// **Position-weighted on purpose.** A plain sum — or worse, an XOR — is blind
+/// to transposed bytes, so swapping two characters of a pasted key would sail
+/// through. A CRC catches every single-byte error, every transposition, and
+/// burst errors, for one byte of key.
+///
+/// This function is part of the wire format and must not change: a build reads
+/// the envelope of a key from *any* version before it knows whether it can
+/// decode the payload, which is what lets a mistyped key ("invalid") be told
+/// apart from a key built by a different release ("older"/"newer").
+pub(super) fn checksum(version: u8, payload: &[u8]) -> u8 {
+    let mut crc: u8 = 0;
+    for &byte in std::iter::once(&version).chain(payload) {
+        crc ^= byte;
+        for _ in 0..8 {
+            crc = if crc & 0x80 != 0 { (crc << 1) ^ 0x07 } else { crc << 1 };
+        }
+    }
+    crc
 }
 
 /// Trim surrounding whitespace and strip the "SMB3R-" prefix
@@ -90,6 +166,20 @@ fn strip_flag_key_prefix(key: &str) -> &str {
     }
 }
 
+/// Decode a prefix-stripped key into its raw bytes, rejecting anything that
+/// fails the envelope check. On success `bytes[0]` is the version and
+/// `bytes[ENVELOPE_BYTES..]` is the payload as transmitted.
+fn decode_envelope(stripped: &str) -> Result<Vec<u8>, String> {
+    let bytes = base32_decode(stripped)?;
+    if bytes.len() < ENVELOPE_BYTES {
+        return Err("Flag key is too short".to_string());
+    }
+    if bytes[1] != checksum(bytes[0], &bytes[ENVELOPE_BYTES..]) {
+        return Err("Flag key failed its checksum — it looks mistyped or truncated".to_string());
+    }
+    Ok(bytes)
+}
+
 /// The flag-key format version this build reads.
 pub fn current_flag_key_version() -> u8 {
     FLAG_KEY_VERSION
@@ -101,353 +191,406 @@ pub fn current_flag_key_version() -> u8 {
 /// isn't a flag key at all" — two failures that need different things from the
 /// user.
 ///
-/// Asymmetric about length on purpose. A short key is rejected outright even
-/// though its first byte is readable: a truncated or mistyped paste is not a
-/// version problem, and since a garbled first byte lands above the current
-/// version far more often than not, trusting it would report almost every typo
-/// as "from a newer version" and send the user hunting for a build that doesn't
-/// exist. A *long* key is fine — a future format that grows a 14th byte is
-/// genuinely newer, and saying so is the whole point.
+/// The checksum is what makes that split honest: a key only gets as far as
+/// reporting a version if its bytes are intact, so a typo is reported as a bad
+/// key rather than sending the user hunting for a build that never existed.
 pub fn flag_key_version_of(key: &str) -> Result<u8, String> {
-    Ok(base32_decode(strip_flag_key_prefix(key), 13)?[0])
+    Ok(decode_envelope(strip_flag_key_prefix(key))?[0])
+}
+
+/// `Options` fields deliberately absent from the flag key, with the reason.
+///
+/// This is the *only* hand-maintained part of the mapping: everything else is
+/// forced by the destructure in [`Options::to_flag_bits`], which names every
+/// field and so fails to compile when `Options` grows one. Adding a name here
+/// is a conscious decision, not an oversight.
+pub(super) const NOT_ENCODED: &[&str] = &[
+    "palettes",            // cosmetic; uses OS randomness, not seed-derived
+    "palette_themed",      // cosmetic
+    "player_color",        // cosmetic
+    "remove_flashing",     // cosmetic/accessibility; static patch, no RNG
+    "skip_rom_validation", // operational (CLI/WASM input handling), not randomization
+];
+
+/// The `Options` field names this build encodes into the flag key.
+///
+/// Derived — the serde field set minus [`NOT_ENCODED`] — so the web app's
+/// `inFlagKey` markings can be checked against what Rust actually persists
+/// instead of being documentation nobody verifies.
+pub fn flag_key_fields() -> Vec<String> {
+    let value = serde_json::to_value(Options::default())
+        .expect("Options is always serializable");
+    value
+        .as_object()
+        .expect("Options serializes to an object")
+        .keys()
+        .filter(|name| !NOT_ENCODED.contains(&name.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Wraps the generated bitfield so the whole macro expansion can be exempted
+/// from `dead_code` in one place.
+///
+/// Reason: the macro emits a getter, a checked getter, a setter, a checked
+/// setter and a builder method per field, in an `impl` block of its own. Decode
+/// uses the checked getters and encode uses the builders; the rest are
+/// unreachable by construction. The attribute has to sit on a module because it
+/// doesn't survive onto the generated `impl` from the struct.
+mod payload {
+    #![allow(dead_code)]
+    use super::*;
+
+    /// The flag-key payload.
+    ///
+    /// **Declaration order is the wire format.** Fields are packed from bit 0
+    /// of byte 0 upward in the order written here, so:
+    ///
+    /// - New options are **appended** immediately before the reserve. Never
+    ///   reorder, never resize an existing field, never insert in the middle —
+    ///   any of those silently repurposes bits that keys in circulation are
+    ///   using, which is the one change that forces a version bump.
+    /// - Removing an option leaves its bits behind as a named `_dead_*` hole
+    ///   rather than closing the gap, for the same reason.
+    #[bitfield(bytes = 30)]
+    #[derive(Debug, Clone, Copy)]
+    pub(super) struct FlagBits {
+        // --- Bools (32) ---
+        pub(super) powerups: bool,
+        pub(super) world_order: bool,
+        pub(super) big_q_blocks: bool,
+        pub(super) chest_items: bool,
+        pub(super) remove_whistles: bool,
+        pub(super) shuffle_airships: bool,
+        pub(super) shuffle_hammer_bros: bool,
+        pub(super) shuffle_spade_games: bool,
+        pub(super) shuffle_toad_houses: bool,
+        pub(super) hands_levels: bool,
+        pub(super) disable_autoscroll: bool,
+        pub(super) include_beta_stages: bool,
+        pub(super) swap_start_airship: bool,
+        pub(super) limit_bro_movement: bool,
+        pub(super) remove_n_cards: bool,
+        pub(super) card_speed_clear: bool,
+        pub(super) skip_wand_cutscene: bool,
+        pub(super) adjust_boss_hitboxes: bool,
+        pub(super) koopaling_hits: bool,
+        pub(super) boomboom_hits: bool,
+        pub(super) hammer_vulnerable_koopalings: bool,
+        pub(super) random_koopalings: bool,
+        pub(super) early_sun: bool,
+        pub(super) japanese_damage: bool,
+        pub(super) infinite_mushroom_houses: bool,
+        pub(super) fast_mushroom_house: bool,
+        pub(super) faster_tail_speed: bool,
+        pub(super) faster_frog: bool,
+        pub(super) no_game_over_penalty: bool,
+        pub(super) poison_mushrooms: bool,
+        pub(super) modern_powerups: bool,
+        pub(super) anchor_visuals: bool,
+
+        // --- Player-hidden tri-state flags (2 bits each) ---
+        // One field each now. The old layout split these into a value bit and a
+        // "maybe" bit in a different byte, purely because no byte had two free
+        // bits left.
+        pub(super) hammer_breaks_locks: Tri,
+        pub(super) hammer_breaks_bridges: Tri,
+        pub(super) more_hammer_rocks: Tri,
+        pub(super) eights_are_wild: Tri,
+        pub(super) troll_pipes: Tri,
+        pub(super) antechamber_shuffle: Tri,
+
+        // --- Per-class enemy modes (2 bits each) ---
+        pub(super) ground: EnemyMode,
+        pub(super) shell: EnemyMode,
+        pub(super) flying: EnemyMode,
+        pub(super) piranhas: EnemyMode,
+        pub(super) ghosts: EnemyMode,
+        pub(super) thwomps: EnemyMode,
+        pub(super) rotodiscs: EnemyMode,
+        pub(super) cannons: EnemyMode,
+        pub(super) water: EnemyMode,
+        pub(super) bros: EnemyMode,
+        pub(super) hb_encounters: EnemyMode,
+
+        // --- Mode enums (2 bits each) ---
+        pub(super) fire_flower: FireFlowerMode,
+        pub(super) piranha_shuffle: PiranhaMode,
+
+        // --- Wild-injection chaser set: one bit each, in WildChaser::ALL order ---
+        pub(super) wild_sun: bool,
+        pub(super) wild_lakitu: bool,
+        pub(super) wild_bass: bool,
+
+        // --- Numbers ---
+        /// Index into [`STARTING_LIVES_VALUES`].
+        pub(super) starting_lives: B2,
+        /// 1–7; 0 is a dead pattern that decodes to the default of 7.
+        pub(super) world_count: B3,
+        /// Item IDs directly (0 = empty slot), including the `ITEM_RANDOM*`
+        /// sentinels — 5 bits covers all of them, where the old layout needed a
+        /// nibble plus a separate 2-bit mode.
+        pub(super) starting_item_0: B5,
+        pub(super) starting_item_1: B5,
+        pub(super) starting_item_2: B5,
+
+        // --- Reserve ---
+        // 147 bits. Spend these from the top when adding an option: an older key
+        // simply has them zero, which is "off" for a bool and the default for
+        // every enum here, so it stays a correct key for the settings it named.
+        // Two fields because the crate's widths stop at B128.
+        #[skip] __: B128,
+        #[skip] __: B19,
+    }
+}
+
+use payload::FlagBits;
+
+/// Reduce a starting-item slot to a value the rest of the app knows: item IDs
+/// `1..=13` and the three `ITEM_RANDOM*` sentinels, or 0 for an empty slot.
+///
+/// Applied on both sides. On encode it keeps a hand-written JSON or CLI input
+/// inside the 5-bit field; on decode it drops the 17–31 patterns, which are
+/// reachable from a corrupt or newer key but mean nothing to the inventory
+/// writer.
+fn sanitize_item(raw: u8) -> u8 {
+    if raw <= ITEM_RANDOM_SUIT_ONLY { raw } else { 0 }
 }
 
 impl Options {
-    /// Encode options into raw bytes.
-    pub fn to_flag_bytes(&self) -> [u8; 13] {
-        let b0 = FLAG_KEY_VERSION;
+    /// Pack options into the flag-key payload.
+    #[rustfmt::skip]
+    fn to_flag_bits(&self) -> FlagBits {
+        // Destructured rather than field-accessed on purpose: adding a field to
+        // `Options` is a compile error here until it is either encoded below or
+        // bound as `field: _` and listed in `NOT_ENCODED`. That is what makes
+        // "did we forget to encode this one?" a build failure instead of a test
+        // that only ever covered the types someone remembered to list.
+        let Options {
+            powerups, world_order, big_q_blocks, chest_items, remove_whistles,
+            shuffle_airships, shuffle_hammer_bros, shuffle_spade_games,
+            shuffle_toad_houses, hands_levels, disable_autoscroll,
+            include_beta_stages, swap_start_airship, limit_bro_movement,
+            remove_n_cards, card_speed_clear, skip_wand_cutscene,
+            adjust_boss_hitboxes, koopaling_hits, boomboom_hits,
+            hammer_vulnerable_koopalings, random_koopalings, early_sun,
+            japanese_damage, infinite_mushroom_houses, fast_mushroom_house,
+            faster_tail_speed, faster_frog, no_game_over_penalty,
+            poison_mushrooms, modern_powerups, anchor_visuals,
+            hammer_breaks_locks, hammer_breaks_bridges, more_hammer_rocks,
+            eights_are_wild, troll_pipes, antechamber_shuffle,
+            ground, shell, flying, piranhas, ghosts, thwomps, rotodiscs,
+            cannons, water, bros, hb_encounters,
+            fire_flower, piranha_shuffle, wild_injections,
+            starting_lives, world_count, starting_items,
+            // Not encoded — see NOT_ENCODED for the reason on each.
+            palettes: _, palette_themed: _, player_color: _,
+            remove_flashing: _, skip_rom_validation: _,
+        } = self;
 
-        // The wild-injection chaser set is one bit each, scattered across three
-        // bytes because no byte had three bits free: sun in b4 bit 0 (where the
-        // old bool lived), lakitu in b12 bit 7, bass in b2 bit 5 (the dead
-        // shuffle_pipes slot). Same trick as eights_are_wild in b11.
-        let has = |c: WildChaser| self.wild_injections.contains(&c) as u8;
+        let item = |i: usize| starting_items.get(i).copied().unwrap_or(0);
+        let has = |c: WildChaser| wild_injections.contains(&c);
 
-        // b1: non-enemy flags. hammer_breaks_locks is tri-state: its value bit
-        // stores On vs (Off/Maybe); the Maybe bit lives in b11.
-        // b1 bit 1 = shuffle_hammer_bros (reuses the slot formerly airship_lock,
-        // now unconditionally on).
-        let b1 = (self.powerups as u8) << 7
-            | (self.hammer_breaks_locks.is_on() as u8) << 6
-            | (self.koopaling_hits as u8) << 5
-            | (self.world_order as u8) << 4
-            | (self.big_q_blocks as u8) << 3
-            | (self.disable_autoscroll as u8) << 2
-            | (self.shuffle_hammer_bros as u8) << 1
-            | (self.chest_items as u8);
+        FlagBits::new()
+            .with_powerups(*powerups)
+            .with_world_order(*world_order)
+            .with_big_q_blocks(*big_q_blocks)
+            .with_chest_items(*chest_items)
+            .with_remove_whistles(*remove_whistles)
+            .with_shuffle_airships(*shuffle_airships)
+            .with_shuffle_hammer_bros(*shuffle_hammer_bros)
+            .with_shuffle_spade_games(*shuffle_spade_games)
+            .with_shuffle_toad_houses(*shuffle_toad_houses)
+            .with_hands_levels(*hands_levels)
+            .with_disable_autoscroll(*disable_autoscroll)
+            .with_include_beta_stages(*include_beta_stages)
+            .with_swap_start_airship(*swap_start_airship)
+            .with_limit_bro_movement(*limit_bro_movement)
+            .with_remove_n_cards(*remove_n_cards)
+            .with_card_speed_clear(*card_speed_clear)
+            .with_skip_wand_cutscene(*skip_wand_cutscene)
+            .with_adjust_boss_hitboxes(*adjust_boss_hitboxes)
+            .with_koopaling_hits(*koopaling_hits)
+            .with_boomboom_hits(*boomboom_hits)
+            .with_hammer_vulnerable_koopalings(*hammer_vulnerable_koopalings)
+            .with_random_koopalings(*random_koopalings)
+            .with_early_sun(*early_sun)
+            .with_japanese_damage(*japanese_damage)
+            .with_infinite_mushroom_houses(*infinite_mushroom_houses)
+            .with_fast_mushroom_house(*fast_mushroom_house)
+            .with_faster_tail_speed(*faster_tail_speed)
+            .with_faster_frog(*faster_frog)
+            .with_no_game_over_penalty(*no_game_over_penalty)
+            .with_poison_mushrooms(*poison_mushrooms)
+            .with_modern_powerups(*modern_powerups)
+            .with_anchor_visuals(*anchor_visuals)
+            .with_hammer_breaks_locks(*hammer_breaks_locks)
+            .with_hammer_breaks_bridges(*hammer_breaks_bridges)
+            .with_more_hammer_rocks(*more_hammer_rocks)
+            .with_eights_are_wild(*eights_are_wild)
+            .with_troll_pipes(*troll_pipes)
+            .with_antechamber_shuffle(*antechamber_shuffle)
+            .with_ground(*ground)
+            .with_shell(*shell)
+            .with_flying(*flying)
+            .with_piranhas(*piranhas)
+            .with_ghosts(*ghosts)
+            .with_thwomps(*thwomps)
+            .with_rotodiscs(*rotodiscs)
+            .with_cannons(*cannons)
+            .with_water(*water)
+            .with_bros(*bros)
+            .with_hb_encounters(*hb_encounters)
+            .with_fire_flower(*fire_flower)
+            .with_piranha_shuffle(*piranha_shuffle)
+            .with_wild_sun(has(WildChaser::Sun))
+            .with_wild_lakitu(has(WildChaser::Lakitu))
+            .with_wild_bass(has(WildChaser::Bass))
+            .with_starting_lives(lives_to_idx(*starting_lives))
+            .with_world_count((*world_count).clamp(1, 7))
+            .with_starting_item_0(sanitize_item(item(0)))
+            .with_starting_item_1(sanitize_item(item(1)))
+            .with_starting_item_2(sanitize_item(item(2)))
+    }
 
-        // b2 bit 5 = wild-injection Bass bit (free since shuffle_pipes, a dead
-        // flag removed in v26).
-        // b2 bit 4 = faster_frog (reuses the slot formerly fix_drawbridges,
-        // now always-on).
-        // b2 bit 3 = boomboom_hits (reuses the slot formerly remove_rocks).
-        let b2 = (self.remove_whistles as u8) << 7
-            | (self.hands_levels as u8) << 6
-            | has(WildChaser::Bass) << 5
-            | (self.faster_frog as u8) << 4
-            | (self.boomboom_hits as u8) << 3
-            | (self.troll_pipes.is_on() as u8) << 2
-            | (self.shuffle_toad_houses as u8) << 1
-            | (self.shuffle_airships as u8);
+    /// Unpack the flag-key payload back into options.
+    ///
+    /// Every enum is read through the crate's *checked* accessor. Three-variant
+    /// enums in two bits leave a dead fourth pattern, and a key with reserve
+    /// bits set by a newer build can land on it — a panicking accessor there
+    /// would take the whole web app down, where falling back to the default is
+    /// exactly the "an unknown value is off" rule the reserve already relies on.
+    fn from_flag_bits(f: FlagBits) -> Options {
+        let chasers: Vec<WildChaser> = [
+            (WildChaser::Sun, f.wild_sun()),
+            (WildChaser::Lakitu, f.wild_lakitu()),
+            (WildChaser::Bass, f.wild_bass()),
+        ]
+        .into_iter()
+        .filter(|&(_, set)| set)
+        .map(|(c, _)| c)
+        .collect();
 
-        // b3: hammer_breaks_bridges(7) starting_lives(6-5) fast_mushroom_house(4)
-        //     faster_tail_speed(3) no_game_over_penalty(2) swap_start_airship(1)
-        //     more_hammer_rocks(0)
-        // starting_lives shrank from a 7-bit clamped 1–99 to a 2-bit index
-        // into {1, 5, 20, 99}, freeing bits 4-0 for future toggles.
-        let b3 = ((self.hammer_breaks_bridges.is_on() as u8) << 7)
-            | (lives_to_idx(self.starting_lives) << 5)
-            | ((self.fast_mushroom_house as u8) << 4)
-            | ((self.faster_tail_speed as u8) << 3)
-            | ((self.no_game_over_penalty as u8) << 2)
-            | ((self.swap_start_airship as u8) << 1)
-            | (self.more_hammer_rocks.is_on() as u8);
+        let items: Vec<u8> = [f.starting_item_0(), f.starting_item_1(), f.starting_item_2()]
+            .into_iter()
+            .map(sanitize_item)
+            .filter(|&i| i != 0)
+            .collect();
 
-        // Helper to encode EnemyMode as 2 bits
-        fn em(m: EnemyMode) -> u8 {
-            match m {
-                EnemyMode::Off => 0,
-                EnemyMode::Shuffle => 1,
-                EnemyMode::Wild => 2,
-            }
+        Options {
+            powerups: f.powerups(),
+            world_order: f.world_order(),
+            big_q_blocks: f.big_q_blocks(),
+            chest_items: f.chest_items(),
+            remove_whistles: f.remove_whistles(),
+            shuffle_airships: f.shuffle_airships(),
+            shuffle_hammer_bros: f.shuffle_hammer_bros(),
+            shuffle_spade_games: f.shuffle_spade_games(),
+            shuffle_toad_houses: f.shuffle_toad_houses(),
+            hands_levels: f.hands_levels(),
+            disable_autoscroll: f.disable_autoscroll(),
+            include_beta_stages: f.include_beta_stages(),
+            swap_start_airship: f.swap_start_airship(),
+            limit_bro_movement: f.limit_bro_movement(),
+            remove_n_cards: f.remove_n_cards(),
+            card_speed_clear: f.card_speed_clear(),
+            skip_wand_cutscene: f.skip_wand_cutscene(),
+            adjust_boss_hitboxes: f.adjust_boss_hitboxes(),
+            koopaling_hits: f.koopaling_hits(),
+            boomboom_hits: f.boomboom_hits(),
+            hammer_vulnerable_koopalings: f.hammer_vulnerable_koopalings(),
+            random_koopalings: f.random_koopalings(),
+            early_sun: f.early_sun(),
+            japanese_damage: f.japanese_damage(),
+            infinite_mushroom_houses: f.infinite_mushroom_houses(),
+            fast_mushroom_house: f.fast_mushroom_house(),
+            faster_tail_speed: f.faster_tail_speed(),
+            faster_frog: f.faster_frog(),
+            no_game_over_penalty: f.no_game_over_penalty(),
+            poison_mushrooms: f.poison_mushrooms(),
+            modern_powerups: f.modern_powerups(),
+            anchor_visuals: f.anchor_visuals(),
+            hammer_breaks_locks: f.hammer_breaks_locks_or_err().unwrap_or_default(),
+            hammer_breaks_bridges: f.hammer_breaks_bridges_or_err().unwrap_or_default(),
+            more_hammer_rocks: f.more_hammer_rocks_or_err().unwrap_or_default(),
+            eights_are_wild: f.eights_are_wild_or_err().unwrap_or_default(),
+            troll_pipes: f.troll_pipes_or_err().unwrap_or_default(),
+            antechamber_shuffle: f.antechamber_shuffle_or_err().unwrap_or_default(),
+            ground: f.ground_or_err().unwrap_or_default(),
+            shell: f.shell_or_err().unwrap_or_default(),
+            flying: f.flying_or_err().unwrap_or_default(),
+            piranhas: f.piranhas_or_err().unwrap_or_default(),
+            ghosts: f.ghosts_or_err().unwrap_or_default(),
+            thwomps: f.thwomps_or_err().unwrap_or_default(),
+            rotodiscs: f.rotodiscs_or_err().unwrap_or_default(),
+            cannons: f.cannons_or_err().unwrap_or_default(),
+            water: f.water_or_err().unwrap_or_default(),
+            bros: f.bros_or_err().unwrap_or_default(),
+            hb_encounters: f.hb_encounters_or_err().unwrap_or_default(),
+            fire_flower: f.fire_flower_or_err().unwrap_or_default(),
+            piranha_shuffle: f.piranha_shuffle_or_err().unwrap_or_default(),
+            wild_injections: chasers,
+            starting_lives: idx_to_lives(f.starting_lives()),
+            // 0 is unreachable from the encoder (it clamps to 1–7) but reachable
+            // from a corrupt or newer key; take the default rather than a world
+            // count the builder can't satisfy.
+            world_count: match f.world_count() { 0 => default_world_count(), n => n },
+            starting_items: items,
+            // Not encoded: fixed to the values a shared key should never
+            // override. The web app skips these fields when applying a decoded
+            // key, so a racer's cosmetic and ROM choices survive.
+            palettes: true,
+            palette_themed: false,
+            player_color: None,
+            remove_flashing: true,
+            skip_rom_validation: false,
         }
+    }
 
-        // b4: card_speed_clear(7) remove_n_cards(6) skip_wand_cutscene(5)
-        //     adjust_boss_hitboxes(4) shuffle_spade_games(3)
-        //     hb_encounters(2-1) wild_injections low bit(0)
-        let b4 = (self.card_speed_clear as u8) << 7
-            | (self.remove_n_cards as u8) << 6
-            | (self.skip_wand_cutscene as u8) << 5
-            | (self.adjust_boss_hitboxes as u8) << 4
-            | (self.shuffle_spade_games as u8) << 3
-            | em(self.hb_encounters) << 1
-            | has(WildChaser::Sun);
-
-        // b5: ground(7-6) shell(5-4) flying(3-2) hammer_vulnerable_koopalings(1) early_sun(0)
-        let b5 = em(self.ground) << 6
-            | em(self.shell) << 4
-            | em(self.flying) << 2
-            | (self.hammer_vulnerable_koopalings as u8) << 1
-            | (self.early_sun as u8);
-
-        // b6: japanese_damage(7) infinite_mushroom_houses(6) piranhas(5-4)
-        //     ghosts(3-2) thwomps(1-0)
-        // Bits 7-6 were the two `bullet_bills` bits before v17; now reused
-        // for the two MaCobra52 player/map mechanic toggles.
-        let b6 = (self.japanese_damage as u8) << 7
-            | (self.infinite_mushroom_houses as u8) << 6
-            | em(self.piranhas) << 4
-            | em(self.ghosts) << 2
-            | em(self.thwomps);
-
-        // b7: rotodiscs(7-6) cannons(5-4) water(3-2) bros(1-0)
-        let b7 = em(self.rotodiscs) << 6
-            | em(self.cannons) << 4
-            | em(self.water) << 2
-            | em(self.bros);
-
-        // b8-b9: starting items (3 nibbles, 0 = none)
-        // For sentinel values (>=14), store 0 in the nibble and encode
-        // the random mode in b10 bits 5-0 instead.
-        let items = &self.starting_items;
-        fn item_nibble(item: u8) -> u8 {
-            if item >= ITEM_RANDOM { 0 } else { item }
-        }
-        fn item_mode(item: u8) -> u8 {
-            match item {
-                ITEM_RANDOM => 1,
-                ITEM_RANDOM_NO_WHISTLE => 2,
-                ITEM_RANDOM_SUIT_ONLY => 3,
-                _ => 0,
-            }
-        }
-        let i0 = items.first().copied().unwrap_or(0);
-        let i1 = items.get(1).copied().unwrap_or(0);
-        let i2 = items.get(2).copied().unwrap_or(0);
-        let b8 = (item_nibble(i0) << 4) | item_nibble(i1);
-        // b9: i2 nibble (7-4) | limit_bro_movement (3) | world_count 1..7 (2-0)
-        let b9 = (item_nibble(i2) << 4)
-            | ((self.limit_bro_movement as u8) << 3)
-            | (self.world_count.clamp(1, 7) & 0x07);
-
-        // b10: extra flags + per-slot random mode (2 bits each)
-        let b10 = (self.random_koopalings as u8) << 7
-            | (self.include_beta_stages as u8) << 6
-            | (item_mode(i0) << 4)
-            | (item_mode(i1) << 2)
-            | item_mode(i2);
-
-        // Encode FireFlowerMode as 2 bits (off=0, on=1, wild=2).
-        fn ffm(m: FireFlowerMode) -> u8 {
-            match m {
-                FireFlowerMode::Off => 0,
-                FireFlowerMode::On => 1,
-                FireFlowerMode::Wild => 2,
-            }
-        }
-
-        // b11: "maybe" bits for the four player-hidden tri-state flags (bits
-        // 0-3). When a maybe bit is set the flag is resolved from the seed at
-        // generation time, and its value bit (in b1/b2/b3) is ignored on decode.
-        // Bits 4-5 hold the Random Fire Flower mode. Bit 6 is the eights_are_wild
-        // ON bit and bit 7 its Maybe bit (both live here since b1-b4 are full).
-        let b11 = (self.hammer_breaks_locks.is_maybe() as u8)
-            | (self.hammer_breaks_bridges.is_maybe() as u8) << 1
-            | (self.troll_pipes.is_maybe() as u8) << 2
-            | (self.more_hammer_rocks.is_maybe() as u8) << 3
-            | ffm(self.fire_flower) << 4
-            | (self.eights_are_wild.is_on() as u8) << 6
-            | (self.eights_are_wild.is_maybe() as u8) << 7;
-
-        // Encode PiranhaMode as 2 bits (off=0, on=1, wild=2).
-        fn pm(m: PiranhaMode) -> u8 {
-            match m {
-                PiranhaMode::Off => 0,
-                PiranhaMode::On => 1,
-                PiranhaMode::Wild => 2,
-            }
-        }
-
-        // b12: piranha_shuffle(1-0), antechamber_shuffle ON bit (2) and
-        // Maybe bit (3), anchor_visuals(4), poison_mushrooms(5),
-        // modern_powerups(6), wild-injection Lakitu bit (7).
-        //
-        // With that bit taken the key is FULL: every bit of b1-b12 is
-        // allocated (checked bit by bit, not assumed — b3's "freeing bits 4-0"
-        // note above is historical, those five were spent since). The next flag
-        // needs a 14th byte, which means a longer key string as well as a
-        // version bump.
-        let b12 = pm(self.piranha_shuffle)
-            | (self.antechamber_shuffle.is_on() as u8) << 2
-            | (self.antechamber_shuffle.is_maybe() as u8) << 3
-            | (self.anchor_visuals as u8) << 4
-            | (self.poison_mushrooms as u8) << 5
-            | (self.modern_powerups as u8) << 6
-            | has(WildChaser::Lakitu) << 7;
-
-        [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12]
+    /// Encode options into the raw key bytes: version, checksum, payload.
+    pub fn to_flag_bytes(&self) -> Vec<u8> {
+        let payload = self.to_flag_bits().into_bytes();
+        // Trailing zero bytes carry nothing, so they are not transmitted. That
+        // is what decouples the format's capacity from the key's length: the
+        // reserve can be generous without anyone ever typing it.
+        let used = payload.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+        let mut bytes = Vec::with_capacity(ENVELOPE_BYTES + used);
+        bytes.push(FLAG_KEY_VERSION);
+        bytes.push(checksum(FLAG_KEY_VERSION, &payload[..used]));
+        bytes.extend_from_slice(&payload[..used]);
+        bytes
     }
 
     /// Encode options into a compact Crockford Base-32 flag key (e.g. "SMB3R-1S0G...").
     pub fn to_flag_key(&self) -> String {
-        let bytes = self.to_flag_bytes();
-        let mut key = String::with_capacity(6 + 18);
+        let mut key = String::with_capacity(FLAG_KEY_PREFIX.len() + 24);
         key.push_str(FLAG_KEY_PREFIX);
-        key.push_str(&base32_encode(&bytes));
+        key.push_str(&base32_encode(&self.to_flag_bytes()));
         key
     }
 
     /// Decode a Crockford Base-32 flag key string into Options.
     pub fn from_flag_key(key: &str) -> Result<Options, String> {
-        let bytes = base32_decode(strip_flag_key_prefix(key), 13)?;
+        let bytes = decode_envelope(strip_flag_key_prefix(key))?;
 
         let version = bytes[0];
         if version != FLAG_KEY_VERSION {
             return Err(format!("Unsupported flag key version {version} (expected {FLAG_KEY_VERSION})"));
         }
 
-        let b1 = bytes[1];
-        let b2 = bytes[2];
-        let b3 = bytes[3];
-        let b4 = bytes[4];
-        let b5 = bytes[5];
-        let b6 = bytes[6];
-        let b7 = bytes[7];
-        let b8 = bytes[8];
-        let b9 = bytes[9];
-        let b10 = bytes[10];
-        let b11 = bytes[11];
-        let b12 = bytes[12];
-
-        let starting_lives = idx_to_lives((b3 >> 5) & 0x3);
-
-        fn dem(bits: u8) -> EnemyMode {
-            match bits & 0x03 {
-                1 => EnemyMode::Shuffle,
-                2 => EnemyMode::Wild,
-                _ => EnemyMode::Off,
-            }
+        let body = &bytes[ENVELOPE_BYTES..];
+        if body.len() > FLAG_PAYLOAD_BYTES {
+            return Err(format!(
+                "Flag key payload is too long ({} bytes, capacity {FLAG_PAYLOAD_BYTES})",
+                body.len(),
+            ));
         }
+        // Zero-fill back to capacity: a key made before some later option
+        // existed simply doesn't carry the bytes that option lives in.
+        let mut payload = [0u8; FLAG_PAYLOAD_BYTES];
+        payload[..body.len()].copy_from_slice(body);
 
-        // Decode a tri-state flag from its value bit (in b1/b2/b3) and its
-        // maybe bit (in b11). Maybe wins; otherwise the value bit picks On/Off.
-        fn dtri(value: bool, maybe: bool) -> Tri {
-            if maybe { Tri::Maybe } else if value { Tri::On } else { Tri::Off }
-        }
-
-        // Decode the 2-bit Random Fire Flower mode (b11 bits 4-5).
-        fn dffm(bits: u8) -> FireFlowerMode {
-            match bits & 0x03 {
-                1 => FireFlowerMode::On,
-                2 => FireFlowerMode::Wild,
-                _ => FireFlowerMode::Off,
-            }
-        }
-
-        // Decode the 2-bit piranha shuffle mode (b12 bits 1-0).
-        fn dpm(bits: u8) -> PiranhaMode {
-            match bits & 0x03 {
-                1 => PiranhaMode::On,
-                2 => PiranhaMode::Wild,
-                _ => PiranhaMode::Off,
-            }
-        }
-
-        // Rebuild the wild-injection chaser set from its three scattered bits,
-        // always in WildChaser::ALL order so a round-trip normalizes.
-        let chasers: Vec<WildChaser> = [
-            (WildChaser::Sun, b4 & 1),
-            (WildChaser::Lakitu, (b12 >> 7) & 1),
-            (WildChaser::Bass, (b2 >> 5) & 1),
-        ]
-        .into_iter()
-        .filter(|&(_, bit)| bit != 0)
-        .map(|(c, _)| c)
-        .collect();
-
-        Ok(Options {
-            powerups: (b1 >> 7) & 1 != 0,
-            palettes: true,
-            palette_themed: false, // cosmetic — not encoded in flag key
-            player_color: None,    // cosmetic — not encoded in flag key
-            remove_flashing: true, // cosmetic/accessibility — not encoded in flag key
-            hammer_breaks_locks: dtri((b1 >> 6) & 1 != 0, b11 & 1 != 0),
-            koopaling_hits: (b1 >> 5) & 1 != 0,
-            boomboom_hits: (b2 >> 3) & 1 != 0,
-            world_order: (b1 >> 4) & 1 != 0,
-            big_q_blocks: (b1 >> 3) & 1 != 0,
-            disable_autoscroll: (b1 >> 2) & 1 != 0,
-            shuffle_hammer_bros: (b1 >> 1) & 1 != 0,
-            chest_items: b1 & 1 != 0,
-            remove_whistles: (b2 >> 7) & 1 != 0,
-            hands_levels: (b2 >> 6) & 1 != 0,
-            faster_frog: (b2 >> 4) & 1 != 0,
-            shuffle_airships: b2 & 1 != 0,
-            shuffle_toad_houses: (b2 >> 1) & 1 != 0,
-            troll_pipes: dtri((b2 >> 2) & 1 != 0, (b11 >> 2) & 1 != 0),
-            starting_lives,
-            card_speed_clear: (b4 >> 7) & 1 != 0,
-            remove_n_cards: (b4 >> 6) & 1 != 0,
-            skip_wand_cutscene: (b4 >> 5) & 1 != 0,
-            adjust_boss_hitboxes: (b4 >> 4) & 1 != 0,
-            shuffle_spade_games: (b4 >> 3) & 1 != 0,
-            hammer_vulnerable_koopalings: (b5 >> 1) & 1 != 0,
-            early_sun: b5 & 1 != 0,
-            limit_bro_movement: (b9 >> 3) & 1 != 0,
-            japanese_damage: (b6 >> 7) & 1 != 0,
-            infinite_mushroom_houses: (b6 >> 6) & 1 != 0,
-            fast_mushroom_house: (b3 >> 4) & 1 != 0,
-            faster_tail_speed: (b3 >> 3) & 1 != 0,
-            no_game_over_penalty: (b3 >> 2) & 1 != 0,
-            swap_start_airship: (b3 >> 1) & 1 != 0,
-            more_hammer_rocks: dtri(b3 & 1 != 0, (b11 >> 3) & 1 != 0),
-            eights_are_wild: dtri((b11 >> 6) & 1 != 0, (b11 >> 7) & 1 != 0),
-            random_koopalings: (b10 >> 7) & 1 != 0,
-            include_beta_stages: (b10 >> 6) & 1 != 0,
-            hammer_breaks_bridges: dtri((b3 >> 7) & 1 != 0, (b11 >> 1) & 1 != 0),
-            fire_flower: dffm(b11 >> 4),
-            piranha_shuffle: dpm(b12),
-            antechamber_shuffle: dtri((b12 >> 2) & 1 != 0, (b12 >> 3) & 1 != 0),
-            ground: dem(b5 >> 6),
-            shell: dem(b5 >> 4),
-            flying: dem(b5 >> 2),
-            piranhas: dem(b6 >> 4),
-            ghosts: dem(b6 >> 2),
-            thwomps: dem(b6),
-            rotodiscs: dem(b7 >> 6),
-            cannons: dem(b7 >> 4),
-            water: dem(b7 >> 2),
-            bros: dem(b7),
-            hb_encounters: dem(b4 >> 1),
-            wild_injections: chasers,
-            starting_items: {
-                // Decode per-slot random mode from b10 bits 5-0
-                fn mode_to_sentinel(mode: u8, nibble: u8) -> u8 {
-                    match mode & 0x03 {
-                        1 => ITEM_RANDOM,
-                        2 => ITEM_RANDOM_NO_WHISTLE,
-                        3 => ITEM_RANDOM_SUIT_ONLY,
-                        _ => nibble,
-                    }
-                }
-                let i0 = mode_to_sentinel((b10 >> 4) & 0x03, b8 >> 4);
-                let i1 = mode_to_sentinel((b10 >> 2) & 0x03, b8 & 0x0F);
-                let i2 = mode_to_sentinel(b10 & 0x03, b9 >> 4);
-                let mut items = Vec::new();
-                if i0 != 0 { items.push(i0); }
-                if i1 != 0 { items.push(i1); }
-                if i2 != 0 { items.push(i2); }
-                items
-            },
-            world_count: {
-                let wc = b9 & 0x07;
-                if wc == 0 { 7 } else { wc.clamp(1, 7) }
-            },
-            skip_rom_validation: false,
-            anchor_visuals: (b12 >> 4) & 1 != 0,
-            poison_mushrooms: (b12 >> 5) & 1 != 0,
-            modern_powerups: (b12 >> 6) & 1 != 0,
-        })
+        Ok(Options::from_flag_bits(FlagBits::from_bytes(payload)))
     }
 
     /// Returns true if any enemy class is enabled (not Off).

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -15,7 +15,7 @@ use flag_key::*;
 use options::*;
 
 // Public API re-exported by the crate root (see lib.rs).
-pub use flag_key::{current_flag_key_version, flag_key_version_of};
+pub use flag_key::{current_flag_key_version, flag_key_fields, flag_key_version_of};
 pub use options::{
     item_display_name, item_id, EnemyMode, FireFlowerMode, Options, PiranhaMode, Tri,
     WildChaser, ITEMS, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY,
@@ -563,14 +563,15 @@ fn randomize_inner(
     }
 
     // Stamp flag key + seed into free space at STAMP_OFFSET (PRG012):
-    //   "S3R" magic + version byte, the flag key bytes (13 in v23), then the
-    //   seed (little-endian u64). Sizes derive from to_flag_bytes() so the
-    //   stamp grows with the flag key.
+    //   "S3R" magic, a length byte, the flag key bytes, then the seed
+    //   (little-endian u64). The key bytes lead with their own format version,
+    //   and since v29 their length varies with how much of the payload the
+    //   options reach — hence the length byte, so the seed can still be found.
     rom.set_tag("stamp");
     let flag_bytes = options.to_flag_bytes();
     let mut stamp = Vec::with_capacity(4 + flag_bytes.len() + 8);
     stamp.extend_from_slice(b"S3R");
-    stamp.push(FLAG_KEY_VERSION);
+    stamp.push(flag_bytes.len() as u8);
     stamp.extend_from_slice(&flag_bytes);
     stamp.extend_from_slice(&seed.to_le_bytes());
     rom.write_range(STAMP_OFFSET, &stamp);

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -82,7 +82,16 @@ pub(super) fn lives_to_idx(lives: u8) -> u8 {
 pub(super) fn default_world_count() -> u8 { 7 }
 
 /// Per-class enemy randomization mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+///
+/// The `Specifier` derive gives this a 2-bit flag-key encoding in declaration
+/// order (`Off` = 0). Three variants in two bits leaves a dead fourth pattern,
+/// so the flag-key decoder reads it through the checked accessor and falls back
+/// to `Off` — see `flag_key.rs`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize,
+    modular_bitfield::Specifier,
+)]
+#[bits = 2]
 #[serde(rename_all = "snake_case")]
 pub enum EnemyMode {
     #[default]
@@ -100,7 +109,11 @@ pub(super) fn default_off() -> EnemyMode { EnemyMode::Off }
 /// flower's level position, instead of always Fire. `On` substitutes among the
 /// four big-form suits (Fire/Frog/Tanooki/Hammer); `Wild` adds the Small/Big
 /// downgrade outcomes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize,
+    modular_bitfield::Specifier,
+)]
+#[bits = 2]
 #[serde(rename_all = "snake_case")]
 pub enum FireFlowerMode {
     #[default]
@@ -115,7 +128,11 @@ pub enum FireFlowerMode {
 /// land. `Wild` also releases them (as plain numbered levels), and instead
 /// scatters plant sprites onto ~1 random level slot per world — stepping on
 /// a plant auto-starts the level under it, vanilla W7 style.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize,
+    modular_bitfield::Specifier,
+)]
+#[bits = 2]
 #[serde(rename_all = "snake_case")]
 pub enum PiranhaMode {
     #[default]
@@ -171,7 +188,11 @@ impl WildChaser {
 /// [`Tri::resolve`]), so the same seed + same flags always produce the same
 /// ROM — the player just can't tell from the flag key which way a `Maybe`
 /// landed, so it can't be planned around.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize,
+    modular_bitfield::Specifier,
+)]
+#[bits = 2]
 #[serde(rename_all = "snake_case")]
 pub enum Tri {
     #[default]
@@ -190,10 +211,6 @@ impl Tri {
             Tri::Maybe => rng.random_bool(0.5),
         }
     }
-    /// True only for the explicit `On` state — drives the value bit in the flag key.
-    pub(super) fn is_on(self) -> bool { matches!(self, Tri::On) }
-    /// True only for the `Maybe` state — drives the maybe bit in the flag key.
-    pub(super) fn is_maybe(self) -> bool { matches!(self, Tri::Maybe) }
 }
 
 pub(super) fn default_tri_on() -> Tri { Tri::On }

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -727,6 +727,45 @@ fn flag_key_version_probe() {
     assert!(flag_key_version_of(&key[..key.len() - 4]).is_err());
 }
 
+/// Keys made before v29 must be classified as *older*, not as mistyped.
+///
+/// They carry no checksum, so the envelope check rejects every one of them —
+/// and on the day v29 ships, that is every key in circulation. Telling those
+/// users to check for a typo would send them looking for something that isn't
+/// there, and it is the exact three-way message (#159) this format is supposed
+/// to keep honest.
+#[test]
+fn flag_key_pre_v29_keys_read_as_older() {
+    // A real v28 key: the default set, quoted in issue #158's typo measurement.
+    let v28 = "SMB3R-3JKWY87RAGA0A00700000";
+    assert_eq!(flag_key_version_of(v28), Ok(28));
+    assert!(Options::from_flag_key(v28).unwrap_err().contains("version 28"));
+
+    // Synthetic keys across the whole legacy range, in the shape those versions
+    // used: 13 bytes, version in byte 0, no checksum.
+    for version in 1..=28u8 {
+        let mut bytes = [0xA5u8; 13];
+        bytes[0] = version;
+        let key = format!("SMB3R-{}", base32_encode(&bytes));
+        assert_eq!(flag_key_version_of(&key), Ok(version), "v{version} must read as older");
+        assert!(Options::from_flag_key(&key).is_err(), "v{version} must not decode");
+    }
+
+    // The fallback must not swallow real damage. A v29 key with a mangled body
+    // is still 13-plus bytes, but its version byte is 29, so it stays invalid
+    // rather than being announced as some older version.
+    let mut broken = Options::default().to_flag_bytes();
+    let last = broken.len() - 1;
+    broken[last] ^= 0xFF;
+    assert!(flag_key_version_of(&base32_encode(&broken)).is_err());
+
+    // And a legacy-length run of garbage whose first byte is out of range is
+    // still invalid — the probe is a range check, not "trust byte 0".
+    let mut garbage = [0x00u8; 13];
+    garbage[0] = 200;
+    assert!(flag_key_version_of(&base32_encode(&garbage)).is_err());
+}
+
 /// Golden fixtures pinning the v29 bit and byte order.
 ///
 /// The layout is generated from declaration order in `FlagBits`, so nothing in

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -905,6 +905,92 @@ fn flag_key_not_encoded_names_are_real_fields() {
     }
 }
 
+/// Cross-check the hand-written Crockford codec against an independent
+/// implementation (`base32`, a dev-dependency — it reaches neither the binary
+/// nor the WASM bundle).
+///
+/// The alphabet layer is the one part of the format that is a published spec
+/// rather than our invention, so it can be verified against someone else's
+/// reading of that spec instead of only against itself. A golden test proves we
+/// still agree with *yesterday's us*; this proves we agree with Crockford.
+///
+/// Worth knowing before reaching for a crate here: "Crockford base32" crates
+/// are **not** interchangeable. `c32` 0.6.1 encodes this same key as
+/// `7D2Z73GY000A4AN001T` — 19 characters against our 20 — and swapping to it
+/// would silently invalidate every key in circulation. `crockford` 1.2.1 only
+/// handles `u64`, which cannot hold a 30-byte payload.
+///
+/// Two behaviours are deliberately *not* delegated, which is why the codec is
+/// still ours: `base32` accepts non-canonical lengths (it decoded a 19-character
+/// truncation of the key below to 11 bytes, where we reject it — that check
+/// catches a tail character the checksum can miss), and it returns `Option`, so
+/// it cannot say *which* character was bad in a message the app shows the user.
+#[test]
+fn base32_matches_an_independent_crockford_implementation() {
+    use base32::Alphabet::Crockford;
+
+    // Every payload width the format can produce, plus the envelope.
+    for n in 0..=(2 + 30usize) {
+        let data: Vec<u8> = (0..n)
+            .map(|i| (i as u8).wrapping_mul(37).wrapping_add(11))
+            .collect();
+        let ours = base32_encode(&data);
+        assert_eq!(ours, base32::encode(Crockford, &data), "encode differs at {n} bytes");
+        assert_eq!(
+            base32_decode(&ours).unwrap(),
+            base32::decode(Crockford, &ours).unwrap(),
+            "decode differs at {n} bytes",
+        );
+    }
+
+    // Real keys, not just synthetic patterns.
+    for opts in [Options::default(), all_off_options(), all_on_options()] {
+        let body = opts.to_flag_key();
+        let body = body.strip_prefix("SMB3R-").unwrap();
+        assert_eq!(
+            base32::decode(Crockford, body).unwrap(),
+            opts.to_flag_bytes(),
+            "an independent decoder disagrees about a real key",
+        );
+    }
+
+    // Crockford's exclusions. Asserted against the expectation as well as
+    // against the crate, so both being wrong the same way still fails.
+    for (probe, want_ok) in [
+        ("3PHFKHRF000525AG00X0", true),  // canonical
+        ("3phfkhrf000525ag00x0", true),  // case-insensitive
+        ("3PHFKHRF000525AGU0X0", false), // U is excluded from the alphabet
+        ("3PHFKHRF000525AG!0X0", false), // not an alphabet character at all
+    ] {
+        assert_eq!(base32_decode(probe).is_ok(), want_ok, "'{probe}' decodable?");
+        assert_eq!(
+            base32_decode(probe).is_ok(),
+            base32::decode(Crockford, probe).is_some(),
+            "disagreement on whether '{probe}' is decodable",
+        );
+    }
+
+    // Crockford's ambiguity normalizations: I and L read as 1, O reads as 0.
+    // Compared by decoded *bytes*, not just by "both accepted it" — dropping
+    // the I/L arm entirely still leaves a decodable string, so an acceptance
+    // check alone sails past it (confirmed by mutating the decoder).
+    for (probe, canonical) in [
+        ("IILL", "1111"),
+        ("iIlL", "1111"),
+        ("OOOO", "0000"),
+        ("oO00", "0000"),
+        ("H1JK", "HIJK"),
+    ] {
+        let expected = base32_decode(canonical).unwrap();
+        assert_eq!(base32_decode(probe).unwrap(), expected, "'{probe}' must read as '{canonical}'");
+        assert_eq!(
+            base32::decode(Crockford, probe).unwrap(),
+            expected,
+            "independent decoder disagrees that '{probe}' reads as '{canonical}'",
+        );
+    }
+}
+
 #[test]
 fn base32_round_trip() {
     // Test with various byte patterns

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -209,7 +209,7 @@ fn flag_key_round_trip_defaults() {
     let opts = Options::default();
     let key = opts.to_flag_key();
     assert!(key.starts_with("SMB3R-"));
-    assert_eq!(key.len(), 27); // "SMB3R-" + 21 base32
+    assert_eq!(key.len(), 26); // "SMB3R-" + 20 base32
     let decoded = Options::from_flag_key(&key).unwrap();
     assert_eq!(decoded, normalized(opts));
 }
@@ -338,14 +338,16 @@ fn flag_key_without_prefix() {
     assert_eq!(opts.powerups, decoded.powerups);
 }
 
+/// A well-formed key from a format version this build doesn't speak is
+/// rejected — but only after passing the envelope check, so the app can say
+/// "older/newer version" rather than "mistyped".
 #[test]
 fn flag_key_invalid_version() {
-    // Encode version 0xFF into base32 (first byte = 0xFF, rest zeros)
-    let mut bad_bytes = [0u8; 13];
-    bad_bytes[0] = 0xFF;
-    let key = format!("SMB3R-{}", base32_encode(&bad_bytes));
-    let result = Options::from_flag_key(&key);
-    assert!(result.is_err());
+    for version in [0x00, FLAG_KEY_VERSION - 1, FLAG_KEY_VERSION + 1, 0xFF] {
+        let key = forge_key(version, &Options::default().to_flag_bytes()[2..]);
+        assert_eq!(flag_key_version_of(&key), Ok(version), "version probe on v{version}");
+        assert!(Options::from_flag_key(&key).is_err(), "v{version} must not decode");
+    }
 }
 
 #[test]
@@ -630,14 +632,10 @@ fn flag_key_per_option_round_trip() {
 /// author either encodes it or consciously adds it to `NOT_ENCODED`.
 #[test]
 fn flag_key_encodes_every_bool_option() {
-    // Bool fields intentionally absent from the flag key, with the reason.
-    // Adding to this list is a conscious decision, not an oversight.
-    const NOT_ENCODED: &[&str] = &[
-        "palettes",            // cosmetic; uses OS randomness, not seed-derived
-        "palette_themed",      // cosmetic
-        "remove_flashing",     // cosmetic/accessibility; static patch, no RNG
-        "skip_rom_validation", // operational (CLI/WASM input handling), not randomization
-    ];
+    // The exclusion list lives with the encoder, not here — the destructure in
+    // `to_flag_bits` names every field, so the two can't disagree about which
+    // ones are deliberately left out.
+    use flag_key::NOT_ENCODED;
 
     let default_key = Options::default().to_flag_key();
     let default_json = serde_json::to_value(Options::default()).unwrap();
@@ -671,29 +669,20 @@ fn flag_key_encodes_every_bool_option() {
     assert!(checked_encoded > 0, "no encoded bool fields found — serde reflection broke?");
 }
 
-#[test]
-fn flag_key_hammer_vuln_koopalings_distinct_from_hb_encounters() {
-    // Regression: hammer_vulnerable_koopalings used to share bit 2 of b4
-    // with the high bit of hb_encounters (a tri-state at bits 2-1).
-    // When hb_encounters=Wild (em=2), bit 2 was already set, so toggling
-    // hammer_vulnerable_koopalings produced no change in the flag key.
-    let a = Options {
-        hb_encounters: EnemyMode::Wild,
-        hammer_vulnerable_koopalings: false,
-        ..Default::default()
-    };
+// Removed at v29: `flag_key_hammer_vuln_koopalings_distinct_from_hb_encounters`
+// was a regression test for a real shipped collision — hammer_vulnerable_koopalings
+// shared a bit with the high bit of hb_encounters, and only misbehaved when
+// hb_encounters was Wild. Bit positions are now assigned by declaration order in
+// `FlagBits`, so no two options can share one; the test would be exercising the
+// bitfield crate rather than this repo.
 
-    let b = Options { hammer_vulnerable_koopalings: true, ..a.clone() };
-
-    assert_ne!(a.to_flag_key(), b.to_flag_key(),
-        "toggling hammer_vulnerable_koopalings must change the flag key");
-
-    let dec_a = Options::from_flag_key(&a.to_flag_key()).unwrap();
-    let dec_b = Options::from_flag_key(&b.to_flag_key()).unwrap();
-    assert!(!dec_a.hammer_vulnerable_koopalings);
-    assert!(dec_b.hammer_vulnerable_koopalings);
-    assert_eq!(dec_a.hb_encounters, EnemyMode::Wild);
-    assert_eq!(dec_b.hb_encounters, EnemyMode::Wild);
+/// Build a key with a valid envelope for an arbitrary version and payload —
+/// the shape a build from a different release would produce. Lets the version
+/// branches be tested without a time machine.
+fn forge_key(version: u8, payload: &[u8]) -> String {
+    let mut bytes = vec![version, checksum(version, payload)];
+    bytes.extend_from_slice(payload);
+    format!("SMB3R-{}", base32_encode(&bytes))
 }
 
 /// The version probe backs the web app's three-way rejection message (older /
@@ -701,6 +690,7 @@ fn flag_key_hammer_vuln_koopalings_distinct_from_hb_encounters() {
 #[test]
 fn flag_key_version_probe() {
     let key = Options::default().to_flag_key();
+    let payload = &Options::default().to_flag_bytes()[2..].to_vec();
     let current = current_flag_key_version();
 
     // A key this build made reports this build's version, with or without the
@@ -710,35 +700,170 @@ fn flag_key_version_probe() {
     assert_eq!(flag_key_version_of(&key.to_lowercase()), Ok(current));
     assert_eq!(flag_key_version_of(&format!("  {key}\n")), Ok(current));
 
-    // An older key: same 13-byte layout, earlier version byte. Reads as "older"
-    // even though the full decode rejects it.
-    let mut older = Options::default().to_flag_bytes();
-    older[0] = current - 1;
-    let older_key = base32_encode(&older);
-    assert_eq!(flag_key_version_of(&older_key), Ok(current - 1));
-    assert!(Options::from_flag_key(&older_key).is_err());
+    // An older key reads as "older" even though the full decode rejects it.
+    let older = forge_key(current - 1, payload);
+    assert_eq!(flag_key_version_of(&older), Ok(current - 1));
+    assert!(Options::from_flag_key(&older).is_err());
 
-    // A key from a future format that grew a 14th byte. The probe must stay
-    // lenient about length or this would read as garbage instead of "newer",
-    // and the app would tell the user to check for typos in a perfectly good
-    // key. This is the direction that bites today: beta runs ahead of the
-    // released app.
-    let mut newer = Options::default().to_flag_bytes().to_vec();
-    newer[0] = current + 1;
-    newer.push(0x00);
-    assert_eq!(flag_key_version_of(&base32_encode(&newer)), Ok(current + 1));
+    // A key from a future format that grew past this build's payload capacity.
+    // The probe must stay lenient about length or this would read as garbage
+    // instead of "newer", and the app would tell the user to check for typos in
+    // a perfectly good key. This is the direction that bites today: beta runs
+    // ahead of the released app.
+    let mut long = payload.clone();
+    long.extend_from_slice(&[0x7F; 40]);
+    assert_eq!(flag_key_version_of(&forge_key(current + 1, &long)), Ok(current + 1));
 
     // Not a flag key at all — the app's third branch.
     assert!(flag_key_version_of("").is_err());
     assert!(flag_key_version_of("!!!!").is_err());
     assert!(flag_key_version_of("SMB3R-").is_err());
 
-    // A truncated paste must NOT be reported as a version mismatch even though
-    // its first byte reads fine. "ZZZZ" decodes to 0xFF, which would otherwise
-    // be announced as "from a newer version of the randomizer" and send the
-    // user looking for a build that was never released. Short is invalid.
+    // A truncated paste is caught by the checksum, so it lands in "invalid"
+    // rather than being announced as a version mismatch and sending the user
+    // looking for a build that was never released. Before the checksum existed
+    // this needed a special rule about length; now it falls out of the format.
     assert!(flag_key_version_of("SMB3R-ZZZZ").is_err());
     assert!(flag_key_version_of(&key[..key.len() - 4]).is_err());
+}
+
+/// Golden fixtures pinning the v29 bit and byte order.
+///
+/// The layout is generated from declaration order in `FlagBits`, so nothing in
+/// the source spells out which bit an option lives in. That makes reordering or
+/// resizing a field an easy, silent way to invalidate every key in circulation.
+/// These literals are the tripwire: if they change, the wire format changed and
+/// `FLAG_KEY_VERSION` has to move with it.
+///
+/// Regenerate deliberately, never by pasting whatever the test printed.
+#[test]
+fn flag_key_v29_golden() {
+    assert_eq!(current_flag_key_version(), 29, "these fixtures pin v29");
+
+    // Defaults.
+    let key = "SMB3R-3PHFKHRF000525AG00X0";
+    assert_eq!(Options::default().to_flag_key(), key);
+    assert_eq!(
+        Options::default().to_flag_bytes(),
+        vec![29, 162, 249, 199, 15, 0, 0, 81, 21, 80, 0, 58],
+    );
+    assert_eq!(Options::from_flag_key(key).unwrap(), normalized(Options::default()));
+
+    // Everything off — the payload is nearly all zeros, so trailing-zero
+    // stripping shows up here as a key that is no shorter than the default one
+    // (the last non-zero byte is what sets the length, not the option count).
+    let all_off = "SMB3R-3Q2000000000000000W0";
+    assert_eq!(all_off_options().to_flag_key(), all_off);
+    assert_eq!(Options::from_flag_key(all_off).unwrap(), normalized(all_off_options()));
+
+    // A spread of non-default values across every field width: 5-bit item
+    // slots, the 3-bit world count, 2-bit enums and the scattered chaser bits.
+    let mixed = Options {
+        starting_items: vec![ITEM_RANDOM, 5, ITEM_RANDOM_SUIT_ONLY],
+        starting_lives: 99,
+        world_count: 3,
+        wild_injections: WildChaser::ALL.to_vec(),
+        eights_are_wild: Tri::Maybe,
+        fire_flower: FireFlowerMode::Wild,
+        piranha_shuffle: PiranhaMode::Wild,
+        hb_encounters: EnemyMode::Wild,
+        ..Default::default()
+    };
+    let mixed_key = "SMB3R-3PTFKHRF020525AGXAFJP40";
+    assert_eq!(mixed.to_flag_key(), mixed_key);
+    assert_eq!(Options::from_flag_key(mixed_key).unwrap(), normalized(mixed));
+}
+
+/// Reserve bits are the whole durability story: adding an option must not
+/// invalidate keys already in circulation. A key that stops short of a byte
+/// decodes as if that byte were zero, which is exactly what an older key looks
+/// like once a new option is appended.
+#[test]
+fn flag_key_short_key_zero_fills() {
+    let full = Options::default().to_flag_bytes();
+
+    // Same key with its all-zero reserve bytes spelled out explicitly: adding
+    // trailing zeros must not change what it decodes to, or the encoder's
+    // truncation would be lossy.
+    let mut padded = full[2..].to_vec();
+    padded.extend_from_slice(&[0u8; 8]);
+    assert_eq!(
+        Options::from_flag_key(&forge_key(FLAG_KEY_VERSION, &padded)).unwrap(),
+        Options::from_flag_key(&Options::default().to_flag_key()).unwrap(),
+    );
+
+    // And a key that predates the last two bytes of payload: the options living
+    // there come back off, everything before them survives.
+    let short = &full[2..full.len() - 2];
+    let decoded = Options::from_flag_key(&forge_key(FLAG_KEY_VERSION, short)).unwrap();
+    assert!(decoded.powerups, "an early option must survive a short key");
+    assert_eq!(decoded.ground, EnemyMode::Shuffle);
+    // starting_lives/world_count/items live in the truncated tail.
+    assert_eq!(decoded.world_count, default_world_count());
+}
+
+/// The checksum's reason for existing, measured.
+///
+/// Before it, a single mistyped character produced a valid key for *different*
+/// settings 89.6% of the time (651 mutations of the default key; the only ones
+/// caught were those that happened to corrupt the version byte). That is the
+/// same failure as issue #158 — a silently different ruleset — but far more
+/// likely, since a fumbled paste beats a version skew for frequency.
+///
+/// Measured at v29 over the same sweep: 605 rejected, 15 harmless (they land on
+/// padding bits), **0 silently different**. Run with `--nocapture` to re-read
+/// the split.
+#[test]
+fn flag_key_typos_are_rejected() {
+    let key = Options::default().to_flag_key();
+    let body = key.strip_prefix("SMB3R-").unwrap();
+    let expected = Options::from_flag_key(&key).unwrap();
+
+    let (mut rejected, mut same, mut different) = (0, 0, 0);
+    for i in 0..body.len() {
+        for &c in CROCKFORD.iter() {
+            if body.as_bytes()[i] == c { continue }
+            let mut mutated: Vec<u8> = body.as_bytes().to_vec();
+            mutated[i] = c;
+            let candidate = format!("SMB3R-{}", String::from_utf8(mutated).unwrap());
+            match Options::from_flag_key(&candidate) {
+                Err(_) => rejected += 1,
+                Ok(o) if o == expected => same += 1,
+                Ok(_) => different += 1,
+            }
+        }
+    }
+
+    let total = rejected + same + different;
+    println!("single-character typos: {rejected} rejected, {same} harmless, {different} silently different (of {total})");
+    assert_eq!(total, body.len() * 31, "every single-character mutation is tried");
+    // A CRC-8 lets through about 1 in 256 by chance. Assert well inside that
+    // rather than on the nose so the test pins the property, not the arithmetic.
+    assert!(
+        different * 100 < total,
+        "{different}/{total} single-character typos decoded to a DIFFERENT ruleset \
+         ({rejected} rejected, {same} harmless) — the checksum is not doing its job",
+    );
+}
+
+/// `NOT_ENCODED` is the one hand-maintained list left in the mapping, and the
+/// web app's `inFlagKey` markings are checked against what it produces. A stale
+/// name in it would quietly drop a real option from that check.
+#[test]
+fn flag_key_not_encoded_names_are_real_fields() {
+    let json = serde_json::to_value(Options::default()).unwrap();
+    let fields = json.as_object().unwrap();
+    for name in flag_key::NOT_ENCODED {
+        assert!(
+            fields.contains_key(*name),
+            "NOT_ENCODED lists '{name}', which is not an Options field (renamed or removed?)",
+        );
+    }
+    let encoded = flag_key_fields();
+    assert_eq!(encoded.len(), fields.len() - flag_key::NOT_ENCODED.len());
+    for name in flag_key::NOT_ENCODED {
+        assert!(!encoded.contains(&name.to_string()), "'{name}' must not be advertised as encoded");
+    }
 }
 
 #[test]
@@ -751,7 +876,7 @@ fn base32_round_trip() {
         (0..11).collect::<Vec<u8>>(),
     ] {
         let encoded = base32_encode(&data);
-        let decoded = base32_decode(&encoded, data.len()).unwrap();
+        let decoded = base32_decode(&encoded).unwrap();
         assert_eq!(data, decoded, "round-trip failed for {data:?} (encoded: {encoded})");
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -81,9 +81,20 @@ pub fn current_flag_key_version() -> u8 {
 /// The format version a key claims, without decoding it. The app pairs this
 /// with `current_flag_key_version()` to tell "key from an older build" from
 /// "key from a newer build" from "not a flag key at all" — three rejections
-/// that need different things from the user. Errors only when the key is
-/// garbled beyond reading its first byte.
+/// that need different things from the user. Errors when the key fails its
+/// checksum, which is what keeps a typo from being announced as a version
+/// mismatch.
 #[wasm_bindgen]
 pub fn flag_key_version_of(key: &str) -> Result<u8, JsError> {
     crate::flag_key_version_of(key).map_err(|e| JsError::new(&e))
+}
+
+/// JSON array of the `Options` field names this build encodes into the flag
+/// key. Lets `assertSchemaParity` check the web schema's `inFlagKey` markings
+/// against what Rust actually persists, instead of leaving them as
+/// documentation nobody verifies.
+#[wasm_bindgen]
+pub fn flag_key_fields_json() -> Result<String, JsError> {
+    serde_json::to_string(&crate::flag_key_fields())
+        .map_err(|e| JsError::new(&format!("Serialize error: {e}")))
 }

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -77,12 +77,20 @@ fn sweep_is_deterministic() {
 /// 27 reproduced the previous hashes exactly, which is the check that this
 /// regeneration hides no real change. Default options leave the injection
 /// mode Off, so no gameplay byte differs.
+///
+/// Re-captured again 2026-08-06 for the v29 flag-key re-layout (issue #158).
+/// Same story, verified the same way but end-to-end rather than by pinning a
+/// constant, since the whole format changed: seeds 1-3 were generated before
+/// and after and diffed byte by byte. Every difference lands in one of the two
+/// places that carry the flag bytes on purpose — the stamp block at 0x19DF0 and
+/// the title-screen verification icons at `FS_SEED_HASH_DATA` (0x3E93D), whose
+/// hash folds `to_flag_bytes()`. No overworld, level, or enemy byte moved.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xE80654E3D012604F, 0x56BC4E0B2651799F, 0x3DA9EB46E38D6B30, 0xDA3EE41D061EDA7B,
-    0xF5D11330921CE33E, 0xAAB1BDBF548B48CE, 0xE0BD2457DB734B68, 0x069292D8922CB143,
-    0x41ADD63B96205A6D, 0x0970C782159DAE35, 0x07203DE4BD1FD154, 0x6E2B6C6D38620047,
-    0x18C631FC4138325E, 0x52F7FC872DBED52D, 0x229493E5CDAC9103, 0x1551C153BAF84493,
-    0x857B1E9A03988D07, 0xFD9E64C758FBB39C, 0xFA1393CD8EB2D7A5, 0xC61841B9C6000A34,
+    0x2F1BCC4337C08F68, 0x2FA22BE766E829C2, 0xBA27EEB114014065, 0x05F1B18F79E8B6CC,
+    0x751E5E0C61AD8D37, 0xBCC5C3EE0CE9982F, 0x602BF085D5943A01, 0x2D88CD0275AF4D2A,
+    0xC468CE9CC9855C58, 0x357E92F0AC2ACC66, 0x6BC4763423B1C59B, 0x88252754C99D7838,
+    0x9EE4278722525DFD, 0x6C09F4B3354F1FC2, 0xA28A8EBBE81A5C3E, 0xDB4F9E42DA4CCA00,
+    0x449BF758A7F46AA8, 0xEF074E3694941F2B, 0xF242865A87826F34, 0xAB0AE92979F23FE3,
 ];
 
 #[test]

--- a/web/app.js
+++ b/web/app.js
@@ -6,6 +6,7 @@ import init, {
 	decode_flag_key,
 	current_flag_key_version,
 	flag_key_version_of,
+	flag_key_fields_json,
 	default_options_json,
 	version,
 } from "./pkg/smb3_rs.js";
@@ -224,7 +225,7 @@ init()
 		const versionEl = document.getElementById("version");
 		if (versionEl) versionEl.textContent = `v${version()}`;
 		updateFlagKey();
-		assertSchemaParity(default_options_json());
+		assertSchemaParity(default_options_json(), flag_key_fields_json());
 		assertPresetParity();
 		selfTestRoundTrip(encode_flag_key, decode_flag_key);
 		applyUrlParams();

--- a/web/options.js
+++ b/web/options.js
@@ -269,6 +269,11 @@ export const SCHEMA = [
 		tip: "Each Koopaling takes a random number of stomps (1–5) instead of the usual 3",
 		icon: KOOPALINGS,
 		group: "bosses", inFlagKey: true },
+	// No icon yet — sprite coordinates get picked by hand in sprite-picker.html.
+	{ id: "boomboom_hits", type: "bool", default: true,
+		label: "Random Boom-Boom Stomps",
+		tip: "Each fortress Boom-Boom takes a random number of stomps (1–5) instead of the usual 3",
+		group: "bosses", inFlagKey: true },
 	{ id: "hammer_vulnerable_koopalings", type: "bool", default: false,
 		label: "Hammer Vulnerable Koopalings",
 		tip: "Koopalings can be damaged by thrown hammers (normally hammers pass through them)",

--- a/web/options.js
+++ b/web/options.js
@@ -101,8 +101,10 @@ const KOOPALINGS = [
 ];
 
 // Schema. Field names match the Rust Options struct; the load-time parity
-// check guarantees they stay aligned. inFlagKey is informational/UX only;
-// the Rust flag-key encoder is what actually decides what's persisted.
+// check guarantees they stay aligned. inFlagKey decides whether applying a
+// shared key or a preset writes this field, and is checked at load against the
+// list of fields Rust actually encodes (`flag_key_fields_json`) — the Rust
+// encoder remains the authority, this just can't drift from it unnoticed.
 //
 // Within each group, entries render in SCHEMA order, so keep each group's
 // entries contiguous and ordered for display.
@@ -1245,7 +1247,7 @@ export function restoreSettings() {
 // (via wasm `default_options_json`). Any drift is shouted via console.error
 // so the developer notices on the next refresh.
 
-export function assertSchemaParity(wasmDefaultsJson) {
+export function assertSchemaParity(wasmDefaultsJson, flagKeyFieldsJson) {
 	let defaults;
 	try {
 		defaults = JSON.parse(wasmDefaultsJson);
@@ -1261,6 +1263,32 @@ export function assertSchemaParity(wasmDefaultsJson) {
 	const missingInRust = [...schemaIds].filter(id => !wasmIds.has(id));
 	if (missingInJs.length || missingInRust.length) {
 		console.error("Options schema drift detected", { missingInJs, missingInRust });
+	}
+
+	// `inFlagKey` used to be documentation — nothing checked it, so an option
+	// marked shareable that Rust didn't actually encode would have been
+	// invisible. It drives applyOptions and applyPreset, so a wrong marking
+	// means a shared key silently doesn't apply that option. Rust reports what
+	// it encodes; anything that disagrees is a bug on one side or the other.
+	if (!flagKeyFieldsJson) return;
+	let encoded;
+	try {
+		encoded = new Set(JSON.parse(flagKeyFieldsJson));
+	} catch (e) {
+		console.error("Schema parity: could not parse the flag-key field list", e);
+		return;
+	}
+	// Truthiness, not `!== false`, because that's what applyOptions and
+	// applyPreset test — an entry that just forgets the marking is skipped by
+	// them, so it should be reported here too.
+	const claimedButNotEncoded = SCHEMA
+		.filter(e => e.inFlagKey && !encoded.has(e.id))
+		.map(e => e.id);
+	const encodedButNotClaimed = SCHEMA
+		.filter(e => !e.inFlagKey && encoded.has(e.id))
+		.map(e => e.id);
+	if (claimedButNotEncoded.length || encodedButNotClaimed.length) {
+		console.error("inFlagKey drift detected", { claimedButNotEncoded, encodedButNotClaimed });
 	}
 }
 


### PR DESCRIPTION
Closes #158.

The v29 re-layout, built to the plan settled in the issue comments. Three format
changes land together so keys break **once** rather than three times — and that
is the last time, because the new format has reserve.

## What changed

### Bitfield layout (`modular-bitfield`)

The payload is a `#[bitfield(bytes = 30)]` struct. Bit positions come from
declaration order, so two options **cannot** share a bit — the class of bug the
bespoke `hammer_vulnerable_koopalings` / `hb_encounters` regression test existed
for. That test is deleted (with a comment in its place saying why); it would now
be testing the crate.

The `Options` → bitfield map is a **destructure**, with non-encoded fields bound
`field: _`. A new `Options` field is a compile error until it is encoded or
explicitly excluded. Verified by adding a field and watching it fail on *both*
sides:

```
error[E0027]: pattern does not mention field `brand_new_option`   (encode)
error[E0063]: missing field `brand_new_option` in initializer     (decode)
```

That retires the old serde-reflection guard's blind spot — it was `as_bool()`
only, which is how `wild_injections` silently left it when it became a `Vec`.

Tri flags are one 2-bit field now instead of a value bit and a "maybe" bit in
different bytes.

### Reserve bits — why this is the last break

93 bits spent of 240. Adding an option spends reserve; an older key decodes
those bits as zero, which is off for every bool and the default for every enum
here. **No version bump.** Only *repurposing* an allocated bit forces one.

Verified end to end rather than argued — a field was added for real, then
reverted:

```
PROBE decoded ok; brand_new_option=false powerups=true ground=Shuffle lives=5 wc=7
PROBE new key with option on = SMB3R-3Q9FKHRF000525AG00X0080 (old 26 chars)
```

The pre-existing golden key still decoded, with the new option off. Cost in
`flag_key.rs` was five lines and no arithmetic.

### Checksum — because most bad keys are typos, not version skew

The format had **no integrity check at all**. Measured on v28: 89.6% of
single-character typos decoded to a silently different ruleset. Byte 1 is now a
position-weighted CRC-8 over the version byte and payload — not a sum or XOR,
which are blind to transpositions.

Same sweep at v29: **605 rejected, 15 harmless, 0 silently different.** Pinned by
`flag_key_typos_are_rejected`.

It also lets #159's asymmetric length rule go. Classification stops being a
heuristic: checksum fails → invalid; passes with an unknown version →
older/newer.

### Variable length

Trailing zero payload bytes are stripped on encode and zero-filled on decode, so
capacity is decoupled from key length — the reserve costs nothing to type. The
default key is **26 characters, one shorter than v28**.

## Pre-v29 keys read as "older", not "mistyped"

Caught by asking what a returning user actually sees, then checking against a
real v28 key instead of reasoning about it:

```
SMB3R-3JKWY87RAGA0A00700000
   version_of -> Err("Flag key failed its checksum — it looks mistyped or truncated")
```

Old keys carry no checksum byte, so the envelope check rejects every one of
them — which collapsed #159's three-way message into "This flag key isn't valid.
Check it and try again" for **every key in circulation** on day one. Sending a
race room hunting for a typo that isn't there is this issue's own failure mode
wearing a new hat.

`legacy_version_of` reads the version off the old shape when the envelope check
fails. Exact, not heuristic, and permanently bounded: every pre-v29 key was 13
bytes with the version in byte 0, and no version past 28 used that layout, so a
v29+ key of the same length (version ≥ 29) cannot be confused with one.

The test pinning this also caught a **panic**: `then_some` evaluates its argument
eagerly, so an empty key indexed a zero-length slice — reachable by pasting
nothing into the flag key box.

## `boomboom_hits` had no web control

Found while wiring the `inFlagKey` parity check. It was encoded in the flag key
but had no row in `web/options.js` — not in `SCHEMA`, not in `CONSTANT_FIELDS`.
So the web app always generated with it on, and a shared key that turned it off
was dropped on apply and re-encoded as on. Same family as this issue.

`assertSchemaParity` had been reporting it as `missingInJs` on every page load;
a `console.error` nobody was watching, which is the actual lesson. Added under
Bosses. No icon — sprite coordinates get picked by hand in `sprite-picker.html`.

After it, all three drift lists are empty:

```
claimedButNotEncoded: []
encodedButNotClaimed: []
encoded but no SCHEMA row: [ 'card_speed_clear', 'disable_autoscroll' ]   <- the two deliberate CONSTANT_FIELDS
```

## Baseline regeneration — verified, not pasted

`overworld_baseline` moved on all 20 seeds. Rather than trust that, seeds 1–3
were generated before and after and diffed byte by byte. Every difference lands
in one of the two places that carry flag bytes on purpose:

| Range | What |
|---|---|
| `0x19DF3–0x19E08` | the stamp block |
| `0x3E93E–0x3E963` | `FS_SEED_HASH_DATA`, the title-screen verification icons |

No overworld, level, or enemy byte moved.

## Deliberately not done

Per the issue's settled plan: no v28 freeze, no versioned decoders, no dispatch
(build when a v30 forces it); no version→release link table (it can't be filled
at bump time, and `/beta/` has no archived target); no generalized bit-collision
test and no non-bool coverage test (both obsolete — collisions are
unrepresentable and the destructure covers every type).

## One deviation from the plan

The plan said `inFlagKey` should be **derived** from the layout. It is
**checked** instead, at load, against a new `flag_key_fields_json()` export —
drift is a `console.error` rather than impossible. Chosen for simplicity, but
full derivation was feasible (`applyOptions` / `applyPreset` only run after wasm
resolves), so this is a judgment call and easy to tighten.

## Known remaining rough edges

- Encode and decode are still two hand-written lists. The compiler checks every
  field is *present* on both sides, but not that `.with_ground(...)` was handed
  `ground` — swapping two same-typed fields compiles.
  `flag_key_per_option_round_trip` catches it, but that is test-caught, not
  structural.
- Shrinking the reserve when adding an option is manual. It is a hard compile
  error if you get it wrong, but a cryptic one
  (`OneMod8: TotalSizeIsMultipleOfEightBits`), so there is a note next to the
  reserve saying what it means.
- `options.rs` now depends on `modular-bitfield` for the `Specifier` derive on
  the four 2-bit enums.

## Testing

- `cargo test` — 386 + integration, all green
- `cargo clippy --all-targets -- -D warnings` — clean
- `wasm-pack build --target web` — clean; `flag_key_fields_json` exported
- New: `flag_key_v29_golden` (pins bit/byte order), `flag_key_typos_are_rejected`,
  `flag_key_short_key_zero_fills`, `flag_key_pre_v29_keys_read_as_older`,
  `flag_key_not_encoded_names_are_real_fields`

## Player-facing note

Bookmarked `?flags=` URLs carrying a pre-v29 key are permanently dead for the
flag part — the seed still applies, the flags don't, and the app says so. That
is the accepted cost of the last break. Archived `/v/<ver>/` builds are
unaffected; they still speak their own format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB
