### PR TITLE
feature: deal each world its own C1 floor instead of a flat 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ deploys.
 
 ## [Unreleased]
 
+### Changed
+
+- **World length varies more between worlds.** Every world used to guarantee
+  the same minimum amount of play before its goal, which made the cheapest
+  route recognisable once you knew the number to look for. Each world now gets
+  its own minimum — a level's worth below, at, or above the old one — rolled
+  per seed and different every time. Some worlds are dealt no variation at all.
+  The overall amount of play across the eight worlds is unchanged.
+
 ### Added
 
 - **Press B on the title screen to mute the menu music**, and B again to bring

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -58,10 +58,11 @@ struct CensusCtx {
     catalog: NodeCatalog,
     pickup: Pickup,
     flags: BuildFlags,
-    /// Per-seed level/fort allotment, rolled once for all 8 worlds via the
-    /// shipping builder's exact machinery (`allot_budgets`).
+    /// Per-seed level/fort/floor allotment, rolled once for all 8 worlds via
+    /// the shipping builder's exact machinery (`allot_budgets`).
     level_counts: [usize; 8],
     fort_counts: [usize; 8],
+    c1_floors: [u32; 8],
 }
 
 fn census_ctx(raw: &Rom, seed: u64) -> CensusCtx {
@@ -90,7 +91,7 @@ fn census_ctx(raw: &Rom, seed: u64) -> CensusCtx {
         eights_are_wild: eights_wild,
         shuffle_hammer_bros,
     };
-    let (level_counts, fort_counts) =
+    let (level_counts, fort_counts, c1_floors) =
         allot_budgets(&rom, &catalog, &pickup, &flags, &mut roll_rng);
     CensusCtx {
         rom,
@@ -99,6 +100,7 @@ fn census_ctx(raw: &Rom, seed: u64) -> CensusCtx {
         flags,
         level_counts,
         fort_counts,
+        c1_floors,
     }
 }
 
@@ -108,6 +110,7 @@ impl CensusCtx {
             from_pickup(&self.rom, &self.catalog, &self.pickup, world_idx, &self.flags);
         state.level_budget = self.level_counts[world_idx];
         state.fort_budget = self.fort_counts[world_idx];
+        state.c1_floor = self.c1_floors[world_idx];
         state
     }
 }
@@ -144,6 +147,7 @@ fn test_builder_schedule_runs_phases_in_order() {
         pipe_budget: 0,
         level_budget: 0,
         fort_budget: 0,
+        c1_floor: C1_FLOOR,
         ptr_slots: 0,
         hb_sprite_pins: Vec::new(),
         log: Vec::new(),
@@ -1410,7 +1414,7 @@ fn test_builder_diversity_census() {
 
     // Per-seed budget allotment for the builder arms — same variance rules the
     // shipping arm gets internally from build().
-    let allotments: Vec<([usize; 8], [usize; 8])> = (0..seeds)
+    let allotments: Vec<([usize; 8], [usize; 8], [u32; 8])> = (0..seeds)
         .map(|seed| {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             allot_budgets(&rom, &catalog, &pickup, &BuildFlags::default(), &mut rng)
@@ -1423,9 +1427,10 @@ fn test_builder_diversity_census() {
         let budgeted_world = |seed: u64| {
             let mut state =
                 from_pickup(&rom, &catalog, &pickup, world_idx, &BuildFlags::default());
-            let (level_counts, fort_counts) = &allotments[seed as usize];
+            let (level_counts, fort_counts, c1_floors) = &allotments[seed as usize];
             state.level_budget = level_counts[world_idx];
             state.fort_budget = fort_counts[world_idx];
+            state.c1_floor = c1_floors[world_idx];
             state
         };
 

--- a/src/randomize/overworld_build/capacity.rs
+++ b/src/randomize/overworld_build/capacity.rs
@@ -403,6 +403,65 @@ pub(crate) fn distribute_levels<R: Rng>(
     counts
 }
 
+/// Step between the dealt C1 floors: exactly ONE LEVEL, read off the cost
+/// model rather than typed in, so a retune of [`COST_LEVEL`] carries the
+/// band with it. A level is the unit the player perceives; finer steps are
+/// not perceivable and measured as not distinguishable either (the 1000-seed
+/// probe put floors 14 and 15 at C1 19.2/19.4, and 16 and 17 both at 20.7).
+const C1_FLOOR_STEP: u32 = COST_LEVEL;
+
+/// The three floors a world can be dealt: one level below [`C1_FLOOR`], the
+/// centre, one level above — 11 / 14 / 17.
+pub(crate) const C1_FLOOR_BAND: [u32; 3] =
+    [C1_FLOOR - C1_FLOOR_STEP, C1_FLOOR, C1_FLOOR + C1_FLOOR_STEP];
+
+/// Most (low, high) PAIRS one seed can deal. At 4 every world sits at an
+/// end and none at the centre.
+const C1_FLOOR_MAX_PAIRS: usize = 4;
+
+/// Deal one C1 floor per world: `k` worlds a level below centre, `k` a level
+/// above, the rest at centre, shuffled — with `k` itself rolled per seed.
+///
+/// **Why the floor varies at all.** A single global floor is learnable. The
+/// shaping loop satisfices, so it climbs to the floor and stops, and the
+/// measured result is a spike sitting exactly ON the floor rather than a
+/// distribution respecting it: under a flat floor every world measured
+/// `min = 14` with `p10 = 14` in four of the eight, i.e. at least a tenth of
+/// worlds priced at exactly the constant. A player who learns that number
+/// can recognise the intended cheap route by pricing it. Dealing the floor
+/// smears that spike across a band the player cannot see.
+///
+/// **Why a hidden roll and not a derived one.** The floor must be neither
+/// constant nor derivable from anything visible, and an SMB3 map is fully
+/// visible from the start — fortresses and levels are countable before
+/// entering anything. So a floor computed from world content (forts, levels)
+/// would be computable by the player too: the tell survives, upgraded from
+/// memorised to derivable. Only hidden per-seed entropy satisfies both.
+///
+/// **Why the total is conserved for free.** Every low is paid for by a high,
+/// so the sum is `8 * C1_FLOOR` identically, whatever `k` comes up — there
+/// is no deal that can violate it and no magic total to keep in step. `k`
+/// may roll 0, leaving a seed flat at the centre; that costs nothing (it is
+/// simply today's behaviour for that seed) and keeps the roll unstructured.
+pub(crate) fn deal_c1_floors<R: Rng>(rng: &mut R) -> [u32; 8] {
+    // A/B arm: `C1_FLOOR_FLAT=1` restores the single global floor, so the
+    // census can measure the deal against the shape it replaced without
+    // needing two checkouts. Test-only — never reaches the CLI or WASM.
+    #[cfg(test)]
+    if std::env::var("C1_FLOOR_FLAT").is_ok() {
+        return [C1_FLOOR; 8];
+    }
+    let [low, centre, high] = C1_FLOOR_BAND;
+    let pairs = rng.random_range(0..=C1_FLOOR_MAX_PAIRS);
+    let mut floors = [centre; 8];
+    for i in 0..pairs {
+        floors[i] = low;
+        floors[pairs + i] = high;
+    }
+    floors.shuffle(rng);
+    floors
+}
+
 /// Distribute 13 fortresses across W1-W7 (each gets 1-3), W8 keeps 4.
 pub(crate) fn redistribute_fortresses<R: Rng>(rng: &mut R) -> [usize; 8] {
     let mut counts = [0usize; 8];

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -132,11 +132,13 @@ use capacity::{SPADE_BUDGET, assign_hb_sprites, promote_hb_slots};
 // modules that post-process the build (hands, troll pipes).
 pub use {types::SlotAssignment, types::SlotKind};
 pub(crate) use capacity::{
-    RESERVED_DYNAMIC_SLOTS, VANILLA_PIPE_PAIRS, bfs_ordered, distribute_levels,
+    RESERVED_DYNAMIC_SLOTS, VANILLA_PIPE_PAIRS, bfs_ordered, deal_c1_floors, distribute_levels,
     fixed_positions_for_world, prepare_capacities, redistribute_fortresses,
 };
 pub(crate) use capacity::{LEVEL_SPREAD_EXPONENT, VANILLA_LEVEL_COUNT};
-pub(crate) use route_choice::{C1_FLOOR, DEFAULT_SLACK, RouteChoice, SHAPING_SLACK, analyze_route_choice};
+pub(crate) use route_choice::{
+    C1_FLOOR, COST_LEVEL, DEFAULT_SLACK, RouteChoice, SHAPING_SLACK, analyze_route_choice,
+};
 pub(crate) use types::{
     BuildFlags, BuildResult, BuiltWorld, CapacityPrep, LockAssignment, OverworldData, stamp_slots,
 };
@@ -160,6 +162,8 @@ pub(crate) use progression::{
     PipeClass, analyze_required_progression, classify_pipes, dump_required_progression,
     hammer_skip, island_count, level_adjacency_pairs, start_goal_express_pipe,
 };
+#[cfg(test)]
+pub(crate) use capacity::C1_FLOOR_BAND;
 #[cfg(test)]
 pub(crate) use route_choice::dump_route_choice;
 #[cfg(test)]
@@ -201,7 +205,7 @@ pub(crate) fn run_shaped_with_web_retries(state: &mut WorldState, rng: &mut dyn 
         // webs that also failed the floor). Such a web redeals like any
         // other degenerate web.
         let full_forts = state.fort_count() == state.fort_budget;
-        if (m.c1 >= C1_FLOOR && full_forts) || redeals >= WEB_RETRIES {
+        if (m.c1 >= state.c1_floor && full_forts) || redeals >= WEB_RETRIES {
             if let Some((key, snap)) = &best
                 && (full_forts, m.c1, m.routes_in_band) < *key
             {
@@ -243,13 +247,15 @@ pub(crate) fn build<R: Rng>(
     // Per-seed budgets: fortresses via redistribute_fortresses (W8 keeps 4;
     // W1-W7 roll 1-3 with the 13-fort total conserved), levels distributed
     // by compressed capacity shares.
-    let (level_counts, fort_counts) = allot_budgets(rom, data.catalog, data.pickup, &flags, rng);
+    let (level_counts, fort_counts, c1_floors) =
+        allot_budgets(rom, data.catalog, data.pickup, &flags, rng);
 
     let mut states: Vec<WorldState> = (0..8)
         .map(|wi| {
             let mut state = from_pickup(rom, data.catalog, data.pickup, wi, &flags);
             state.level_budget = level_counts[wi];
             state.fort_budget = fort_counts[wi];
+            state.c1_floor = c1_floors[wi];
             state
         })
         .collect();

--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -5,8 +5,8 @@
 //! loop reads the world through [`measure_world`], and the measured symptom
 //! selects the move — no move portfolio is evaluated side by side:
 //!
-//! - **Satisfied** (routes in band ≥ [`TARGET_ROUTES`] AND C1 ≥ the shipping
-//!   builder's [`C1_FLOOR`], reused verbatim): no move at all. Satisficing,
+//! - **Satisfied** (routes in band ≥ [`TARGET_ROUTES`] AND C1 ≥ this world's
+//!   dealt floor, `WorldState::c1_floor`): no move at all. Satisficing,
 //!   not optimizing — worlds the dumb roll already made interesting keep
 //!   their shape, and the across-seed diversity the uniform baseline bought
 //!   is only spent where the measure says the world is linear or nearly
@@ -64,7 +64,7 @@
 //! so most iterations cost one proposal, not five. Acceptance is minimal —
 //! routes up (or, for lock re-place, zero-gate down at equal routes) — PLUS
 //! the floor guard: every choice-mode acceptance requires `after.c1 >=
-//! C1_FLOOR`. The original design had no C1 guard, arguing that for the
+//! floor`. The original design had no C1 guard, arguing that for the
 //! route count to rise the old structure must stay within the band of the
 //! new cheapest, so trivializing shortcuts reject themselves. Measured
 //! FALSE (census 2026-07-31): one new pipe can create two brand-new cheap
@@ -112,6 +112,7 @@ impl Phase for Shaping {
     }
 
     fn run(&self, state: &mut WorldState, rng: &mut dyn RngCore) -> PhaseReport {
+        let floor = state.c1_floor;
         let mut actions = Vec::new();
         let mut moves = 0usize;
         let mut accepted = 0usize;
@@ -125,7 +126,7 @@ impl Phase for Shaping {
         let status = loop {
             let before = measure_world(state);
             let routes_needy = before.routes_in_band < TARGET_ROUTES;
-            let cheap = before.c1 < C1_FLOOR;
+            let cheap = before.c1 < floor;
             if !routes_needy && !cheap {
                 break "satisfied";
             }
@@ -139,7 +140,7 @@ impl Phase for Shaping {
             // sub-floor world does nothing else until the floor holds. Every
             // rung except the shortcut (pipes only cheapen) is available and
             // accepts on C1 progress; the try_ fns branch their acceptance
-            // on the same `before.c1 < C1_FLOOR` test. Above the floor, the
+            // on the same `before.c1 < floor` test. Above the floor, the
             // normal choice ladder.
             let available = if cheap {
                 // The pipe move is the final cost rung: when no lock cuts
@@ -218,10 +219,11 @@ fn try_lock_replace(
     before: &WorldMeasure,
     zero_gate_before: usize,
 ) -> Result<String, String> {
+    let floor = state.c1_floor;
     let saved = state.locks.clone();
     // Below the floor, ask for a goal gate: the pipe-proof cut that raises
     // C1 when nothing else does.
-    if !place_locks_gating(state, rng, before.c1 < C1_FLOOR) {
+    if !place_locks_gating(state, rng, before.c1 < floor) {
         state.locks = saved;
         return Err("lock_replace REJECT: could not lock every fort".into());
     }
@@ -230,13 +232,13 @@ fn try_lock_replace(
     // Below the floor, cost first: accept iff C1 rose. Routes may drop — a
     // goal gate collapses the express variants it prices up, and the choice
     // ladder re-earns routes once the floor holds.
-    let improved = if before.c1 < C1_FLOOR {
+    let improved = if before.c1 < floor {
         after.c1 > before.c1
     } else {
         (after.routes_in_band > before.routes_in_band
             || (after.routes_in_band == before.routes_in_band
                 && zero_gate_after < zero_gate_before))
-            && after.c1 >= C1_FLOOR
+            && after.c1 >= floor
     };
     let line = format!(
         "routes {} -> {}, C1 {} -> {}, zero-gate {zero_gate_before} -> {zero_gate_after}",
@@ -279,6 +281,7 @@ fn try_arm_balance(
     rng: &mut dyn RngCore,
     before: &WorldMeasure,
 ) -> Result<String, String> {
+    let floor = state.c1_floor;
     let wide_before = analyze_route_choice(&state.to_built(), SHAPING_SLACK);
     let cheap: HashSet<Pos> = match wide_before.routes.first() {
         Some(r) => r.path.iter().copied().collect(),
@@ -346,7 +349,7 @@ fn try_arm_balance(
         // runner-up — after a detour-splitting move the before/after gaps
         // would describe different detours.
         let had_runner_up = wide_before.routes.len() >= 2;
-        let improved = after.c1 >= C1_FLOOR
+        let improved = after.c1 >= floor
             && (after.routes_in_band > before.routes_in_band
                 || (after.routes_in_band == before.routes_in_band
                     && (wide_after.routes.len() > wide_before.routes.len()
@@ -399,6 +402,7 @@ fn try_gated_shortcut(
     rng: &mut dyn RngCore,
     before: &WorldMeasure,
 ) -> Result<String, String> {
+    let floor = state.c1_floor;
     let saved_grid = state.grid.clone();
     let saved_slots = state.slots.clone();
     let saved_locks = state.locks.clone();
@@ -428,7 +432,7 @@ fn try_gated_shortcut(
         // Shortcut moves only run above the floor — no goal gate wanted.
         if place_locks_gating(state, rng, false) {
             let after = measure_world(state);
-            if after.c1 >= C1_FLOOR {
+            if after.c1 >= floor {
                 // In-band already: parity for free.
                 if after.routes_in_band > before.routes_in_band {
                     return Ok(format!(
@@ -473,6 +477,7 @@ fn try_fort_lock(
     rng: &mut dyn RngCore,
     before: &WorldMeasure,
 ) -> Result<String, String> {
+    let floor = state.c1_floor;
     let saved_slots = state.slots.clone();
     let saved_locks = state.locks.clone();
 
@@ -509,14 +514,14 @@ fn try_fort_lock(
             let Some(&new_pos) = candidates.choose(rng) else { break };
             state.slots[fi].pos = new_pos;
             evals += 1;
-            if place_locks_gating(state, rng, before.c1 < C1_FLOOR) {
+            if place_locks_gating(state, rng, before.c1 < floor) {
                 let after = measure_world(state);
                 // Below the floor: any relocation that raises C1 is
                 // progress (routes may be spent). Above: routes must rise.
-                let improved = if before.c1 < C1_FLOOR {
+                let improved = if before.c1 < floor {
                     after.c1 > before.c1
                 } else {
-                    after.routes_in_band > before.routes_in_band && after.c1 >= C1_FLOOR
+                    after.routes_in_band > before.routes_in_band && after.c1 >= floor
                 };
                 if improved {
                     return Ok(format!(
@@ -552,6 +557,7 @@ fn try_level_move(
     rng: &mut dyn RngCore,
     before: &WorldMeasure,
 ) -> Result<String, String> {
+    let floor = state.c1_floor;
     let trunk: HashSet<Pos> = before
         .rc
         .routes
@@ -596,12 +602,12 @@ fn try_level_move(
         let after = measure_world(state);
         // Below the floor: C1 progress (routes may be spent). Above: routes
         // up, or the fine +3 trim at flat routes.
-        let improved = if before.c1 < C1_FLOOR {
+        let improved = if before.c1 < floor {
             after.c1 > before.c1
         } else {
             (after.routes_in_band > before.routes_in_band
                 || (after.routes_in_band == before.routes_in_band && after.c1 > before.c1))
-                && after.c1 >= C1_FLOOR
+                && after.c1 >= floor
         };
         if improved {
             return Ok(format!(

--- a/src/randomize/overworld_build/sources.rs
+++ b/src/randomize/overworld_build/sources.rs
@@ -12,14 +12,15 @@
 
 use super::*;
 
-/// Roll the per-seed level/fort allotment EXACTLY like the shipping builder,
+/// Roll the per-seed level/fort/floor allotment EXACTLY like the shipping builder,
 /// by calling its machinery verbatim: fortresses via
 /// `redistribute_fortresses` (W8 always keeps 4; W1-W7 roll 1-3 each with
 /// the 13-fort total conserved), then levels via `distribute_levels` over
 /// `prepare_capacities` (capacity^0.5-weighted shares of the 62 vanilla
-/// levels, random leftover topping up random worlds). One roll covers all 8
-/// worlds — the caller writes the result onto each `WorldState`'s budgets
-/// before scheduling. `from_pickup` alone stays vanilla-frozen; variance is
+/// levels, random leftover topping up random worlds), then the C1 floors via
+/// `deal_c1_floors` (a permuted multiset summing to 8 x `C1_FLOOR`). One roll
+/// covers all 8 worlds — the caller writes the result onto each
+/// `WorldState`'s budgets before scheduling. `from_pickup` alone stays vanilla-frozen; variance is
 /// the caller's choice, made here.
 pub(crate) fn allot_budgets(
     rom: &Rom,
@@ -27,7 +28,7 @@ pub(crate) fn allot_budgets(
     pickup: &PickupResult,
     flags: &BuildFlags,
     mut rng: &mut dyn RngCore,
-) -> ([usize; 8], [usize; 8]) {
+) -> ([usize; 8], [usize; 8], [u32; 8]) {
     let fort_counts = redistribute_fortresses(&mut rng);
     let CapacityPrep { capacities, .. } = prepare_capacities(
         rom,
@@ -40,7 +41,8 @@ pub(crate) fn allot_budgets(
     );
     let level_counts =
         distribute_levels(&capacities, VANILLA_LEVEL_COUNT, LEVEL_SPREAD_EXPONENT, &mut rng);
-    (level_counts, fort_counts)
+    let c1_floors = deal_c1_floors(&mut rng);
+    (level_counts, fort_counts, c1_floors)
 }
 
 /// Wrap a finished `BuiltWorld` back into a `WorldState`. Start/target are
@@ -69,6 +71,7 @@ pub(crate) fn from_built(built: &BuiltWorld) -> WorldState {
             .iter()
             .filter(|s| s.kind == SlotKind::Fortress)
             .count(),
+        c1_floor: C1_FLOOR,
         ptr_slots: 0,
         hb_sprite_pins: Vec::new(),
         log: Vec::new(),
@@ -150,6 +153,7 @@ pub(crate) fn from_pickup(
         pipe_budget: VANILLA_PIPE_PAIRS[world_idx],
         level_budget,
         fort_budget,
+        c1_floor: C1_FLOOR,
         ptr_slots: pickup.worlds[world_idx].pool_indices.len(),
         hb_sprite_pins,
         log: Vec::new(),
@@ -200,6 +204,7 @@ pub(crate) fn from_vanilla(rom: &Rom, catalog: &NodeCatalog, world_idx: usize) -
         pipe_budget: VANILLA_PIPE_PAIRS[world_idx],
         level_budget,
         fort_budget,
+        c1_floor: C1_FLOOR,
         ptr_slots: 0,
         hb_sprite_pins: Vec::new(),
         log: Vec::new(),

--- a/src/randomize/overworld_build/spare_pipes.rs
+++ b/src/randomize/overworld_build/spare_pipes.rs
@@ -52,6 +52,7 @@ impl Phase for SparePipes {
     }
 
     fn run(&self, state: &mut WorldState, rng: &mut dyn RngCore) -> PhaseReport {
+        let floor = state.c1_floor;
         let mut actions = Vec::new();
         let mut placed_any = false;
 
@@ -99,7 +100,7 @@ impl Phase for SparePipes {
                 state.add_pipe_pair(a, b);
                 let m = measure_world(state);
                 state.pop_pipe_pair();
-                if m.c1 >= C1_FLOOR && m.routes_in_band >= before.routes_in_band {
+                if m.c1 >= floor && m.routes_in_band >= before.routes_in_band {
                     if m.routes_in_band > before.routes_in_band {
                         creator = Some((a, b));
                         break;
@@ -108,7 +109,7 @@ impl Phase for SparePipes {
                         harmless = Some((a, b));
                     }
                 }
-                let key = (!doubling, m.c1.min(C1_FLOOR), m.routes_in_band, m.c1);
+                let key = (!doubling, m.c1.min(floor), m.routes_in_band, m.c1);
                 if best.as_ref().is_none_or(|(k, _)| key > *k) {
                     best = Some((key, (a, b)));
                 }

--- a/src/randomize/overworld_build/state.rs
+++ b/src/randomize/overworld_build/state.rs
@@ -45,6 +45,12 @@ pub(crate) struct WorldState {
     /// How many fortresses the Forts phase places — same pattern as
     /// `level_budget`, seeded from the vanilla catalog's Fortress tally.
     pub fort_budget: usize,
+    /// Floor on this world's cheapest route ("C1"), in scorer points — the
+    /// per-world value of [`C1_FLOOR`], dealt by [`allot_budgets`] so a seed
+    /// mixes short worlds with long ones at a conserved total. Every site
+    /// that used to read the constant reads this instead; the constant is
+    /// the band's center and the default for the loader sources.
+    pub c1_floor: u32,
     /// Pointer-table entries available to this world (the pickup pool size).
     /// Every slot — level, fort, hammer bro, pipe endpoint — consumes one;
     /// the hammer-bro fill phase caps itself against this.
@@ -292,6 +298,7 @@ impl WorldState {
             section_count: self.fort_count(),
             pipe_pairs: self.pipe_pairs.clone(),
             hb_sprites: Vec::new(),
+            c1_floor: self.c1_floor,
         }
     }
 }

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1531,6 +1531,9 @@ fn pctile_of(sorted: &[u32], p: usize) -> u32 {
 struct RouteSample {
     routes: usize,
     c1: u32,
+    /// The floor this world was DEALT (`deal_c1_floors`) — every floor
+    /// column scores against this, not against the band's center.
+    floor: u32,
     reachable: bool,
     goal_open: bool,
     has_rock: bool,
@@ -1606,6 +1609,7 @@ fn test_route_census() {
             out[built.world_idx] = Some(RouteSample {
                 routes: if rc.reachable { rc.routes.len() } else { 0 },
                 c1: rc.best_cost,
+                floor: built.c1_floor,
                 reachable: rc.reachable,
                 goal_open: world_topology(built)
                     .is_some_and(|t| t.fort_count >= 2 && t.depth == 0),
@@ -1631,6 +1635,16 @@ fn test_route_census() {
     let mut c1s: Vec<Vec<u32>> = vec![Vec::new(); 8];
     let mut goal_open = [0usize; 8];
     let mut rocks = [[0u64; 4]; 8]; // seen, rock-world, C1 rock, alt rock
+    // Floor accounting: per world, (samples, missed own floor, floor sum);
+    // and the same sliced BY the dealt floor, which is the cut that shows
+    // what a floor actually buys (one row per distinct value in the deal).
+    let mut floor_stat = [[0u64; 3]; 8];
+    let mut by_floor: Vec<(u32, Vec<u32>, Vec<u32>, u64)> = {
+        let mut vals = C1_FLOOR_BAND.to_vec();
+        vals.sort_unstable();
+        vals.dedup();
+        vals.into_iter().map(|f| (f, Vec::new(), Vec::new(), 0)).collect()
+    };
     for worlds in &per_seed {
         for (wi, s) in worlds.iter().enumerate() {
             let Some(s) = s else { continue };
@@ -1638,6 +1652,17 @@ fn test_route_census() {
             if s.reachable {
                 c1s[wi].push(s.c1);
                 goal_open[wi] += s.goal_open as usize;
+                let stat = &mut floor_stat[wi];
+                stat[0] += 1;
+                stat[1] += (s.c1 < s.floor) as u64;
+                stat[2] += s.floor as u64;
+                if let Some(row) =
+                    by_floor.iter_mut().find(|(f, ..)| *f == s.floor)
+                {
+                    row.1.push(s.c1);
+                    row.2.push(s.routes as u32);
+                    row.3 += (s.c1 < s.floor) as u64;
+                }
             }
             let row = &mut rocks[wi];
             row[0] += 1;
@@ -1662,25 +1687,28 @@ fn test_route_census() {
         }
         all_routes.extend(r.iter().copied());
         all_c1.extend(c.iter().copied());
+        let stat = floor_stat[wi];
         eprintln!(
-            "  W{:<3} {:>6.2} {:>7.0}% {:>7.0}% {:>5} {:>7.1} {:>8.0}%",
+            "  W{:<3} {:>6.2} {:>7.0}% {:>7.0}% {:>5} {:>7.1} {:>8.1}%",
             wi + 1,
             mean_of(r),
             pct_of(r, |n| n <= 1),
             pct_of(r, |n| n >= 2),
             r.iter().copied().max().unwrap_or(0),
             mean_of(c),
-            pct_of(c, |v| v < C1_FLOOR),
+            stat[1] as f64 / stat[0].max(1) as f64 * 100.0,
         );
     }
     if !all_routes.is_empty() {
+        let (n, missed): (u64, u64) =
+            floor_stat.iter().fold((0, 0), |(n, m), s| (n + s[0], m + s[1]));
         eprintln!(
-            "  overall: mean {:.3} routes/world; {:.2}% linear; C1 {:.1}, {:.1}% below \
-             floor {C1_FLOOR} (n={})",
+            "  overall: mean {:.3} routes/world; {:.2}% linear; C1 {:.1}, {:.2}% below \
+             its own dealt floor (n={})",
             mean_of(&all_routes),
             pct_of(&all_routes, |n| n <= 1),
             mean_of(&all_c1),
-            pct_of(&all_c1, |v| v < C1_FLOOR),
+            missed as f64 / n.max(1) as f64 * 100.0,
             all_routes.len(),
         );
     }
@@ -1688,8 +1716,8 @@ fn test_route_census() {
     // -- 2. C1 floor --------------------------------------------------------
     eprintln!("\n=== C1 floor probe over {seeds} seeds ===");
     eprintln!(
-        "  {:<4} {:>5} {:>5} {:>6} {:>6} {:>6} {:>6} {:>9} {:>8}",
-        "", "min", "p10", "mean", "<8", "<14", "<17", "goal-open", "linear%",
+        "  {:<4} {:>5} {:>5} {:>6} {:>6} {:>6} {:>6} {:>6} {:>9} {:>8}",
+        "", "min", "p10", "mean", "floor", "<8", "<14", "<own", "goal-open", "linear%",
     );
     for wi in 0..8 {
         let c = &mut c1s[wi];
@@ -1697,17 +1725,36 @@ fn test_route_census() {
             continue;
         }
         c.sort_unstable();
+        let stat = floor_stat[wi];
         eprintln!(
-            "  W{:<3} {:>5} {:>5} {:>6.1} {:>5.0}% {:>5.0}% {:>5.0}% {:>8.1}% {:>7.0}%",
+            "  W{:<3} {:>5} {:>5} {:>6.1} {:>6.1} {:>5.0}% {:>5.0}% {:>5.1}% {:>8.1}% {:>7.0}%",
             wi + 1,
             c[0],
             pctile_of(c, 10),
             mean_of(c),
+            stat[2] as f64 / stat[0].max(1) as f64,
             pct_of(c, |x| x < 8),
             pct_of(c, |x| x < 14),
-            pct_of(c, |x| x < 17),
+            stat[1] as f64 / stat[0].max(1) as f64 * 100.0,
             goal_open[wi] as f64 / c.len() as f64 * 100.0,
             pct_of(&routes[wi], |n| n <= 1),
+        );
+    }
+    // Per-seed total C1 — the "is the budget really conserved" number. The
+    // dealt floor conserves the GUARANTEE (8 x C1_FLOOR) but only bounds
+    // from below, so this is what actually moves. Seeds with an unreachable
+    // world are skipped rather than counted short.
+    let seed_totals: Vec<u32> = per_seed
+        .iter()
+        .filter(|w| w.iter().all(|s| s.as_ref().is_some_and(|s| s.reachable)))
+        .map(|w| w.iter().flatten().map(|s| s.c1).sum())
+        .collect();
+    if !seed_totals.is_empty() {
+        eprintln!(
+            "  per-seed total C1: mean {:.1} (floor total {}, n={})",
+            mean_of(&seed_totals),
+            C1_FLOOR * 8,
+            seed_totals.len(),
         );
     }
     if !all_c1.is_empty() {
@@ -1721,6 +1768,32 @@ fn test_route_census() {
             pct_of(&all_c1, |x| x < 14),
             go as f64 / all_c1.len() as f64 * 100.0,
             pct_of(&all_routes, |n| n <= 1),
+        );
+    }
+
+    // What the dealt floor actually buys, sliced by the floor itself — the
+    // per-world table above averages the whole band away (every world sees
+    // every floor across seeds, so its mean floor is ~14 by construction).
+    // `lift` is C1 minus the floor: how far ABOVE its guarantee the world
+    // finished, which is what says whether a floor is binding or inert.
+    eprintln!("\n=== By dealt C1 floor ===");
+    eprintln!(
+        "  {:<6} {:>7} {:>7} {:>7} {:>7} {:>8} {:>7}",
+        "floor", "n", "C1", "lift", "routes", "linear%", "missed%",
+    );
+    for (f, c1, rts, missed) in &by_floor {
+        if c1.is_empty() {
+            continue;
+        }
+        eprintln!(
+            "  {:<6} {:>7} {:>7.1} {:>7.1} {:>7.2} {:>7.0}% {:>6.1}%",
+            f,
+            c1.len(),
+            mean_of(c1),
+            mean_of(c1) - *f as f64,
+            mean_of(rts),
+            pct_of(rts, |n| n <= 1),
+            *missed as f64 / c1.len() as f64 * 100.0,
         );
     }
 

--- a/src/randomize/overworld_build/types.rs
+++ b/src/randomize/overworld_build/types.rs
@@ -117,6 +117,12 @@ pub(crate) struct BuiltWorld {
     /// Redistributed wandering Hammer Bro sprites for this world. Empty when
     /// `shuffle_hammer_bros` is off (the writer keeps the vanilla sprites).
     pub hb_sprites: Vec<HbSprite>,
+    /// The C1 floor this world was built to (see `deal_c1_floors`). Carried
+    /// out of the build so the census can score each world against its OWN
+    /// floor — a global comparison would read a dealt 11 as a failure and a
+    /// dealt 17 as a pass it never had to earn.
+    #[allow(dead_code)] // read in tests
+    pub c1_floor: u32,
 }
 
 /// Complete Phase 3 output.

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -100,12 +100,25 @@ fn sweep_is_deterministic() {
 /// by byte. Exactly 24 bytes differ per seed, in two places — the `JSR` operand
 /// at the hook site 0x30C94 and the 22-byte routine at 0x33529, which was $FF
 /// filler. No overworld, level or enemy byte moved.
+///
+/// Re-captured 2026-08-11 for the dealt C1 floor (`capacity::deal_c1_floors`).
+/// This one DOES change overworld topology, on purpose: each world is dealt a
+/// floor of 11 / 14 / 17 instead of a flat 14, so shaping resolves differently.
+/// It also draws twice from the shared RNG (the pair count, then a shuffle),
+/// which shifts every downstream stream position — so all 20 seeds move for
+/// two reasons at once and a byte-level diff could not attribute them.
+/// Verified by pinning instead, the way the v28 recapture was: making
+/// `deal_c1_floors` return `[C1_FLOOR; 8]` with no draw reproduced the
+/// PREVIOUS hashes exactly, which shows the difference is the deal alone and
+/// that threading the floor through the shaping sites changed no decision.
+/// (The `C1_FLOOR_FLAT` env arm cannot do this job — it is `cfg(test)`, and
+/// this file links the library as an outside consumer.)
 const BASELINE: [u64; SEEDS as usize] = [
-    0xB94EAEB231B53157, 0x4E77C9EBD2C7FC17, 0x1FA65412B35EA4B4, 0x6DF4D6047DC8F457,
-    0xFACDF601C15ABFA7, 0x34FE0AC25192E976, 0x8C67515F5289906A, 0x20CDD66A9B3E99A1,
-    0xE18B699FB2BFA028, 0x5E54F56DF25EE227, 0xA020A0057C39501D, 0xA389662E7E3DF0BF,
-    0x2E529762AE3049AA, 0xD3562D897C162822, 0x71519D7F0CEB874C, 0x6418203CC4E10283,
-    0xF9D73A5FAD8A6B75, 0x9A6128ABB4E437F8, 0x851FD8A719E18073, 0xB9A634E3FA005F16,
+    0xACE6D29C567449F8, 0x550C792486224F4B, 0xA8C5F0A6B296759D, 0x61CC712A9D8232FF,
+    0x8DA95E9C5FEA6A31, 0xE02746EC8F23D59F, 0xB7FA7BEAEF413EBA, 0xACEBCAE4470A4C11,
+    0xC269A39320B27CFB, 0xEF8AFBB90E2A00AD, 0x14129EF370846280, 0xAADFE1EEB4E9E188,
+    0x6546BD69DCFAB8FE, 0x94C37EDDC54B6A0D, 0x543AC2A0587F25BF, 0x97DB071E9067030A,
+    0x39D2EC7C5988E1F3, 0xDA4AE0193B48CDDF, 0xA77453960E7F51DF, 0x2A1B1A9E8C0DC998,
 ];
 
 #[test]


### PR DESCRIPTION
## Why

A single global floor is learnable. The shaping loop satisfices — it climbs until the floor is met and stops — so the measured result is a spike sitting **on** the floor rather than a distribution respecting it. Under a flat 14, every world measured `min = 14` with `p10 = 14` in four of the eight, meaning at least a tenth of worlds priced at exactly the constant. A player who learns that number can recognise the intended cheap route by pricing it.

## What

Each world is dealt a floor of **11 / 14 / 17** — one level either side of the old value. The step is read off `COST_LEVEL` rather than typed in, because a level is the unit the player perceives, and finer steps measured as indistinguishable anyway.

`k` worlds low, `k` high, the rest centre, with `k` rolled per seed over `0..=4`. `k` may come up 0, leaving that seed flat — allowed on purpose, since it keeps the roll unstructured and a flat seed harms nothing.

Pairing every low with a high makes the per-seed total `8 * C1_FLOOR` **identically**, so the overall guarantee is conserved by construction rather than by a maintained magic number.

The floor is a hidden roll rather than derived from world content deliberately: an SMB3 map is fully visible from the start, so a floor computed from fortress and level counts would be computable by the player too — the tell would survive, upgraded from memorised to derivable. Only hidden per-seed entropy satisfies both "not constant" and "not derivable from anything on screen".

## Measured — 1000 seeds, flat vs dealt

| | flat 14 | dealt 11/14/17 |
|---|---|---|
| routes/world | 2.532 | 2.548 |
| linear% | 6.75% | 6.60% |
| mean C1 | 19.3 | 19.5 |
| per-seed total C1 | 154.6 | 155.6 |
| worlds under 14 | 0.1% | 4.7% |

```
  floor      n      C1   lift  routes  linear%  missed%
  11      2000    18.4    7.4    2.49       8%     0.0%
  14      4000    19.4    5.4    2.54       6%     0.0%
  17      2000    20.8    3.8    2.62       6%     1.4%
```

Choice is unaffected — both metrics move marginally favourably and both inside noise. The 25/50/25 split of `n` confirms the roll behaves as designed (mean `k` of 2). Floors are honoured except 1.4% at 17, where the redeal loop gives up.

A seven-value multiset (`11,12,13,14,14,15,16,17`) was measured first and **discarded**: floors 14/15 and 16/17 were indistinguishable, so the intermediate values were sub-level noise. It produced the same realized costs (18.4 / 19.2 / 20.7), which is decent evidence the effect is real.

`all_world_targets_reachable` passes at **500 seeds/arm** — the check that matters here, since a floor of 17 pushes shaping harder on a quarter of worlds and shaping moves forts and locks around.

## Baseline regeneration

All 20 seeds move, for two reasons at once: the rule genuinely changes topology, and the deal draws twice from the shared RNG, shifting every downstream stream position. A byte diff could not attribute that, so it was verified by **pinning** instead — making `deal_c1_floors` return `[C1_FLOOR; 8]` with no draw reproduced the previous hashes **exactly**. That shows the difference is the deal alone, and that threading the floor through the 14 shaping sites changed no decision.

(`C1_FLOOR_FLAT` cannot serve as the pin: it is `cfg(test)`, and `tests/overworld_baseline.rs` links the library as an outside consumer. Noted in the baseline's doc comment for whoever hits this next.)

## Notes for review

- Deliberately **not** included: hoisting the floor check into `WorldMeasure` / centralising the acceptance guard. That refactor predates this change and is worth doing, but keeping it separate is what makes "no census number moved" a meaningful test for it.
- #176 tracks the related finding that the byte-level baseline fires mostly on changes it was not built to guard.
- **Seed compatibility:** this changes overworld generation, so every existing seed generates different maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJzRSD5GY4ypCM7GXbVXVB