### PR TITLE
ci: scope deploy concurrency by branch, take versions.json current from the archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,14 @@ concurrency:
   # Scope by event type so a `pull_request` sync run can't preempt the
   # `push` run that actually does the deploy (the `build` and `deploy`
   # jobs below are gated on `github.event_name == 'push'`).
-  group: pages-${{ github.event_name }}
+  #
+  # AND by branch: `push` fires on both `main` and `beta/next`, so an
+  # event-only group put them in the same bucket and the later push killed
+  # the earlier run. That bit the 1.2.0 release — pushing `beta/next` back
+  # after the merge (which the release runbook tells you to do) cancelled
+  # the `main` deploy 12s in. Same-branch pushes still supersede each
+  # other, which is what you want; cross-branch ones no longer do.
+  group: pages-${{ github.event_name }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -233,8 +240,21 @@ jobs:
           fi
 
           # Manifest for the in-app version picker (newest first).
+          #
+          # `current` comes from the ARCHIVE, not from main's Cargo.toml. Every
+          # run writes this file, including runs triggered by `beta/next` — and
+          # those skip the snapshot above, so reading Cargo.toml let a beta push
+          # advertise a version that had never been archived. That happened on
+          # 1.2.0: the main run was cancelled before it snapshotted, the beta run
+          # that replaced it published `current: 1.2.0` against an archive whose
+          # newest entry was 1.1.0, and /v/1.2.0/ 404'd from the picker.
+          # Newest-archived is always the version the root is serving, because
+          # the snapshot above runs before this line on the main push that
+          # produced that root.
           ARR=$(ls versions-repo/v 2>/dev/null | sort -Vr | sed 's/.*/"&"/' | paste -sd, -)
-          printf '{"current":"%s","versions":[%s]}\n' "$VER" "$ARR" > _site/versions.json
+          CUR=$(ls versions-repo/v 2>/dev/null | sort -V | tail -1)
+          CUR=${CUR:-$VER}   # empty archive (first ever run): fall back to main's version
+          printf '{"current":"%s","versions":[%s]}\n' "$CUR" "$ARR" > _site/versions.json
           cat _site/versions.json
 
       - name: Upload artifact


### PR DESCRIPTION
Two independent defects, both exposed by the 1.2.0 release. Two lines of actual
change; the rest is comment explaining why.

## 1. Deploy concurrency was scoped by event, not by branch

```yaml
group: pages-${{ github.event_name }}          # before
group: pages-${{ github.event_name }}-${{ github.ref_name }}   # after
```

`push` fires on both `main` and `beta/next`, so the two shared a bucket and the
later push cancelled the earlier run. Pushing `beta/next` back after the release
merge — which the runbook tells you to do, since the merge auto-deletes it —
killed the `main` deploy 12 seconds in.

The original intent is preserved: a `pull_request` sync still can't preempt the
deploying `push` run, and same-branch pushes still supersede each other.

## 2. `versions.json` could advertise a version that was never archived

This is the one that reached players.

Every run writes `versions.json`, including runs triggered by `beta/next` — but
the snapshot step above it only runs on `main`. Taking `current` from main's
`Cargo.toml` therefore let a beta-triggered deploy name a version that had never
been archived.

Which is exactly what happened. The cancelled main run never snapshotted, the
beta run that replaced it published:

```json
{"current":"1.2.0","versions":["1.1.0","1.0.7", ...]}
```

— current 1.2.0, no `v/1.2.0`, and the in-app picker offering a `/v/1.2.0/` that
404'd. Already repaired by re-running the cancelled workflow; this stops it
recurring.

`current` now comes from the archive (newest of `versions-repo/v`), which is
always the version the root is serving, because the snapshot runs *before* this
line on the main push that produced that root. **A run can no longer name a
version it cannot serve.**

It's also more truthful in the window between a version bump landing on
`beta/next` and the release merging to `main` — the root really is still the old
version then, and this says so rather than jumping the gun.

## Checked against the real archive

Simulated the shell on the actual `site-versions` contents:

| case | result |
|---|---|
| today's archive | output unchanged |
| 1.3.0 in Cargo.toml, not archived | `current: 1.2.0` (was: `1.3.0`) |
| empty archive (first ever run) | falls back to Cargo.toml, as before |
| `1.9.0` vs `1.10.0` | `sort -V` picks 1.10.0 |

YAML re-parsed after editing.

## No main push needed

For `push` events the workflow file comes from the ref that was pushed, so
beta-triggered runs pick these up immediately. They reach `main` with the next
release — no 1.2.1 required.

## Deliberately not included

The larger "don't rebuild main on every beta push" idea. It's worth ~45s on a
90s job and needs real machinery; these two are the ones that fix bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW
