### PR TITLE
docs: describe the CHR icon system in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,14 @@ web/
   index.html           # Browser frontend
   style.css
   app.js               # Loads WASM, handles file input, triggers download
+  options.js           # Option schema (labels, tips, defaults, icon specs)
+  chr.js               # CHR decoder — every icon in the app is drawn from the
+                       #   player's own ROM, so there are no bundled sprite
+                       #   sheets. Pixel art only ever scales by a whole number.
+  chr-picker.html      # Icon picker. Lays CHR out as 8x16 pairs, which is the
+                       #   only way sprite art is legible (a flat tile grid
+                       #   interleaves each sprite's halves). Emits icon specs
+                       #   for options.js, or ICON_TILES rows in title-hash mode.
 tools/
   README.md            # INDEX OF ALL 16 TOOLS — read this before writing a throwaway script
   rom_map.py           # ROM map generator + diagnostic modes (see below)


### PR DESCRIPTION
The `web/` listing in CLAUDE.md predated the icon work and stopped at `app.js`. Nothing there told a reader that every icon is decoded from the player's own ROM rather than a bundled sprite sheet, or that `chr-picker.html` is how new ones get curated.

Adds `options.js`, `chr.js` and `chr-picker.html` with the two facts that are easy to get wrong: CHR has to be laid out as 8×16 pairs to be legible (a flat tile grid interleaves each sprite's halves and the page looks like noise), and pixel art only survives whole-number scaling.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB