### PR TITLE
feature: deal W8's bridges-out count per seed instead of ranking it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,6 @@ deploys.
 
 ## [Unreleased]
 
-### Changed
-
-- **World 8's bridges to Bowser's castle now vary.** How many of the five
-  spans are out is rolled per seed — usually one or two, sometimes three,
-  occasionally none at all, and about one seed in five thousand takes out
-  four. Which spans go is drawn fresh each time. Previously it was almost
-  always exactly one, and almost always the same one: the third span won the
-  builder's ranking by a single tile every seed, and once it was taken the
-  others had nothing left to gate.
-
 ## [1.2.0] - 2026-08-22
 
 ### Added
@@ -48,6 +38,14 @@ deploys.
   sequence's own graphics.
 
 ### Changed
+
+- **World 8's bridges to Bowser's castle now vary.** How many of the five
+  spans are out is rolled per seed — usually one or two, sometimes three,
+  occasionally none at all, and about one seed in five thousand takes out
+  four. Which spans go is drawn fresh each time. Previously it was almost
+  always exactly one, and almost always the same one: the third span won the
+  builder's ranking by a single tile every seed, and once it was taken the
+  others had nothing left to gate.
 
 - **World length varies more between worlds.** Every world used to guarantee
   the same minimum amount of play before its goal, which made the cheapest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ deploys.
 
 ## [Unreleased]
 
+### Changed
+
+- **World 8's bridges to Bowser's castle now vary.** How many of the five
+  spans are out is rolled per seed — usually one or two, sometimes three,
+  occasionally none at all, and about one seed in five thousand takes out
+  four. Which spans go is drawn fresh each time. Previously it was almost
+  always exactly one, and almost always the same one: the third span won the
+  builder's ranking by a single tile every seed, and once it was taken the
+  others had nothing left to gate.
+
 ## [1.2.0] - 2026-08-22
 
 ### Added

--- a/docs/choice_first_charter.md
+++ b/docs/choice_first_charter.md
@@ -621,3 +621,57 @@ CENSUS_SEEDS=100 cargo test --release --lib test_required_progression -- --ignor
   (Python classified, Rust scored) that was validated against vanilla
   (routes `[1, 3, 2, 2, 4, 12, 2, 1]`, identical both ways) and then deleted.
   Redoing this needs that bridge again, or an obj_ptr-based catalog mode.
+
+## The W8 bridge row — dealt, not ranked (2026-08-20)
+
+The five spans on W8 screen 3 (`qol::overworld_map::W8_BRIDGE_COLS`, row 5,
+cols 51/53/55/57/59) are the approach to Bowser's castle: a chain of spans and
+nodes over water, entered only where the seed's pipe web touches it. A lock
+landing on one shows as a water gap its fortress rebuilds — a "bridge out".
+
+**Marginal cut cannot produce a distribution there.** Measured at HEAD before
+the change (600 seeds), the count was 1 in 62% of seeds and 4 in none of them,
+and the span was col 55 in 78% of the seeds that had one. Both follow from the
+ranking rather than from the map: on a chain, one span always wins the cut
+(col 55 by exactly one node, every seed), and once its cut is claimed the rest
+score zero MARGINAL cut and lose to fresh territory anywhere else in the world.
+
+So the count is rolled (`capacity::BRIDGES_OUT_WEIGHTS`) and the spans dealt
+(`locks::deal_bridge_spans`), with the row excluded from `lock_candidates` so
+the ranker cannot add a span the deal did not ask for. Owner's call on the
+shape (2026-08-20): 3% / 45% / 40% / 11.98% / 0.02% for 0-4 out. The ceiling
+of 4 is not chosen — it is W8's fort roster, since every gap needs a fortress
+to restore it.
+
+**Cost per count** (600 seeds per pinned arm via `BRIDGES_OUT=n`, W8 only):
+
+| out | C1 | routes | linear% |
+|---|---|---|---|
+| 0 | 20.66 | 1.56 | 53.3% |
+| 1 | 25.58 | 2.23 | 4.0% |
+| 2 | 27.67 | 2.30 | 4.0% |
+| 3 | 29.58 | 2.38 | 2.8% |
+| 4 | 30.86 | 2.43 | 4.0% |
+
+More spans out is **cheaper**, not dearer: each one drags another fortress onto
+the mandatory path, which raises C1 and pulls more alternatives into the choice
+band. The one arm that costs anything is 0 — an intact row leaves W8 with no
+gate anywhere on its own approach — which is why it is the thin one.
+
+**Why the draw leads with a gating span.** A flat draw over all five was
+measured and rejected: cols 51/53 sever the goal in only ~20% of seeds (it
+depends where the web enters the chain, which is why it cannot be decided from
+the terrain alone), so a single span drawn flat landed decorative a third of
+the time and took W8 linear from 4.0% to 16.3%. The first span is now drawn
+from the spans that actually sever the approach on this seed's web; the extras
+stay flat. That holds the 1-out arm at the baseline 4.0% while cutting the
+same-span rate from 78% to 33%.
+
+Net, `test_route_census` at 1000 seeds: W8 mean routes 2.27 → 2.25 (linear
+4% → 5%), overall 2.548 → 2.537 (linear 6.60% → 6.91%), nothing below its own
+dealt floor either way. Reproduce with:
+
+```sh
+CENSUS_SEEDS=3000 cargo test --release --lib w8_bridges_out -- --ignored --nocapture
+BRIDGES_OUT=3 CENSUS_SEEDS=600 cargo test --release --lib w8_bridges_out -- --ignored --nocapture
+```

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -63,6 +63,11 @@ struct CensusCtx {
     level_counts: [usize; 8],
     fort_counts: [usize; 8],
     c1_floors: [u32; 8],
+    /// W8's bridges-out count, rolled the way `build` rolls it — right after
+    /// `allot_budgets`, off the same stream. Without this every census here
+    /// would silently measure a W8 pinned to the 0-span arm, which is the one
+    /// arm that behaves differently from the rest (53% linear).
+    bridges_out: usize,
 }
 
 fn census_ctx(raw: &Rom, seed: u64) -> CensusCtx {
@@ -93,6 +98,7 @@ fn census_ctx(raw: &Rom, seed: u64) -> CensusCtx {
     };
     let (level_counts, fort_counts, c1_floors) =
         allot_budgets(&rom, &catalog, &pickup, &flags, &mut roll_rng);
+    let bridges_out = roll_bridges_out(&mut roll_rng);
     CensusCtx {
         rom,
         catalog,
@@ -101,6 +107,7 @@ fn census_ctx(raw: &Rom, seed: u64) -> CensusCtx {
         level_counts,
         fort_counts,
         c1_floors,
+        bridges_out,
     }
 }
 
@@ -111,6 +118,9 @@ impl CensusCtx {
         state.level_budget = self.level_counts[world_idx];
         state.fort_budget = self.fort_counts[world_idx];
         state.c1_floor = self.c1_floors[world_idx];
+        if world_idx == rom_data::W8_IDX {
+            state.bridges_out = self.bridges_out;
+        }
         state
     }
 }
