### PR TITLE
fix: a SPOILED_SEGMENT_RANGES row ended one byte too late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ deploys.
 
 ## [Unreleased]
 
+### Fixed
+
+- With autoscroll removal on, the **two Big Berthas in 4-1's underwater room
+  and the two para-troopas in 5-4** were left vanilla in every seed. Removing
+  an autoscroller writes a stream terminator into the enemy data, and the range
+  that tells the randomizer where to pick the parse back up was one byte long,
+  so it read that whole stretch out of step and skipped past both levels'
+  enemies. Nothing was ever written to a wrong byte; those four simply never
+  randomized. (#181)
+
 ## [1.2.0] - 2026-08-22
 
 ### Added

--- a/src/randomize/autoscroll.rs
+++ b/src/randomize/autoscroll.rs
@@ -21,12 +21,18 @@ use crate::rom::Rom;
 /// jumps past the spoiled bytes and resumes parsing at the next real
 /// segment.
 ///
-/// Each range is conservative: it starts at the leading `$FF` (or page
-/// byte) of the affected level's data and ends at the byte just before
-/// the next real segment's page byte.
+/// A range starts at the page byte of the first spoiled stream, and its
+/// **exclusive end is the page byte of the next real stream** — the byte
+/// the walker has to resume on. Off by one in either direction and the
+/// walker parses at the wrong phase for the rest of the block, reading
+/// X/Y and page bytes as obj_ids until it happens to land on an `$FF`
+/// again. `every_enemy_entry_point_is_a_walker_segment_start` (below) is
+/// the guard: it checks every `enemy_ptr` in the ROM against the walker's
+/// segment starts, so a new `$FF` insertion with no row here — or a row
+/// whose end is wrong — fails a test instead of going latent.
 pub const SPOILED_SEGMENT_RANGES: &[Range<usize>] = &[
     0x0CFE2..0x0CFE7,
-    0x0D037..0x0D042,
+    0x0D037..0x0D041,
     0x0D102..0x0D107,
 ];
 
@@ -501,5 +507,118 @@ mod tests {
         // Matches the reference IPS exactly. The 3-7 coin heaven autoscroll
         // is deliberately left intact (chest risk/reward).
         assert_eq!(PATCHES.len(), 64);
+    }
+
+    /// Every enemy-stream entry point the engine can use must land on a
+    /// segment boundary the block-wide walker also recognizes.
+    ///
+    /// The engine enters a stream at an `enemy_ptr` and reads
+    /// `[page byte][id,x,y]...[$FF]`. `enemies.rs` instead scans the whole
+    /// block sequentially, so the two only agree while every real stream
+    /// start is also a walker segment start. `disable_autoscroll` breaks
+    /// that by writing `$FF` over a mid-stream obj_id — the walker keeps
+    /// parsing, mistakes the orphaned bytes for a segment, and from then on
+    /// reads X/Y/page bytes as obj_ids until it happens to resync. Those are
+    /// bytes it will write back.
+    ///
+    /// [`SPOILED_SEGMENT_RANGES`] is what re-syncs it, so this test is
+    /// really a check on those ranges: each must end exactly on the next
+    /// real stream's page byte. An off-by-one there desynchronizes the
+    /// walker for the rest of the block (it did, for `0x0D037..0x0D042`).
+    ///
+    /// Entry points come from both directions the ROM names a stream: the
+    /// per-world pointer tables and the level headers (which reach sub-areas
+    /// the pointer tables don't). Needs the ROM; skips without it.
+    #[test]
+    fn every_enemy_entry_point_is_a_walker_segment_start() {
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            return;
+        };
+        let vanilla = Rom::from_bytes(&bytes).unwrap();
+        let mut patched = Rom::from_bytes(&bytes).unwrap();
+        disable_autoscroll(&mut patched);
+
+        // Entry points are read per-ROM: the airship pointer redirects above
+        // move several `enemy_ptr`s, and those new streams need checking too.
+        let vanilla_eps = all_enemy_entry_points(&vanilla);
+        let patched_eps = all_enemy_entry_points(&patched);
+        assert!(
+            vanilla_eps.len() > 100 && patched_eps.len() > 100,
+            "entry-point collection came up near-empty ({} / {}) — the check \
+             would pass vacuously",
+            vanilla_eps.len(),
+            patched_eps.len(),
+        );
+
+        // Vanilla is the oracle: no skipping needed, nothing may be adrift.
+        assert_eq!(
+            adrift_entry_points(&vanilla, &vanilla_eps, &[]),
+            Vec::<String>::new(),
+            "vanilla enemy streams don't line up with the walker — \
+             the check itself is wrong, not the patch",
+        );
+
+        assert_eq!(
+            adrift_entry_points(&patched, &patched_eps, SPOILED_SEGMENT_RANGES),
+            Vec::<String>::new(),
+            "autoscroll removal desynchronized the enemy-data walker. \
+             Every $FF written into a stream needs a SPOILED_SEGMENT_RANGES \
+             row ending on the next real stream's page byte.",
+        );
+    }
+
+    /// Every `enemy_ptr` the ROM names: the per-world pointer tables plus the
+    /// level headers (the latter reach sub-areas the tables don't).
+    fn all_enemy_entry_points(rom: &Rom) -> Vec<u16> {
+        use crate::randomize::rom_data::{read_entry, WORLDS};
+
+        let mut pts: Vec<u16> = crate::randomize::enemies::enemy_entry_points(rom);
+        for world in &WORLDS {
+            for idx in 0..world.entry_count {
+                let e = read_entry(rom, world, idx);
+                pts.push(((e.obj_hi as u16) << 8) | e.obj_lo as u16);
+            }
+        }
+        pts.retain(|&ep| {
+            ep >= 0xC000
+                && crate::randomize::rom_data::enemy_ptr_to_file_offset(ep)
+                    < crate::randomize::rom_data::ENEMY_DATA_END
+        });
+        pts.sort_unstable();
+        pts.dedup();
+        pts
+    }
+
+    /// Entry points the walker would not see as a stream start, described for
+    /// the failure message. An entry point is fine if it is a walker segment
+    /// start, an empty stream (`$FF` right after the page byte — which is
+    /// what a neutralized autoscroll becomes, and what the block's leading
+    /// placeholders already were in vanilla), or inside a skip range.
+    fn adrift_entry_points(
+        rom: &Rom,
+        entry_points: &[u16],
+        skip: &[Range<usize>],
+    ) -> Vec<String> {
+        use crate::randomize::rom_data::{
+            enemy_ptr_to_file_offset, ENEMY_DATA_END, ENEMY_DATA_START,
+        };
+        use crate::randomize::segment_writer::walk_segments;
+
+        let starts: std::collections::HashSet<usize> =
+            walk_segments(&rom.data, ENEMY_DATA_START, ENEMY_DATA_END, skip)
+                .iter()
+                .map(|b| b.file_offset)
+                .collect();
+
+        entry_points
+            .iter()
+            .filter_map(|&ep| {
+                let fo = enemy_ptr_to_file_offset(ep);
+                let ok = starts.contains(&fo)
+                    || rom.data[fo + 1] == 0xFF
+                    || skip.iter().any(|r| r.contains(&fo));
+                (!ok).then(|| format!("${ep:04X} (file {fo:#07X})"))
+            })
+            .collect()
     }
 }

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -146,12 +146,33 @@ fn sweep_is_deterministic() {
 /// the same-span rate from 78% to 33%, and `test_route_census` at 1000 seeds
 /// shows W8 mean routes 2.27 -> 2.25 (linear 4% -> 5%), overall 2.548 -> 2.537
 /// (linear 6.60% -> 6.91%), nothing below its dealt floor either way.
+///
+/// Re-captured 2026-08-24 for the `SPOILED_SEGMENT_RANGES` off-by-one
+/// (issue #181). The middle row ended one byte past the next real stream's
+/// page byte, so after autoscroll removal the enemy-data walker resumed
+/// mid-entry and stayed out of phase for 18 slots. Attribution is by
+/// pinning, as with the v28 and C1-floor recaptures: restoring the range to
+/// `0x0D037..0x0D042` reproduces the hashes above exactly, so this one byte
+/// is the whole difference. What it changes: the walker now sees the two
+/// segments it was reading through, whose 17 entries were pinned to vanilla
+/// in every seed before. They are unrelated levels that merely sit next to
+/// each other in the block — `0x0D041` is 4-1's underwater sub-area and
+/// `0x0D049` is 5-4. Only four of the 17 can move: the two Big Berthas at
+/// `0x0D042`/`0x0D045` (water) and the two para-troopas at
+/// `0x0D068`/`0x0D074` (flying). The other 13 are `$90`-`$93`, the tilting
+/// and twirling platforms, which belong to no class pool and so never draw
+/// at any flag setting. Those four extra draws shift the shared RNG stream,
+/// which is why all 20 seeds move and the overworld moves with them.
+/// Nothing was being written to a wrong byte before the fix — the 18
+/// out-of-phase slots held X, Y and page bytes, all `$01..$19` and in no
+/// class pool, so 500 seeds at all-Wild never wrote one. It was latent, and
+/// `every_enemy_entry_point_is_a_walker_segment_start` keeps it that way.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x23BB0B1661EB4991, 0x8BCB87C002850E1B, 0xD35E65FB6393BA7B, 0x28316C60D5B50C8C,
-    0x71D46A423D87F88D, 0x16C8AF59B8BB0589, 0x9DE59CE91689D794, 0x4C5689DE1274B707,
-    0xCF0D452FCB5F3BA5, 0xA0DA1A4EA05C9840, 0x913CB348A60E1204, 0xFB9B9EACB78D1131,
-    0x9F479C3584CDB1C9, 0x704A60C34AA3185F, 0xFEBF4CA438E54465, 0x46495F783B0C2C96,
-    0x8B9271CB5F45BD14, 0x7931621C85178986, 0xFC800FBE4F077B0A, 0xEADB5C1E7B634CA5,
+    0x500AD778776D337C, 0x5094FC748FF2B4A0, 0x20B5E2E0BEF7D0D9, 0xEC95C1580A2BEE84,
+    0xC6B2A9E00C225CB0, 0x44176CCCD2205ADA, 0x72BD61D4494E339B, 0x731F65BE6351EFD6,
+    0x4B121B725E5FE009, 0x7C56E69368F19D0B, 0x17DA3F4A44B528BE, 0xDAB9D9E9664DFF6E,
+    0xEF249386B9EE1856, 0xFBC5053F17052149, 0xA4D37AF9D4FF4E73, 0xED82D0729BCF4787,
+    0xE0201F610E43A939, 0xFDEE0F3892D95E78, 0xD57B93C62D8B9C1B, 0x96C2A5DEAF2ECF88,
 ];
 
 #[test]


### PR DESCRIPTION
Closes #181 — though not where the issue expected.

## What the issue found, and what was actually wrong

#181 measured pointer-table `obj_ptr`s against the walker's segment starts and found two adrift. That measurement was taken **without** `SPOILED_SEGMENT_RANGES`, which is the mechanism that already exists to resync the walker — with the ranges honored (which `enemies.rs` does), both of those are fine.

Re-running the check the way the walker actually runs turned up a different offender, and a real one:

```
$D039 @ 0x0D049 MISALIGNED in segment 0x0D042
```

`SPOILED_SEGMENT_RANGES`'s middle row was `0x0D037..0x0D042`. Each row's exclusive end has to be the page byte of the next real stream — the byte the walker resumes on. The next real stream's page byte is `0x0D041`. Ending at `0x0D042` put the walker on an obj_id byte, which it took for a page byte, and it stayed one byte out of phase for the next 18 slots, reading X, Y and page bytes as obj_ids until it happened to land on an `$FF` again.

The other two rows (`0x0CFE2..0x0CFE7`, `0x0D102..0x0D107`) end exactly on their next page byte and were always correct.

## Effect

**17 real slots went unwalked.** They belong to two unrelated levels that merely sit next to each other in the enemy data block — adjacency there says nothing about level identity (5-4's own sub-area is at `$CE81`, elsewhere entirely):

| segment | `enemy_ptr` | level | entries |
|---|---|---|---|
| `0x0D041` | `$D031` | **4-1 sub-area 1** (underwater) | 2 × `OBJ_BIGBERTHABIRTHER` — `class:water` |
| `0x0D049` | `$D039` | **5-4** | 13 × `$90`–`$93` tilting/twirling platform — no class; `OBJ_FLYINGREDPARATROOPA` + `OBJ_PARATROOPAGREENHOP` — `class:flying` |

**Four of those can actually move.** The two Big Berthas at `0x0D042`/`0x0D045` and the two para-troopas at `0x0D068`/`0x0D074` were pinned to vanilla in every seed with autoscroll removal on, and now draw — verified per-slot against seeds 1–3, before and after. The other 13 are the platforms 5-4 is built out of; `$90`–`$93` appear in none of the 32 class pools in `tables.rs` (`THWOMPS` is `$8A`–`$8F`), so they never draw at any flag setting.

**The 18 phantom slots never fired.** They held X, Y and page bytes, all in `$01..$19`, none in any class pool — 500 seeds at all-Wild wrote none of them. Latent, exactly as the issue predicted for its own findings, and for the same reason. Worth noting what the failure would have looked like: those bytes are level geometry the engine reads for platform placement, so a pool that ever reached down into low ids would have started moving 5-4's platforms.

## The guard

`every_enemy_entry_point_is_a_walker_segment_start` is option (3) from the issue, which is worth having whichever fix is chosen. It collects every `enemy_ptr` the ROM names — the per-world pointer tables plus the level headers, which reach the sub-areas the tables don't — and requires each to land on a walker segment start, an empty stream, or inside a skip range.

Two details that matter:

- Entry points are read **per-ROM**, not once from vanilla: autoscroll removal redirects the airship `ObjSets` pointers, so the patched ROM names streams vanilla doesn't.
- Vanilla is asserted first, with no skip ranges, as the oracle. If that arm ever fails the check itself is wrong, not the patch.

Mutation-tested three ways: it fails on the old `..0x0D042` (`$D039`, `$D068`), fails with the range list emptied (`$CFD7`, `$D031`, `$D0F7` — the issue's own ghost segments), and asserts the entry-point set is non-trivial so it can't pass vacuously. It needs the ROM, so it skips on CI.

Option (2) from the issue — using `$00` instead of `$FF` — isn't needed once the ranges are right, and the 6-byte write at `0x0D038` turns out to change only two bytes (`d3`→`FF` twice); the other four already matched vanilla.

## Baseline

`overworld_baseline` moves on all 20 seeds: four slots draw where they previously didn't, which shifts the shared RNG stream and carries the overworld with it. Attributed by pinning, as with the v28 and C1-floor recaptures — restoring `0x0D037..0x0D042` reproduces the old hashes exactly, so the one byte is the whole difference.

`cargo test` (390 lib + integration), `cargo clippy --all-targets`, and the wasm32 clippy pass are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW