### PR TITLE
fix: run CI on pull requests into release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,17 @@ on:
     # beta/next -> /beta/. No other branch can touch the deployed site.
     branches: [main, 'beta/next']
   pull_request:
-    # Run CI for feature PRs into beta/next as well as PRs into main.
-    branches: [main, 'beta/next']
+    # Run CI for feature PRs into beta/next as well as PRs into main, and for
+    # backports into a release branch — without this a bad backport is not
+    # caught until the release PR itself runs, which is after it has already
+    # landed on the release branch.
+    #
+    # Safe to widen here but NOT in `push` above: `build` and `deploy` are both
+    # gated on `github.event_name == 'push'`, so a pull_request event can only
+    # ever reach the `ci` job. (`version-guard` gates on
+    # `github.base_ref == 'main'`, so it stays off backport PRs — the version
+    # bump belongs to the release PR, not to each backport into it.)
+    branches: [main, 'beta/next', 'release/**']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
A backport into a release branch got **no checks at all**. The `pull_request` trigger listed only `main` and `beta/next`, so nothing ran until the release PR itself — by which point the commits were already sitting on the release branch. #180 merged into `release/1.1.1` with no status of any kind.

```diff
   pull_request:
-    branches: [main, 'beta/next']
+    branches: [main, 'beta/next', 'release/**']
```

## Why only the `pull_request` list

The `push` list is deliberately untouched. `build` and `deploy` are both gated on `github.event_name == 'push'` (lines 100-102 and 236-238), so a `pull_request` event can only ever reach the `ci` job — lint and tests, no deploy, by construction.

Adding `release/**` to `push` would start a deploy, and that deploy would not even publish the release branch: the build job checks out `main` and `beta/next` explicitly, whatever ref triggered the run. So it would be pointless churn that also contends for the Pages deployment, whose concurrency group is keyed on `github.event_name`. The reasoning is in a comment on the trigger so the next person doesn't have to re-derive it.

## `version-guard` needs no change

It gates on `github.base_ref == 'main'`, so it stays off backport PRs. That is correct — the version bump belongs to the release PR, not to each backport into it.

## Verification

`yq` reparses the file, `push` is byte-identical, and this PR itself exercises the edited workflow (base is `beta/next`, which is in the trigger list).

Found while backporting #179 to `release/1.1.1` as #180.