### PR TITLE
refactor: drop the dead want_paths flag from the route measure

### DIFF
--- a/src/randomize/overworld_build/route_choice.rs
+++ b/src/randomize/overworld_build/route_choice.rs
@@ -332,8 +332,17 @@ fn unpack_mask(key: PackedState) -> u64 {
 
 /// Enumerate every distinct near-optimal route to the goal and summarise the
 /// choice they offer.
+///
+/// Compiles the walk-invariant base and measures `built` against it. The
+/// compile and the measure are split (`WalkGraph::compile` /
+/// `WalkGraph::measure`) so a selection step can hoist the compile and reuse it
+/// across its kind/lock candidates; this single-shot entry point keeps the
+/// one-call form.
 pub(crate) fn analyze_route_choice(built: &BuiltWorld, slack: u32) -> RouteChoice {
-    analyze_route_choice_inner(built, slack, true)
+    match WalkGraph::compile(built) {
+        Some(g) => g.measure(built, slack),
+        None => RouteChoice::default(),
+    }
 }
 
 /// The walk-invariant base of a route measurement — the `walk_map` BFS graph
@@ -434,7 +443,7 @@ impl WalkGraph {
     /// share the grid tiles and `pipe_pairs` the base was compiled from (only
     /// its slot KINDS / sections and `locks` may differ) — the reuse contract on
     /// `WalkGraph`, verified in debug builds below.
-    pub(super) fn measure(&self, built: &BuiltWorld, slack: u32, want_paths: bool) -> RouteChoice {
+    pub(super) fn measure(&self, built: &BuiltWorld, slack: u32) -> RouteChoice {
         // Walk-invariance guard: reusing this base for `built` is sound only if
         // `built`'s walk graph still matches the compiled one. Catches a stale
         // reuse across a graph-changing trial (spare pipe, or a slot flip onto a
@@ -674,11 +683,8 @@ impl WalkGraph {
         }
 
         // Rebuild the node path for a goal state by walking the recorded
-        // predecessors back to start. Counts-only measures skip this.
+        // predecessors back to start.
         let reconstruct = |goal: PackedState| -> Vec<Pos> {
-            if !want_paths {
-                return Vec::new();
-            }
             let mut nodes = vec![unpack_pos(goal)];
             let mut cur = goal;
             while let Some(p) = dist.prev_of(cur) {
@@ -758,17 +764,6 @@ impl WalkGraph {
             runner_up_gap,
             detours,
         }
-    }
-}
-
-/// Compile the walk-invariant base and measure `built` against it. The compile
-/// and the measure are split (`WalkGraph::compile` / `WalkGraph::measure`) so a
-/// selection step can hoist the compile and reuse it across its kind/lock
-/// candidates; the single-shot public entry points keep the one-call form.
-fn analyze_route_choice_inner(built: &BuiltWorld, slack: u32, want_paths: bool) -> RouteChoice {
-    match WalkGraph::compile(built) {
-        Some(g) => g.measure(built, slack, want_paths),
-        None => RouteChoice::default(),
     }
 }
 

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1931,7 +1931,7 @@ fn test_walkgraph_reuse() {
             // (1) Split is behavior-preserving: reuse on the SAME world equals
             // the one-shot entry point, byte for byte (paths included).
             assert_eq!(
-                base.measure(built, slack, true),
+                base.measure(built, slack),
                 analyze_route_choice(built, slack),
                 "W{world} seed {seed}: base-measure differs from one-shot",
             );
@@ -1950,7 +1950,7 @@ fn test_walkgraph_reuse() {
                     if base.walk_invariant(&cand) {
                         invariant_flips += 1;
                         assert_eq!(
-                            base.measure(&cand, slack, true),
+                            base.measure(&cand, slack),
                             analyze_route_choice(&cand, slack),
                             "W{world} seed {seed}: reuse != fresh for a walk-invariant \
                              {:?}→{new_kind:?} flip at slot {i}",
@@ -1987,7 +1987,7 @@ fn test_walkgraph_reuse() {
                     );
                     lock_trials += 1;
                     assert_eq!(
-                        base.measure(&cand, slack, true),
+                        base.measure(&cand, slack),
                         analyze_route_choice(&cand, slack),
                         "W{world} seed {seed}: reuse != fresh after adding a lock",
                     );


### PR DESCRIPTION
Second finding from the dead-flag sweep that followed #185. Same shape as
`WriteFlags::cross_world`, and the same cause: a subsystem replaced wholesale,
leaving a selector with one surviving value.

## Where it came from

`want_paths` was born legitimate in `7cb6cb7` (perf: pack the route Dijkstra),
which put two entry points over one engine:

| entry point | passes | for |
|---|---|---|
| `analyze_route_choice(built, slack)` | `true` | anything reading a route's node path |
| `measure_counts(built, slack)` | `false` | trial flips — "flip a slot, read two numbers, flip back" |

Then `c93451a` ("the choice-first rebuild becomes THE overworld builder")
replaced the builder wholesale and deleted `measure_counts` along with the
trial loops that called it. **The `false` caller died there; the parameter did
not.** Every call site since has passed `true`, so `if !want_paths { return
Vec::new() }` has never executed — not in production, not in CI.

Issue #120's `WalkGraph` split (`7aa1bf9`) only threaded the parameter into
`WalkGraph::measure` three days earlier, while it was still live. That is why
it sat in three signatures rather than two, and it is the whole of #120's
involvement.

## Why remove it rather than leave it

It is not inert. Three shaping rungs read `.rc.routes[].path`
(`shaping.rs:518`, `592`, `677`) to decide which tiles lie on the cheap route.
A future caller reaching for the counts-only path would hand them routes with
empty paths and get silently wrong shaping decisions — there is no assertion
guarding that.

Keeping it against a possible future re-wire is also weaker than it looks. When
written, `false` skipped both the prev map and the reconstruction. `prev` is now
written unconditionally inside `DistMap::improve` (in-slot, same write as the
value), so a counts-only measure would skip only the final walk-back. The saving
is strictly smaller than the commit that introduced it claimed, and nobody has
measured what it currently is.

I did check whether it could simply be switched back on instead. It can't
cleanly: only `shaping.rs:444` and the `SHORTCUT_TRIES` loop at `479` are
counts-only, so a re-wire is a per-call-site judgment with an unmeasured payoff.
If builder speed becomes a target, #120's closing measurement already says where
to aim — enumeration at 60.8% of the run, not the walk-graph BFS at 5%.

## What changed

- `want_paths` gone from `WalkGraph::measure` and the reconstruct closure.
- `analyze_route_choice_inner` folded into `analyze_route_choice` — with the
  flag gone it had one caller and no parameter left to distinguish it. Its doc
  comment moves up with it.
- The `WalkGraph::compile` / `measure` split is **untouched** and still
  available to a future hoist, as is its reuse contract.
- Three `base.measure(…, true)` call sites in `test_walkgraph_reuse` updated.

## Verification

- `tests/overworld_baseline.rs` — 20/20 hashes unchanged, not regenerated (ROM present, no SKIP)
- `test_walkgraph_reuse` at `CENSUS_SEEDS=100` — 71,704 walk-invariant kind flips, 0 walk-changing, 800 lock trials, all reuse results matching a fresh measure
- `cargo test` — 389 passed, 0 failed
- `cargo clippy --all-targets` and the wasm32 `--lib` pass — both clean

No changelog entry: internal refactor, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW