### PR TITLE
feature: show the seed's title hash in the web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ deploys.
 
 ## [Unreleased]
 
+### Added
+
+- The web app now shows the seed's **title hash** under the Generate button as
+  soon as a seed is entered — the same five icons the title screen will show,
+  drawn from your own ROM's graphics (and from the selected visual patch, if
+  one is chosen). Racers can compare icons before generating instead of after
+  booting. Hidden while the seed box is empty, since a blank seed is rolled at
+  generate time, and while ROM validation is off, since the hash isn't applied
+  then.
+
 ## [1.1.0] - 2026-08-08
 
 ### Added

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1546,6 +1546,7 @@ logic into the engine without rebuilding callers.
 | 0x32AFE | Title screen background final color |
 | 0x317B1 | Sprite loop hook: vanilla `JSR $B7D6`, patched to `JMP $E914` for seed hash sprites |
 | 0x31976 | Sprite palette data (4 palettes × 4 bytes); palette 3 is modifiable here |
+| 0x326AD | `Title_Load_Palette` (PRG025): 32-byte upload to $3F00 — 16 background colors, then the 16 sprite colors (4 per palette) the title screen actually runs with. Sprite palette 0 = `0F 16 36 0F` (red), 2 = `0F 27 30 0F` (orange). This is the table to read for title sprite colors; 0x31976 does not reach them. |
 | 0x3E924 | Free space in PRG031 (CPU $E914): seed hash sprite copy routine (25 bytes) |
 | 0x3E93D | Free space in PRG031 (CPU $E92D): seed hash sprite data table (40 bytes) |
 
@@ -1554,6 +1555,17 @@ Each icon is 16×16 (two 8×16 sprites side by side). Uses 8x16 sprite mode — 
 select PT1 ($1000–$1FFF). Tiles can be drawn from any CHR slot (R2–R5) since the slot is
 determined by tile ID, not a global setting. The ASM routine copies sprite data to OAM with
 stride (every 8th sprite slot) to avoid the 8-sprites-per-scanline hardware limit.
+
+**Title screen sprite CHR banks:** the reset path in PRG030 (`PRG030_845A`, the "Load title
+screen graphics" block) sets MMC3 R2–R5 to pages `$20 / $21 / $04 / $7F` before handing off to
+the title handler. So a sprite tile ID of $00–$3F reads from page $20, $40–$7F from $21,
+$80–$BF from $04, and $C0–$FF from $7F — i.e. CHR file offset
+`0x40010 + page * 0x400 + (tile & 0x3F) * 16`. Note that `Title_DrawMarioLuigi` (PRG024)
+overwrites R2/R3 with the bros' own VROM pages (`$50` + sprite page for a small bro) whenever it
+runs, so those two slots are the ones to re-check if title sprites ever come out wrong. Decoding
+the seed-hash icon table under the reset banks reproduces the art `ICON_TILES` names (icon 7,
+tile $13 in R2, is the mushroom house), which is what the web app relies on to draw the icons
+from the player's own ROM (`title_screen.rs::seed_hash_preview`).
 
 ---
 

--- a/src/randomize/title_screen.rs
+++ b/src/randomize/title_screen.rs
@@ -80,6 +80,16 @@ pub(super) fn pick_menu_music(seed: u64) -> u8 {
     MENU_MUSIC_TRACKS[(h % MENU_MUSIC_TRACKS.len() as u64) as usize]
 }
 
+/// CHR page (1 KB) loaded into each sprite pattern slot on the title screen.
+/// The reset path in PRG030 (`PRG030_845A`) sets MMC3 R2–R5 to $20/$21/$04/$7F
+/// before handing control to the title handler, so an OAM tile ID of $00–$3F
+/// reads from page $20, $40–$7F from $21, $80–$BF from $04, $C0–$FF from $7F.
+const TITLE_SPRITE_CHR_PAGES: [usize; 4] = [0x20, 0x21, 0x04, 0x7F];
+
+/// File offset of `Title_Load_Palette` (PRG025): a 32-byte upload to $3F00 —
+/// 16 background colors followed by the 16 sprite colors, four per palette.
+const TITLE_SPRITE_PALETTE_OFFSET: usize = 0x326AD + 16;
+
 /// Sprite positions: vertical column in top-left corner, inset from edge.
 const X_LEFT: u8 = 16;
 const X_RIGHT: u8 = 24;
@@ -123,6 +133,66 @@ fn compute_hash(seed: u64, options: &Options) -> ([usize; HASH_LENGTH], u8) {
     }
     let palette = PALETTES[(h % PALETTES.len() as u64) as usize];
     (icons, palette)
+}
+
+/// One hash icon as a CHR renderer needs it: four 8x8 tile indices into CHR
+/// ROM in `[top-left, top-right, bottom-left, bottom-right]` order, plus
+/// whether the right half is the left half mirrored.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeedHashIcon {
+    pub tiles: [usize; 4],
+    pub flip_right: bool,
+}
+
+/// The five title-screen hash icons for a seed + options, resolved against a
+/// specific ROM's title-screen CHR banks and palette. Lets the web app draw
+/// the icons the player is about to see, from their own ROM's graphics.
+#[derive(serde::Serialize)]
+pub struct SeedHashPreview {
+    pub icons: Vec<SeedHashIcon>,
+    /// NES color indices of the chosen sprite palette. Entry 0 is the
+    /// universal backdrop and renders transparent.
+    pub palette: [u8; 4],
+}
+
+/// Resolve an 8x16-mode OAM tile ID to its absolute CHR ROM tile index.
+/// Every `ICON_TILES` entry is odd (pattern table 1), so the top tile of the
+/// pair is `tile & 0xFE` and the bottom is the one after it.
+fn chr_tile_index(tile: u8) -> usize {
+    TITLE_SPRITE_CHR_PAGES[(tile >> 6) as usize] * 64 + (tile & 0x3F) as usize
+}
+
+/// Describe the hash `write_seed_hash` would stamp for `seed` + `options`,
+/// without writing anything. `rom` is only read for its title sprite palette.
+pub fn seed_hash_preview(rom: &[u8], seed: u64, options: &Options) -> SeedHashPreview {
+    let (icons, palette_attr) = compute_hash(seed, options);
+    let icons = icons
+        .iter()
+        .map(|&i| {
+            let (tile_l, tile_r, extra_attr_r) = ICON_TILES[i];
+            let (top_l, top_r) = (tile_l & 0xFE, tile_r & 0xFE);
+            SeedHashIcon {
+                tiles: [
+                    chr_tile_index(top_l),
+                    chr_tile_index(top_r),
+                    chr_tile_index(top_l + 1),
+                    chr_tile_index(top_r + 1),
+                ],
+                flip_right: extra_attr_r & 0x40 != 0,
+            }
+        })
+        .collect();
+
+    // A ROM too short to hold the table (only reachable with validation off,
+    // where the hash isn't written anyway) falls back to all-backdrop.
+    let base = TITLE_SPRITE_PALETTE_OFFSET + (palette_attr & 0x03) as usize * 4;
+    let mut palette = [0x0Fu8; 4];
+    if let Some(colors) = rom.get(base..base + 4) {
+        palette.copy_from_slice(colors);
+    }
+
+    SeedHashPreview { icons, palette }
 }
 
 /// Write seed hash sprites to the title screen.
@@ -307,6 +377,53 @@ mod tests {
 
         // Attract-mode demo trigger neutralized: LDA #$FF operand becomes #$00.
         assert_eq!(rom.read_byte(DEMO_TRIGGER_OPERAND_OFFSET), 0x00);
+    }
+
+    #[test]
+    fn icon_tiles_are_all_pattern_table_1() {
+        // `chr_tile_index` assumes every icon tile is odd (bit 0 = pattern
+        // table 1), which is what makes `tile & 0xFE` the top half of the
+        // 8x16 pair. An even entry would silently render from PT0.
+        for (i, &(l, r, _)) in ICON_TILES.iter().enumerate() {
+            assert_eq!(l & 1, 1, "icon {i} left tile {l:#04X} is not in PT1");
+            assert_eq!(r & 1, 1, "icon {i} right tile {r:#04X} is not in PT1");
+        }
+    }
+
+    #[test]
+    fn preview_matches_written_sprite_data() {
+        let opts = Options::default();
+        let mut rom = crate::randomize::qol::test_support::make_test_rom();
+        write_seed_hash(&mut rom, 42, &opts);
+        let written = rom.read_range(DATA_OFFSET, HASH_LENGTH * 8).to_vec();
+
+        let preview = seed_hash_preview(&rom.data, 42, &opts);
+        assert_eq!(preview.icons.len(), HASH_LENGTH);
+
+        for (i, icon) in preview.icons.iter().enumerate() {
+            // Icon i sits in group HASH_LENGTH-1-i of the OAM data table.
+            let base = (HASH_LENGTH - 1 - i) * 8;
+            let (tile_l, tile_r) = (written[base + 1], written[base + 5]);
+            assert_eq!(icon.tiles[0], chr_tile_index(tile_l & 0xFE));
+            assert_eq!(icon.tiles[1], chr_tile_index(tile_r & 0xFE));
+            assert_eq!(icon.tiles[2], icon.tiles[0] + 1);
+            assert_eq!(icon.tiles[3], icon.tiles[1] + 1);
+            assert_eq!(icon.flip_right, written[base + 6] & 0x40 != 0);
+        }
+    }
+
+    #[test]
+    fn preview_tile_indices_stay_inside_chr() {
+        // 128 KB of CHR = 8192 tiles.
+        let opts = Options::default();
+        let rom = crate::randomize::qol::test_support::make_test_rom();
+        for seed in 0..100u64 {
+            for icon in seed_hash_preview(&rom.data, seed, &opts).icons {
+                for t in icon.tiles {
+                    assert!(t < 8192, "tile index {t} past the end of CHR");
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -47,6 +47,25 @@ pub fn build_ips_patch(original: &[u8], modified: &[u8]) -> Result<Vec<u8>, JsEr
     Ok(crate::ips::build_ips_patch(original, modified))
 }
 
+/// Apply an IPS patch to `rom` and return the result. The app uses this to
+/// preview a visual patch's graphics (the seed-hash icons) without running a
+/// full randomization; generation itself applies the patch inside Rust.
+#[wasm_bindgen]
+pub fn apply_ips_patch(rom: &[u8], patch: &[u8]) -> Result<Vec<u8>, JsError> {
+    crate::ips::apply_ips_patch(rom, patch).map_err(|e| JsError::new(&e))
+}
+
+/// The title-screen seed-hash icons for `seed` + options, resolved against
+/// `rom`'s title CHR banks and palette so the app can draw exactly what the
+/// player will see. JSON: `{"icons":[{"tiles":[..4],"flipRight":bool}],
+/// "palette":[..4]}` — tile indices are absolute CHR ROM tiles.
+#[wasm_bindgen]
+pub fn seed_hash_json(rom: &[u8], seed: u64, options_json: &str) -> Result<String, JsError> {
+    let options: Options = parse_options(options_json)?;
+    let preview = crate::randomize::title_screen::seed_hash_preview(rom, seed, &options);
+    serde_json::to_string(&preview).map_err(|e| JsError::new(&format!("Serialize error: {e}")))
+}
+
 fn parse_options(json: &str) -> Result<Options, JsError> {
     serde_json::from_str(json).map_err(|e| JsError::new(&format!("Invalid options: {e}")))
 }

--- a/web/app.js
+++ b/web/app.js
@@ -8,8 +8,11 @@ import init, {
 	flag_key_version_of,
 	flag_key_fields_json,
 	default_options_json,
+	seed_hash_json,
+	apply_ips_patch,
 	version,
 } from "./pkg/smb3_rs.js";
+import { renderIcon } from "./chr.js";
 import {
 	renderOptions,
 	wireListeners,
@@ -168,6 +171,8 @@ const shareUrlBtn = document.getElementById("share-url-btn");
 const visualPatchPills = document.getElementById("visual-patch-pills");
 const visualPatchCredit = document.getElementById("visual-patch-credit");
 const skipValidationWarning = document.getElementById("skip-validation-warning");
+const seedHashRow = document.getElementById("seed-hash");
+const seedHashIcons = document.getElementById("seed-hash-icons");
 const changesSummaryToggle = document.getElementById("changes-summary-toggle");
 const changesSummaryText = document.getElementById("changes-summary-text");
 const changesSummaryList = document.getElementById("changes-summary-list");
@@ -263,6 +268,7 @@ function validateLoadedRom() {
 		showStatus(`${err.message ?? err}`, "error");
 	}
 	updateGenerateButton();
+	updateSeedHash();
 }
 
 romInput.addEventListener("change", (e) => {
@@ -337,6 +343,7 @@ function renderVisualPatchPills() {
 			saveSettings();
 			updateVisualPatchAccent();
 			updateVisualPatchCredit();
+			updateSeedHash(); // the re-skin may change the icons' graphics
 		});
 		const label = document.createElement("label");
 		label.htmlFor = inputId;
@@ -412,7 +419,72 @@ cleanupOrphanVisualPatch().catch(() => {});
 
 randomSeedBtn.addEventListener("click", () => {
 	seedInput.value = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString();
+	updateSeedHash();
 });
+
+seedInput.addEventListener("input", updateSeedHash);
+
+// --- Seed hash: the icons this seed will put on the title screen ---
+//
+// Same five icons `write_seed_hash` stamps, drawn from the user's own ROM CHR
+// so what's on screen here matches what's on screen there pixel for pixel.
+// Rust resolves the tiles and palette (title-screen CHR banks, sprite palette
+// table); this side just decodes and blits them.
+
+// romBytes with the selected visual patch applied — a re-skin changes the CHR
+// the icons come from. Keyed on both the patch and the ROM it was built from,
+// so swapping either one invalidates it.
+let patchedHashRom = null; // { source, id, bytes }
+
+// The ROM to draw icons from, applying the selected visual patch if it's ready.
+// Until it is, the unpatched ROM stands in — identical unless the patch
+// happens to re-skin one of the 15 icons.
+function seedHashRom() {
+	if (!wasmReady || !romBytes) return null;
+	const id = selectedVisualPatchId();
+	if (!id) return romBytes;
+	if (patchedHashRom?.source === romBytes && patchedHashRom.id === id) {
+		return patchedHashRom.bytes;
+	}
+	const source = romBytes;
+	fetchVisualPatch(id)
+		.then((patch) => {
+			patchedHashRom = { source, id, bytes: apply_ips_patch(source, patch) };
+			if (romBytes === source && selectedVisualPatchId() === id) updateSeedHash();
+		})
+		.catch(() => {}); // patch unreachable — the unpatched icons are close enough
+	return romBytes;
+}
+
+function updateSeedHash() {
+	if (!seedHashRow) return;
+	const rom = seedHashRom();
+	// No seed means a random one at generate time, so there's no hash to show
+	// yet. With validation off the randomizer skips the hash patch entirely.
+	if (!rom || !seedInput.value.trim() || getSkipValidation()) {
+		seedHashRow.hidden = true;
+		return;
+	}
+	let spec;
+	try {
+		spec = JSON.parse(seed_hash_json(rom, BigInt(seedInput.value.trim()), getOptionsJson()));
+	} catch (_) {
+		seedHashRow.hidden = true; // not a u64 (yet) — mid-typing or junk
+		return;
+	}
+	while (seedHashIcons.children.length > spec.icons.length) {
+		seedHashIcons.lastChild.remove();
+	}
+	spec.icons.forEach((icon, i) => {
+		let canvas = seedHashIcons.children[i];
+		if (!canvas) {
+			canvas = document.createElement("canvas");
+			seedHashIcons.append(canvas);
+		}
+		renderIcon(canvas, rom, { ...icon, palette: spec.palette });
+	});
+	seedHashRow.hidden = false;
+}
 
 generateBtn.addEventListener("click", async () => {
 	if (!wasmReady || !romBytes) return;
@@ -576,6 +648,9 @@ function updateFlagKey() {
 		// applied.
 		setFlagKeyError(null);
 	} catch (_) {}
+	// The hash is computed from the same flag bytes this key encodes, so every
+	// path that refreshes the key has changed the icons too.
+	updateSeedHash();
 }
 
 function applyFlagKey(key) {

--- a/web/chr.js
+++ b/web/chr.js
@@ -45,7 +45,8 @@ export function resolvePalette(indices) {
 
 // Decode a single 8×8 CHR tile to an ImageData. paletteRgb = 4 [r,g,b] tuples.
 // Color 0 → fully transparent. Colors 1-3 → opaque.
-export function decodeTile(romBytes, tileId, paletteRgb) {
+// flipX mirrors horizontally, the way OAM attribute bit 6 does.
+export function decodeTile(romBytes, tileId, paletteRgb, flipX = false) {
 	const base = CHR_BASE + tileId * TILE_BYTES;
 	const data = new Uint8ClampedArray(8 * 8 * 4);
 	for (let y = 0; y < 8; y++) {
@@ -54,7 +55,7 @@ export function decodeTile(romBytes, tileId, paletteRgb) {
 		for (let x = 0; x < 8; x++) {
 			const bit = 7 - x;
 			const idx = (((p1 >> bit) & 1) << 1) | ((p0 >> bit) & 1);
-			const o = (y * 8 + x) * 4;
+			const o = (y * 8 + (flipX ? 7 - x : x)) * 4;
 			if (idx === 0) {
 				data[o + 3] = 0; // transparent
 			} else {
@@ -81,7 +82,9 @@ export function renderTileToCanvas(canvas, romBytes, tileId, paletteRgb) {
 // Render a 2×2 metasprite (16×16 px) from four tile IDs in [tl, tr, bl, br] order.
 // Native 16×16 pixels — caller scales via CSS for crisp rendering with
 // `image-rendering: pixelated`.
-export function renderMetatile(canvas, romBytes, tileIds, paletteRgb) {
+// flipRight mirrors the right column, for icons built from one tile column
+// and its h-flipped twin (the title-screen seed hash does this).
+export function renderMetatile(canvas, romBytes, tileIds, paletteRgb, flipRight = false) {
 	canvas.width = 16;
 	canvas.height = 16;
 	const ctx = canvas.getContext("2d");
@@ -96,13 +99,14 @@ export function renderMetatile(canvas, romBytes, tileIds, paletteRgb) {
 		const tid = tileIds[i];
 		if (tid == null) continue;
 		const [x, y] = positions[i];
-		ctx.putImageData(decodeTile(romBytes, tid, paletteRgb), x, y);
+		const flip = flipRight && (i === 1 || i === 3);
+		ctx.putImageData(decodeTile(romBytes, tid, paletteRgb, flip), x, y);
 	}
 }
 
 // Convenience: render an icon spec (from the schema) into a canvas.
-// spec = { tiles: [tl, tr, bl, br], palette: [c0, c1, c2, c3] }
+// spec = { tiles: [tl, tr, bl, br], palette: [c0, c1, c2, c3], flipRight? }
 export function renderIcon(canvas, romBytes, spec) {
 	if (!canvas || !romBytes || !spec) return;
-	renderMetatile(canvas, romBytes, spec.tiles, resolvePalette(spec.palette));
+	renderMetatile(canvas, romBytes, spec.tiles, resolvePalette(spec.palette), !!spec.flipRight);
 }

--- a/web/index.html
+++ b/web/index.html
@@ -112,6 +112,13 @@
             </button>
             <div id="changes-summary-list" class="changes-summary-list" hidden></div>
             <button id="generate-btn" type="button" disabled>Generate</button>
+            <!-- The five icons this seed + these flags will show on the title
+                 screen. Drawn from the loaded ROM's own CHR by app.js. -->
+            <div id="seed-hash" class="seed-hash" hidden
+                 title="These icons appear on the title screen — check they match everyone else's">
+                <span class="seed-hash-label">Title hash</span>
+                <div class="seed-hash-icons" id="seed-hash-icons"></div>
+            </div>
             <p class="early-access-note"><em>Early access — you may encounter bugs. Report issues on <a href="https://github.com/hamstringquestionable/smb3-rs/issues" target="_blank" rel="noopener">GitHub</a>.</em></p>
             <div id="status" class="status" hidden></div>
         </div>

--- a/web/style.css
+++ b/web/style.css
@@ -587,6 +587,36 @@ input[type="radio"] {
     text-shadow: none;
 }
 
+/* --- Seed hash (title screen verification icons) --- */
+
+.seed-hash {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-top: 0.7rem;
+}
+
+.seed-hash-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #7a7ab0;
+}
+
+.seed-hash-icons {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.seed-hash-icons canvas {
+    width: 24px;
+    height: 24px;
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    background: transparent;
+}
+
 /* --- Status --- */
 
 .status {


### PR DESCRIPTION
Racers can't compare title hashes today until someone boots the ROM. This shows the five icons under the Generate button as soon as a seed is entered, decoded from the user's own ROM CHR so they match the title screen pixel for pixel.

Hidden while the seed box is empty (a blank seed is rolled at generate time, so there's no hash yet) and while ROM validation is off (the randomizer skips the hash patch entirely in that case). When a visual patch is selected, the preview is taken from the patched ROM, so a re-skin of the icon graphics shows up here too.

## Two ROM facts this needed

Both were new, and both are now in `docs/smb3_rom_reference.md`.

**Title sprite CHR banks.** `PRG030_845A` sets MMC3 R2–R5 to `$20 / $21 / $04 / $7F` before handing off to the title handler, so tile ID → CHR offset is `0x40010 + page * 0x400 + (tile & 0x3F) * 16`. Decoding `ICON_TILES` under those banks reproduces the art the table names — icon 7, tile `$13` in R2, comes out as the mushroom house — which is what confirms the mapping.

**Title sprite palette.** Not `0x31976`; that table never reaches the title screen. It's `Title_Load_Palette` at `0x326AD`, whose 16 sprite colors follow the 16 background ones. Sprite palette 0 is `0F 16 36 0F` (red), 2 is `0F 27 30 0F` (orange) — matching what `PALETTES` in `title_screen.rs` claims.

## Shape

`seed_hash_preview(rom, seed, options)` resolves both facts against a given ROM and returns the tile indices and palette a CHR renderer needs. `write_seed_hash` is untouched, so **ROM output is byte-identical** — this is a read-only view of a hash that was already being written.

`apply_ips_patch` is exposed to WASM so the preview can be taken from the visual-patched ROM. `chr.js` gained h-flip support (OAM attribute bit 6) for the mirrored icons.

## Verification

- `cargo clippy --all-targets` clean; full suite green (377 lib + integration).
- New test pins the preview against the OAM bytes `write_seed_hash` actually writes, so the two can't drift.
- New test asserts every `ICON_TILES` entry is odd — pattern table 1 is what makes `tile & 0xFE` the top half of the 8×16 pair, and an even entry would silently decode from PT0.
- The 15-icon set was decoded from a real ROM through the same math and eyeballed against the labels in `ICON_TILES`.

Browser wiring itself was checked with `node --check` only — the Chrome DevTools MCP tools weren't available in the session, so the rendered row hasn't been seen in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB