### PR TITLE
feature: widen the title hash to 20 icons and drop the colour digit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ deploys.
 
 ### Fixed
 
+- **The title hash no longer changes colour when you use a visual patch.** It
+  used to encode part of itself in the icons' colour, drawn from Mario's
+  palette — which every character re-skin rewrites, so the same seed showed red
+  on a vanilla ROM, green under Luigi and cyan under Toad. Two racers on
+  different skins saw different colours for the identical game, and there was no
+  way to tell that apart from a genuinely different seed. The colour is now
+  fixed and means nothing; the icon set grew from 15 to 20 instead, which more
+  than replaces what the colour was worth (3,200,000 combinations, up from
+  1,518,750). **Hash icons change for every seed**, as they do on any version
+  bump.
+
 - Option icons are no longer squashed. Every sprite was being forced into a
   24x24 box, which scaled 16x16 art by 1.5x and distorted the taller sprites;
   pixel art is now only ever scaled by a whole number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ deploys.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-10
+
 ### Added
+
+- The web app now shows the seed's **title hash** under the Generate button as
+  soon as a seed is entered — the same five icons the title screen will show,
+  drawn from your own ROM's graphics (and from the selected visual patch, if
+  one is chosen). Racers can compare icons before generating instead of after
+  booting. Hidden while the seed box is empty, since a blank seed is rolled at
+  generate time, and while ROM validation is off, since the hash isn't applied
+  then.
 
 - A "The End" sign-off in the web app's footer, drawn from the ending
   sequence's own graphics.
@@ -32,24 +42,12 @@ deploys.
   way to tell that apart from a genuinely different seed. The colour is now
   fixed and means nothing; the icon set grew from 15 to 20 instead, which more
   than replaces what the colour was worth (3,200,000 combinations, up from
-  1,518,750). **Hash icons change for every seed**, as they do on any version
-  bump.
+  1,518,750). **Your title hash icons will differ from 1.1.0's for the same
+  seed**, as they do on any version change.
 
 - Option icons are no longer squashed. Every sprite was being forced into a
   24x24 box, which scaled 16x16 art by 1.5x and distorted the taller sprites;
   pixel art is now only ever scaled by a whole number.
-
-## [1.1.1] - 2026-08-09
-
-### Added
-
-- The web app now shows the seed's **title hash** under the Generate button as
-  soon as a seed is entered — the same five icons the title screen will show,
-  drawn from your own ROM's graphics (and from the selected visual patch, if
-  one is chosen). Racers can compare icons before generating instead of after
-  booting. Hidden while the seed box is empty, since a blank seed is rolled at
-  generate time, and while ROM validation is off, since the hash isn't applied
-  then.
 
 ## [1.1.0] - 2026-08-08
 

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1550,6 +1550,16 @@ logic into the engine without rebuilding callers.
 | 0x3E924 | Free space in PRG031 (CPU $E914): seed hash sprite copy routine (25 bytes) |
 | 0x3E93D | Free space in PRG031 (CPU $E92D): seed hash sprite data table (40 bytes) |
 
+**Why the hash's colour is fixed:** sprite palettes 0 and 1 are Mario's and
+Luigi's, and any player re-skin rewrites them — the same seed then renders red on
+vanilla, green under a Luigi skin and cyan under a Toad skin. The hash used to
+encode a digit in the choice of palette 0 vs 2, which made that digit
+unverifiable: a player comparing title screens can't tell a recoloured palette
+from a different seed, and unlike a re-skinned *shape* (which reads as "that's a
+skin") a colour carries no signal to discount. The icons now always draw in
+palette 2, which no re-skin touches, and the lost entropy is more than recovered
+by a wider icon set — 20^5 = 3,200,000 against the old 15^5 × 2 = 1,518,750.
+
 **Title screen seed hash sprites:** 5 icons displayed vertically in the top-left corner.
 Each icon is 16×16 (two 8×16 sprites side by side). Uses 8x16 sprite mode — odd tile IDs
 select PT1 ($1000–$1FFF). Tiles can be drawn from any CHR slot (R2–R5) since the slot is

--- a/src/randomize/title_screen.rs
+++ b/src/randomize/title_screen.rs
@@ -4,7 +4,7 @@ use crate::rom::Rom;
 /// Tile pairs for each icon: (left_tile, right_tile, right_extra_attributes).
 /// `right_extra_attributes` is OR'd with the palette bits — 0x40 means h-flip
 /// (symmetric icon using the same tile mirrored), 0x00 means a distinct R tile.
-const ICON_TILES: [(u8, u8, u8); 15] = [
+const ICON_TILES: [(u8, u8, u8); 20] = [
     (0xF1, 0xF3, 0x00), // leaf (L/R pair)
     (0xF5, 0xF5, 0x40), // mirrored
     (0xF7, 0xF7, 0x40), // mirrored
@@ -20,13 +20,36 @@ const ICON_TILES: [(u8, u8, u8); 15] = [
     (0x6B, 0x6D, 0x00), // L/R pair
     (0x79, 0x79, 0x40), // mirrored
     (0xDB, 0xDB, 0x40), // mirrored
+    (0x75, 0x77, 0x00), // shoe
+    (0x55, 0x57, 0x00), // flame
+    (0xB9, 0xBB, 0x00), // note on a panel
+    (0xB5, 0xB5, 0x40), // window block (mirrored)
+    (0x89, 0x89, 0x00), // "00" (half doubled, not mirrored)
 ];
 
 const NUM_ICONS: usize = ICON_TILES.len();
 const HASH_LENGTH: usize = 5;
 
-/// Sprite palettes to choose from: palette 0 (red) and palette 2 (orange/yellow).
-const PALETTES: [u8; 2] = [0x00, 0x02];
+/// Sprite palette the icons are drawn in. Fixed, and deliberately not part of
+/// the hash.
+///
+/// It used to be a sixth digit picking between palettes 0 and 2, which doubled
+/// the output space — but palette 0 is Mario's, and every player re-skin in the
+/// web app's visual patch catalog rewrites it. The same seed then showed red on
+/// vanilla, green under Luigi and cyan under Toad, so a player comparing title
+/// screens couldn't tell a recoloured palette from a different seed. Unlike a
+/// re-skinned *shape*, which reads as "that's a skin" and can be discounted, a
+/// colour carries no such signal — it was pure payload, and unverifiable.
+///
+/// Widening `ICON_TILES` from 15 to 20 more than replaces what dropping the
+/// digit cost: 20^5 = 3,200,000 against the old 15^5 * 2 = 1,518,750. Slot 2 is
+/// not the bros', so no re-skin has reason to touch it.
+const HASH_PALETTE: u8 = 0x02;
+
+// Slots 0 and 1 are the bros', and every player re-skin rewrites them. Guard it
+// at compile time rather than in a test — this is a fact about which slot is
+// safe, not behaviour that needs exercising.
+const _: () = assert!(HASH_PALETTE >= 2, "hash palette must not be the bros'");
 
 /// Hook: replace JSR $B7D6 at CPU $97B1 with JMP $E914.
 const HOOK_OFFSET: usize = 0x317B1;
@@ -109,14 +132,15 @@ pub(super) fn intro_skip_music_bytes(seed: u64) -> [u8; 9] {
     ]
 }
 
-/// Compute 5 icon indices and a palette choice from seed + flag bytes.
+/// Compute the 5 icon indices from seed + flag bytes — five base-`NUM_ICONS`
+/// digits read off one accumulator.
 ///
 /// The randomizer version (`CARGO_PKG_VERSION`) is folded in so two builds with
 /// different randomization logic never collide on the same icons for a shared
 /// seed + options. CI (`version-guard` in `.github/workflows/ci.yml`) requires a
 /// version bump on every merge to `main`, so any output-affecting change lands
 /// under a distinct version and thus a distinct hash.
-fn compute_hash(seed: u64, options: &Options) -> ([usize; HASH_LENGTH], u8) {
+fn compute_hash(seed: u64, options: &Options) -> [usize; HASH_LENGTH] {
     let flag_bytes = options.to_flag_bytes();
     let mut h = seed;
     for &b in &flag_bytes {
@@ -131,8 +155,7 @@ fn compute_hash(seed: u64, options: &Options) -> ([usize; HASH_LENGTH], u8) {
         *icon = (h % NUM_ICONS as u64) as usize;
         h /= NUM_ICONS as u64;
     }
-    let palette = PALETTES[(h % PALETTES.len() as u64) as usize];
-    (icons, palette)
+    icons
 }
 
 /// One hash icon as a CHR renderer needs it: four 8x8 tile indices into CHR
@@ -166,7 +189,7 @@ fn chr_tile_index(tile: u8) -> usize {
 /// Describe the hash `write_seed_hash` would stamp for `seed` + `options`,
 /// without writing anything. `rom` is only read for its title sprite palette.
 pub fn seed_hash_preview(rom: &[u8], seed: u64, options: &Options) -> SeedHashPreview {
-    let (icons, palette_attr) = compute_hash(seed, options);
+    let icons = compute_hash(seed, options);
     let icons = icons
         .iter()
         .map(|&i| {
@@ -186,7 +209,7 @@ pub fn seed_hash_preview(rom: &[u8], seed: u64, options: &Options) -> SeedHashPr
 
     // A ROM too short to hold the table (only reachable with validation off,
     // where the hash isn't written anyway) falls back to all-backdrop.
-    let base = TITLE_SPRITE_PALETTE_OFFSET + (palette_attr & 0x03) as usize * 4;
+    let base = TITLE_SPRITE_PALETTE_OFFSET + HASH_PALETTE as usize * 4;
     let mut palette = [0x0Fu8; 4];
     if let Some(colors) = rom.get(base..base + 4) {
         palette.copy_from_slice(colors);
@@ -208,7 +231,7 @@ pub fn seed_hash_preview(rom: &[u8], seed: u64, options: &Options) -> SeedHashPr
 ///   data[0..7]   -> OAM[128..135]
 /// We place icon 0 (topmost) in the highest data group so it lands
 /// in the lowest OAM slot (highest sprite priority).
-fn build_sprite_data(icons: &[usize; HASH_LENGTH], palette: u8) -> [u8; HASH_LENGTH * 8] {
+fn build_sprite_data(icons: &[usize; HASH_LENGTH]) -> [u8; HASH_LENGTH * 8] {
     let mut sprite_data = [0u8; HASH_LENGTH * 8];
     for i in 0..HASH_LENGTH {
         let group = HASH_LENGTH - 1 - i; // icon 0 -> group 4 (bytes 32-39)
@@ -217,19 +240,19 @@ fn build_sprite_data(icons: &[usize; HASH_LENGTH], palette: u8) -> [u8; HASH_LEN
         let base = group * 8;
         sprite_data[base] = y;
         sprite_data[base + 1] = tile_l;
-        sprite_data[base + 2] = palette;
+        sprite_data[base + 2] = HASH_PALETTE;
         sprite_data[base + 3] = X_LEFT;
         sprite_data[base + 4] = y;
         sprite_data[base + 5] = tile_r;
-        sprite_data[base + 6] = palette | extra_attr_r;
+        sprite_data[base + 6] = HASH_PALETTE | extra_attr_r;
         sprite_data[base + 7] = X_RIGHT;
     }
     sprite_data
 }
 
 pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
-    let (icons, palette) = compute_hash(seed, options);
-    let sprite_data = build_sprite_data(&icons, palette);
+    let icons = compute_hash(seed, options);
+    let sprite_data = build_sprite_data(&icons);
 
     // ASM routine (25 bytes) at CPU $E914:
     //   LDY #$07
@@ -317,7 +340,7 @@ mod tests {
         let opts = Options::default();
         let a = compute_hash(1, &opts);
         let b = compute_hash(2, &opts);
-        assert_ne!(a.0, b.0);
+        assert_ne!(a, b);
     }
 
     #[test]
@@ -326,29 +349,25 @@ mod tests {
         let opts_b = Options { ground: crate::randomizer::EnemyMode::Wild, ..Default::default() };
         let a = compute_hash(42, &opts_a);
         let b = compute_hash(42, &opts_b);
-        assert_ne!(a.0, b.0);
+        assert_ne!(a, b);
     }
 
     #[test]
     fn hash_values_in_range() {
         let opts = Options::default();
         for seed in 0..100u64 {
-            let (icons, palette) = compute_hash(seed, &opts);
+            let icons = compute_hash(seed, &opts);
             for &v in &icons {
                 assert!(v < NUM_ICONS, "icon index {v} out of range");
             }
-            assert!(
-                PALETTES.contains(&palette),
-                "palette {palette} not in PALETTES"
-            );
         }
     }
 
     #[test]
     fn sprite_data_positions() {
         let opts = Options::default();
-        let (icons, palette) = compute_hash(42, &opts);
-        let sprite_data = build_sprite_data(&icons, palette);
+        let icons = compute_hash(42, &opts);
+        let sprite_data = build_sprite_data(&icons);
 
         // Icon 0 is in group 4 (bytes 32-39), should have Y_START
         assert_eq!(sprite_data[32], Y_START);
@@ -367,8 +386,8 @@ mod tests {
         write_seed_hash(&mut rom, 42, &opts);
 
         // The data table in ROM must be exactly what build_sprite_data emits.
-        let (icons, palette) = compute_hash(42, &opts);
-        let expected = build_sprite_data(&icons, palette);
+        let icons = compute_hash(42, &opts);
+        let expected = build_sprite_data(&icons);
         assert_eq!(rom.read_range(DATA_OFFSET, expected.len()), &expected[..]);
 
         // Hook and intro-skip hook target the derived CPU addresses.
@@ -452,23 +471,26 @@ mod tests {
     }
 
     #[test]
-    fn palette_varies_across_seeds() {
+    fn every_icon_is_reachable() {
+        // A digit is `h % NUM_ICONS`, so every index must map to a real row —
+        // and the table's length is what NUM_ICONS is derived from, so this
+        // catches a row added without the count following.
         let opts = Options::default();
-        let mut saw_pal0 = false;
-        let mut saw_pal2 = false;
-        for seed in 0..1000u64 {
-            let (_, palette) = compute_hash(seed, &opts);
-            if palette == 0x00 {
-                saw_pal0 = true;
+        let mut seen = [false; NUM_ICONS];
+        for seed in 0..200_000u64 {
+            for i in compute_hash(seed, &opts) {
+                seen[i] = true;
             }
-            if palette == 0x02 {
-                saw_pal2 = true;
-            }
-            if saw_pal0 && saw_pal2 {
-                break;
+            if seen.iter().all(|&s| s) {
+                return;
             }
         }
-        assert!(saw_pal0, "palette 0 never selected in 1000 seeds");
-        assert!(saw_pal2, "palette 2 never selected in 1000 seeds");
+        let missing: Vec<_> = seen
+            .iter()
+            .enumerate()
+            .filter(|&(_, &s)| !s)
+            .map(|(i, _)| i)
+            .collect();
+        panic!("icons never selected across 200k seeds: {missing:?}");
     }
 }

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -78,6 +78,14 @@ fn sweep_is_deterministic() {
 /// regeneration hides no real change. Default options leave the injection
 /// mode Off, so no gameplay byte differs.
 ///
+/// Re-captured again 2026-08-09 for the wider title-hash icon set: ICON_TILES
+/// grew from 15 to 20 rows and the palette digit was dropped, so the 40-byte
+/// sprite table at `FS_SEED_HASH_DATA` differs for every seed and all 20 moved.
+/// Verified the same way as the v29 recapture — seeds 1-3 generated before and
+/// after with `--no-palettes` (the player wardrobe is not seed-deterministic)
+/// and diffed byte by byte. Every difference lands inside FS_SEED_HASH_DATA; no
+/// overworld, level or enemy byte moved.
+///
 /// Re-captured again 2026-08-06 for the v29 flag-key re-layout (issue #158).
 /// Same story, verified the same way but end-to-end rather than by pinning a
 /// constant, since the whole format changed: seeds 1-3 were generated before
@@ -86,11 +94,11 @@ fn sweep_is_deterministic() {
 /// the title-screen verification icons at `FS_SEED_HASH_DATA` (0x3E93D), whose
 /// hash folds `to_flag_bytes()`. No overworld, level, or enemy byte moved.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x2F1BCC4337C08F68, 0x2FA22BE766E829C2, 0xBA27EEB114014065, 0x05F1B18F79E8B6CC,
-    0x751E5E0C61AD8D37, 0xBCC5C3EE0CE9982F, 0x602BF085D5943A01, 0x2D88CD0275AF4D2A,
-    0xC468CE9CC9855C58, 0x357E92F0AC2ACC66, 0x6BC4763423B1C59B, 0x88252754C99D7838,
-    0x9EE4278722525DFD, 0x6C09F4B3354F1FC2, 0xA28A8EBBE81A5C3E, 0xDB4F9E42DA4CCA00,
-    0x449BF758A7F46AA8, 0xEF074E3694941F2B, 0xF242865A87826F34, 0xAB0AE92979F23FE3,
+    0xBB2A7CBF02AF4BBA, 0x761607361C034EDA, 0xC4E3267B24430DB5, 0x871D2AEE7C896AB6,
+    0xF27E5B34E1EEABDD, 0x9D9F280937717403, 0xE879479EEA8398FF, 0x2991D7B20C48097E,
+    0xEFF71177664A5822, 0x4EF2AB92BC810522, 0xD188D3A10F375DB5, 0x833E8EFC349D2154,
+    0x280B67E04F3F5F87, 0xCD041C077C531F96, 0x675C1986FEEDE464, 0x3286199B722396FA,
+    0xD108207D0F8A21EC, 0x13D64C84EB019B01, 0x6C77A703B2285A5A, 0x437324880DC9D14B,
 ];
 
 #[test]

--- a/web/chr-picker.html
+++ b/web/chr-picker.html
@@ -40,6 +40,15 @@ input[type=text], input[type=number], select { background: #0a0a1a; border: 1px 
 
   <h2>View</h2>
   <div class="row">
+    <label><input type="checkbox" id="hashMode"> title hash icons only</label>
+  </div>
+  <div class="row" id="hashPageRow" hidden>
+    <label>page <select id="hashPage"></select></label>
+  </div>
+  <div class="note" id="hashNote" hidden>Only these four 1&nbsp;KB pages are
+  reachable from a title-screen sprite — the banks are fixed, so nothing else can
+  be referenced. Picks come out as <code>ICON_TILES</code> rows.</div>
+  <div class="row" id="pageRow">
     <label>page <input type="number" id="page" value="0" min="0" max="127" style="width:56px"></label>
     <label>count <input type="number" id="pageCount" value="8" min="1" max="32" style="width:48px"></label>
   </div>
@@ -117,6 +126,11 @@ const swatchesEl = document.getElementById("swatches");
 const palGridEl = document.getElementById("palgrid");
 const labelEl = document.getElementById("label");
 const mirrorEl = document.getElementById("mirror");
+const hashModeEl = document.getElementById("hashMode");
+const hashPageEl = document.getElementById("hashPage");
+const hashPageRow = document.getElementById("hashPageRow");
+const hashNote = document.getElementById("hashNote");
+const pageRow = document.getElementById("pageRow");
 const cursorEl = document.getElementById("cursor");
 const lastEl = document.getElementById("last");
 const recentEl = document.getElementById("recent");
@@ -239,9 +253,30 @@ function renderPalGrid() {
 	}
 }
 
+// The four 1 KB CHR pages a title-screen sprite can address, in slot order.
+// PRG030's reset path fixes MMC3 R2-R5 to these, so an OAM tile ID's top two
+// bits pick one of them and nothing outside this set is reachable. Order
+// matters — the index here *is* the tile ID's high bits.
+const HASH_PAGES = [0x20, 0x21, 0x04, 0x7F];
+
+function hashMode() {
+	return hashModeEl.checked;
+}
+
+// Absolute CHR tile -> the OAM tile ID that names it on the title screen, or
+// null if it isn't on an addressable page. ICON_TILES stores the odd (pattern
+// table 1) ID, whose top half is the even tile before it.
+function oamTileId(absTop) {
+	const slot = HASH_PAGES.indexOf(Math.floor(absTop / TILES_PER_PAGE));
+	if (slot < 0) return null;
+	return (slot << 6) | (absTop % TILES_PER_PAGE) | 1;
+}
+
 function view() {
-	const firstTile = Math.max(0, (+pageEl.value || 0)) * TILES_PER_PAGE;
-	const tiles = Math.min((+pageCountEl.value || 1) * TILES_PER_PAGE, TOTAL_TILES - firstTile);
+	const page = hashMode() ? HASH_PAGES[+hashPageEl.value || 0] : Math.max(0, +pageEl.value || 0);
+	const firstTile = page * TILES_PER_PAGE;
+	const count = hashMode() ? 1 : +pageCountEl.value || 1;
+	const tiles = Math.min(count * TILES_PER_PAGE, TOTAL_TILES - firstTile);
 	const stride = Math.max(1, +strideEl.value || 16);
 	const pairs = Math.floor(tiles / 2);
 	return {
@@ -372,6 +407,19 @@ function addPick(r) {
 		}
 	}
 	const pal = palValues();
+	// In hash mode also record the pick as ICON_TILES names it: the left and
+	// right halves' OAM tile IDs, and the attribute byte that h-flips the right
+	// one. A mirrored pick uses the same tile twice, which is what 0x40 means.
+	const left = pairTile(v, r.c, r.r);
+	const oam = hashMode()
+		? {
+			left: oamTileId(left),
+			right: oamTileId(mirror ? left : pairTile(v, r.c + 1, r.r)),
+			attr: mirror ? 0x40 : 0x00,
+			// A hash icon is exactly 16x16: two pairs across, or one plus mirror.
+			shapeOk: r.rows === 1 && r.cols === (mirror ? 1 : 2),
+		}
+		: null;
 	picks.push({
 		label: labelEl.value.trim(),
 		tiles,
@@ -379,6 +427,7 @@ function addPick(r) {
 		palette: pal,
 		flipRight: mirror,
 		pairRows: r.rows,
+		oam,
 		view: { firstTile: v.firstTile, stride: v.stride, col: r.c, row: r.r },
 	});
 	lastEl.textContent = specText(picks[picks.length - 1]);
@@ -387,8 +436,18 @@ function addPick(r) {
 	drawOverlay(v);
 }
 
+const rustHex = (v) => `0x${hex2(v)}`;
+
 function specText(p) {
-	const pal = p.palette.map((c) => `0x${c.toString(16).toUpperCase().padStart(2, "0")}`).join(", ");
+	if (p.oam) {
+		if (p.oam.left == null || p.oam.right == null) {
+			return `// ${p.label || "pick"}: not on an addressable page`;
+		}
+		const why = p.oam.shapeOk ? "" : "  // NOT 16x16 — a hash icon is two pairs, or one plus mirror";
+		const note = p.label ? ` // ${p.label}` : "";
+		return `(${rustHex(p.oam.left)}, ${rustHex(p.oam.right)}, ${rustHex(p.oam.attr)}),${note}${why}`;
+	}
+	const pal = p.palette.map(rustHex).join(", ");
 	const head = p.label ? `${p.label}: ` : "";
 	const flip = p.flipRight ? ", flipRight: true" : "";
 	return `${head}{ tiles: [${p.tiles.join(", ")}], cols: ${p.cols}, palette: [${pal}]${flip} }`;
@@ -432,6 +491,29 @@ paletteEl.addEventListener("input", refreshPalette);
 for (const el of [pageEl, pageCountEl, strideEl, scaleEl]) {
 	el.addEventListener("input", render);
 }
+
+// Title-hash mode: the only pages a title sprite can name, labelled by what
+// each slot holds so it's obvious where to look.
+const HASH_PAGE_LABELS = ["items & UI", "Mario/Luigi + UI", "score popups", "items (leaf, mushroom…)"];
+HASH_PAGES.forEach((page, slot) => {
+	const opt = document.createElement("option");
+	opt.value = String(slot);
+	opt.textContent = `$${page.toString(16).toUpperCase().padStart(2, "0")} — ${HASH_PAGE_LABELS[slot]}`;
+	hashPageEl.append(opt);
+});
+hashPageEl.value = "3"; // $7F, where most of the current icon set lives
+
+function syncHashMode() {
+	const on = hashMode();
+	hashPageRow.hidden = !on;
+	hashNote.hidden = !on;
+	pageRow.hidden = on;
+	if (on) strideEl.value = "8"; // 8 pairs/row lines a 64-tile page into 4 rows
+	render();
+}
+hashModeEl.addEventListener("change", syncHashMode);
+hashPageEl.addEventListener("change", render);
+
 renderSwatches();
 </script>
 </body>

--- a/web/chr-picker.html
+++ b/web/chr-picker.html
@@ -396,6 +396,10 @@ cv.addEventListener("mouseleave", () => { if (drag) { drag = null; drawOverlay(v
 function addPick(r) {
 	const v = view();
 	const mirror = mirrorEl.checked;
+	// Mirror appends the selection reversed. In hash mode a one-pair pick is
+	// appended as-is instead, because a hash icon is always two halves wide —
+	// so the preview shows the doubled icon the emitted row describes.
+	const doubleSingle = hashMode() && r.cols === 1 && !mirror;
 	const tiles = [];
 	for (let row = 0; row < r.rows; row++) {
 		for (const half of [0, 1]) {
@@ -403,27 +407,34 @@ function addPick(r) {
 			for (let col = 0; col < r.cols; col++) {
 				line.push(pairTile(v, r.c + col, r.r + row) + half);
 			}
-			tiles.push(...line, ...(mirror ? [...line].reverse() : []));
+			if (mirror) tiles.push(...line, ...[...line].reverse());
+			else if (doubleSingle) tiles.push(...line, ...line);
+			else tiles.push(...line);
 		}
 	}
 	const pal = palValues();
 	// In hash mode also record the pick as ICON_TILES names it: the left and
 	// right halves' OAM tile IDs, and the attribute byte that h-flips the right
 	// one. A mirrored pick uses the same tile twice, which is what 0x40 means.
+	// A hash icon is 16x16 — two 8x16 halves side by side — so a pick is either
+	// two pairs across, or one pair used for both halves. In the one-pair case
+	// the second half is that same tile again, drawn flipped or not; reading the
+	// pair next door would silently pull in art that wasn't selected.
 	const left = pairTile(v, r.c, r.r);
+	const single = r.cols === 1;
 	const oam = hashMode()
 		? {
 			left: oamTileId(left),
-			right: oamTileId(mirror ? left : pairTile(v, r.c + 1, r.r)),
+			right: oamTileId(single ? left : pairTile(v, r.c + 1, r.r)),
 			attr: mirror ? 0x40 : 0x00,
-			// A hash icon is exactly 16x16: two pairs across, or one plus mirror.
-			shapeOk: r.rows === 1 && r.cols === (mirror ? 1 : 2),
+			doubled: single,
+			shapeOk: r.rows === 1 && r.cols <= 2,
 		}
 		: null;
 	picks.push({
 		label: labelEl.value.trim(),
 		tiles,
-		cols: r.cols * (mirror ? 2 : 1),
+		cols: r.cols * (mirror || doubleSingle ? 2 : 1),
 		palette: pal,
 		flipRight: mirror,
 		pairRows: r.rows,
@@ -443,8 +454,11 @@ function specText(p) {
 		if (p.oam.left == null || p.oam.right == null) {
 			return `// ${p.label || "pick"}: not on an addressable page`;
 		}
-		const why = p.oam.shapeOk ? "" : "  // NOT 16x16 — a hash icon is two pairs, or one plus mirror";
-		const note = p.label ? ` // ${p.label}` : "";
+		const why = p.oam.shapeOk
+			? ""
+			: "  // NOT 16x16 — select one or two pairs on a single row";
+		const how = p.oam.doubled ? (p.oam.attr ? " (half, mirrored)" : " (half, doubled)") : "";
+		const note = p.label || how ? ` // ${p.label}${how}` : "";
 		return `(${rustHex(p.oam.left)}, ${rustHex(p.oam.right)}, ${rustHex(p.oam.attr)}),${note}${why}`;
 	}
 	const pal = p.palette.map(rustHex).join(", ");


### PR DESCRIPTION
Makes the title hash verifiable for players using a visual patch, and adds the picker mode used to curate the wider icon set.

## The problem

The hash encoded a digit in the icons' *colour*, picking between sprite palettes 0 and 2. Palette 0 is Mario's, and every player re-skin in the catalogue rewrites it:

| | palette 0 |
|---|---|
| vanilla | `16` red |
| Luigi | `1A` green |
| Toad | `22` cyan |
| Peach | `25` pink |

Same seed, same hash value, four different colours on screen. Two racers on different skins saw different colours for an identical game — and nothing distinguished that from a genuinely different seed.

A re-skinned *shape* doesn't have this problem: an obviously-Peach sprite reads as "that's a skin" and gets discounted. A colour carries no such signal. It was pure payload, and unverifiable. Measured, it bit **~16% of seeds** for the three patches that recolour palette 0.

## The fix

Colour is now fixed at palette 2 — which no re-skin touches — and carries nothing. The entropy it provided is replaced by widening `ICON_TILES` from 15 to 20:

**20⁵ = 3,200,000** against the old **15⁵ × 2 = 1,518,750** — a net gain while removing the unverifiable part entirely.

This costs nothing on screen or in ROM. The OAM table is 40 bytes for five icons however large the set is, the 6502 copy routine is untouched, and no sixth sprite row risks colliding with the menu text. Considered and rejected: stamping palettes 2/3 from the randomizer, which would have silently reverted a future full re-skin's colours for the four title objects that share those slots (`Title_ObjPal`, prg024:4503).

## The new icons

Five picks on pages `$21` and `$04`, each checked against all six bundled patches — none re-skins them. The three existing player-art icons stay: a substituted character is legible as a substitution, so they cost nothing.

## Picker support

A hash icon can only come from the four pages PRG030 fixes the sprite banks to (`$20`/`$21`/`$04`/`$7F`) — the OAM tile ID's top two bits pick one, so nothing else is reachable. "Title hash icons only" narrows the page control to those four and emits `ICON_TILES` rows in OAM tile-ID space rather than absolute CHR indices. The conversion is pinned: all 15 original icons round-trip to the exact bytes the table already stores.

Also fixes a bug in that mode where a one-pair pick emitted the tile *next to* the selection — art that was never picked — producing plausible but wrong rows. It bit three picks before being spotted.

## Verification

- Hash rendered straight out of a generated ROM: palette slot 2, `0F 27 30 0F`.
- `every_icon_is_reachable` proves all 20 rows are actually selected, so a row added without the count following fails.
- The palette invariant is a `const` assert — compile-time, since it's a fact about which slot is safe rather than behaviour.
- Full suite green, clippy clean.

**Baseline regenerated** — whole-ROM hashes, so all 20 seeds moved. Verified confined per that test's own rule: seeds 1–3 generated before and after with `--no-palettes` and diffed byte by byte, every difference inside `FS_SEED_HASH_DATA`. No overworld, level or enemy byte moved. (`--no-palettes` because the player wardrobe is not seed-deterministic — two runs of the same binary on the same seed differ in those 7 bytes. Pre-existing, untouched here.)

Version stays 1.1.1, which never reached main, so this ships as part of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB