### PR TITLE
fix: treasure-box room softlocks (backport to 1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,28 @@ deploys.
   icon now have one — Boom-Boom Stomps, Cannons, Ghosts, Shell, Rotodiscs,
   Faster Frog, Swap Start / Airship, Shuffle Spade Games and Remove N-Cards.
 
+- The 8-Tank treasure room now draws from the same enemy pool as the other
+  bro-fight rooms, so its enemy follows Hammer Bro encounter randomization
+  along with the rest.
+
 ### Fixed
+
+- **Treasure-box rooms could be made unwinnable.** A room whose exit is a
+  treasure box only opens once you have cleared it, so anything in it that
+  cannot be killed traps you there. Two ways that happened:
+
+  A Hammer Bro in such a room is not really an enemy — the game treats it as
+  "whichever bro's map sprite you walked in through", and in a room you did not
+  reach through a bro sprite it turns into something unkillable. This is what
+  players hit in the Coin Ship's reward fight, and it could also reach the
+  8-Tank and White Toad House reward rooms. Hammer Bros are now kept out of
+  every such room.
+
+  Dry Bones could also appear there. Stomping one works but it gets back up, so
+  in a room you have to clear it is a dead end. It is now only ever placed
+  alongside a Koopa shell, which does kill it for good.
+
+  Both are unchanged everywhere else in the game.
 
 - **The title hash no longer changes colour when you use a visual patch.** It
   used to encode part of itself in the icons' colour, drawn from Mario's

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -3561,11 +3561,35 @@ walking into the Coin Ship loads an autoscroll ship level in the Ship tileset
 (PRG023). The end of that level contains a pipe junction whose destination is a
 small sub-area with **two BoomerangBros** as the fight reward.
 
+#### How the Coin Ship is loaded
+
+Every step is a table read, and all of them are worth knowing because the coin
+ship is the one level whose *entry path* changes what spawns inside it.
+
+1. Stepping on a map object stores its ID: `Map_EnterViaID = Map_Objects_IDs[slot]`
+   (`prg011.asm:3896`). For a coin ship that is `MAPOBJ_COINSHIP = $0B`.
+   **Entering an ordinary level tile leaves `Map_EnterViaID = 0`** — `prg012.asm:641`
+   branches on non-zero, and `prg002.asm:3712` calls a non-zero value "a Map
+   Entry override."
+2. `$0B` = index 11 of the dispatch table at `prg012.asm:681` → `MO_CoinShip`.
+3. `MO_CoinShip` (`prg012.asm:917`) sets the layout and object pointers from
+   `CoinShip_Layouts[World_Num]` / `CoinShip_Objects[World_Num]` and forces
+   `Level_Tileset = 10`. Both tables are eight identical per-world words —
+   the disassembly wonders aloud whether per-world coin ships were planned.
+
 | Item | Value |
 |------|-------|
+| `CoinShip_Layouts` | file `0x19337` — 8 × `$BC15` |
+| `CoinShip_Objects` | file `0x19347` — 8 × `$DA04` |
+| Ship layout header | `$BC15` → file `0x2FC25` (PRG023) |
+| Ship enemy data | `$DA04` → file `0x0DA14` — autoscroll, clouds, prop; no enemies |
+| Junction | ship header bytes 0-3 = `B8 BC 0F DA` → alt layout `$BCB8`, alt objects `$DA0F` |
+| Sub-area tileset | source header byte 6 low nibble (`0x2FC2B` = `$8A`) = **10** |
 | Sub-area enemy pointer | CPU `$DA0F` (file `0x0DA1F`) |
-| Junction reference | File `0x2FC27` in PRG023 (Ship tileset) — bytes `BC 0F DA` |
-| Enemy contents | 2× `0x82` (BoomerangBro) + `0xBA` terminator (3 entries) |
+| Enemy contents | 2× `0x82` (BoomerangBro) + `0xBA` `OBJ_TREASUREBOXAPPEAR` |
+
+There is exactly **one** reward room: the sub-area header at `$BCB8` contains
+zero junction commands, so the chain dead-ends there.
 
 The sub-area has no world pointer table entry — it's reached only via the
 in-layout junction — so the randomizer protects it via a `LevelProtection`
@@ -3574,11 +3598,80 @@ WalkerSegmentRule::HammerBro`). This routes its enemy randomization through
 the HB-wild path (stompable-only pool, optionally one shell-killable + one
 shell partner).
 
-Dry Bones (`0x3F`) is additionally excluded from this segment's stompable pool
-(`is_coinship_fight` in `enemy_protections.rs`): the reward room is enclosed and
-never scrolls, so a Dry Bones revives after every stomp with no screen edge to
-wander off and can never be cleared. It stays a valid HB-wild pick everywhere
-else.
+The 8-Tank sub-area (`$DA29`) is the other room of this shape — a treasure box
+reached through a non-bro map sprite — and carries the same rule.
+
+**A treasure-box room is cleared to be left, so every enemy in it must be
+permanently killable, not merely stompable.** That is the whole reason the
+bro-fight pool splits in two: `STOMPABLE_ENEMIES` for anything a jump clears,
+and `HB_NEEDS_SHELL_ENEMIES` for what needs a kicked shell, which the 2-enemy
+path always pairs one with. Dry Bones (`0x3F`) is why the distinction is
+load-bearing rather than pedantic: stomping it works and it revives, so it can
+never be cleared by jumping, but a shell does kill it. It therefore sits in
+`HB_NEEDS_SHELL_ENEMIES`, which also means it can only be dealt into a 2-enemy
+room — the 1-enemy rooms (including the 8-Tank) draw from the stompable pool
+alone and never see one.
+
+### `BattleEnemy_ByEnterID` Overrun — a Hammer Bro is a Placeholder
+
+**In any room with `Level_Event = 7` (i.e. whose enemy data contains
+`OBJ_TREASUREBOXAPPEAR`, `$BA`), object `$81` is not a Hammer Bro.** It is a
+placeholder meaning *"whichever bro's map sprite the player walked in
+through"* — which is how one arena serves all four bro battles.
+
+`ObjInit_HammerBro` (`prg004.asm:866`):
+
+```asm
+LDA Level_Event
+CMP #$07
+BNE  ...                 ; not a treasure-box room -> ordinary Hammer Bro
+LDY Map_EnterViaID
+LDA BattleEnemy_ByEnterID,Y
+CMP #OBJ_HAMMERBRO
+BEQ  ...                 ; already the right bro -> keep
+STA Level_ObjectID,X     ; otherwise REWRITE this object's own ID
+DEC Objects_State,X      ; and re-init as whatever that was
+```
+
+`BattleEnemy_ByEnterID` (`prg004.asm:851`, file **`0x08478`**) defines only
+indices 0-9 — the disassembly says so outright: *"No definition for `$0A-$10`
+map objects."* The bytes that follow it are the routine's own machine code
+(`AD 66 05` = `LDA $0566`, i.e. `LDA Level_Event`), so any higher index reads
+an opcode or an operand as an object ID:
+
+| Entered via | Index | `$81` becomes | Result |
+|---|---|---|---|
+| `MAPOBJ_HAMMERBRO` `$03` | 3 | `$81` HammerBro | intended |
+| `MAPOBJ_BOOMERANG/HEAVY/FIREBRO` `$04`-`$06` | 4-6 | `$82`/`$86`/`$87` | intended |
+| ordinary level tile, HELP, airship, W7 plant, N-Spade | 0-2, 7-9 | `$00` | invisible, inert |
+| `MAPOBJ_WHITETOADHOUSE` `$0A` | 10 | `$AD` RockyWrench | out of range |
+| **`MAPOBJ_COINSHIP` `$0B`** | 11 | **`$66` WaterCurrentDown** | out of range |
+| `MAPOBJ_UNK0C` `$0C` | 12 | `$05` | out of range |
+| `MAPOBJ_BATTLESHIP` `$0D` | 13 | `$C9` | out of range |
+| `MAPOBJ_TANK` `$0E` | 14 | `$07` `OBJ_WARPHIDE` | invisible |
+| `MAPOBJ_W8AIRSHIP` `$0F` | 15 | `$D0` | out of range |
+| `MAPOBJ_CANOE` `$10` | 16 | `$16` | out of range |
+
+None of those can be killed, and the treasure box only appears once the room
+is empty — so a `$81` in the wrong treasure-box room is an unescapable room.
+
+**Vanilla observes the rule.** `$81` appears in exactly five treasure-box
+rooms, all bro battles (`$C640`, `$C72B`, `$D0EA`, `$D142`, `$D14D`), and the
+two treasure-box rooms reached by a non-bro map object — the Coin Ship
+(`$DA0F`) and the 8-Tank sub-area (`$DA29`) — use a literal `$82` instead.
+
+The randomizer enforces this generically in `rewrites_hammer_bro`
+(`enemy_protections.rs`), keyed off the existing `HAMMER_BRO_OBJ_PTRS`. It replaced a
+hand-curated `ForceTankBro` row on the 8-Tank sub-area that was labelled
+"HammerBro fails to spawn in ts=10" — a misdiagnosis. The tileset was never
+the cause; index 14 yields `OBJ_WARPHIDE`, which is invisible, and that is
+what "fails to spawn" actually was.
+
+> **Testing caveat.** `testrom --place CoinShip` parks the coin ship's
+> layout/object pointers on a numbered tile, which reproduces the *level* but
+> not `Map_EnterViaID` — entered that way it is 0, so a `$81` there becomes
+> `$00` (invisible) instead of `$66` (a water current). Anything that depends
+> on the entry path cannot be reproduced by placing the level on a tile.
 
 ### Enemy Stompability Classification
 

--- a/src/bin/testrom.rs
+++ b/src/bin/testrom.rs
@@ -9,7 +9,7 @@ use std::process;
 
 use clap::Parser;
 
-use smb3_rs::testrom::{self, Base, Placement, TestRomSpec};
+use smb3_rs::testrom::{self, Base, EnemyOverride, Placement, TestRomSpec};
 use smb3_rs::Options;
 
 const DEFAULT_ROM: &str = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes";
@@ -128,6 +128,13 @@ struct Cli {
     #[arg(long)]
     hammer_bridges: bool,
 
+    /// Overwrite one enemy slot outright, as "PTR:SLOT:ID" in hex, e.g.
+    /// "DA0F:1:66" to put a downward water current in the Coin Ship fight's
+    /// second slot. Repeatable. Use to see what an object actually does in a
+    /// room the randomizer's pools would never put it in.
+    #[arg(long, value_name = "PTR:SLOT:ID")]
+    set_enemy: Vec<String>,
+
     /// List valid --starting-items names and exit.
     #[arg(long)]
     list_items: bool,
@@ -167,6 +174,29 @@ fn parse_placement(spec: &str) -> Result<Placement, String> {
         }
         None => Ok(Placement { level: spec.trim().to_string(), slot: None }),
     }
+}
+
+/// Parse a `--set-enemy` item: `"DA0F:1:66"` — enemy pointer, slot, object ID.
+/// Pointer and ID are hex (a leading `0x` is accepted); the slot is decimal.
+fn parse_set_enemy(spec: &str) -> Result<EnemyOverride, String> {
+    fn hex(s: &str) -> &str {
+        s.trim().trim_start_matches("0x").trim_start_matches("0X")
+    }
+    let bad = || format!("bad --set-enemy {spec:?} (expected PTR:SLOT:ID, e.g. DA0F:1:66)");
+    let mut parts = spec.split(':');
+    let (p, s, i) = match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(p), Some(s), Some(i), None) => (p, s, i),
+        _ => return Err(bad()),
+    };
+    let enemy_ptr = u16::from_str_radix(hex(p), 16).map_err(|_| bad())?;
+    if !(0xC000..=0xDFFF).contains(&enemy_ptr) {
+        return Err(format!("enemy pointer ${enemy_ptr:04X} is outside $C000-$DFFF"));
+    }
+    Ok(EnemyOverride {
+        enemy_ptr,
+        slot: s.trim().parse().map_err(|_| bad())?,
+        id: u8::from_str_radix(hex(i), 16).map_err(|_| bad())?,
+    })
 }
 
 fn main() {
@@ -259,6 +289,12 @@ fn main() {
         .map(|s| parse_placement(s).unwrap_or_else(|e| die(e)))
         .collect();
 
+    let set_enemies: Vec<EnemyOverride> = cli
+        .set_enemy
+        .iter()
+        .map(|s| parse_set_enemy(s).unwrap_or_else(|e| die(e)))
+        .collect();
+
     let starting_items: Vec<u8> = cli
         .starting_items
         .iter()
@@ -308,6 +344,7 @@ fn main() {
         hammer_breaks_locks: cli.hammer_locks,
         hammer_breaks_bridges: cli.hammer_bridges,
         include_beta: cli.beta,
+        set_enemies,
     };
 
     let built = testrom::build(&vanilla, &spec).unwrap_or_else(|e| die(e));

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -12,12 +12,12 @@ use rand::Rng;
 use rand::seq::IndexedRandom;
 
 use crate::randomize::enemy_protections::{
-    entry_protection_at, is_coinship_fight, walker_segment_rule_at, EntryProtection,
-    WalkerSegmentRule,
+    entry_protection_at, rewrites_hammer_bro, walker_segment_rule_at,
+    EntryProtection, WalkerSegmentRule,
 };
 use crate::randomize::rom_data::{
-    ENEMY_DATA_END, ENEMY_DATA_START, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS, STOMPABLE_ENEMIES,
-    TANK_BRO_POOL,
+    ENEMY_DATA_END, ENEMY_DATA_START, HAMMER_BRO_ID, HB_NEEDS_SHELL_ENEMIES, LEVEL_DATA_REGIONS,
+    STOMPABLE_ENEMIES, TREASURE_BOX_APPEAR,
 };
 use crate::randomize::segment_writer::{self, SegmentEntry as WriterEntry, SortMode};
 use crate::randomizer::{EnemyMode, Options, WildChaser};
@@ -151,9 +151,18 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
             i += 3;
         }
 
+        // A treasure box in the room means `Level_Event = 7`, which arms the
+        // Hammer Bro placeholder rewrite. Decided once from the segment's own
+        // vanilla contents, before any pick, so both paths below agree.
+        let no_hammer_bro = rewrites_hammer_bro(
+            seg_file_offset,
+            entries.iter().any(|e| e.obj_id == TREASURE_BOX_APPEAR),
+        );
+
         // HB Wild: batch-assign enemies with stompability constraints.
         if is_hb_segment && opts.hb_encounters == EnemyMode::Wild && !big_q_only {
-            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, seg_file_offset, rng);
+            let limits = SegmentLimits { cap_full: false, no_hammer_bro };
+            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, limits, rng);
             continue;
         }
 
@@ -256,14 +265,17 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                 }
 
                 let was_bertha = BERTHA_IDS.contains(&data[entry.data_index]);
-                let cap_full = bertha_count.saturating_sub(was_bertha as u8)
-                    >= MAX_BERTHA_PER_SEGMENT;
+                let limits = SegmentLimits {
+                    cap_full: bertha_count.saturating_sub(was_bertha as u8)
+                        >= MAX_BERTHA_PER_SEGMENT,
+                    no_hammer_bro,
+                };
                 let chr = ChrCtx {
                     local: (committed_slot4, committed_slot5),
                     segment: (seg_all4, seg_all5),
                 };
                 let Some(chosen) = pick_replacement(
-                    entry, protection, modes, wild_pool, chr, cap_full, rng,
+                    entry, protection, modes, wild_pool, chr, limits, rng,
                 ) else {
                     // No swap (protection mode off, unknown class, or no
                     // compatible candidate) — the vanilla enemy stays, so its

--- a/src/randomize/enemies/picking.rs
+++ b/src/randomize/enemies/picking.rs
@@ -83,7 +83,7 @@ pub(super) fn pick_replacement<R: Rng>(
     modes: &ClassModes,
     wild_pool: &[u8],
     chr: ChrCtx,
-    cap_full: bool,
+    limits: SegmentLimits,
     rng: &mut R,
 ) -> Option<u8> {
     let (slot4, slot5) = chr.local;
@@ -96,10 +96,6 @@ pub(super) fn pick_replacement<R: Rng>(
         Some(EntryProtection::ForceShell) if modes.shell != EnemyMode::Off => Some((
             pick_compatible(SHELL_ENEMIES, slot4, slot5, rng),
             Cow::Borrowed(SHELL_ENEMIES),
-        )),
-        Some(EntryProtection::ForceTankBro) if modes.bros != EnemyMode::Off => Some((
-            pick_compatible(TANK_BRO_POOL, slot4, slot5, rng),
-            Cow::Borrowed(TANK_BRO_POOL),
         )),
         Some(EntryProtection::ForceStompable) => {
             find_class_pool(entry.obj_id, modes).map(|pool| {
@@ -149,14 +145,18 @@ pub(super) fn pick_replacement<R: Rng>(
     // true when `id` is allowed in this slot.
     let keep = |id: u8| -> bool {
         // Big Bertha cap: no new bertha once the segment is full.
-        let over_cap = cap_full && BERTHA_IDS.contains(&id);
+        let over_cap = limits.cap_full && BERTHA_IDS.contains(&id);
+        // A Hammer Bro in a treasure-box room is a placeholder the engine
+        // rewrites into an unkillable object, stranding the player (see
+        // `rewrites_hammer_bro`).
+        let hb_rewritten = limits.no_hammer_bro && id == HAMMER_BRO_ID;
         // Giant red piranha (off-center hitbox) only where one was.
         let bad_giant = id == GIANT_RED_PIRANHA && entry.obj_id != GIANT_RED_PIRANHA;
         // A level-wide chaser must be CHR-compatible with every page
         // committed anywhere in the segment, not just this group — it
         // follows the player into all of them (see CHASER_IDS).
         let chaser_clash = CHASER_IDS.contains(&id) && !is_chr_compatible(id, seg4, seg5);
-        !(over_cap || bad_giant || chaser_clash)
+        !(over_cap || bad_giant || chaser_clash || hb_rewritten)
     };
     // (A piranha slot can't become a hazard: the piranha pools are
     // self-contained and contain none — verified by the harness's

--- a/src/randomize/enemies/segments.rs
+++ b/src/randomize/enemies/segments.rs
@@ -21,6 +21,19 @@ pub(super) struct SegmentPins {
     pub(super) chaser: (ChrSlot, ChrSlot),
 }
 
+/// Placement limits that hold for every entry in one segment, whatever pool
+/// that entry draws from. Both are properties of the *room*, not the slot,
+/// which is why they ride alongside the per-entry protections rather than
+/// being expressed as `EntryRule`s.
+#[derive(Clone, Copy)]
+pub(super) struct SegmentLimits {
+    /// The Big Bertha cap is already reached — no new bertha here.
+    pub(super) cap_full: bool,
+    /// No `$81` here: this room rewrites one into an unkillable object. See
+    /// `enemy_protections::rewrites_hammer_bro`.
+    pub(super) no_hammer_bro: bool,
+}
+
 impl SegmentPins {
     /// Nothing committed — the Big-?-block pass, which skips the CHR model.
     pub(super) fn none() -> Self {
@@ -104,15 +117,17 @@ pub(super) fn randomize_hb_wild_segment<R: Rng>(
     data: &mut [u8],
     entries: &[SegmentEntry],
     hb_modes: &ClassModes,
-    seg_file_offset: usize,
+    limits: SegmentLimits,
     rng: &mut R,
 ) {
-    // The coin-ship reward room is enclosed and never scrolls, so Dry Bones
-    // (0x3F) — which revives after every stomp and has no edge to wander off —
-    // can never be cleared there. Drop it from the stompable pool for that one
-    // segment; everywhere else it's a fine HB-wild pick.
-    let stompable: Cow<[u8]> = if is_coinship_fight(seg_file_offset) {
-        Cow::Owned(STOMPABLE_ENEMIES.iter().copied().filter(|&id| id != 0x3F).collect())
+    // A Hammer Bro is a placeholder the engine rewrites into something
+    // unkillable in a treasure-box room that isn't a real bro battle, which
+    // would strand the player (see `rewrites_hammer_bro`). Clearability is
+    // otherwise a property of the pools themselves, not of the room.
+    let stompable: Cow<[u8]> = if limits.no_hammer_bro {
+        Cow::Owned(
+            STOMPABLE_ENEMIES.iter().copied().filter(|&id| id != HAMMER_BRO_ID).collect(),
+        )
     } else {
         Cow::Borrowed(STOMPABLE_ENEMIES)
     };

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1238,11 +1238,6 @@
                     {
                         bad("ForceStompable but result not stompable".into());
                     }
-                    Some(EntryProtection::ForceTankBro)
-                        if opts.bros != EnemyMode::Off && !TANK_BRO_POOL.contains(&new) =>
-                    {
-                        bad("ForceTankBro but result not a tank bro".into());
-                    }
                     Some(EntryProtection::ExcludeHazards)
                         if hazard_excluded(new, orig) =>
                     {
@@ -1254,10 +1249,7 @@
                 // --- Class validity: a swap must land in the original's class
                 // pool, be a wild injection, be a Boom-Boom self-swap, or be
                 // covered by a pool-replacing Force* protection above. ---
-                let forced_pool = matches!(
-                    prot,
-                    Some(EntryProtection::ForceShell | EntryProtection::ForceTankBro)
-                );
+                let forced_pool = matches!(prot, Some(EntryProtection::ForceShell));
                 if !forced_pool {
                     let in_class = find_class_pool(orig, modes)
                         .is_some_and(|p| p.slice(wild_pool).contains(&new));
@@ -1279,6 +1271,28 @@
                     && hazard_category(new).is_some()
                 {
                     bad("piranha slot replaced by a hazard".into());
+                }
+            }
+
+            // Shell pairing: hard invariant. A treasure-box room only opens once
+            // it is empty, so an enemy from HB_NEEDS_SHELL_ENEMIES is only fair
+            // there if the room also holds a shell to kill it with. Dry Bones is
+            // the member that makes this load-bearing rather than cosmetic — it
+            // is stompable but revives, so nothing else in the room clears it.
+            if hb_batch {
+                let ids: Vec<u8> = (0..b.entry_count)
+                    .map(|i| randomized[b.file_offset + 1 + i * 3])
+                    .collect();
+                let needs_shell: Vec<u8> =
+                    ids.iter().copied().filter(|id| HB_NEEDS_SHELL_ENEMIES.contains(id)).collect();
+                if !needs_shell.is_empty() && !ids.iter().any(|id| SHELL_ENEMIES.contains(id)) {
+                    out.push(format!(
+                        "seed {seed} @ seg {:#07X}: {:02X?} needs a shell and the room has none \
+                         (ids {:02X?})",
+                        ENEMY_DATA_START + b.file_offset,
+                        needs_shell,
+                        ids,
+                    ));
                 }
             }
 
@@ -1355,30 +1369,86 @@
         );
     }
 
-    /// The coin-ship reward fight (2×BoomerangBro sub-area at enemy_ptr 0xDA0F,
-    /// file 0x0DA1F) must never receive a Dry Bones: that room is enclosed and
-    /// never scrolls, so a Dry Bones — which revives after every stomp and has
-    /// no edge to wander off — could never be cleared.
+    // `coinship_fight_never_gets_dry_bones` lived here. Its assertion is false
+    // by design now: Dry Bones moved from `STOMPABLE_ENEMIES` into
+    // `HB_NEEDS_SHELL_ENEMIES`, so it is a legal pick in that room provided the
+    // other slot is a shell. The invariant that replaced it is the shell-pairing
+    // check in `check_seed`, which covers every bro-fight room instead of one.
+
+    /// No treasure-box room outside the real bro battles may end up holding a
+    /// Hammer Bro. `$81` there is not an enemy — `ObjInit_HammerBro` rewrites it
+    /// via `BattleEnemy_ByEnterID[Map_EnterViaID]`, and every index a non-bro
+    /// map object produces is an object that cannot be killed, so the treasure
+    /// box never appears and the player is stranded (see
+    /// `rewrites_hammer_bro`).
+    ///
+    /// Scans every `$FF` segment rather than fixed offsets, so a room nobody
+    /// has thought about yet is covered too, and sweeps the two enemy modes
+    /// that reach the different code paths (HB-Wild is batch-assigned; the rest
+    /// go through the walker).
     #[test]
-    fn coinship_fight_never_gets_dry_bones() {
+    fn treasure_box_rooms_never_get_a_hammer_bro() {
         let Some(base) = load_reference_rom() else {
-            eprintln!("reference ROM not present — skipping coinship_fight_never_gets_dry_bones");
+            eprintln!("reference ROM absent — skipping treasure_box_rooms_never_get_a_hammer_bro");
             return;
         };
-        // Vanilla layout: [FF] 01 (page) | 82 03 17 | 82 0C 17 | BA 0F 11 | FF.
-        // The two 0x82 BoomerangBro obj_id bytes sit at 0x0DA20 and 0x0DA23.
-        const BRO0: usize = 0x0DA20;
-        const BRO1: usize = 0x0DA23;
-        assert_eq!(base.read_range(BRO0, 1)[0], 0x82, "vanilla layout drifted");
-        assert_eq!(base.read_range(BRO1, 1)[0], 0x82, "vanilla layout drifted");
 
-        for seed in 0..400u64 {
-            let mut rom = base.clone();
-            let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            randomize(&mut rom, &mut rng, &preset_recommended());
-            for off in [BRO0, BRO1] {
-                let id = rom.read_range(off, 1)[0];
-                assert_ne!(id, 0x3F, "seed {seed}: Dry Bones placed in coin-ship fight");
+        // Segment starts, parsed the way the walker does: page byte, 3-byte
+        // entries, 0xFF terminator.
+        let segments = |rom: &Rom| -> Vec<(usize, Vec<usize>)> {
+            let data = rom.read_range(ENEMY_DATA_START, ENEMY_DATA_END - ENEMY_DATA_START).to_vec();
+            let mut out = Vec::new();
+            let mut i = 0;
+            while i < data.len() {
+                if data[i] == 0xFF {
+                    i += 1;
+                    continue;
+                }
+                let start = ENEMY_DATA_START + i;
+                i += 1;
+                let mut ids = Vec::new();
+                while i + 2 < data.len() && data[i] != 0xFF {
+                    ids.push(ENEMY_DATA_START + i);
+                    i += 3;
+                }
+                out.push((start, ids));
+            }
+            out
+        };
+
+        // Rooms to police, decided from vanilla so a swap can't hide one.
+        let at_risk: Vec<(usize, Vec<usize>)> = segments(&base)
+            .into_iter()
+            .filter(|(start, ids)| {
+                let has_box =
+                    ids.iter().any(|&o| base.read_range(o, 1)[0] == TREASURE_BOX_APPEAR);
+                rewrites_hammer_bro(*start, has_box)
+            })
+            .collect();
+        assert!(
+            at_risk.len() >= 8,
+            "expected the vanilla treasure-box rooms to be found, got {}",
+            at_risk.len()
+        );
+
+        for mode in [EnemyMode::Wild, EnemyMode::Shuffle] {
+            let mut opts = preset_recommended();
+            opts.hb_encounters = mode;
+            opts.bros = EnemyMode::Wild;
+            for seed in 0..200u64 {
+                let mut rom = base.clone();
+                let mut rng = ChaCha8Rng::seed_from_u64(seed);
+                randomize(&mut rom, &mut rng, &opts);
+                for (start, ids) in &at_risk {
+                    for &off in ids {
+                        assert_ne!(
+                            rom.read_range(off, 1)[0],
+                            HAMMER_BRO_ID,
+                            "seed {seed} ({mode:?}): Hammer Bro at {off:#07X} in treasure-box \
+                             room {start:#07X} — it rewrites to an unkillable object",
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/randomize/enemy_protections.rs
+++ b/src/randomize/enemy_protections.rs
@@ -14,7 +14,7 @@
 //! derived helpers (`entry_protection_at`, `walker_segment_rule_at`)
 //! — never the table directly.
 
-use super::rom_data::enemy_ptr_to_file_offset;
+use super::rom_data::{enemy_ptr_to_file_offset, HAMMER_BRO_OBJ_PTRS};
 
 /// One logical level or sub-area with protections that affect enemy
 /// randomization.
@@ -61,8 +61,6 @@ pub(super) enum EntryProtection {
     ForceShell,
     /// Walker forces a pick from the entry's natural pool ∩ STOMPABLE_ENEMIES.
     ForceStompable,
-    /// Walker forces a pick from TANK_BRO_POOL when bros mode is on.
-    ForceTankBro,
     /// Walker excludes hazard-category enemies from the chosen pool (additive-only:
     /// a hazard of the same category as the vanilla enemy here is kept). See
     /// `hazard_excluded` in enemies.rs.
@@ -159,14 +157,23 @@ pub(super) const LEVEL_PROTECTIONS: &[LevelProtection] = &[
         ],
     },
 
-    // --- Bros-pool restriction (HammerBro fails to spawn in tileset 10) ---
+    // --- Bro-fight rooms reached by a non-bro map object ---
+    // A treasure-box room is cleared to be left, so it needs the bro-fight
+    // pool: every enemy in it must be permanently killable. These two are
+    // fight-shaped rooms the player reaches through the Coin Ship / Tank map
+    // sprite rather than a bro sprite, so nothing else classifies them.
+    //
+    // This replaced a `ForceTankBro` row on $DA29 labelled "HammerBro fails to
+    // spawn in ts=10". The tileset was never the cause: it is a
+    // `Level_Event = 7` room entered via `MAPOBJ_TANK` ($0E), so a $81 there
+    // resolved through `BattleEnemy_ByEnterID[14]` to $07 `OBJ_WARPHIDE`, which
+    // is invisible — that is what "fails to spawn" actually was. The ID half of
+    // it is now handled generically by `rewrites_hammer_bro`.
     LevelProtection {
-        label: "8-Tank sub-area (HammerBro fails to spawn in ts=10)",
+        label: "8-Tank sub-area treasure room (bro fight via the Tank sprite)",
         enemy_ptr: 0xDA29,
-        walker_segment: WalkerSegmentRule::Default,
-        entries: &[
-            EntryRule { offset: 0x0DA3A, rule: EntryProtection::ForceTankBro }, // BoomerangBro scr=0 col=12
-        ],
+        walker_segment: WalkerSegmentRule::HammerBro,
+        entries: &[],
     },
 
     // --- Hazard-excluded entries (no Patooie/Lavalotus on player walking path) ---
@@ -331,16 +338,43 @@ pub(super) fn entry_protection_at(file_offset: usize) -> Option<EntryProtection>
         .find_map(|e| (e.offset == file_offset).then_some(e.rule))
 }
 
-/// CPU enemy pointer of the coin-ship reward fight (the 2×BoomerangBro
-/// sub-area past the end-pipe). Kept in sync with its `LEVEL_PROTECTIONS` row.
-const COINSHIP_FIGHT_ENEMY_PTR: u16 = 0xDA0F;
+// The coin-ship reward fight used to need a special case here — a
+// `is_coinship_fight` predicate feeding a Dry Bones filter, because a Dry Bones
+// revives forever in an enclosed room. Dry Bones now lives in
+// `HB_NEEDS_SHELL_ENEMIES`, so it can only ever be dealt into a room that also
+// has a shell to kill it with, in that room and every other. The coin ship is
+// no longer a special case: it is one bro-fight room among several.
 
-/// Whether `segment_file_offset` is the coin-ship reward fight. That sub-area is
-/// an enclosed, non-scrolling room, so an enemy that can never be permanently
-/// cleared — Dry Bones revives after every stomp and has no screen edge to
-/// wander off — must be kept out of its wild pool.
-pub(super) fn is_coinship_fight(segment_file_offset: usize) -> bool {
-    enemy_ptr_to_file_offset(COINSHIP_FIGHT_ENEMY_PTR) == segment_file_offset
+/// Whether this room rewrites a Hammer Bro into something else — in which case
+/// it must never be given one.
+///
+/// In a room with `Level_Event = 7` (i.e. whose enemy data holds
+/// [`TREASURE_BOX_APPEAR`]) a `$81` is not an enemy but a *placeholder* meaning
+/// "whichever bro's map sprite the player walked in through", which is how one
+/// arena serves all four bro battles. `ObjInit_HammerBro` (`prg004.asm:866`)
+/// overwrites the object's own ID with `BattleEnemy_ByEnterID[Map_EnterViaID]`
+/// and re-inits. That table (file `0x08478`) defines only indices 0-9 — the
+/// disassembly says so outright: *"No definition for $0A-$10 map objects"* — so
+/// any other entry path reads the routine's own machine code as an object ID.
+/// The Coin Ship (`MAPOBJ_COINSHIP` = `$0B`) lands on `$66`, a water current;
+/// the 8-Tank (`$0E`) on `$07` `OBJ_WARPHIDE`; an ordinary level tile on `$00`.
+/// None can be killed, so the treasure box never appears and the room has no
+/// exit. Full table in `docs/smb3_rom_reference.md`.
+///
+/// Both halves are load-bearing. The treasure box says the rewrite is *armed*;
+/// [`HAMMER_BRO_OBJ_PTRS`] says whether it is *benign* — in a real bro battle
+/// the lookup resolves correctly and `$81` is the vanilla value, so excluding
+/// it there would mean a Hammer Bro could never appear as an HB encounter.
+/// (W8's `0xC03D` is in that list but is the full 7-7 action level with no
+/// treasure box, so it never reaches this check.)
+///
+/// Nothing here depends on the tileset — an earlier `ForceTankBro` row on the
+/// 8-Tank sub-area blamed tileset 10, which was a misdiagnosis of this.
+pub(super) fn rewrites_hammer_bro(segment_file_offset: usize, has_treasure_box: bool) -> bool {
+    has_treasure_box
+        && !HAMMER_BRO_OBJ_PTRS
+            .iter()
+            .any(|&p| enemy_ptr_to_file_offset(p) == segment_file_offset)
 }
 
 /// Walker rule for the segment whose page byte sits at this absolute file

--- a/src/randomize/rom_data/access.rs
+++ b/src/randomize/rom_data/access.rs
@@ -120,13 +120,13 @@ pub const ENEMY_DATA_START: usize = 0x0BFD8;
 
 pub const ENEMY_DATA_END: usize = 0x0E00D;
 
-/// Bro enemies that work in tileset 10 (8-Tank sub-area).
-/// Excludes HammerBro (0x81) which fails to spawn in ts=10.
-pub(crate) const TANK_BRO_POOL: &[u8] = &[
-    0x82, // OBJ_BOOMERANGBRO
-    0x86, // OBJ_HEAVYBRO
-    0x87, // OBJ_FIREBRO
-];
+/// `OBJ_TREASUREBOXAPPEAR`. A segment containing this is a `Level_Event = 7`
+/// room: its exit only appears once the room is cleared. See
+/// `enemy_protections::rewrites_hammer_bro`.
+pub(crate) const TREASURE_BOX_APPEAR: u8 = 0xBA;
+
+/// `OBJ_HAMMERBRO`.
+pub(crate) const HAMMER_BRO_ID: u8 = 0x81;
 
 /// Check whether the first enemy data segment at `obj_ptr` contains `target_id`.
 ///

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -597,6 +597,11 @@ pub(crate) struct LevelEntry {
 /// numbered tile is the only way to walk into the Coin Ship on demand, since
 /// the real thing only spawns when `OBJ_BONUSCONTROLLER`'s coin/score check
 /// fires.
+///
+/// Native-only: `testrom` (itself `cfg(not(wasm32))`) is the sole consumer, so
+/// on the WASM build this is dead code and warns. Gated rather than
+/// `allow(dead_code)`d so that a genuinely unused item still gets caught.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const UNLISTED_LEVELS: &[(&str, LevelEntry)] = &[(
     "CoinShip",
     LevelEntry { tileset: 10, obj_lo: 0x04, obj_hi: 0xDA, lay_lo: 0x15, lay_hi: 0xBC },

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -487,13 +487,17 @@ pub(crate) const HB_EXCLUDE_OBJ_PTRS: &[u16] = &[
     0xC03D, // W8 — 7-7 layout
 ];
 
-/// Stompable enemies — safe for single-enemy HB Wild segments and the default
-/// pool for 2-enemy segments. The player can always defeat these by jumping.
+/// Enemies a player can clear from a closed room with nothing but a jump —
+/// safe for single-enemy HB Wild segments and the default pool for 2-enemy
+/// segments.
+///
+/// "Clear", not merely "stomp": these rooms only open once they are empty, so
+/// an enemy that survives being stomped does not belong here even though
+/// jumping on it works. See `HB_NEEDS_SHELL_ENEMIES` for that case.
 pub(crate) const STOMPABLE_ENEMIES: &[u8] = &[
     // Ground (stompable)
     0x29, // Spike
     0x2B, // GoombShoe (Kuribo)
-    0x3F, // DryBones
     0x40, // BusterBeetle
     0x55, // BobOmb
     0x58, // FireChomp
@@ -525,15 +529,22 @@ pub(crate) const STOMPABLE_ENEMIES: &[u8] = &[
     // instead.
 ];
 
-/// Non-stompable enemies allowed in 2-enemy HB Wild segments only.
-/// If one of these is picked, the other enemy MUST be a shell so the
-/// player can use it to kill the non-stompable.
+/// Enemies allowed in 2-enemy HB Wild segments only, where the other slot is
+/// guaranteed to be a shell the player can kick into them.
+///
+/// These rooms are cleared to be left — the exit (`OBJ_TREASUREBOXAPPEAR`) only
+/// appears once the room is empty — so "the player can deal with it" is not
+/// enough; it has to be permanently killable. Dry Bones is the reason that
+/// distinction matters: it *is* stompable, but it revives every time, so
+/// stomping never clears it. A kicked shell does, which is what puts it here
+/// rather than in `STOMPABLE_ENEMIES`.
 pub(crate) const HB_NEEDS_SHELL_ENEMIES: &[u8] = &[
     0x71, // Spiny
     0x2A, // Patooie
     0x33, // Nipper
     0x39, // NipperHopping
     0x63, // BigBertha
+    0x3F, // DryBones — stompable but revives; only a shell clears it
 ];
 
 /// Specific (obj_ptr, tileset) pairs to exclude from the HB cycling pool.
@@ -574,6 +585,22 @@ pub(crate) struct LevelEntry {
     pub lay_lo: u8,
     pub lay_hi: u8,
 }
+
+/// Levels the engine reaches without going through a world pointer table, so
+/// `NodeCatalog` never classifies them and `--place` cannot name them from the
+/// catalog. Listed here as ready-made entries `testrom` can park on a tile.
+///
+/// The Coin Ship is the only one so far. `MO_CoinShip` (PRG012, reached via
+/// `Map_EnterViaID` = `MAPOBJ_COINSHIP`) loads its layout and objects straight
+/// out of `CoinShip_Layouts` / `CoinShip_Objects` — eight identical per-world
+/// words, `$BC15` and `$DA04` — and forces tileset 10. Placing that triple on a
+/// numbered tile is the only way to walk into the Coin Ship on demand, since
+/// the real thing only spawns when `OBJ_BONUSCONTROLLER`'s coin/score check
+/// fires.
+pub(crate) const UNLISTED_LEVELS: &[(&str, LevelEntry)] = &[(
+    "CoinShip",
+    LevelEntry { tileset: 10, obj_lo: 0x04, obj_hi: 0xDA, lay_lo: 0x15, lay_hi: 0xBC },
+)];
 
 /// A beta (unreferenced) level — layout data exists in the ROM but no vanilla
 /// pointer table entry references it. Injected into the shuffle pool when

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -297,6 +297,21 @@ pub struct Placement {
     pub slot: Option<u8>,
 }
 
+/// One enemy slot overwritten by hand, for "what does object X actually do in
+/// room Y" experiments the randomizer's pools would never produce.
+///
+/// Addressed by the room's enemy pointer rather than a file offset, so the
+/// arithmetic stays in `rom_data::enemy_ptr_to_file_offset` instead of being
+/// re-derived by whoever is running the test.
+pub struct EnemyOverride {
+    /// CPU enemy pointer of the segment, e.g. `0xDA0F` for the Coin Ship fight.
+    pub enemy_ptr: u16,
+    /// 0-based entry within the segment, past the leading page byte.
+    pub slot: usize,
+    /// Object ID to write.
+    pub id: u8,
+}
+
 /// A full description of the test ROM to build.
 pub struct TestRomSpec {
     pub base: Base,
@@ -345,6 +360,9 @@ pub struct TestRomSpec {
     pub hammer_breaks_bridges: bool,
     /// Include the 9 unreferenced beta stages as placeable names.
     pub include_beta: bool,
+    /// Enemy slots to overwrite outright. Applied last, so they win over the
+    /// randomizer's own choices on a `--randomize` base.
+    pub set_enemies: Vec<EnemyOverride>,
 }
 
 /// Result of a build: the ROM bytes plus a human-readable account of what was
@@ -377,8 +395,14 @@ fn source_catalog(vanilla: &[u8], include_beta: bool) -> Result<Vec<EntryView>, 
 }
 
 /// Resolve a level name to the data that travels with it when placed.
+///
+/// `UNLISTED_LEVELS` is checked first: those levels have no pointer table entry
+/// for the catalog to have classified, so they can only be resolved by name.
 fn resolve(catalog: &[EntryView], name: &str) -> Result<LevelEntry, String> {
     let want = norm(name);
+    if let Some((_, entry)) = rom_data::UNLISTED_LEVELS.iter().find(|(n, _)| norm(n) == want) {
+        return Ok(entry.clone());
+    }
     let hit = catalog
         .iter()
         .find(|e| norm(&e.name) == want)
@@ -726,6 +750,33 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
         }
     }
 
+    // 8. Hand-set enemy slots. Last of all, so they survive everything above.
+    for ov in &spec.set_enemies {
+        let seg = rom_data::enemy_ptr_to_file_offset(ov.enemy_ptr);
+        // Walk the segment the way the engine does — page byte, then 3-byte
+        // entries to the 0xFF terminator — so a slot past the end is an error
+        // rather than a silent write into the next room's data.
+        let off = seg + 1 + ov.slot * 3;
+        let mut probe = seg + 1;
+        let mut len = 0usize;
+        while rom.read_range(probe, 1)[0] != 0xFF {
+            len += 1;
+            probe += 3;
+        }
+        if ov.slot >= len {
+            return Err(format!(
+                "segment ${:04X} has {len} enemy slot(s); slot {} is past the end",
+                ov.enemy_ptr, ov.slot
+            ));
+        }
+        let was = rom.read_range(off, 1)[0];
+        rom.write_byte(off, ov.id);
+        report.push(format!(
+            "enemy ${:04X}[{}] @ 0x{off:05X}: {was:#04X} -> {:#04X}",
+            ov.enemy_ptr, ov.slot, ov.id
+        ));
+    }
+
     Ok(TestRom { bytes: rom.output_bytes().to_vec(), report })
 }
 
@@ -736,6 +787,11 @@ pub fn list_levels(vanilla: &[u8], include_beta: bool) -> Result<Vec<String>, St
         .iter()
         .filter(|e| e.level_entry.is_some())
         .map(|e| format!("{:<8} {}", e.name, e.kind_label))
+        .chain(
+            rom_data::UNLISTED_LEVELS
+                .iter()
+                .map(|(n, _)| format!("{n:<8} unlisted (no pointer table entry)")),
+        )
         .collect())
 }
 
@@ -766,6 +822,7 @@ mod tests {
             hammer_breaks_locks: false,
             hammer_breaks_bridges: false,
             include_beta: false,
+            set_enemies: Vec::new(),
         }
     }
 
@@ -803,6 +860,38 @@ mod tests {
             .find(|(num, _)| *num == 1)
             .expect("W1 has a tile 1");
         assert_eq!(rom_data::read_entry(&out, &WORLDS[0], slot.1), want);
+    }
+
+    /// The Coin Ship has no world pointer table entry, so the catalog cannot
+    /// name it — `resolve` has to reach it through `UNLISTED_LEVELS`. Placing it
+    /// must write the exact triple `MO_CoinShip` sets up: tileset 10, objects
+    /// `$DA04`, layout `$BC15`.
+    #[test]
+    fn coin_ship_places_the_triple_mo_coinship_loads() {
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+
+        let built = build(
+            &van,
+            &TestRomSpec {
+                placements: vec![Placement { level: "coinship".into(), slot: Some(1) }],
+                world: Some(1),
+                ..spec()
+            },
+        )
+        .unwrap();
+
+        let out = Rom::from_bytes_lax(&built.bytes, true).unwrap();
+        let slot = numbered_slots(&out, 0, false)
+            .into_iter()
+            .find(|(num, _)| *num == 1)
+            .expect("W1 has a tile 1");
+        let got = rom_data::read_entry(&out, &WORLDS[0], slot.1);
+        assert_eq!(got.tileset, 10);
+        assert_eq!((got.obj_hi, got.obj_lo), (0xDA, 0x04));
+        assert_eq!((got.lay_hi, got.lay_lo), (0xBC, 0x15));
     }
 
     /// Regression: map grids are screen-major, so a row-major offset walks off

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -93,12 +93,33 @@ fn sweep_is_deterministic() {
 /// places that carry the flag bytes on purpose — the stamp block at 0x19DF0 and
 /// the title-screen verification icons at `FS_SEED_HASH_DATA` (0x3E93D), whose
 /// hash folds `to_flag_bytes()`. No overworld, level, or enemy byte moved.
+/// Re-captured 2026-08-17 for the treasure-box room rules, backported from
+/// beta/next (PR #179). Two changes, both deliberate:
+///
+/// 1. A `$81` in a `Level_Event = 7` room that is not a real bro battle is
+///    rewritten by `ObjInit_HammerBro` into an unkillable object, so it is now
+///    excluded from every such room (`rewrites_hammer_bro`).
+/// 2. Those rooms are cleared to be left, so they take the bro-fight pool: the
+///    8-Tank treasure room joins the Coin Ship as a `HammerBro` segment, and
+///    Dry Bones moved from `STOMPABLE_ENEMIES` to `HB_NEEDS_SHELL_ENEMIES` (it
+///    is stompable but revives, so only a kicked shell clears it).
+///
+/// All 20 seeds move, attributed rather than assumed. Diffing every seed
+/// against the previous build at default flags: 132 enemy IDs differ, and the
+/// only one in a treasure-box room is `0x0DA3A` (the 8-Tank slot) in 13 of 20
+/// seeds — always landing on vanilla `$82`. That is the whole story: with
+/// `hb_encounters` Off, `hb_modes` is all-Off, so routing that room through the
+/// HB path means its single entry no longer draws where the old `ForceTankBro`
+/// row drew once. One fewer draw per seed, and every downstream consumer moves.
+/// The pool changes themselves only bite with `hb_encounters` on, which this
+/// sweep does not exercise — `treasure_box_rooms_never_get_a_hammer_bro` and the
+/// shell-pairing invariant in `enemies::tests` cover that instead.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xBB2A7CBF02AF4BBA, 0x761607361C034EDA, 0xC4E3267B24430DB5, 0x871D2AEE7C896AB6,
-    0xF27E5B34E1EEABDD, 0x9D9F280937717403, 0xE879479EEA8398FF, 0x2991D7B20C48097E,
-    0xEFF71177664A5822, 0x4EF2AB92BC810522, 0xD188D3A10F375DB5, 0x833E8EFC349D2154,
-    0x280B67E04F3F5F87, 0xCD041C077C531F96, 0x675C1986FEEDE464, 0x3286199B722396FA,
-    0xD108207D0F8A21EC, 0x13D64C84EB019B01, 0x6C77A703B2285A5A, 0x437324880DC9D14B,
+    0xEB1D086CF43E7E7F, 0x02E4DCE7E42B348A, 0xBAD8F096C16A1FEA, 0x36405B1BFFD1AD19,
+    0x87BD1EDE71B1EFDF, 0xB6C1D95A38B58750, 0x9193EE881B115CAB, 0x41DAC2C522E79CD4,
+    0x5F6C6417F4F92282, 0x9FF56031107CC744, 0x13510D9E5ED3A92D, 0xEE591E82C9467E9D,
+    0xB6E5A619BA25A237, 0xE9A3A423A47A7BFC, 0xCD0F15909326141E, 0x5F810FF18B7A1BCF,
+    0x6670AC3A7560C08A, 0xE03981FCBD7F7D71, 0xF52170A75443F148, 0xF0509D50AC9D91D1,
 ];
 
 #[test]


### PR DESCRIPTION
Backport of #179 onto `release/1.1.1`, so the fix ships in 1.1.1 rather than waiting for the next release. Targets `release/1.1.1`, so it lands in #171.

## Why backport

The Coin Ship's reward fight can be dealt an enemy that cannot be killed. The room only opens once it is empty, so the player is stranded with no exit. This is live in the current deploy — it was hit in play on `main`'s build.

## What came across

Both commits from #179 cherry-picked. **All nine source files applied cleanly**; only two files needed a hand, and neither is logic:

- **`CHANGELOG.md`** — entries go into the existing `[1.1.1]` section rather than `[Unreleased]`, since that is the release they ship in. The world-length and title-mute entries from `beta/next` are deliberately **not** carried over — they belong to a later release.
- **`tests/overworld_baseline.rs`** — `release/1.1.1` predates the C1-floor work, so its hashes are its own and `beta/next`'s cannot be carried across. Recaptured against this branch.

## Baseline attribution

All 20 seeds move. Attributed rather than assumed — diffing every seed against `aee85af` at default flags:

- 132 enemy IDs differ; **the only one in a treasure-box room is `0x0DA3A`** (the 8-Tank slot), in 13 of 20 seeds, and it always lands on vanilla `$82`.
- That is the whole story: with `hb_encounters` Off, `hb_modes` is all-Off, so routing that room through the HB path means its single entry no longer draws where the old `ForceTankBro` row drew once. One fewer draw per seed, and every downstream consumer moves.

The pool changes themselves only bite with `hb_encounters` on, which this sweep does not exercise; `treasure_box_rooms_never_get_a_hammer_bro` and the shell-pairing invariant cover that instead.

## Seed compatibility — worth a decision

**This changes generated output for every seed.** Flag keys stay valid (no new options, no key version bump), but a given seed + flag key produces a different ROM than the current deploy does. Anyone racing a published seed from 1.1.0 would get a different game.

That trade is the point of the backport — the current build can hand a player an unwinnable room — but it is your call whether it belongs in 1.1.1 or in the next release, which breaks seeds anyway.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --lib --target wasm32-unknown-unknown -- -D warnings` — clean (this is the gate that failed on #179; run explicitly here)
- `cargo test` — 378 lib + 7 integration, 0 failures

Full mechanism, the `BattleEnemy_ByEnterID` overrun table, and the reasoning behind each rule are in #179 and in `docs/smb3_rom_reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)