### PR TITLE
feature: press B on the title screen to mute the menu music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ deploys.
 
 ## [Unreleased]
 
+### Added
+
+- **Press B on the title screen to mute the menu music**, and B again to bring
+  it back. Handy when you are generating and verifying seeds back to back, or
+  streaming with the title screen up. Start still begins the game as normal,
+  and the world map queues its own music either way.
+
 ## [1.1.1] - 2026-08-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ is the one to read:
 | PRG006 | `$C000–$DFFF`, in-level (enemy data) | 1392 | 1392 |
 | PRG007 | swapped, in-level (object AI) | 27 | 27 |
 | PRG010 | `$C000–$DFFF`, map | 896 | 588 |
+| PRG025 | `$C000–$DFFF`, title screen | 2771 | 2759 |
 | PRG026 | `$A000–$BFFF`, map/inventory | 2603 | 2537 |
 
 PRG000 and PRG002 have no `$FF` filler left at all.
@@ -129,7 +130,12 @@ The two largest gaps here have been through the unreferenced check already
 (2026-08-04): `prg004.asm` ends with "Rest of ROM bank was empty" at `$BE56`,
 and PRG006's last assembled data is the dead object stream `_DA60` (file
 0x0DA70..0x0DA74), referenced from nowhere, with the furthest referenced enemy
-stream ending at 0x0D9F6.
+stream ending at 0x0D9F6. PRG025's tail was checked the same way (2026-08-10):
+`prg025.asm` ends with "Rest of ROM bank was empty" after the palette sequence
+at `$D505`, so the whole run from 0x33529 to the bank end is filler. That bank
+is mapped at `$C000` for the entire title screen (PRG030's title entry loads
+page 24 into `$A000` and page 25 into `$C000`), which makes it the right home
+for title-only code instead of the nearly-full always-mapped banks.
 
 ### Size techniques that have actually paid off here
 

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -3837,10 +3837,12 @@ Each entry represents a 16x16 metatile column on the world map.
 
 | Address | Description |
 |---------|-------------|
+| $04E4 | `SndCur_Music1` — fanfare currently playing (0 = none) |
+| $04E5 | `SndCur_Music2` — theme currently playing (0 = none). Read this to ask "is music audible right now"; `Music_StopAll` zeroes it. |
 | $04F1 | Sound effect trigger 1 (jump, blocks, swimming) |
 | $04F2 | Sound effect trigger 2 (coins, power-ups, items) |
 | $04F3 | Sound effect trigger 3 (bricks, fire, airship) |
-| $04F4 | Fanfare music trigger (death, victory) |
+| $04F4 | Fanfare music trigger (death, victory). `0x80` = `MUS1_STOPMUSIC`, the engine's own "stop all music". |
 | $04F5 | Music change (world maps, themes) |
 | $04F6 | Sound effect trigger 4 (map movement, level entry) |
 | $04F7 | Pause control (0x01=pause, 0x02=resume) |
@@ -3873,13 +3875,48 @@ Vanilla SMB3 leaves the 1P/2P select menu silent (the only title-screen music is
 
 The track is chosen deterministically from the seed via a curated 16-entry table (world map themes 1–9, plus level themes 0x10/0x20/0x30/0x40/0x60/0x80/0x90). See `src/randomize/title_screen.rs::MENU_MUSIC_TRACKS` and `pick_menu_music`. When `starting_items` is active it overwrites the lives-init hook, so `qol::write_starting_items` mirrors the same `STA $04F5` inside its own trampoline.
 
+### Title Menu Input Loop (PRG024) — and the B-to-mute hook
+
+`Title_Do1P2PMenu` (CPU $AC35, file 0x30C45) is the per-frame handler for the
+1P/2P screen, and it is where every title-menu input is read. PRG030's title
+entry point maps **page 24 to $A000 and page 25 to $C000** before calling
+`Do_Title_Screen` (CPU $A8AF), so both banks are live for the whole title screen.
+The handler reads `Pad_Input` (zero page **$18**, newly-pressed-only; `Pad_Holding`
+is $17) — Select at CPU $AC55 toggles `Total_Players`, Start at CPU $AC86 begins
+the game. Button bits are `A=$80, B=$40, Select=$20, Start=$10, Up=$08, Down=$04,
+Left=$02, Right=$01`.
+
+| Offset | CPU | Vanilla | Note |
+|--------|-----|---------|------|
+| 0x30C62 | $AC52 | `JSR $B78E` | `Title_Menu_UpdateKoopas` |
+| 0x30C65 | $AC55 | `LDA $18 / AND #$20` | Select — 1P/2P toggle |
+| 0x30C93 | $AC83 | `JSR $AA7D` | `Title_3Glow` — the mute hook site |
+| 0x30C96 | $AC86 | `LDA $18 / AND #$10` | Start — begin the game |
+
+**Mute toggle.** The randomizer replaces the `JSR $AA7D` at 0x30C93 with a `JSR`
+into a 22-byte routine in PRG025 free space (CPU $D519, file 0x33529), which
+tail-jumps back to `Title_3Glow` — so the '3' still glows, its `RTS` returns to
+the menu, and Start is untouched. The routine tests B via `BIT $18` (B is bit 6,
+which `BIT` copies straight into V), then reads `SndCur_Music2` ($04E5) to decide
+direction: non-zero means a Set-2 track is audible, so it queues `MUS1_STOPMUSIC`
+($80) to `Sound_QMusic1` ($04F4); zero means silence, so it re-queues the seeded
+track to `Sound_QMusic2` ($04F5). Because `MUS1_STOPMUSIC` runs through
+`Music_StopAll`, which zeroes `SndCur_Music2`, the engine's own state *is* the
+mute flag and no RAM byte is spent on it. The two queues being adjacent is what
+lets a single `STA $04F4,X` with X as a 0/1 selector serve both paths.
+
+The mute persists because the attract-mode patch below holds `$E1` at 0 — without
+it the menu would reset roughly every 20 × 96 frames (~32 s) and the intro-skip
+routine would re-queue the track. See `title_screen.rs::mute_routine`.
+
 ### Attract-Mode Demo Trigger (PRG024)
 
-While the 1P/2P menu sits idle, a two-stage countdown decrements each frame: the
-menu handler at CPU **$8C4E** (file **0x30C45**) does `DEC $E0` (low byte, reloads
-to 0x60) and, on rollover, `DEC $DF` (high byte, seeded to 0x14 at CPU $8C28).
-When `$DF` hits zero it runs `LDA #$FF / STA $E1` — the `#$FF` operand is at file
-**0x30C5F**. A later check at CPU **$8979** (file 0x30989) reads the flag:
+While the 1P/2P menu sits idle, a two-stage countdown decrements each frame:
+`Title_Do1P2PMenu` (CPU **$AC35**, file **0x30C45**) does `DEC $E0` at CPU $AC42
+(low byte, reloads to 0x60) and, on rollover, `DEC $DF` (high byte, seeded to
+0x14 at CPU $AC28 / file 0x30C38). When `$DF` hits zero it runs
+`LDA #$FF / STA $E1` at CPU $AC4E — the `#$FF` operand is at file **0x30C5F**. A
+later check at CPU **$A979** (file 0x30989) reads the flag:
 
 ```
 $8979:  A5 E1        LDA $E1

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -112,6 +112,8 @@ pub const FREE_SPACE_ALLOCATIONS: &[FreeSpaceAlloc] = &[
     fs(0x3E281, 69, &["start_airship_swap"], "4 tables (X/XHi/ScrL/ScrH × 8) + Map_Init seed helper"),
     fs(0x3E965, 13, &["title_screen"], "intro skip + menu music routine"),
     fs(0x3FFF0, 26, &["card_speed_clear"], "XOR trampoline"),
+    // PRG025 (file 0x32010, CPU $C000–$DFFF while the title screen runs)
+    fs(0x33529, 32, &["title_screen"], "title menu B-to-mute toggle (32 reserved, 22 used)"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
     fs(0x35572, 13, &["mystery_anchor"], "item redirect trampoline"),
     fs(0x3557F, 50, &["hammer_breaks_tiles"], "hammer_locks: tile check subroutine + tables"),
@@ -173,6 +175,14 @@ pub(crate) const FS_SEED_HASH_DATA: usize    = 0x3E93D; // 40 bytes
 pub(crate) const FS_INTRO_SKIP: usize        = 0x3E965; // 13 bytes
 
 pub(crate) const FS_CARD_CLEAR: usize        = 0x3FFF0; // 26 bytes
+
+// PRG025 — the title-screen bank at $C000–$DFFF (PRG030's title entry loads
+// page 24 into $A000 and page 25 into $C000 before `Do_Title_Screen`). The
+// disassembly ends this bank with "Rest of ROM bank was empty" just before this
+// offset, so the whole 2791-byte run to the bank end is unreferenced filler;
+// only 32 bytes are claimed here. Costs nothing from the always-mapped banks,
+// which is what makes this the right home for a title-only routine.
+pub(crate) const FS_TITLE_MUTE: usize        = 0x33529; // 32 reserved, 22 used
 
 pub(crate) const FS_STARTING_ITEMS: usize    = 0x3E260; // 33 bytes
 
@@ -805,6 +815,7 @@ mod free_space_tests {
             (FS_SEED_HASH_DATA, "FS_SEED_HASH_DATA"),
             (FS_INTRO_SKIP, "FS_INTRO_SKIP"),
             (FS_CARD_CLEAR, "FS_CARD_CLEAR"),
+            (FS_TITLE_MUTE, "FS_TITLE_MUTE"),
             (FS_STARTING_ITEMS, "FS_STARTING_ITEMS"),
             (FS_SAS_BLOCK, "FS_SAS_BLOCK"),
             (FS_SAS_GAMEOVER_FINALIZE, "FS_SAS_GAMEOVER_FINALIZE"),

--- a/src/randomize/title_screen.rs
+++ b/src/randomize/title_screen.rs
@@ -77,6 +77,65 @@ const INTRO_SKIP_CPU: u16 = super::rom_data::prg031_file_to_cpu(INTRO_SKIP_ROUTI
 /// starts — the menu just holds. The byte at 0x30C5F is the `#$FF` operand.
 const DEMO_TRIGGER_OPERAND_OFFSET: usize = 0x30C5F;
 
+/// Mute toggle: press B on the 1P/2P menu to stop the menu music, B again to
+/// bring it back.
+///
+/// `Title_Do1P2PMenu` (PRG024) calls `Title_3Glow` once per frame at CPU $AC83,
+/// between drawing the cursor sprite and testing Start. That `JSR $AA7D` becomes
+/// `JSR mute_routine`, and the routine tail-jumps to `Title_3Glow` — so the glow
+/// still runs and its `RTS` returns to the menu exactly as before.
+///
+/// The routine lives in PRG025, which the title entry point in PRG030 maps to
+/// $C000 alongside PRG024 at $A000. Putting it there rather than in PRG031
+/// spends none of the always-mapped space (30 bytes is its largest gap), and the
+/// routine has no reason to run anywhere but the title screen.
+const MUTE_HOOK_OFFSET: usize = 0x30C93;
+const TITLE_3GLOW_CPU: u16 = 0xAA7D;
+const MUTE_ROUTINE_OFFSET: usize = super::rom_data::FS_TITLE_MUTE;
+/// PRG025 file 0x32010 is CPU $C000 while the title screen runs.
+const MUTE_ROUTINE_CPU: u16 = (0xC000 + MUTE_ROUTINE_OFFSET - 0x32010) as u16; // $D519
+
+/// Assemble the 22-byte mute toggle. `music` is the seeded track it restores.
+///
+/// ```text
+///   BIT $18        ; Pad_Input — bit 6 is B, and BIT drops it straight into V
+///   BVC done       ; B not newly pressed this frame: nothing to do
+///   LDX #$01       ; assume unmute: $04F4 + 1 = $04F5 (Sound_QMusic2)
+///   LDA #music
+///   LDY $04E5      ; SndCur_Music2 — a Set 2 track is playing iff non-zero
+///   BEQ store      ; silent already, so the B press means unmute
+///   LDA #$80       ; MUS1_STOPMUSIC
+///   DEX            ; X = 0 → $04F4 (Sound_QMusic1)
+/// store:
+///   STA $04F4,X
+/// done:
+///   JMP $AA7D      ; Title_3Glow, the call this routine displaced
+/// ```
+///
+/// Two size choices worth keeping: `BIT` tests B in 2 bytes where `LDA`/`AND`
+/// takes 4 (B is bit 6, which is exactly the bit `BIT` copies into V), and the
+/// two music queues are adjacent, so one `STA $04F4,X` with X as the 0/1
+/// selector replaces a second store and the branch that would skip it.
+///
+/// The engine's own `SndCur_Music2` is the mute flag — `MUS1_STOPMUSIC` runs
+/// through `Music_StopAll`, which zeroes it — so no RAM byte is spent tracking
+/// state, and nothing can drift out of sync with what is actually audible.
+#[rustfmt::skip]
+fn mute_routine(music: u8) -> [u8; 22] {
+    [
+        0x24, 0x18,             // BIT $18       (Pad_Input)
+        0x50, 0x0F,             // BVC done
+        0xA2, 0x01,             // LDX #$01
+        0xA9, music,            // LDA #music
+        0xAC, 0xE5, 0x04,       // LDY $04E5     (SndCur_Music2)
+        0xF0, 0x03,             // BEQ store
+        0xA9, 0x80,             // LDA #$80      (MUS1_STOPMUSIC)
+        0xCA,                   // DEX
+        0x9D, 0xF4, 0x04,       // STA $04F4,X   (Sound_QMusic1 / Sound_QMusic2)
+        0x4C, TITLE_3GLOW_CPU as u8, (TITLE_3GLOW_CPU >> 8) as u8, // JMP Title_3Glow
+    ]
+}
+
 /// Curated music tracks for the title menu. Values are written to the music
 /// change trigger at $04F5 — each one is a looping theme that fits a static
 /// menu screen (map themes 1–8 plus a handful of level / mushroom / hilly
@@ -321,6 +380,17 @@ pub fn write_seed_hash(rom: &mut Rom, seed: u64, options: &Options) {
     // Disable the attract-mode demo: LDA #$FF → LDA #$00 so the idle-timeout
     // never raises the demo-trigger flag $E1 (see DEMO_TRIGGER_OPERAND_OFFSET).
     rom.write_byte(DEMO_TRIGGER_OPERAND_OFFSET, 0x00);
+
+    // B on the 1P/2P menu toggles the menu music. The routine replaces the
+    // per-frame `JSR Title_3Glow` and tail-jumps back into it, so the '3' keeps
+    // glowing and Start still advances to the map. The demo-disable above is
+    // what makes the mute stick: with $E1 held at 0 the menu never resets, so
+    // the intro-skip routine never re-queues the track behind the player's back.
+    rom.write_range(MUTE_ROUTINE_OFFSET, &mute_routine(pick_menu_music(seed)));
+    rom.write_range(
+        MUTE_HOOK_OFFSET,
+        &[0x20, MUTE_ROUTINE_CPU as u8, (MUTE_ROUTINE_CPU >> 8) as u8],
+    );
 }
 
 #[cfg(test)]
@@ -471,6 +541,52 @@ mod tests {
     }
 
     #[test]
+    fn mute_routine_restores_the_seeded_track() {
+        // The unmute path writes the same track the intro-skip routine queues,
+        // so muting and unmuting cannot land the player on a different song.
+        for seed in [0u64, 1, 42, 12345, u64::MAX] {
+            let routine = mute_routine(pick_menu_music(seed));
+            assert_eq!(routine[7], pick_menu_music(seed));
+            assert_eq!(intro_skip_music_bytes(seed)[5], routine[7]);
+        }
+    }
+
+    #[test]
+    fn write_seed_hash_installs_the_mute_hook() {
+        let opts = Options::default();
+        let mut rom = crate::randomize::qol::test_support::make_test_rom();
+        write_seed_hash(&mut rom, 42, &opts);
+
+        // JSR $D519 in place of the vanilla JSR Title_3Glow.
+        assert_eq!(rom.read_range(MUTE_HOOK_OFFSET, 3), &[0x20, 0x19, 0xD5]);
+        assert_eq!(
+            rom.read_range(MUTE_ROUTINE_OFFSET, 22),
+            &mute_routine(pick_menu_music(42))[..]
+        );
+    }
+
+    #[test]
+    fn mute_hook_site_matches_vanilla() {
+        // Guards the offset itself: 0x30C93 is CPU $AC83, the per-frame
+        // `JSR Title_3Glow` inside Title_Do1P2PMenu. A drifted offset would
+        // splice a JSR into the middle of some other instruction.
+        let Some(v) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+        assert_eq!(
+            &v[MUTE_HOOK_OFFSET..MUTE_HOOK_OFFSET + 3],
+            &[0x20, TITLE_3GLOW_CPU as u8, (TITLE_3GLOW_CPU >> 8) as u8],
+        );
+        // ...followed by the Start test the menu does every frame.
+        assert_eq!(&v[MUTE_HOOK_OFFSET + 3..MUTE_HOOK_OFFSET + 7], &[0xA5, 0x18, 0x29, 0x10]);
+    }
+
+    fn vanilla() -> Option<Vec<u8>> {
+        std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()
+    }
+
+    #[test]
     fn every_icon_is_reachable() {
         // A digit is `h % NUM_ICONS`, so every index must map to a real row —
         // and the table's length is what NUM_ICONS is derived from, so this
@@ -492,5 +608,121 @@ mod tests {
             .map(|(i, _)| i)
             .collect();
         panic!("icons never selected across 200k seeds: {missing:?}");
+    }
+}
+
+#[cfg(test)]
+mod asm_checks {
+    use super::*;
+    use crate::randomize::rom_data::asm;
+
+    #[test]
+    fn mute_routine_is_well_formed() {
+        asm::check(&mute_routine(0x10))
+            .allocation(MUTE_ROUTINE_OFFSET)
+            .origin(MUTE_ROUTINE_CPU)
+            .assert_ok();
+    }
+
+    /// The hook overwrites `JSR Title_3Glow` — one whole 3-byte instruction —
+    /// and must aim at the routine's own origin. Split out because comparing
+    /// against vanilla needs the ROM, which CI does not have.
+    #[test]
+    fn mute_hook_displaces_whole_instructions() {
+        let Some(v) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+        let patch = [0x20, MUTE_ROUTINE_CPU as u8, (MUTE_ROUTINE_CPU >> 8) as u8];
+        asm::check(&mute_routine(0x10))
+            .origin(MUTE_ROUTINE_CPU)
+            .hook(&v, MUTE_HOOK_OFFSET, &patch)
+            .assert_ok();
+    }
+
+    /// Run the mute routine on an emulated CPU and report what it queued.
+    ///
+    /// The routine is self-contained up to its tail `JMP Title_3Glow` — it reads
+    /// `Pad_Input` and `SndCur_Music2` and writes one of the two music queues —
+    /// so the whole thing can be executed rather than merely decoded. Stops at
+    /// the `JMP`, which would otherwise run off into unloaded memory.
+    fn run_mute(pad: u8, playing: u8, music: u8) -> (u8, u8) {
+        use mos6502::cpu::CPU;
+        use mos6502::instruction::{Instruction, Ricoh2a03};
+        use mos6502::memory::{Bus, Memory};
+        use mos6502::Variant;
+
+        let code = mute_routine(music);
+        let mut mem = Memory::new();
+        mem.set_bytes(MUTE_ROUTINE_CPU, &code);
+        mem.set_byte(0x0018, pad); // Pad_Input
+        mem.set_byte(0x04E5, playing); // SndCur_Music2
+        mem.set_byte(0x04F4, 0x00); // Sound_QMusic1, cleared every frame
+        mem.set_byte(0x04F5, 0x00); // Sound_QMusic2, likewise
+        let mut cpu = CPU::new(mem, Ricoh2a03);
+        cpu.registers.program_counter = MUTE_ROUTINE_CPU;
+
+        for _ in 0..code.len() {
+            let op = cpu.memory.get_byte(cpu.registers.program_counter);
+            if matches!(Ricoh2a03::decode(op), Some((Instruction::JMP, _))) {
+                return (cpu.memory.get_byte(0x04F4), cpu.memory.get_byte(0x04F5));
+            }
+            cpu.single_step();
+        }
+        panic!("mute routine ran past {} instructions without reaching its JMP", code.len());
+    }
+
+    /// The routine's actual behaviour, over every input it can see: 256 pad
+    /// states x 256 "what's playing" values. Decoding cannot tell whether `BIT`
+    /// really lands B in V, or whether `LDX #$01`/`DEX` really selects between
+    /// two adjacent queues — executing it can.
+    #[test]
+    fn mute_routine_queues_the_right_thing() {
+        const MUSIC: u8 = 0x30;
+        for playing in 0..=u8::MAX {
+            for pad in 0..=u8::MAX {
+                let (fanfare, theme) = run_mute(pad, playing, MUSIC);
+                let want = match (pad & 0x40 != 0, playing != 0) {
+                    (false, _) => (0x00, 0x00),  // B not pressed: queue nothing
+                    (true, true) => (0x80, 0x00), // audible: MUS1_STOPMUSIC
+                    (true, false) => (0x00, MUSIC), // silent: restore the track
+                };
+                assert_eq!(
+                    (fanfare, theme),
+                    want,
+                    "pad {pad:#04X}, SndCur_Music2 {playing:#04X}",
+                );
+            }
+        }
+    }
+
+    /// Pressing B twice returns to the starting state, which is what makes it a
+    /// toggle rather than a one-way mute. The engine's own `SndCur_Music2` is
+    /// the state, so the second press has to see it as `Music_StopAll` left it.
+    #[test]
+    fn two_presses_restore_the_track() {
+        const MUSIC: u8 = 0x60;
+        const B: u8 = 0x40;
+        // Playing -> the press queues a stop; Music_StopAll then zeroes
+        // SndCur_Music2, which is what the next press reads.
+        assert_eq!(run_mute(B, MUSIC, MUSIC), (0x80, 0x00));
+        assert_eq!(run_mute(B, 0x00, MUSIC), (0x00, MUSIC));
+    }
+
+    /// The seed-hash sprite copy routine and the intro-skip routine predate the
+    /// `asm::check` rule; check them here now that the module exists.
+    #[test]
+    fn seed_hash_routines_are_well_formed() {
+        let mut rom = crate::randomize::qol::test_support::make_test_rom();
+        write_seed_hash(&mut rom, 42, &Options::default());
+
+        asm::check(rom.read_range(ROUTINE_OFFSET, 25))
+            .allocation(ROUTINE_OFFSET)
+            .origin(ROUTINE_CPU)
+            .assert_ok();
+        asm::check(rom.read_range(INTRO_SKIP_ROUTINE_OFFSET, 13))
+            .allocation(INTRO_SKIP_ROUTINE_OFFSET)
+            .origin(INTRO_SKIP_CPU)
+            .assert_ok();
     }
 }

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -93,12 +93,19 @@ fn sweep_is_deterministic() {
 /// places that carry the flag bytes on purpose — the stamp block at 0x19DF0 and
 /// the title-screen verification icons at `FS_SEED_HASH_DATA` (0x3E93D), whose
 /// hash folds `to_flag_bytes()`. No overworld, level, or enemy byte moved.
+/// Re-captured 2026-08-10 for the title-screen B-to-mute toggle, which writes
+/// 25 bytes into every ROM (`title_screen::mute_routine` plus its hook), so all
+/// 20 seeds moved. Verified the same way as the recaptures above: seeds 1-3
+/// generated before and after with `--no-palettes --patched-rom` and diffed byte
+/// by byte. Exactly 24 bytes differ per seed, in two places — the `JSR` operand
+/// at the hook site 0x30C94 and the 22-byte routine at 0x33529, which was $FF
+/// filler. No overworld, level or enemy byte moved.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xBB2A7CBF02AF4BBA, 0x761607361C034EDA, 0xC4E3267B24430DB5, 0x871D2AEE7C896AB6,
-    0xF27E5B34E1EEABDD, 0x9D9F280937717403, 0xE879479EEA8398FF, 0x2991D7B20C48097E,
-    0xEFF71177664A5822, 0x4EF2AB92BC810522, 0xD188D3A10F375DB5, 0x833E8EFC349D2154,
-    0x280B67E04F3F5F87, 0xCD041C077C531F96, 0x675C1986FEEDE464, 0x3286199B722396FA,
-    0xD108207D0F8A21EC, 0x13D64C84EB019B01, 0x6C77A703B2285A5A, 0x437324880DC9D14B,
+    0xB94EAEB231B53157, 0x4E77C9EBD2C7FC17, 0x1FA65412B35EA4B4, 0x6DF4D6047DC8F457,
+    0xFACDF601C15ABFA7, 0x34FE0AC25192E976, 0x8C67515F5289906A, 0x20CDD66A9B3E99A1,
+    0xE18B699FB2BFA028, 0x5E54F56DF25EE227, 0xA020A0057C39501D, 0xA389662E7E3DF0BF,
+    0x2E529762AE3049AA, 0xD3562D897C162822, 0x71519D7F0CEB874C, 0x6418203CC4E10283,
+    0xF9D73A5FAD8A6B75, 0x9A6128ABB4E437F8, 0x851FD8A719E18073, 0xB9A634E3FA005F16,
 ];
 
 #[test]

--- a/web/index.html
+++ b/web/index.html
@@ -121,6 +121,9 @@
                  title="These icons appear on the title screen — check they match everyone else's">
                 <span class="seed-hash-label">Title hash</span>
                 <div class="seed-hash-icons" id="seed-hash-icons"></div>
+                <!-- Shown alongside the hash because both are title-screen
+                     behaviour, and both are skipped when validation is off. -->
+                <p class="seed-hash-hint">Press <strong>B</strong> on the title screen to mute the music.</p>
             </div>
             <p class="early-access-note"><em>Early access — you may encounter bugs. Report issues on <a href="https://github.com/hamstringquestionable/smb3-rs/issues" target="_blank" rel="noopener">GitHub</a>.</em></p>
             <div id="status" class="status" hidden></div>

--- a/web/style.css
+++ b/web/style.css
@@ -638,6 +638,18 @@ input[type="radio"] {
     background: transparent;
 }
 
+/* Quieter than the label: a one-off tip, not a section heading. */
+.seed-hash-hint {
+    margin: 0;
+    font-size: 0.7rem;
+    text-align: center;
+    color: #7a7ab0;
+}
+
+.seed-hash-hint strong {
+    color: #e0e0e0;
+}
+
 /* --- Status --- */
 
 .status {


### PR DESCRIPTION
Closes #48.

## What

Press **B** on the 1P/2P menu to silence the menu music, B again to bring it back. Start still begins the game, and the world map queues its own music either way. Always on, like the seed-hash icons it ships alongside — no flag, no key bit.

## How

`Title_Do1P2PMenu` calls `Title_3Glow` once per frame at CPU $AC83 (file 0x30C93). That `JSR` becomes a `JSR` into a 22-byte routine that tail-jumps back into `Title_3Glow`, so the '3' still glows and its `RTS` returns to the menu untouched.

```
BIT $18        ; Pad_Input — B is bit 6, the bit BIT copies into V
BVC done
LDX #$01       ; assume unmute: $04F4 + 1 = $04F5
LDA #music
LDY $04E5      ; SndCur_Music2 — non-zero iff a theme is audible
BEQ store
LDA #$80       ; MUS1_STOPMUSIC
DEX            ; X = 0 → $04F4
store:
STA $04F4,X
done:
JMP $AA7D      ; Title_3Glow, the displaced call
```

It is a real toggle and spends **no RAM** on the state. `MUS1_STOPMUSIC` runs through `Music_StopAll`, which zeroes `SndCur_Music2`, so the engine's own "what is playing" byte *is* the mute flag and cannot drift out of sync with what is audible. The unmute path restores the same seeded track `pick_menu_music` gave the intro-skip routine, so a mute/unmute round trip cannot land on a different song.

Two size choices: `BIT` tests B in 2 bytes where `LDA`/`AND` takes 4, and the two music queues are adjacent, so one `STA $04F4,X` with X as the 0/1 selector replaces a second store plus the branch that would skip it. 26 bytes → 22.

## Where it lives

PRG025 free space (CPU $D519, file 0x33529), 32 reserved / 22 used. PRG030's title entry maps page 24 to $A000 and page 25 to $C000 before `Do_Title_Screen`, so both banks are live for the whole title screen. Putting it there costs **nothing** from the always-mapped banks — PRG031's largest gap is 30 bytes, and that is the last one of any size. `prg025.asm` ends with "Rest of ROM bank was empty" just before the offset, so the run is unreferenced filler; recorded as a `FREE_SPACE_ALLOCATIONS` row and in CLAUDE.md's per-bank table (regenerated, not hand-edited).

The mute persists because the existing attract-mode patch holds `$E1` at 0. Without it the menu resets roughly every 20 × 96 frames (~32 s) and the intro-skip routine would re-queue the track behind the player's back.

## Testing

- **Executed**, not just decoded: the routine runs on an emulated 6502 over all 65,536 `(Pad_Input, SndCur_Music2)` inputs and must queue exactly the right byte to exactly the right address. That is what actually verifies the `BIT`/V trick and the X selector.
- `asm::check` with `.allocation` + `.origin`, and a `.hook` check against the real ROM confirming whole instructions are displaced and the `JSR` names the routine's origin. The pre-existing seed-hash and intro-skip routines got their overdue `asm::check` in the same module.
- A vanilla-ROM assert that 0x30C93 really holds `JSR $AA7D` followed by the Start test, so a drifted offset cannot splice a `JSR` mid-instruction.
- Full suite green; clippy clean; `tools/offset_dups.py` clean.
- **Baseline re-captured.** Seeds 1-3 generated before and after with `--no-palettes --patched-rom` and diffed byte by byte: exactly 24 bytes move per seed, in two places — the `JSR` operand at 0x30C94 and the routine at 0x33529, which was `$FF` filler. No overworld, level or enemy byte moved.

Not verified on hardware or in an emulator by me — worth a quick boot before merge.

## Also

- Documented the title menu input loop (`Pad_Input` $18, the Select/Start/Glow call sites with offsets) and `SndCur_Music1/2` in `docs/smb3_rom_reference.md` — issue #48 called out that this routine was undocumented.
- Corrected three CPU addresses in the attract-mode section that were off by $2000 (PRG024 is mapped at $A000, not $8000); the file offsets there were already right.
- Web app: a one-line hint under the title hash, shown under the same condition — both are title-screen behaviour, and both are skipped when ROM validation is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB