### PR TITLE
refactor: one acceptance judge for the shaping ladder

### DIFF
--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -64,7 +64,9 @@
 //! so most iterations cost one proposal, not five. Acceptance is minimal —
 //! routes up (or, for lock re-place, zero-gate down at equal routes) — PLUS
 //! the floor guard: every choice-mode acceptance requires `after.c1 >=
-//! floor`. The original design had no C1 guard, arguing that for the
+//! floor`. Both halves live in [`accepted`], which each rung calls with its
+//! own gain and nothing else, so the floor half cannot be forgotten by a
+//! rung added later. The original design had no C1 guard, arguing that for the
 //! route count to rise the old structure must stay within the band of the
 //! new cheapest, so trivializing shortcuts reject themselves. Measured
 //! FALSE (census 2026-07-31): one new pipe can create two brand-new cheap
@@ -103,6 +105,41 @@ const LEVELMOVE_TRIES: usize = 4;
 const PIPEMOVE_TRIES: usize = 4;
 /// Consecutive rejections of a move type before escalating past it.
 const ESCALATE_AFTER: usize = 2;
+
+/// Does this world still clear its own floor? The ONLY place the floor
+/// comparison is written; everything else asks through here or through
+/// [`accepted`].
+fn meets_floor(m: &WorldMeasure, floor: u32) -> bool {
+    m.c1 >= floor
+}
+
+/// Whether a proposed move is accepted — the shared half of every rung's
+/// verdict, in one place instead of once per rung. `gain` is the rung's OWN
+/// idea of improvement (routes up, a gap closed, a decoy lock converted);
+/// the floor rule wrapped around it is common to all of them.
+///
+/// Below the floor the world is in COST MODE and the only currency is C1,
+/// with routes spendable: gating an express collapses its variants into one
+/// route, so demanding "routes not down" would veto the very move that
+/// repairs the world. At or above the floor, the rung's own gain must hold
+/// AND the move must not price the world back under.
+///
+/// Rungs route their verdict through here so the floor half has one home
+/// rather than five copies. Nothing FORCES a rung to call this — a new one
+/// can still compare fields itself and skip the floor — so this is a
+/// signpost, not a guard rail. Worth having anyway, because that omission
+/// is not hypothetical and no test would catch it: the original ladder had
+/// no C1 guard, on the argument that a trivializing shortcut would reject
+/// itself for lack of route gain, and a census (2026-07-31) measured that
+/// false — one new pipe can create two brand-new cheap routes at once, so
+/// "routes rose" held while C1 crashed 18 -> 5, on ~8% of all worlds.
+fn accepted(before: &WorldMeasure, after: &WorldMeasure, floor: u32, gain: bool) -> bool {
+    if before.c1 < floor {
+        after.c1 > before.c1
+    } else {
+        gain && meets_floor(after, floor)
+    }
+}
 
 pub(crate) struct Shaping;
 
@@ -229,17 +266,11 @@ fn try_lock_replace(
     }
     let after = measure_world(state);
     let zero_gate_after = state.zero_gate_locks().len();
-    // Below the floor, cost first: accept iff C1 rose. Routes may drop — a
-    // goal gate collapses the express variants it prices up, and the choice
-    // ladder re-earns routes once the floor holds.
-    let improved = if before.c1 < floor {
-        after.c1 > before.c1
-    } else {
-        (after.routes_in_band > before.routes_in_band
-            || (after.routes_in_band == before.routes_in_band
-                && zero_gate_after < zero_gate_before))
-            && after.c1 >= floor
-    };
+    // This rung's gain: routes up, or — at flat routes — decorative locks
+    // converted into gating ones. The floor/cost half is `accepted`'s.
+    let gain = after.routes_in_band > before.routes_in_band
+        || (after.routes_in_band == before.routes_in_band && zero_gate_after < zero_gate_before);
+    let improved = accepted(before, &after, floor, gain);
     let line = format!(
         "routes {} -> {}, C1 {} -> {}, zero-gate {zero_gate_before} -> {zero_gate_after}",
         before.routes_in_band, after.routes_in_band, before.c1, after.c1,
@@ -349,11 +380,13 @@ fn try_arm_balance(
         // runner-up — after a detour-splitting move the before/after gaps
         // would describe different detours.
         let had_runner_up = wide_before.routes.len() >= 2;
-        let improved = after.c1 >= floor
-            && (after.routes_in_band > before.routes_in_band
-                || (after.routes_in_band == before.routes_in_band
-                    && (wide_after.routes.len() > wide_before.routes.len()
-                        || (had_runner_up && gap_after < gap_before))));
+        // Choice-only rung (never dispatched below the floor), so `accepted`
+        // always takes its choice branch here.
+        let gain = after.routes_in_band > before.routes_in_band
+            || (after.routes_in_band == before.routes_in_band
+                && (wide_after.routes.len() > wide_before.routes.len()
+                    || (had_runner_up && gap_after < gap_before)));
+        let improved = accepted(before, &after, floor, gain);
         if improved {
             return Ok(format!(
                 "arm_balance ACCEPT: level {old_pos:?} -> {target:?} (cheap-exclusive), routes {} -> {}, wide {} -> {}, gap {gap_before} -> {}, C1 {} -> {}",
@@ -432,7 +465,7 @@ fn try_gated_shortcut(
         // Shortcut moves only run above the floor — no goal gate wanted.
         if place_locks_gating(state, rng, false) {
             let after = measure_world(state);
-            if after.c1 >= floor {
+            if meets_floor(&after, floor) {
                 // In-band already: parity for free.
                 if after.routes_in_band > before.routes_in_band {
                     return Ok(format!(
@@ -516,13 +549,10 @@ fn try_fort_lock(
             evals += 1;
             if place_locks_gating(state, rng, before.c1 < floor) {
                 let after = measure_world(state);
-                // Below the floor: any relocation that raises C1 is
-                // progress (routes may be spent). Above: routes must rise.
-                let improved = if before.c1 < floor {
-                    after.c1 > before.c1
-                } else {
-                    after.routes_in_band > before.routes_in_band && after.c1 >= floor
-                };
+                // This rung's gain: routes up, nothing subtler — moving a
+                // fort re-prices the whole world, so a finer test is noise.
+                let gain = after.routes_in_band > before.routes_in_band;
+                let improved = accepted(before, &after, floor, gain);
                 if improved {
                     return Ok(format!(
                         "fort_lock ACCEPT: fort {fort_id} {old_pos:?} -> {new_pos:?}, routes {} -> {}, C1 {} -> {}",
@@ -600,15 +630,10 @@ fn try_level_move(
         state.slots[si].pos = target;
         evals += 1;
         let after = measure_world(state);
-        // Below the floor: C1 progress (routes may be spent). Above: routes
-        // up, or the fine +3 trim at flat routes.
-        let improved = if before.c1 < floor {
-            after.c1 > before.c1
-        } else {
-            (after.routes_in_band > before.routes_in_band
-                || (after.routes_in_band == before.routes_in_band && after.c1 > before.c1))
-                && after.c1 >= floor
-        };
+        // This rung's gain: routes up, or the fine +3 trim at flat routes.
+        let gain = after.routes_in_band > before.routes_in_band
+            || (after.routes_in_band == before.routes_in_band && after.c1 > before.c1);
+        let improved = accepted(before, &after, floor, gain);
         if improved {
             return Ok(format!(
                 "level_move ACCEPT: level {old_pos:?} -> {target:?} (on trunk), routes {} -> {}, C1 {} -> {}",
@@ -642,6 +667,7 @@ fn try_pipe_move(
     rng: &mut dyn RngCore,
     before: &WorldMeasure,
 ) -> Result<String, String> {
+    let floor = state.c1_floor;
     let saved_grid = state.grid.clone();
     let saved_slots = state.slots.clone();
     let saved_locks = state.locks.clone();
@@ -701,7 +727,13 @@ fn try_pipe_move(
 
             if all_content_reachable(state) && place_locks_gating(state, rng, true) {
                 let after = measure_world(state);
-                if after.c1 > before.c1 {
+                // Cost-only rung: there is no choice gain to claim, so the
+                // verdict is `accepted`'s cost branch alone — exactly the
+                // rule this used to spell out itself. Were the rung ever made
+                // available above the floor, a `gain` of false makes it
+                // refuse rather than accept blind.
+                let no_choice_gain = false;
+                if accepted(before, &after, floor, no_choice_gain) {
                     return Ok(format!(
                         "pipe_move ACCEPT: mouth {old:?} -> {new_pos:?} (pair with {keep:?}), routes {} -> {}, C1 {} -> {}",
                         before.routes_in_band, after.routes_in_band, before.c1, after.c1,


### PR DESCRIPTION
Every shaping rung ended with some variant of `... && after.c1 >= floor` — one cross-cutting rule written out five times, once per rung, because each rung owns its own accept/reject/rollback. The charter records that clause being **missing** originally and retrofitted after a census (2026-07-31) caught worlds where "routes rose" held while C1 crashed 18 → 5, on ~8% of worlds.

## What this does

`accepted(before, after, floor, gain)` holds both halves of the verdict:

- **below the floor** — cost mode: C1 up, routes spendable (gating an express collapses its variants into one route, so "routes not down" would veto the very move that repairs the world)
- **at or above** — the rung's own `gain` must hold **and** the move must not price the world back under

Each rung computes a named `gain` and passes it, so the floor rule has one home instead of five. `meets_floor` is the single place the comparison is written.

It is a **signpost, not a guard rail** — nothing forces a new rung to call `accepted`, and the doc comment says so rather than claiming enforcement the code doesn't provide.

## Not hoisted to the loop

That was the first idea and it's wrong. The guard sits *inside* each rung's candidate loop (every rung tries up to 4 and returns on the first acceptable one), so a candidate that breaks the floor is rejected and the rung keeps searching. Central screening would take the rung's first choice-improving candidate, veto it wholesale, and never try the rest — a weaker search, not a refactor.

## Two deliberate carve-outs

- **`try_gated_shortcut`** adopts `meets_floor` only. Its second acceptance tier runs an extra `analyze_route_choice` at `SHAPING_SLACK`, and only when the first tier misses. Collapsing it into a `gain` bool would compute that eagerly — a second Dijkstra per candidate, in the pass that is already 61% of build time.
- **`try_pipe_move`** had *no* floor clause at all, correct today only because the availability table makes it cost-mode-only. It now passes `no_choice_gain` (false), identical in cost mode, and would correctly **refuse** if the rung were ever made available above the floor.

## Ergonomics

Every call site binds its gain to a `let` before the call, so all five read as the same one-liner and a reader sees what's being claimed without opening the judge. No bare expressions, no bare `false`.

**Code lines are a wash: +27/−27.** The whole +67/−35 file delta is the judge's doc comment carrying reasoning the five copies used to restate.

## Verification

Pure refactor — no RNG consumption changed.

- `tests/overworld_baseline.rs` **green**, all 20 seeds hash identically. This is the strong check: byte-identical ROMs.
- `test_route_census` at 1000 seeds reproduces every figure exactly — 2.548 routes/world, 6.60% linear, C1 19.5, per-seed total 155.6, by-floor 18.4 / 19.4 / 20.8 with identical `n` and miss rates.
- `all_world_targets_reachable` passes at 500 seeds/arm.
- Full suite green (385 lib tests), `cargo clippy --all-targets` clean.

No changelog entry — internal refactor, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYHYEdATVEnAPH8CGUe4yR