@@ -149,6 +159,8 @@ fn test_builder_schedule_runs_phases_in_order() {
         fort_budget: 0,
         c1_floor: C1_FLOOR,
         ptr_slots: 0,
+        bridges_out: 0,
+        bridge_spans: Vec::new(),
         hb_sprite_pins: Vec::new(),
         log: Vec::new(),
     };

--- a/src/randomize/overworld_build/capacity.rs
+++ b/src/randomize/overworld_build/capacity.rs
@@ -487,6 +487,64 @@ pub(crate) fn redistribute_fortresses<R: Rng>(rng: &mut R) -> [usize; 8] {
     counts
 }
 
+/// Per-seed weights for how many of W8's four locks land on the bridge
+/// approach to Bowser's castle — the "bridges out" count, indexed 0..=4 and
+/// summing to 10000.
+///
+/// A bridge out is a lock like any other, so the ceiling is W8's fort roster
+/// (always 4, see [`redistribute_fortresses`]) and each extra one drags
+/// another fortress onto the mandatory path: 3 out means three forts must
+/// fall before the corridor is walkable. 4 is the jackpot and stays at one
+/// seed in 5000 — an owner call about how a fully serialized endgame feels,
+/// not a quality budget.
+///
+/// Left to itself the marginal-cut ranking deals 1 nearly always (measured
+/// 62%, and 79% of those on the same span — the third span wins the cut by a
+/// single node every seed), and 4 never: once the first span's cut is claimed
+/// the rest score zero MARGINAL cut and lose to fresh territory. The count is
+/// dealt rather than ranked for exactly that reason.
+///
+/// The shape is measured, not guessed (600 seeds per pinned arm, W8 only):
+///
+/// ```text
+///   out   C1      routes   linear
+///   0     20.66   1.56     53.3%
+///   1     25.58   2.23      4.0%
+///   2     27.67   2.30      4.0%
+///   3     29.58   2.38      2.8%
+///   4     30.86   2.43      4.0%
+/// ```
+///
+/// More spans out is CHEAPER, not dearer: the forts they add to the
+/// mandatory path raise C1 and pull more alternatives into the choice band.
+/// The one arm that costs anything is 0 — an intact row leaves W8 with no
+/// gate anywhere on its own approach — so that is the thin one, and the
+/// weight it gave up went to 3.
+pub(super) const BRIDGES_OUT_WEIGHTS: [u32; 5] = [300, 4500, 4000, 1198, 2];
+
+/// Roll the per-seed W8 bridges-out count from [`BRIDGES_OUT_WEIGHTS`].
+pub(crate) fn roll_bridges_out<R: Rng>(rng: &mut R) -> usize {
+    // Census arm: `BRIDGES_OUT=n` pins the count so the cost of each value
+    // can be measured on its own (see `w8_bridges_out_census`), instead of
+    // being read off a distribution where 4 is one seed in 5000. Test-only —
+    // never reaches the CLI or WASM.
+    #[cfg(test)]
+    if let Ok(n) = std::env::var("BRIDGES_OUT")
+        && let Ok(n) = n.parse::<usize>()
+    {
+        return n;
+    }
+    let total: u32 = BRIDGES_OUT_WEIGHTS.iter().sum();
+    let mut roll = rng.random_range(..total);
+    for (n, &w) in BRIDGES_OUT_WEIGHTS.iter().enumerate() {
+        if roll < w {
+            return n;
+        }
+        roll -= w;
+    }
+    0
+}
+
 /// Largest number of Hammer Bro sprites placed in a single world.
 pub(super) const MAX_HB_PER_WORLD: usize = 3;
 

--- a/src/randomize/overworld_build/locks.rs
+++ b/src/randomize/overworld_build/locks.rs
@@ -11,6 +11,14 @@
 //! corridor scores only the slice between, and loses to fresh territory.
 //! The first candidate that keeps the world completable wins.
 //!
+//! One row is dealt rather than ranked: the five spans of the W8 bridge
+//! approach to Bowser's castle ([`deal_bridge_spans`], weights in
+//! [`capacity::BRIDGES_OUT_WEIGHTS`]). Marginal cut cannot produce a
+//! distribution there — the corridor is a chain, so one span wins the cut
+//! every seed and the rest score zero marginal once it is claimed, which is
+//! why the count sat at 1 and the same span was out 79% of the time. Every
+//! other bridge on the map, W1 and W4-W6 included, is still ranked.
+//!
 //! Hard invariants (true safety, per the charter):
 //!
 //! - **ORDER-FREE completability** (`WorldState::completable`): close every
@@ -33,6 +41,7 @@
 
 use super::*;
 
+use crate::randomize::qol::{W8_BRIDGE_COLS, W8_BRIDGE_ROW};
 use rand::seq::SliceRandom;
 
 pub(crate) struct Locks;
@@ -56,8 +65,18 @@ impl Phase for Locks {
         stamp_slots(&mut open, &state.slots);
         let open_reach = walk_reachable(&open, &state.pipe_pairs, state.start, state.world_idx);
         let mut covered: HashSet<Pos> = HashSet::new();
+        state.bridge_spans = deal_bridge_spans(state, &open, &open_reach, rng);
+        let mut pending = state.bridge_spans.clone();
 
         for fort_id in fort_ids {
+            if let Some(cut) =
+                claim_bridge_span(state, &open, &open_reach, &mut pending, fort_id)
+            {
+                let pos = state.locks.last().expect("just pushed").pos;
+                actions.push(format!("lock for fort {fort_id} at {pos:?} (dealt bridge)"));
+                covered.extend(cut);
+                continue;
+            }
             let candidates = rank_candidates(state, &open, &open_reach, &covered, rng);
 
             let mut placed = false;
@@ -151,6 +170,11 @@ pub(crate) fn ensure_secret_exit_safe(
         let open_reach = walk_reachable(&open, &state.pipe_pairs, state.start, state.world_idx);
         let mut lock_indices: Vec<usize> = (0..state.locks.len()).collect();
         lock_indices.shuffle(rng);
+        // Stable sort: dealt bridge locks last. Relocating one costs the seed
+        // a bridge (the ranked candidates below exclude the row), so it is the
+        // last lock to disturb — but never a forbidden one, because a world
+        // with no safe lock anywhere is the harder failure.
+        lock_indices.sort_by_key(|&li| is_bridge_span(state, state.locks[li].pos));
         for li in lock_indices {
             let original = state.locks[li].clone();
             // Marginal ranking against the OTHER locks' cuts — the
@@ -245,10 +269,18 @@ pub(crate) fn place_locks_gating(
         .map(|s| s.section)
         .collect();
     fort_ids.shuffle(rng);
+    let mut pending = state.bridge_spans.clone();
 
     let mut covered: HashSet<Pos> = HashSet::new();
     let mut goal_gated = false;
     for fort_id in fort_ids {
+        // The dealt spans come first and are not negotiable — every shaping
+        // rung that re-places locks routes through here, so skipping the deal
+        // would let the ladder quietly undo the seed's bridge count.
+        if let Some(cut) = claim_bridge_span(state, &open, &open_reach, &mut pending, fort_id) {
+            covered.extend(cut);
+            continue;
+        }
         // Ranked candidates carry their cut sets, so pass admission reads
         // straight off them (no per-candidate walk here).
         let candidates = rank_candidates(state, &open, &open_reach, &covered, rng);
@@ -296,6 +328,105 @@ pub(crate) fn place_locks_gating(
 /// vanilla's natural lock sites (the drawbridge). Used as the TIEBREAK in
 /// candidate ranking: among equal marginal cuts, the bridge wins the look.
 const BRIDGE_TILES: [u8; 3] = [0xB3, 0xB1, 0xB2];
+
+/// Is `pos` one of the five spans on the W8 bridge approach to Bowser's
+/// castle — the row whose out-count is dealt per seed rather than ranked?
+/// False in every other world: W1 and W4-W6 have vanilla bridges too, and
+/// those stay ordinary lock sites that earn their place on marginal cut.
+fn is_bridge_span(state: &WorldState, pos: Pos) -> bool {
+    state.world_idx == rom_data::W8_IDX
+        && pos.0 == W8_BRIDGE_ROW
+        && W8_BRIDGE_COLS.contains(&pos.1)
+}
+
+/// The spans still available to the deal: on the bridge row, still a bridge
+/// tile, and not already locked.
+fn free_bridge_spans(state: &WorldState) -> Vec<Pos> {
+    if state.world_idx != rom_data::W8_IDX {
+        return Vec::new();
+    }
+    let locked: HashSet<Pos> = state.locks.iter().map(|l| l.pos).collect();
+    W8_BRIDGE_COLS
+        .iter()
+        .map(|&c| (W8_BRIDGE_ROW, c))
+        .filter(|&p| state.grid.get(p.0, p.1) == rom_data::BRIDGE_TILE && !locked.contains(&p))
+        .collect()
+}
+
+/// Draw this world's [`WorldState::bridges_out`] spans: uniform, except that
+/// the FIRST one leads with a span that actually severs the approach on this
+/// seed's web.
+///
+/// Uniform alone was measured and rejected (600 seeds/arm): the corridor is a
+/// chain entered by pipe, so which spans gate depends on where the web enters
+/// it — cols 51/53 sever the goal in only ~20% of seeds. A single span drawn
+/// flat lands on a decorative one a third of the time, leaving W8 with no
+/// gate at all on its own approach: linear 4.0% -> 16.3%. Leading with a
+/// gating span keeps the count and the five-way variety while the corridor
+/// still means something; the extras stay flat, so a decoy span is a thing
+/// that HAPPENS to a multi-span seed rather than something dealt on purpose.
+fn deal_bridge_spans(
+    state: &WorldState,
+    open: &Grid,
+    open_reach: &Reach,
+    rng: &mut dyn RngCore,
+) -> Vec<Pos> {
+    let mut spans = free_bridge_spans(state);
+    if state.bridges_out == 0 || spans.is_empty() {
+        return Vec::new();
+    }
+    spans.shuffle(rng);
+    if let Some(target) = state.target
+        && let Some(i) = spans.iter().position(|&pos| {
+            cut_set(
+                open, open_reach, &state.pipe_pairs, state.start, state.world_idx, pos,
+                state.grid.get(pos.0, pos.1),
+            )
+            .contains(&target)
+        })
+    {
+        spans.swap(0, i);
+    }
+    spans.truncate(state.bridges_out);
+    spans
+}
+
+/// Give `fort_id` the first of `pending` it can take, returning that span's
+/// cut set (for the ranker's `covered`). Every span is tried, not just the
+/// head: a span whose owner would end up sealed behind it is fine for a
+/// different fortress, and the alternative — pairing by position and giving
+/// up on the first miss — loses spans the world could have carried.
+///
+/// `None` means no pending span works for this fortress; the caller falls
+/// back to the ranked candidates and the world ships one span under the
+/// deal. Forcing it anyway would be an unplayable world.
+fn claim_bridge_span(
+    state: &mut WorldState,
+    open: &Grid,
+    open_reach: &Reach,
+    pending: &mut Vec<Pos>,
+    fort_id: usize,
+) -> Option<HashSet<Pos>> {
+    for (i, &pos) in pending.iter().enumerate() {
+        let tile = state.grid.get(pos.0, pos.1);
+        state.locks.push(LockAssignment {
+            pos,
+            gap_tile: gap_tile_for(tile),
+            replace_tile: tile,
+            fort_section: fort_id,
+            secret_exit_safe: false,
+        });
+        if state.completable() {
+            let cut = cut_set(
+                open, open_reach, &state.pipe_pairs, state.start, state.world_idx, pos, tile,
+            );
+            pending.remove(i);
+            return Some(cut);
+        }
+        state.locks.pop();
+    }
+    None
+}
 
 /// Positions severed when `pos` alone is closed on the all-open world:
 /// reachable normally, unreachable with the gap. The measure of what a
@@ -362,12 +493,19 @@ fn rank_candidates(
 fn lock_candidates(state: &WorldState) -> Vec<(Pos, u8)> {
     let locked: HashSet<Pos> = state.locks.iter().map(|l| l.pos).collect();
     let content: HashSet<Pos> = state.slots.iter().map(|s| s.pos).collect();
+    // The W8 bridge approach is dealt, never ranked. Excluding it here is what
+    // pins the count to the roll from both ends: a seed that rolled 0 keeps
+    // the row intact, and a seed that rolled 2 cannot pick up a third span
+    // because the ranker happened to like it.
     let mut out = Vec::new();
     for r in 0..state.grid.rows() {
         for c in 0..state.grid.cols {
             let pos = (r, c);
             let tile = state.grid.get(r, c);
-            if !LOCKABLE_TILES.contains(&tile) || locked.contains(&pos) {
+            if !LOCKABLE_TILES.contains(&tile)
+                || locked.contains(&pos)
+                || is_bridge_span(state, pos)
+            {
                 continue;
             }
             if let Some(partner) = row78_partner(pos)

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -163,7 +163,7 @@ pub(crate) use progression::{
     hammer_skip, island_count, level_adjacency_pairs, start_goal_express_pipe,
 };
 #[cfg(test)]
-pub(crate) use capacity::C1_FLOOR_BAND;
+pub(crate) use capacity::{C1_FLOOR_BAND, roll_bridges_out};
 #[cfg(test)]
 pub(crate) use route_choice::dump_route_choice;
 #[cfg(test)]
@@ -235,6 +235,7 @@ pub(crate) fn run_shaped_with_web_retries(state: &mut WorldState, rng: &mut dyn 
         state.pickup_pipes();
         run_schedule(state, &[&Connectivity, &Locks, &Shaping, &SparePipes], rng);
     }
+
 }
 
 /// Execute Phase 3: build slot assignments for all 8 worlds.
@@ -250,6 +251,11 @@ pub(crate) fn build<R: Rng>(
     let (level_counts, fort_counts, c1_floors) =
         allot_budgets(rom, data.catalog, data.pickup, &flags, rng);
 
+    // How many of W8's four locks land on the bridge approach to Bowser's
+    // castle. Rolled here with the other per-seed budgets, because that is
+    // what it is: a lock budget for one row.
+    let bridges_out = capacity::roll_bridges_out(rng);
+
     let mut states: Vec<WorldState> = (0..8)
         .map(|wi| {
             let mut state = from_pickup(rom, data.catalog, data.pickup, wi, &flags);
@@ -259,6 +265,7 @@ pub(crate) fn build<R: Rng>(
             state
         })
         .collect();
+    states[rom_data::W8_IDX].bridges_out = bridges_out;
 
     for state in &mut states {
         run_shaped_with_web_retries(state, rng);

--- a/src/randomize/overworld_build/sources.rs
+++ b/src/randomize/overworld_build/sources.rs
@@ -73,6 +73,8 @@ pub(crate) fn from_built(built: &BuiltWorld) -> WorldState {
             .count(),
         c1_floor: C1_FLOOR,
         ptr_slots: 0,
+        bridges_out: 0,
+        bridge_spans: Vec::new(),
         hb_sprite_pins: Vec::new(),
         log: Vec::new(),
     }
@@ -155,6 +157,8 @@ pub(crate) fn from_pickup(
         fort_budget,
         c1_floor: C1_FLOOR,
         ptr_slots: pickup.worlds[world_idx].pool_indices.len(),
+        bridges_out: 0,
+        bridge_spans: Vec::new(),
         hb_sprite_pins,
         log: Vec::new(),
     }
@@ -206,6 +210,8 @@ pub(crate) fn from_vanilla(rom: &Rom, catalog: &NodeCatalog, world_idx: usize) -
         fort_budget,
         c1_floor: C1_FLOOR,
         ptr_slots: 0,
+        bridges_out: 0,
+        bridge_spans: Vec::new(),
         hb_sprite_pins: Vec::new(),
         log: Vec::new(),
     }

--- a/src/randomize/overworld_build/state.rs
+++ b/src/randomize/overworld_build/state.rs
@@ -55,6 +55,24 @@ pub(crate) struct WorldState {
     /// Every slot — level, fort, hammer bro, pipe endpoint — consumes one;
     /// the hammer-bro fill phase caps itself against this.
     pub ptr_slots: usize,
+    /// How many spans of the W8 bridge approach to Bowser's castle this seed
+    /// wants gapped out, rolled by `capacity::roll_bridges_out`. Always 0
+    /// outside W8: the deal is scoped to that one row, and the vanilla
+    /// bridges in W1 and W4-W6 stay ordinary lock sites ranked on their
+    /// merits.
+    pub bridges_out: usize,
+    /// Which spans, drawn by `locks::deal_bridge_spans` in the [`Locks`]
+    /// phase — after connectivity, because whether a span gates anything
+    /// depends on where this seed's pipes enter the corridor.
+    ///
+    /// Held on the state, not re-drawn, because every shaping rung that
+    /// re-places locks re-enters `place_locks_gating`. Drawing there would
+    /// let the ladder's accept test pick WHICH bridge is out — it accepts on
+    /// falling zero-gate, so it kept the spans that gate and discarded the
+    /// ones the web left decorative (measured: 55/57/59 drawn twice as often
+    /// as 51/53). A pipe-web redeal re-enters [`Locks`] and does draw again,
+    /// which is right: the new web moves where the corridor is entered.
+    pub bridge_spans: Vec<Pos>,
     /// Vanilla wandering-sprite positions that MUST become HammerBro slots
     /// (a sprite starts there and can be encountered immediately, so the
     /// tile needs a pointer entry). Empty when hammer-bro shuffle is on —
@@ -245,6 +263,7 @@ impl WorldState {
             slots: self.slots.clone(),
             locks: self.locks.clone(),
             pipe_pairs: self.pipe_pairs.clone(),
+            bridge_spans: self.bridge_spans.clone(),
         }
     }
 
@@ -255,6 +274,7 @@ impl WorldState {
         self.slots = snap.slots.clone();
         self.locks = snap.locks.clone();
         self.pipe_pairs = snap.pipe_pairs.clone();
+        self.bridge_spans = snap.bridge_spans.clone();
     }
 
     /// Undo the most recent [`add_pipe_pair`](Self::add_pipe_pair): remove
@@ -310,6 +330,10 @@ pub(crate) struct WorldSnapshot {
     slots: Vec<SlotAssignment>,
     locks: Vec<LockAssignment>,
     pipe_pairs: Vec<TeleportEdge>,
+    /// Travels with the locks it explains: a web redeal draws fresh spans,
+    /// and keeping the winning attempt's locks beside a later attempt's
+    /// spans would leave the two disagreeing about which bridge is out.
+    bridge_spans: Vec<Pos>,
 }
 
 /// The cell sharing `pos`'s completion bit: (8,c) for (7,c) and vice versa.

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -176,6 +176,41 @@ fn census_build(rom: &Rom, seed: u64) -> BuildResult {
     )
 }
 
+/// The roll itself, independent of any world: every count is reachable and
+/// the shares track [`BRIDGES_OUT_WEIGHTS`]. The realized rate after
+/// placement is lower (a span a fort cannot take falls back to the ranked
+/// candidates) and is measured by `w8_bridges_out_census`, which needs the
+/// ROM; this one pins the deal at its source.
+#[test]
+fn test_bridges_out_roll() {
+    // `BRIDGES_OUT=n` pins the roll so a census can measure one arm; it also
+    // makes this test meaningless, and running the suite under it is the
+    // point of the arm (it stress-tests a whole game at that count).
+    if std::env::var("BRIDGES_OUT").is_ok() {
+        eprintln!("SKIP: BRIDGES_OUT pins the roll this test measures");
+        return;
+    }
+    let mut rng = ChaCha8Rng::seed_from_u64(7);
+    let draws = 200_000;
+    let mut hist = [0usize; 5];
+    for _ in 0..draws {
+        hist[capacity::roll_bridges_out(&mut rng)] += 1;
+    }
+    let total: u32 = capacity::BRIDGES_OUT_WEIGHTS.iter().sum();
+    for (n, &w) in capacity::BRIDGES_OUT_WEIGHTS.iter().enumerate() {
+        let want = w as f64 / total as f64;
+        let got = hist[n] as f64 / draws as f64;
+        // 4-out is 1 in 5000, so ~40 hits in 200k — a wide relative band on
+        // purpose. What is being pinned is "reachable and roughly right",
+        // not the fourth decimal.
+        assert!(
+            (got - want).abs() < want.max(0.001) * 0.35,
+            "bridges_out {n}: rolled {got:.5}, weights say {want:.5}",
+        );
+    }
+    assert!(hist[4] > 0, "4 out must be reachable, however rare");
+}
+
 #[test]
 fn test_fortress_redistribution() {
     let mut rng = ChaCha8Rng::seed_from_u64(42);
@@ -2054,4 +2089,109 @@ fn test_render_route_choice() {
         dump_route_choice(built, slack);
         eprintln!("{}", route_choice::render_route_choice(built, slack));
     }
+}
+
+/// W8 bridge-approach census: how many of the five spans to Bowser's castle
+/// are out, which ones, and what each count costs the world.
+///
+///   CENSUS_SEEDS=2000 cargo test --release --lib w8_bridges_out -- --ignored --nocapture
+///
+/// `BRIDGES_OUT=n` pins the count (see `capacity::roll_bridges_out`) so a
+/// single value's cost can be read on its own — the whole point of the arm,
+/// since 4-out is one seed in 5000 under the shipping weights and would never
+/// show up in a census otherwise.
+#[test]
+#[ignore]
+fn w8_bridges_out_census() {
+    let rom_bytes = match std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("ROM not found, skipping");
+            return;
+        }
+    };
+    let rom = Rom::from_bytes(&rom_bytes).unwrap();
+    let seeds: u64 = std::env::var("CENSUS_SEEDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(500);
+
+    let per_seed = par_seeds(seeds, |seed| {
+        let result = census_build(&rom, seed);
+        let w8 = result.worlds.iter().find(|w| w.world_idx == 7).unwrap();
+        let state = from_built(w8);
+        let rc = analyze_route_choice(w8, route_choice::DEFAULT_SLACK);
+        W8Sample {
+            spans: w8
+                .locks
+                .iter()
+                .filter(|l| l.replace_tile == rom_data::BRIDGE_TILE)
+                .map(|l| l.pos.1)
+                .collect(),
+            zero_gate: state.zero_gate_locks().len(),
+            safe: w8.locks.iter().filter(|l| l.secret_exit_safe).count(),
+            c1: rc.best_cost,
+            floor: w8.c1_floor,
+            routes: if rc.reachable { rc.routes.len() } else { 0 },
+        }
+    });
+
+    let mut count_hist = [0usize; 5];
+    let mut col_hist = std::collections::BTreeMap::<usize, usize>::new();
+    let mut zero_gate_hist = [0usize; 5];
+    let (mut c1_sum, mut routes_sum, mut linear, mut sub_floor) = (0u64, 0u64, 0usize, 0usize);
+    for s in &per_seed {
+        count_hist[s.spans.len().min(4)] += 1;
+        for c in &s.spans {
+            *col_hist.entry(*c).or_default() += 1;
+        }
+        zero_gate_hist[s.zero_gate.min(4)] += 1;
+        c1_sum += s.c1 as u64;
+        routes_sum += s.routes as u64;
+        if s.routes <= 1 {
+            linear += 1;
+        }
+        if s.c1 < s.floor {
+            sub_floor += 1;
+        }
+    }
+    let pct = |n: usize| 100.0 * n as f64 / seeds as f64;
+    println!("\nW8 bridges out over {seeds} seeds:");
+    for (n, &count) in count_hist.iter().enumerate() {
+        println!("  {n} out: {count:6} ({:6.2}%)", pct(count));
+    }
+    let spans: usize = col_hist.values().sum();
+    println!("  which span (uniform would be {:.0} each):", spans as f64 / 5.0);
+    for (col, count) in &col_hist {
+        println!("    col {col}: {count}");
+    }
+    println!(
+        "  C1 {:.2} (floor {:.2}, {:.2}% below), routes {:.2}, linear {:.2}%",
+        c1_sum as f64 / seeds as f64,
+        per_seed.iter().map(|s| s.floor as f64).sum::<f64>() / seeds as f64,
+        pct(sub_floor),
+        routes_sum as f64 / seeds as f64,
+        pct(linear),
+    );
+    println!("  zero-gate locks (0..4): {zero_gate_hist:?}");
+    let mut safe_hist = [0usize; 5];
+    for s in &per_seed {
+        safe_hist[s.safe.min(4)] += 1;
+    }
+    println!(
+        "  secret-exit-safe locks (0..4): {safe_hist:?}  ({:.2}% of seeds have none in W8)",
+        pct(safe_hist[0]),
+    );
+}
+
+struct W8Sample {
+    spans: Vec<usize>,
+    zero_gate: usize,
+    /// Locks that stay safe with the 1-F secret exit — the pool the writer
+    /// parks that level in. Reported because a heavily-gapped corridor is
+    /// exactly where a world could run out of them.
+    safe: usize,
+    c1: u32,
+    floor: u32,
+    routes: usize,
 }

--- a/src/randomize/qol/mod.rs
+++ b/src/randomize/qol/mod.rs
@@ -31,6 +31,7 @@ pub use overworld_map::{
     apply_w1_shortcut, apply_w8_bridges, apply_w8_canoe_and_paths, fix_w3_drawbridges,
     make_hammer_rocks, remove_n_cards, remove_rocks,
 };
+pub(crate) use overworld_map::{W8_BRIDGE_COLS, W8_BRIDGE_ROW};
 pub use starting_state::{set_starting_lives, write_starting_items};
 
 #[cfg(test)]

--- a/src/randomize/qol/overworld_map.rs
+++ b/src/randomize/qol/overworld_map.rs
@@ -1,7 +1,9 @@
 //! Overworld map tile edits: rocks, W8 canoe/bridges, drawbridges, N-cards.
 
 use crate::rom::Rom;
-use crate::randomize::rom_data::{FX_MAP_TILE_REPLACE, map_tile_offset, write_map_sprite};
+use crate::randomize::rom_data::{
+    BRIDGE_TILE, FX_MAP_TILE_REPLACE, map_tile_offset, write_map_sprite,
+};
 
 // W3 drawbridge map tile patches: (file offset, replacement tile).
 // Vanilla: 2× $B2 horizontal + 2× $B1 vertical. Replace with $B3
@@ -145,21 +147,32 @@ pub fn apply_w1_shortcut(rom: &mut Rom, breakable: bool) {
     rom.write_byte(map_tile_offset(0, stub_row, stub_col), stub);
 }
 
-/// W8 (Dark World) screen-3 water + bridge edits, always applied. The bridge
-/// tiles (`0xB3`) on the final page get gated as water gaps (`gap_tile_for`:
-/// `0xB3 -> 0x9D`) by the builder instead of locks. See [`apply_w8_bridges`].
-const W8_BRIDGE_EDITS: &[(usize, usize, u8)] = &[
-    // --- Screen 3: water (row 4) + bridges (row 5) on the final page ---
+/// W8 (Dark World) screen-3 water decor, always applied: the row above the
+/// bridge approach becomes open water so the corridor reads as a chain of
+/// spans rather than a solid path.
+const W8_WATER_EDITS: &[(usize, usize, u8)] = &[
     (4, 51, 0x99), (4, 52, 0xA2), (4, 53, 0x83), (4, 54, 0xA2), (4, 55, 0x83),
     (4, 56, 0xA2), (4, 57, 0x83), (4, 58, 0xA2), (4, 59, 0x9A),
-    (5, 51, 0xB3), (5, 53, 0xB3), (5, 55, 0xB3), (5, 57, 0xB3), (5, 59, 0xB3),
 ];
 
+/// The W8 bridge approach to Bowser's castle: five spans on screen 3, row 5,
+/// alternating with the nodes between them. Each is an ordinary lockable path
+/// tile, so a lock landing on one shows as a water gap (`gap_tile_for`:
+/// `0xB3 -> 0x9D`) that its fortress rebuilds — the "bridge out" the builder
+/// deals per seed (`overworld_build::locks`). Single source of truth: the
+/// builder reads these positions rather than repeating the coordinates.
+pub(crate) const W8_BRIDGE_ROW: usize = 5;
+pub(crate) const W8_BRIDGE_COLS: [usize; 5] = [51, 53, 55, 57, 59];
+
 /// Apply the always-on W8 screen-3 water + bridge approach (see
-/// [`W8_BRIDGE_EDITS`]). Independent of the `8s are Wild` option.
+/// [`W8_WATER_EDITS`] and [`W8_BRIDGE_COLS`]). Independent of the `8s are
+/// Wild` option.
 pub fn apply_w8_bridges(rom: &mut Rom) {
-    for &(row, col, tile) in W8_BRIDGE_EDITS {
+    for &(row, col, tile) in W8_WATER_EDITS {
         rom.write_byte(map_tile_offset(7, row, col), tile);
+    }
+    for col in W8_BRIDGE_COLS {
+        rom.write_byte(map_tile_offset(7, W8_BRIDGE_ROW, col), BRIDGE_TILE);
     }
     // Vanilla FX slot 16 sits at W8 (row 5, col 53) — right on our new bridge
     // row — and its replace_tile is 0x45 (plain path). The builder's pickup
@@ -167,7 +180,7 @@ pub fn apply_w8_bridges(rom: &mut Rom) {
     // 0xB3 bridge. Point it at the bridge tile so the slot opens to a bridge,
     // matching the other bridge columns (and gating as a water gap if a
     // fortress lands there).
-    rom.write_byte(FX_MAP_TILE_REPLACE + 16, 0xB3);
+    rom.write_byte(FX_MAP_TILE_REPLACE + 16, BRIDGE_TILE);
 }
 
 /// Apply the W8 canoe docks + extra paths and place the canoe sprite (see

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -134,12 +134,24 @@ fn sweep_is_deterministic() {
 /// pool changes themselves only bite with `hb_encounters` on, which this sweep
 /// does not exercise — `treasure_box_rooms_never_get_a_hammer_bro` and the
 /// shell-pairing invariant in `enemies::tests` cover that instead.
+///
+/// Re-captured 2026-08-20 for the W8 bridges-out deal
+/// (`overworld_build::locks::deal_bridge_spans`). Every seed moves, and for
+/// the usual two reasons at once: `capacity::roll_bridges_out` draws once
+/// from the shared RNG before the worlds are built, shifting every downstream
+/// stream position, and the deal itself changes W8's lock placement on
+/// purpose. Attribution is by census rather than by byte, since a lock moving
+/// re-prices the world: `w8_bridges_out_census` shows the count going from
+/// 11.5/62.3/18.0/8.2/0% to 3.0/46.1/40.2/10.8/~0.02% across 0-4 spans out,
+/// the same-span rate from 78% to 33%, and `test_route_census` at 1000 seeds
+/// shows W8 mean routes 2.27 -> 2.25 (linear 4% -> 5%), overall 2.548 -> 2.537
+/// (linear 6.60% -> 6.91%), nothing below its dealt floor either way.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xC1C71A7A4F68594D, 0x534A4AE58D1A3363, 0x44C686DF79468198, 0xC2A259353E396A87,
-    0x362C802799120D4A, 0xACA60B2E92B70172, 0x006C15769D3150F9, 0xC9B5C7A81BCCFF84,
-    0x7619C233EDA9C4A8, 0xA09A4F5BC20009B5, 0x424C0BFC98308197, 0xEFE5625EBEECEACD,
-    0x4CF3C1FC3700FBEB, 0x2D32C04ACB5E0D7D, 0xED60682BD8DC03FA, 0x920F58E88CE8F433,
-    0xA78130770839D989, 0xF0F6E652FEAE6D0B, 0xD3E21E5ED23526D8, 0xEF1FF6F1C5FA9B11,
+    0x23BB0B1661EB4991, 0x8BCB87C002850E1B, 0xD35E65FB6393BA7B, 0x28316C60D5B50C8C,
+    0x71D46A423D87F88D, 0x16C8AF59B8BB0589, 0x9DE59CE91689D794, 0x4C5689DE1274B707,
+    0xCF0D452FCB5F3BA5, 0xA0DA1A4EA05C9840, 0x913CB348A60E1204, 0xFB9B9EACB78D1131,
+    0x9F479C3584CDB1C9, 0x704A60C34AA3185F, 0xFEBF4CA438E54465, 0x46495F783B0C2C96,
+    0x8B9271CB5F45BD14, 0x7931621C85178986, 0xFC800FBE4F077B0A, 0xEADB5C1E7B634CA5,
 ];
 
 #[test]


### PR DESCRIPTION
Reported in play: W8's bridge to Bowser's castle is "always one out, and always
the same one." It was.

Measured at HEAD, 600 seeds:

```
0 out 11.5% | 1 out 62.3% | 2 out 18.0% | 3 out 8.2% | 4 out 0%
same span (col 55) out in 78% of the seeds that had one
```

## Why the ranking couldn't do better

The five spans on screen 3 are a chain over water, entered only where the seed's
pipe web touches it. Candidates are ranked by **marginal cut**, so one span wins
every seed — col 55, by exactly one node — and once its cut is claimed the other
four score zero *marginal* cut and lose to fresh territory anywhere else in the
world. That's why 4-out was impossible rather than rare.

## What this does

Rolls the count (`capacity::BRIDGES_OUT_WEIGHTS`) and deals the spans
(`locks::deal_bridge_spans`), with the row excluded from `lock_candidates` so the
ranker can neither add a span the deal didn't ask for nor keep one when the roll
was 0. The ceiling of 4 isn't chosen — it's W8's fort roster, since every gap
needs a fortress to restore it.

```
        HEAD      this PR
0 out   11.5%      3.0%
1 out   62.3%     46.1%
2 out   18.0%     40.2%
3 out    8.2%     10.8%
4 out      0%    ~0.02%   (1 in 5000)
col 55    78%       33%
```

## Two measured findings, both against my initial guess

**More spans out is cheaper, not dearer.** Each drags another fort onto the
mandatory path, which raises C1 and pulls more alternatives into the choice band
(600 seeds per pinned arm via `BRIDGES_OUT=n`):

| out | C1 | routes | linear% |
|---|---|---|---|
| 0 | 20.66 | 1.56 | 53.3% |
| 1 | 25.58 | 2.23 | 4.0% |
| 2 | 27.67 | 2.30 | 4.0% |
| 3 | 29.58 | 2.38 | 2.8% |
| 4 | 30.86 | 2.43 | 4.0% |

The only arm that costs anything is 0 — an intact row leaves W8 with no gate
anywhere on its own approach — so that's the thin one, and the weight it gave up
went to 3.

**A flat draw over all five costs real quality.** Cols 51/53 sever the goal in
only ~20% of seeds (it depends where the web enters the chain), so a single span
drawn flat landed decorative a third of the time: linear 4.0% -> 16.3%. The first
span is now drawn from the spans that actually sever the approach on *this*
seed's web; extras stay flat, so a decoy is something that happens to a
multi-span seed rather than something dealt on purpose.

## Net effect

`test_route_census`, 1000 seeds:

```
              HEAD             this PR
W8            2.27 routes, linear 4%     2.25 routes, linear 5%
overall       2.548, linear 6.60%        2.537, linear 6.91%
below floor   0.36%                      0.34%
```

- `all_world_targets_reachable` clean at 500 seeds/arm, and at 200 seeds/arm with
  `BRIDGES_OUT=4` forcing the whole corridor sealed.
- Build time 57.9 ms/seed.
- Verified on a real ROM: `testrom --randomize --require 'gap@w8:s3>=3'` finds
  seed 3, and `tools/fx_check.py` confirms all four W8 FX slots resolve — three
  `$9D -> $B3` water restores and one lock, each paired to its fortress.

## Secret-exit safety is untouched

`secret_exit_safe` is computed per lock by the same `completable_sealed` fixpoint,
spans included, and the writer picks 1-F's home uniformly from every safe lock in
the seed. Even with all four W8 locks on the corridor, 84.8% of W8s still carry a
safe lock; the backstop relocation fired 0 times in 100 seeds in both arms,
including under `BRIDGES_OUT=4`.

## Also in here

- **Harness bug fix.** `CensusCtx` builds worlds directly rather than through
  `build()`, so it never set `bridges_out` — every builder census was silently
  measuring a W8 pinned to the 0-span arm, the one arm that behaves differently
  from the rest. It now rolls off the same stream, in the same position, as
  production.
- **Nothing outside W8 changes.** `is_bridge_span` requires world 8, row 5, and
  one of the five columns; W1/W3/W4/W5/W6/W7 bridge tiles stay ordinary ranked
  lock sites with the `BRIDGE_TILES` tiebreak, and their per-world lock rates came
  back identical to HEAD digit for digit.

## Baseline

Regenerated on purpose. The roll draws once from the shared RNG before the worlds
are built, so every seed moves for that reason as well as for the deal — a byte
diff can't attribute it, so the doc comment attributes it by census instead.

## Follow-up

#185 (remove the dead `cross_world` flag) should land *after* this, because its
acceptance test is "baseline hashes don't move" and this PR regenerates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW
