### PR TITLE
release: 1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,14 @@ concurrency:
   # Scope by event type so a `pull_request` sync run can't preempt the
   # `push` run that actually does the deploy (the `build` and `deploy`
   # jobs below are gated on `github.event_name == 'push'`).
-  group: pages-${{ github.event_name }}
+  #
+  # AND by branch: `push` fires on both `main` and `beta/next`, so an
+  # event-only group put them in the same bucket and the later push killed
+  # the earlier run. That bit the 1.2.0 release — pushing `beta/next` back
+  # after the merge (which the release runbook tells you to do) cancelled
+  # the `main` deploy 12s in. Same-branch pushes still supersede each
+  # other, which is what you want; cross-branch ones no longer do.
+  group: pages-${{ github.event_name }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -233,8 +240,21 @@ jobs:
           fi
 
           # Manifest for the in-app version picker (newest first).
+          #
+          # `current` comes from the ARCHIVE, not from main's Cargo.toml. Every
+          # run writes this file, including runs triggered by `beta/next` — and
+          # those skip the snapshot above, so reading Cargo.toml let a beta push
+          # advertise a version that had never been archived. That happened on
+          # 1.2.0: the main run was cancelled before it snapshotted, the beta run
+          # that replaced it published `current: 1.2.0` against an archive whose
+          # newest entry was 1.1.0, and /v/1.2.0/ 404'd from the picker.
+          # Newest-archived is always the version the root is serving, because
+          # the snapshot above runs before this line on the main push that
+          # produced that root.
           ARR=$(ls versions-repo/v 2>/dev/null | sort -Vr | sed 's/.*/"&"/' | paste -sd, -)
-          printf '{"current":"%s","versions":[%s]}\n' "$VER" "$ARR" > _site/versions.json
+          CUR=$(ls versions-repo/v 2>/dev/null | sort -V | tail -1)
+          CUR=${CUR:-$VER}   # empty archive (first ever run): fall back to main's version
+          printf '{"current":"%s","versions":[%s]}\n' "$CUR" "$ARR" > _site/versions.json
           cat _site/versions.json
 
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ deploys.
 
 ## [Unreleased]
 
+### Fixed
+
+- With autoscroll removal on, the **two Big Berthas in 4-1's underwater room
+  and the two para-troopas in 5-4** were left vanilla in every seed. Removing
+  an autoscroller writes a stream terminator into the enemy data, and the range
+  that tells the randomizer where to pick the parse back up was one byte long,
+  so it read that whole stretch out of step and skipped past both levels'
+  enemies. Nothing was ever written to a wrong byte; those four simply never
+  randomized. (#181)
+
 ## [1.2.0] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ deploys.
 
 ### Fixed
 
+- The **Super Princess Peach** visual patch drew a band of garbage tiles across
+  the title screen. Peach's title logo needs room in the ROM bank the title
+  screen runs from, and took it from the same stretch of empty space the B-to-
+  mute toggle was written to; the randomizer applies the visual patch first, so
+  it landed on top of the logo data. The toggle moved to the far end of that
+  bank, and a test now checks every bundled visual patch against the whole
+  free-space registry.
+
 - With autoscroll removal on, the **two Big Berthas in 4-1's underwater room
   and the two para-troopas in 5-4** were left vanilla in every seed. Removing
   an autoscroller writes a stream terminator into the enemy data, and the range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ deploys.
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-26
+
 ### Fixed
 
 - The **Super Princess Peach** visual patch drew a band of garbage tiles across

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base32",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 
 [lib]

--- a/src/randomize/autoscroll.rs
+++ b/src/randomize/autoscroll.rs
@@ -21,12 +21,18 @@ use crate::rom::Rom;
 /// jumps past the spoiled bytes and resumes parsing at the next real
 /// segment.
 ///
-/// Each range is conservative: it starts at the leading `$FF` (or page
-/// byte) of the affected level's data and ends at the byte just before
-/// the next real segment's page byte.
+/// A range starts at the page byte of the first spoiled stream, and its
+/// **exclusive end is the page byte of the next real stream** — the byte
+/// the walker has to resume on. Off by one in either direction and the
+/// walker parses at the wrong phase for the rest of the block, reading
+/// X/Y and page bytes as obj_ids until it happens to land on an `$FF`
+/// again. `every_enemy_entry_point_is_a_walker_segment_start` (below) is
+/// the guard: it checks every `enemy_ptr` in the ROM against the walker's
+/// segment starts, so a new `$FF` insertion with no row here — or a row
+/// whose end is wrong — fails a test instead of going latent.
 pub const SPOILED_SEGMENT_RANGES: &[Range<usize>] = &[
     0x0CFE2..0x0CFE7,
-    0x0D037..0x0D042,
+    0x0D037..0x0D041,
     0x0D102..0x0D107,
 ];
 
@@ -501,5 +507,118 @@ mod tests {
         // Matches the reference IPS exactly. The 3-7 coin heaven autoscroll
         // is deliberately left intact (chest risk/reward).
         assert_eq!(PATCHES.len(), 64);
+    }
+
+    /// Every enemy-stream entry point the engine can use must land on a
+    /// segment boundary the block-wide walker also recognizes.
+    ///
+    /// The engine enters a stream at an `enemy_ptr` and reads
+    /// `[page byte][id,x,y]...[$FF]`. `enemies.rs` instead scans the whole
+    /// block sequentially, so the two only agree while every real stream
+    /// start is also a walker segment start. `disable_autoscroll` breaks
+    /// that by writing `$FF` over a mid-stream obj_id — the walker keeps
+    /// parsing, mistakes the orphaned bytes for a segment, and from then on
+    /// reads X/Y/page bytes as obj_ids until it happens to resync. Those are
+    /// bytes it will write back.
+    ///
+    /// [`SPOILED_SEGMENT_RANGES`] is what re-syncs it, so this test is
+    /// really a check on those ranges: each must end exactly on the next
+    /// real stream's page byte. An off-by-one there desynchronizes the
+    /// walker for the rest of the block (it did, for `0x0D037..0x0D042`).
+    ///
+    /// Entry points come from both directions the ROM names a stream: the
+    /// per-world pointer tables and the level headers (which reach sub-areas
+    /// the pointer tables don't). Needs the ROM; skips without it.
+    #[test]
+    fn every_enemy_entry_point_is_a_walker_segment_start() {
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            return;
+        };
+        let vanilla = Rom::from_bytes(&bytes).unwrap();
+        let mut patched = Rom::from_bytes(&bytes).unwrap();
+        disable_autoscroll(&mut patched);
+
+        // Entry points are read per-ROM: the airship pointer redirects above
+        // move several `enemy_ptr`s, and those new streams need checking too.
+        let vanilla_eps = all_enemy_entry_points(&vanilla);
+        let patched_eps = all_enemy_entry_points(&patched);
+        assert!(
+            vanilla_eps.len() > 100 && patched_eps.len() > 100,
+            "entry-point collection came up near-empty ({} / {}) — the check \
+             would pass vacuously",
+            vanilla_eps.len(),
+            patched_eps.len(),
+        );
+
+        // Vanilla is the oracle: no skipping needed, nothing may be adrift.
+        assert_eq!(
+            adrift_entry_points(&vanilla, &vanilla_eps, &[]),
+            Vec::<String>::new(),
+            "vanilla enemy streams don't line up with the walker — \
+             the check itself is wrong, not the patch",
+        );
+
+        assert_eq!(
+            adrift_entry_points(&patched, &patched_eps, SPOILED_SEGMENT_RANGES),
+            Vec::<String>::new(),
+            "autoscroll removal desynchronized the enemy-data walker. \
+             Every $FF written into a stream needs a SPOILED_SEGMENT_RANGES \
+             row ending on the next real stream's page byte.",
+        );
+    }
+
+    /// Every `enemy_ptr` the ROM names: the per-world pointer tables plus the
+    /// level headers (the latter reach sub-areas the tables don't).
+    fn all_enemy_entry_points(rom: &Rom) -> Vec<u16> {
+        use crate::randomize::rom_data::{read_entry, WORLDS};
+
+        let mut pts: Vec<u16> = crate::randomize::enemies::enemy_entry_points(rom);
+        for world in &WORLDS {
+            for idx in 0..world.entry_count {
+                let e = read_entry(rom, world, idx);
+                pts.push(((e.obj_hi as u16) << 8) | e.obj_lo as u16);
+            }
+        }
+        pts.retain(|&ep| {
+            ep >= 0xC000
+                && crate::randomize::rom_data::enemy_ptr_to_file_offset(ep)
+                    < crate::randomize::rom_data::ENEMY_DATA_END
+        });
+        pts.sort_unstable();
+        pts.dedup();
+        pts
+    }
+
+    /// Entry points the walker would not see as a stream start, described for
+    /// the failure message. An entry point is fine if it is a walker segment
+    /// start, an empty stream (`$FF` right after the page byte — which is
+    /// what a neutralized autoscroll becomes, and what the block's leading
+    /// placeholders already were in vanilla), or inside a skip range.
+    fn adrift_entry_points(
+        rom: &Rom,
+        entry_points: &[u16],
+        skip: &[Range<usize>],
+    ) -> Vec<String> {
+        use crate::randomize::rom_data::{
+            enemy_ptr_to_file_offset, ENEMY_DATA_END, ENEMY_DATA_START,
+        };
+        use crate::randomize::segment_writer::walk_segments;
+
+        let starts: std::collections::HashSet<usize> =
+            walk_segments(&rom.data, ENEMY_DATA_START, ENEMY_DATA_END, skip)
+                .iter()
+                .map(|b| b.file_offset)
+                .collect();
+
+        entry_points
+            .iter()
+            .filter_map(|&ep| {
+                let fo = enemy_ptr_to_file_offset(ep);
+                let ok = starts.contains(&fo)
+                    || rom.data[fo + 1] == 0xFF
+                    || skip.iter().any(|r| r.contains(&fo));
+                (!ok).then(|| format!("${ep:04X} (file {fo:#07X})"))
+            })
+            .collect()
     }
 }

--- a/src/randomize/enemies/class_modes.rs
+++ b/src/randomize/enemies/class_modes.rs
@@ -67,13 +67,15 @@ impl ClassModes {
         //    class swap.
         //
         // 2. **Distribution (legacy of the bucket-first picker).** cfire
-        //    IDs share the NOCHANGE CHR slot, so they got per-bucket
-        //    appended in PageBuckets; with the old bucket-first picker
-        //    that over-weighted them ~K× per draw and flooded every level
+        //    IDs share the NOCHANGE CHR slot, so the old `PageBuckets`
+        //    appended them to every bucket; the bucket-first pick then
+        //    over-weighted them ~K× per draw and flooded every level
         //    (observed: 49 → 213 bullet bill cannons before the fix).
-        //    `PageBuckets::pick` is now uniform-among-compatibles, so this
-        //    flooding mechanism no longer exists — but reason (1) alone
-        //    is enough to keep cfire out.
+        //    That picker is gone — `PageBuckets` was deleted once its
+        //    `pick` became identical to `pick_compatible` over the wild
+        //    pool, which draws uniformly among CHR-compatible ids — so the
+        //    flooding mechanism no longer exists. Reason (1) alone is
+        //    enough to keep cfire out.
         //
         // Net semantic: cfire can still transform INTO other wild enemies,
         // but other classes never swap TO cfire — total cfire count stays

--- a/src/randomize/overworld_build/route_choice.rs
+++ b/src/randomize/overworld_build/route_choice.rs
@@ -332,8 +332,17 @@ fn unpack_mask(key: PackedState) -> u64 {
 
 /// Enumerate every distinct near-optimal route to the goal and summarise the
 /// choice they offer.
+///
+/// Compiles the walk-invariant base and measures `built` against it. The
+/// compile and the measure are split (`WalkGraph::compile` /
+/// `WalkGraph::measure`) so a selection step can hoist the compile and reuse it
+/// across its kind/lock candidates; this single-shot entry point keeps the
+/// one-call form.
 pub(crate) fn analyze_route_choice(built: &BuiltWorld, slack: u32) -> RouteChoice {
-    analyze_route_choice_inner(built, slack, true)
+    match WalkGraph::compile(built) {
+        Some(g) => g.measure(built, slack),
+        None => RouteChoice::default(),
+    }
 }
 
 /// The walk-invariant base of a route measurement — the `walk_map` BFS graph
@@ -434,7 +443,7 @@ impl WalkGraph {
     /// share the grid tiles and `pipe_pairs` the base was compiled from (only
     /// its slot KINDS / sections and `locks` may differ) — the reuse contract on
     /// `WalkGraph`, verified in debug builds below.
-    pub(super) fn measure(&self, built: &BuiltWorld, slack: u32, want_paths: bool) -> RouteChoice {
+    pub(super) fn measure(&self, built: &BuiltWorld, slack: u32) -> RouteChoice {
         // Walk-invariance guard: reusing this base for `built` is sound only if
         // `built`'s walk graph still matches the compiled one. Catches a stale
         // reuse across a graph-changing trial (spare pipe, or a slot flip onto a
@@ -674,11 +683,8 @@ impl WalkGraph {
         }
 
         // Rebuild the node path for a goal state by walking the recorded
-        // predecessors back to start. Counts-only measures skip this.
+        // predecessors back to start.
         let reconstruct = |goal: PackedState| -> Vec<Pos> {
-            if !want_paths {
-                return Vec::new();
-            }
             let mut nodes = vec![unpack_pos(goal)];
             let mut cur = goal;
             while let Some(p) = dist.prev_of(cur) {
@@ -758,17 +764,6 @@ impl WalkGraph {
             runner_up_gap,
             detours,
         }
-    }
-}
-
-/// Compile the walk-invariant base and measure `built` against it. The compile
-/// and the measure are split (`WalkGraph::compile` / `WalkGraph::measure`) so a
-/// selection step can hoist the compile and reuse it across its kind/lock
-/// candidates; the single-shot public entry points keep the one-call form.
-fn analyze_route_choice_inner(built: &BuiltWorld, slack: u32, want_paths: bool) -> RouteChoice {
-    match WalkGraph::compile(built) {
-        Some(g) => g.measure(built, slack, want_paths),
-        None => RouteChoice::default(),
     }
 }
 

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -1931,7 +1931,7 @@ fn test_walkgraph_reuse() {
             // (1) Split is behavior-preserving: reuse on the SAME world equals
             // the one-shot entry point, byte for byte (paths included).
             assert_eq!(
-                base.measure(built, slack, true),
+                base.measure(built, slack),
                 analyze_route_choice(built, slack),
                 "W{world} seed {seed}: base-measure differs from one-shot",
             );
@@ -1950,7 +1950,7 @@ fn test_walkgraph_reuse() {
                     if base.walk_invariant(&cand) {
                         invariant_flips += 1;
                         assert_eq!(
-                            base.measure(&cand, slack, true),
+                            base.measure(&cand, slack),
                             analyze_route_choice(&cand, slack),
                             "W{world} seed {seed}: reuse != fresh for a walk-invariant \
                              {:?}→{new_kind:?} flip at slot {i}",
@@ -1987,7 +1987,7 @@ fn test_walkgraph_reuse() {
                     );
                     lock_trials += 1;
                     assert_eq!(
-                        base.measure(&cand, slack, true),
+                        base.measure(&cand, slack),
                         analyze_route_choice(&cand, slack),
                         "W{world} seed {seed}: reuse != fresh after adding a lock",
                     );

--- a/src/randomize/overworld_writer/assign.rs
+++ b/src/randomize/overworld_writer/assign.rs
@@ -56,30 +56,21 @@ fn shuffled_obj_groups<R: Rng>(
     (keys, groups)
 }
 
-/// Take the next level pool entry for a slot. `take_front` selects which end
-/// of the pool feeds regular slots: the cross-world deque drains from the
-/// front, the intra-world pools drain from the back (preserving the original
-/// per-mode take order). Troll-pipe slots scan from that same end for the
-/// first eligible entry; when none qualifies, the slot takes the plain next
-/// entry and reports itself demoted (second tuple field).
+/// Take the next level pool entry for a slot. Regular slots drain the deque
+/// from the front; a troll-pipe slot scans from the front for the first
+/// eligible entry, and when none qualifies takes the plain next entry and
+/// reports itself demoted (second tuple field).
 fn take_level_slot(
     pool: &mut VecDeque<usize>,
-    take_front: bool,
     is_troll_pipe: bool,
     is_ineligible: impl Fn(usize) -> bool,
 ) -> (usize, bool) {
-    if is_troll_pipe {
-        let found = if take_front {
-            pool.iter().position(|&pi| !is_ineligible(pi))
-        } else {
-            pool.iter().rposition(|&pi| !is_ineligible(pi))
-        };
-        if let Some(idx) = found {
-            return (pool.remove(idx).unwrap(), false);
-        }
+    if is_troll_pipe
+        && let Some(idx) = pool.iter().position(|&pi| !is_ineligible(pi))
+    {
+        return (pool.remove(idx).unwrap(), false);
     }
-    let pi = if take_front { pool.pop_front() } else { pool.pop_back() };
-    (pi.expect("level pool exhausted"), is_troll_pipe)
+    (pool.pop_front().expect("level pool exhausted"), is_troll_pipe)
 }
 
 pub(super) fn assign_pool<R: Rng>(
@@ -89,7 +80,7 @@ pub(super) fn assign_pool<R: Rng>(
     rng: &mut R,
     flags: WriteFlags,
 ) -> Vec<WorldAssignments> {
-    let WriteFlags { cross_world, shuffle_hammer_bros, .. } = flags;
+    let WriteFlags { shuffle_hammer_bros, .. } = flags;
     let pickup = data.pickup;
     let catalog = data.catalog;
     // Partition pool by kind.
@@ -154,23 +145,19 @@ pub(super) fn assign_pool<R: Rng>(
     }).expect("1-F fortress not found in pool");
     let fort_1f_pi = fort_pool.remove(fort_1f_pos);
 
-    // Collect all safe (world_idx, section) slots. In intra-world mode,
-    // 1-F can only go to a safe slot in its origin world.
-    let fort_1f_origin = catalog.entries[pickup.pool[fort_1f_pi].catalog_idx].world_idx;
+    // Collect all safe (world_idx, section) slots. World order is
+    // load-bearing: the draw below indexes into this list.
     let mut safe_slots: Vec<(usize, usize)> = Vec::new();
     for wi in 0..8 {
-        if !cross_world && wi != fort_1f_origin {
-            continue;
-        }
         for lock in &build.worlds[wi].locks {
             if lock.secret_exit_safe {
                 safe_slots.push((wi, lock.fort_section));
             }
         }
     }
-    // Pre-assign 1-F to a safe slot if one exists. In intra-world mode,
-    // W1 may have no safe lock — that's fine, the player must use the
-    // normal exit (beat Boom-Boom) to open the lock.
+    // Pre-assign 1-F to a safe slot if one exists. If no world offers one,
+    // that's fine — the player must use the normal exit (beat Boom-Boom)
+    // to open the lock.
     let mut preassigned_forts: HashMap<(usize, usize), usize> = HashMap::new();
     if let Some(&(safe_wi, safe_section)) = safe_slots.choose(rng) {
         preassigned_forts.insert((safe_wi, safe_section), fort_1f_pi);
@@ -188,20 +175,6 @@ pub(super) fn assign_pool<R: Rng>(
     // that depend on specific level assignments per seed.
     toad_pool.as_mut_slice().shuffle(rng);
     let mut toad_iter = toad_pool.into_iter();
-
-    // For intra-world mode, partition fort/level pools by origin world.
-    let mut fort_by_world: HashMap<usize, Vec<usize>> = HashMap::new();
-    let mut level_by_world: HashMap<usize, VecDeque<usize>> = HashMap::new();
-    if !cross_world {
-        for &pi in &fort_pool {
-            let wi = catalog.entries[pickup.pool[pi].catalog_idx].world_idx;
-            fort_by_world.entry(wi).or_default().push(pi);
-        }
-        for &pi in &level_pool {
-            let wi = catalog.entries[pickup.pool[pi].catalog_idx].world_idx;
-            level_by_world.entry(wi).or_default().push_back(pi);
-        }
-    }
 
     let mut fort_iter = fort_pool.into_iter();
     let mut level_pool: VecDeque<usize> = level_pool.into();
@@ -236,15 +209,9 @@ pub(super) fn assign_pool<R: Rng>(
                 s.kind == SlotKind::Fortress && s.section == section
             }) {
                 // Check if this slot was pre-assigned (1-F safe placement).
-                let pi = if let Some(pre) = preassigned_forts.remove(&(wi, section)) {
-                    pre
-                } else if cross_world {
-                    fort_iter.next().expect("fortress pool exhausted")
-                } else {
-                    fort_by_world
-                        .get_mut(&wi)
-                        .and_then(|v| v.pop())
-                        .expect("intra-world fortress pool exhausted")
+                let pi = match preassigned_forts.remove(&(wi, section)) {
+                    Some(pre) => pre,
+                    None => fort_iter.next().expect("fortress pool exhausted"),
                 };
                 fortress.push(Assignment { pool_idx: pi, pos: slot.pos });
             }
@@ -275,15 +242,11 @@ pub(super) fn assign_pool<R: Rng>(
         ordered.extend(level_slots.iter().copied().filter(|s| !s.is_troll_pipe));
 
         for slot in ordered {
-            let pool = if cross_world {
-                &mut level_pool
-            } else {
-                level_by_world
-                    .get_mut(&wi)
-                    .expect("intra-world level pool missing")
-            };
-            let (pi, demoted) =
-                take_level_slot(pool, cross_world, slot.is_troll_pipe, is_troll_pipe_ineligible);
+            let (pi, demoted) = take_level_slot(
+                &mut level_pool,
+                slot.is_troll_pipe,
+                is_troll_pipe_ineligible,
+            );
             if demoted {
                 demoted_troll_pipes.insert(slot.pos);
             }

--- a/src/randomize/overworld_writer/mod.rs
+++ b/src/randomize/overworld_writer/mod.rs
@@ -125,19 +125,12 @@ pub(crate) fn write_overworld<R: Rng>(
     }
 }
 
-/// Feature/mode flags consumed by the writer. `cross_world` is the standard
-/// mode and defaults on; feature flags default off. Construct exhaustively in
-/// production so a new flag forces a conscious wire-up; in tests use
-/// `WriteFlags { ..Default::default() }` so adding a flag leaves them untouched.
-#[derive(Copy, Clone)]
+/// Feature flags consumed by the writer, all defaulting off. Construct
+/// exhaustively in production so a new flag forces a conscious wire-up; in
+/// tests use `WriteFlags { ..Default::default() }` so adding a flag leaves
+/// them untouched.
+#[derive(Copy, Clone, Default)]
 pub(crate) struct WriteFlags {
-    pub cross_world: bool,
     pub shuffle_hammer_bros: bool,
     pub piranha: PiranhaMode,
-}
-
-impl Default for WriteFlags {
-    fn default() -> Self {
-        Self { cross_world: true, shuffle_hammer_bros: false, piranha: PiranhaMode::Off }
-    }
 }

--- a/src/randomize/overworld_writer/tests.rs
+++ b/src/randomize/overworld_writer/tests.rs
@@ -722,7 +722,6 @@ fn test_march_veto_pipeline_writes_registry() {
     write_overworld(&mut out, &build, &data, &mut rng, WriteFlags {
         piranha: PiranhaMode::Wild,
         shuffle_hammer_bros: true,
-        ..Default::default()
     });
 
     assert_veto_hook_installed(&out);

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -113,7 +113,7 @@ pub const FREE_SPACE_ALLOCATIONS: &[FreeSpaceAlloc] = &[
     fs(0x3E965, 13, &["title_screen"], "intro skip + menu music routine"),
     fs(0x3FFF0, 26, &["card_speed_clear"], "XOR trampoline"),
     // PRG025 (file 0x32010, CPU $C000–$DFFF while the title screen runs)
-    fs(0x33529, 32, &["title_screen"], "title menu B-to-mute toggle (32 reserved, 22 used)"),
+    fs(0x33FF0, 32, &["title_screen"], "title menu B-to-mute toggle (32 reserved, 22 used)"),
     // PRG026 (file 0x34010, CPU $A000–$BFFF)
     fs(0x35572, 13, &["mystery_anchor"], "item redirect trampoline"),
     fs(0x3557F, 50, &["hammer_breaks_tiles"], "hammer_locks: tile check subroutine + tables"),
@@ -178,11 +178,19 @@ pub(crate) const FS_CARD_CLEAR: usize        = 0x3FFF0; // 26 bytes
 
 // PRG025 — the title-screen bank at $C000–$DFFF (PRG030's title entry loads
 // page 24 into $A000 and page 25 into $C000 before `Do_Title_Screen`). The
-// disassembly ends this bank with "Rest of ROM bank was empty" just before this
-// offset, so the whole 2791-byte run to the bank end is unreferenced filler;
-// only 32 bytes are claimed here. Costs nothing from the always-mapped banks,
-// which is what makes this the right home for a title-only routine.
-pub(crate) const FS_TITLE_MUTE: usize        = 0x33529; // 32 reserved, 22 used
+// disassembly ends this bank with "Rest of ROM bank was empty" at 0x33529, so
+// the whole 2791-byte run to the bank end is unreferenced filler; only 32 bytes
+// are claimed here. Costs nothing from the always-mapped banks, which is what
+// makes this the right home for a title-only routine.
+//
+// Sited at the *end* of that run rather than its start, and deliberately: a
+// third-party title-screen hack that needs room in this bank starts at the
+// first $FF it finds, which is 0x33529. Super Princess Peach does exactly that
+// — its five 36-byte logo VRAM-upload blocks run 0x33530..0x336A7 — and the
+// routine used to sit right on top of the first one, so a Peach seed drew a
+// band of garbage tiles across the title screen (`visual_patches_clear_the_free
+// _space_registry` guards the whole registry against the bundled patches now).
+pub(crate) const FS_TITLE_MUTE: usize        = 0x33FF0; // 32 reserved, 22 used
 
 pub(crate) const FS_STARTING_ITEMS: usize    = 0x3E260; // 33 bytes
 
@@ -966,5 +974,67 @@ mod free_space_tests {
         assert_eq!(j[0], 0x20);
         let cpu = u16::from_le_bytes([j[1], j[2]]);
         assert_eq!(prg_bank_cpu_to_file(11, cpu), FS_MARCH_VETO);
+    }
+
+    /// Every bundled visual patch must leave the free-space registry alone.
+    ///
+    /// The web app applies the player's chosen visual patch *before*
+    /// randomization, so a patch and an allocation that want the same bytes do
+    /// not collide loudly — the randomizer simply writes last and silently
+    /// corrupts the patch's data. That is what happened to Super Princess
+    /// Peach: its title logo needs room in PRG025 and, like any hack looking
+    /// for space, took it from the first `$FF` run in the bank — the same run
+    /// [`FS_TITLE_MUTE`] was sited at. Every Peach seed drew a band of garbage
+    /// tiles across the title screen.
+    ///
+    /// The patch is a third-party artifact and cannot be edited, so the
+    /// allocation is what moves. This reads the shipped `.ips` files directly,
+    /// needs no ROM, and so runs in CI — a patch dropped into
+    /// `web/visual-patches/` is checked the moment it lands.
+    #[test]
+    fn bundled_visual_patches_clear_the_free_space_registry() {
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/web/visual-patches");
+        let mut checked = 0;
+        let mut collisions = Vec::new();
+
+        for entry in std::fs::read_dir(dir).expect("web/visual-patches must exist") {
+            let path = entry.expect("readable dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("ips") {
+                continue;
+            }
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            let bytes = std::fs::read(&path).expect("readable patch");
+            let records = crate::ips::parse_ips_records(&bytes).expect("valid IPS");
+            checked += 1;
+
+            for rec in &records {
+                let (rec_start, rec_end) = (rec.offset, rec.offset + rec.payload.len());
+                for alloc in FREE_SPACE_ALLOCATIONS {
+                    let (a_start, a_end) = (alloc.offset, alloc.offset + alloc.size);
+                    let overlap = rec_start.max(a_start)..rec_end.min(a_end);
+                    if !overlap.is_empty() {
+                        collisions.push(format!(
+                            "  {name}: 0x{:05X}..0x{:05X} ({} bytes) lands in {} @ 0x{:05X}+{} ({})",
+                            overlap.start,
+                            overlap.end,
+                            overlap.len(),
+                            alloc.owners.join("/"),
+                            alloc.offset,
+                            alloc.size,
+                            alloc.label,
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(checked > 0, "no .ips files found in {dir}");
+        assert!(
+            collisions.is_empty(),
+            "bundled visual patches write into reserved free space — the \
+             randomizer would overwrite them. Move the allocation, not the \
+             patch:\n{}",
+            collisions.join("\n"),
+        );
     }
 }

--- a/src/randomize/title_screen.rs
+++ b/src/randomize/title_screen.rs
@@ -93,7 +93,7 @@ const MUTE_HOOK_OFFSET: usize = 0x30C93;
 const TITLE_3GLOW_CPU: u16 = 0xAA7D;
 const MUTE_ROUTINE_OFFSET: usize = super::rom_data::FS_TITLE_MUTE;
 /// PRG025 file 0x32010 is CPU $C000 while the title screen runs.
-const MUTE_ROUTINE_CPU: u16 = (0xC000 + MUTE_ROUTINE_OFFSET - 0x32010) as u16; // $D519
+const MUTE_ROUTINE_CPU: u16 = (0xC000 + MUTE_ROUTINE_OFFSET - 0x32010) as u16; // $DFE0
 
 /// Assemble the 22-byte mute toggle. `music` is the seeded track it restores.
 ///
@@ -557,8 +557,8 @@ mod tests {
         let mut rom = crate::randomize::qol::test_support::make_test_rom();
         write_seed_hash(&mut rom, 42, &opts);
 
-        // JSR $D519 in place of the vanilla JSR Title_3Glow.
-        assert_eq!(rom.read_range(MUTE_HOOK_OFFSET, 3), &[0x20, 0x19, 0xD5]);
+        // JSR $DFE0 in place of the vanilla JSR Title_3Glow.
+        assert_eq!(rom.read_range(MUTE_HOOK_OFFSET, 3), &[0x20, 0xE0, 0xDF]);
         assert_eq!(
             rom.read_range(MUTE_ROUTINE_OFFSET, 22),
             &mute_routine(pick_menu_music(42))[..]

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -311,7 +311,6 @@ fn randomize_inner(
         &data,
         &mut rng,
         randomize::overworld_writer::WriteFlags {
-            cross_world: true,
             shuffle_hammer_bros: options.shuffle_hammer_bros,
             piranha: options.piranha_shuffle,
         },

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -146,12 +146,33 @@ fn sweep_is_deterministic() {
 /// the same-span rate from 78% to 33%, and `test_route_census` at 1000 seeds
 /// shows W8 mean routes 2.27 -> 2.25 (linear 4% -> 5%), overall 2.548 -> 2.537
 /// (linear 6.60% -> 6.91%), nothing below its dealt floor either way.
+///
+/// Re-captured 2026-08-24 for the `SPOILED_SEGMENT_RANGES` off-by-one
+/// (issue #181). The middle row ended one byte past the next real stream's
+/// page byte, so after autoscroll removal the enemy-data walker resumed
+/// mid-entry and stayed out of phase for 18 slots. Attribution is by
+/// pinning, as with the v28 and C1-floor recaptures: restoring the range to
+/// `0x0D037..0x0D042` reproduces the hashes above exactly, so this one byte
+/// is the whole difference. What it changes: the walker now sees the two
+/// segments it was reading through, whose 17 entries were pinned to vanilla
+/// in every seed before. They are unrelated levels that merely sit next to
+/// each other in the block — `0x0D041` is 4-1's underwater sub-area and
+/// `0x0D049` is 5-4. Only four of the 17 can move: the two Big Berthas at
+/// `0x0D042`/`0x0D045` (water) and the two para-troopas at
+/// `0x0D068`/`0x0D074` (flying). The other 13 are `$90`-`$93`, the tilting
+/// and twirling platforms, which belong to no class pool and so never draw
+/// at any flag setting. Those four extra draws shift the shared RNG stream,
+/// which is why all 20 seeds move and the overworld moves with them.
+/// Nothing was being written to a wrong byte before the fix — the 18
+/// out-of-phase slots held X, Y and page bytes, all `$01..$19` and in no
+/// class pool, so 500 seeds at all-Wild never wrote one. It was latent, and
+/// `every_enemy_entry_point_is_a_walker_segment_start` keeps it that way.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x23BB0B1661EB4991, 0x8BCB87C002850E1B, 0xD35E65FB6393BA7B, 0x28316C60D5B50C8C,
-    0x71D46A423D87F88D, 0x16C8AF59B8BB0589, 0x9DE59CE91689D794, 0x4C5689DE1274B707,
-    0xCF0D452FCB5F3BA5, 0xA0DA1A4EA05C9840, 0x913CB348A60E1204, 0xFB9B9EACB78D1131,
-    0x9F479C3584CDB1C9, 0x704A60C34AA3185F, 0xFEBF4CA438E54465, 0x46495F783B0C2C96,
-    0x8B9271CB5F45BD14, 0x7931621C85178986, 0xFC800FBE4F077B0A, 0xEADB5C1E7B634CA5,
+    0x500AD778776D337C, 0x5094FC748FF2B4A0, 0x20B5E2E0BEF7D0D9, 0xEC95C1580A2BEE84,
+    0xC6B2A9E00C225CB0, 0x44176CCCD2205ADA, 0x72BD61D4494E339B, 0x731F65BE6351EFD6,
+    0x4B121B725E5FE009, 0x7C56E69368F19D0B, 0x17DA3F4A44B528BE, 0xDAB9D9E9664DFF6E,
+    0xEF249386B9EE1856, 0xFBC5053F17052149, 0xA4D37AF9D4FF4E73, 0xED82D0729BCF4787,
+    0xE0201F610E43A939, 0xFDEE0F3892D95E78, 0xD57B93C62D8B9C1B, 0x96C2A5DEAF2ECF88,
 ];
 
 #[test]

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -178,12 +178,26 @@ fn sweep_is_deterministic() {
 /// returning to `$FF` filler, and the byte-identical routine reappearing at
 /// 0x33FF0. The routine's seeded music byte is unchanged per seed, so no RNG
 /// draw shifted; no overworld, level or enemy byte moved.
+///
+/// Re-captured 2026-08-26 for the 1.2.1 bump. A version bump alone moves every
+/// seed: `compute_hash` folds `CARGO_PKG_VERSION`, which is the whole point of
+/// the version-guard. Attribution is by round trip *and* by byte. Round trip:
+/// 1.2.0 on this same tree reproduces the previous array exactly and 1.2.1
+/// reproduces this one, so the version string is the only cause. Byte: seeds
+/// 1-3 generated at each version with `--no-palettes --patched-rom` differ in
+/// 2-3 bytes, every one of them inside `FS_SEED_HASH_DATA` (0x3E93D+40) -- the
+/// title-screen verification icons, which is exactly what is supposed to move.
+///
+/// One trap worth naming: `cargo` did NOT rebuild on a version-only edit to
+/// `Cargo.toml` here, so the first recapture attempt printed a stale binary's
+/// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
+/// trusting any number this test prints after a bump.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xC1672935E5BE725B, 0xB06CA2D567B1D2C3, 0x17AD5FEF5255106E, 0x4BD4107152F354EB,
-    0x5206D328FB18E899, 0x93CBC953E7CE1151, 0x75C391FD37763CA4, 0xBC969C8412C1C6AD,
-    0x93AC4F94222D42D0, 0xF2043CAEAD240B78, 0xBA6A10BA15FDEF37, 0xD5E046C58E004629,
-    0xEBE210006571D655, 0x748856D512DC4078, 0x2781725105A210AE, 0x076C97B103DA58DC,
-    0x514C3F9D58DD8C46, 0xFDCF738729FEDA5F, 0xC12C828A80132458, 0xD16EBAE7996DB3F7,
+    0xBED95ABDD9439FB5, 0xDBF47F5B31DA86EF, 0xB04474783CB4D0C2, 0x74AC5BCD65AD258D,
+    0x03A4151A9BBFCF29, 0x1F35830291CF10D1, 0x2C970403032C84A6, 0x56890C44D7D2E751,
+    0xD0F5B5E94A13DD88, 0x5C83EEC7421A3608, 0x7652B197D0160E55, 0x0D99057DED830981,
+    0xB8D7424F73B99BF1, 0x1DC2D6E4F10E3616, 0x883D33A2E3BB6E7C, 0xED0DEA0D8520786C,
+    0x650CEA1C0A0A5996, 0x8EDA0264B99A185F, 0x181B0A493C5FEC2C, 0xF39CB84027935889,
 ];
 
 #[test]

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -167,12 +167,23 @@ fn sweep_is_deterministic() {
 /// out-of-phase slots held X, Y and page bytes, all `$01..$19` and in no
 /// class pool, so 500 seeds at all-Wild never wrote one. It was latent, and
 /// `every_enemy_entry_point_is_a_walker_segment_start` keeps it that way.
+///
+/// Re-captured 2026-08-26 for the Super Princess Peach title-screen fix. The
+/// B-to-mute routine moved from 0x33529 to 0x33FF0 — same 22 bytes, different
+/// home, because Peach's title logo claims 0x33530..0x336A7 and the randomizer
+/// writes last. Every seed moves because the ROM bytes moved. Attribution is by
+/// byte diff, as with the recaptures above: seeds 1-3 generated before and
+/// after with `--no-palettes --patched-rom` differ in exactly 46 bytes, in
+/// three runs — the 2-byte `JSR` operand at 0x30C94, the 22 bytes at 0x33529
+/// returning to `$FF` filler, and the byte-identical routine reappearing at
+/// 0x33FF0. The routine's seeded music byte is unchanged per seed, so no RNG
+/// draw shifted; no overworld, level or enemy byte moved.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x500AD778776D337C, 0x5094FC748FF2B4A0, 0x20B5E2E0BEF7D0D9, 0xEC95C1580A2BEE84,
-    0xC6B2A9E00C225CB0, 0x44176CCCD2205ADA, 0x72BD61D4494E339B, 0x731F65BE6351EFD6,
-    0x4B121B725E5FE009, 0x7C56E69368F19D0B, 0x17DA3F4A44B528BE, 0xDAB9D9E9664DFF6E,
-    0xEF249386B9EE1856, 0xFBC5053F17052149, 0xA4D37AF9D4FF4E73, 0xED82D0729BCF4787,
-    0xE0201F610E43A939, 0xFDEE0F3892D95E78, 0xD57B93C62D8B9C1B, 0x96C2A5DEAF2ECF88,
+    0xC1672935E5BE725B, 0xB06CA2D567B1D2C3, 0x17AD5FEF5255106E, 0x4BD4107152F354EB,
+    0x5206D328FB18E899, 0x93CBC953E7CE1151, 0x75C391FD37763CA4, 0xBC969C8412C1C6AD,
+    0x93AC4F94222D42D0, 0xF2043CAEAD240B78, 0xBA6A10BA15FDEF37, 0xD5E046C58E004629,
+    0xEBE210006571D655, 0x748856D512DC4078, 0x2781725105A210AE, 0x076C97B103DA58DC,
+    0x514C3F9D58DD8C46, 0xFDCF738729FEDA5F, 0xC12C828A80132458, 0xD16EBAE7996DB3F7,
 ];
 
 #[test]

--- a/tests/web_schema_parity.rs
+++ b/tests/web_schema_parity.rs
@@ -1,0 +1,340 @@
+//! The web app's option schema, checked against Rust in CI.
+//!
+//! `web/options.js` already carries `assertSchemaParity` / `assertPresetParity`,
+//! which compare its `SCHEMA` and `PRESETS` against the WASM exports at page
+//! load. They are the right checks — but they run in a browser and report via
+//! `console.error`, and CI executes no JavaScript at all (clippy twice, build,
+//! `cargo test`, an advisory offset scan). So the alarm only ever sounded for
+//! someone who happened to have devtools open.
+//!
+//! That is the path by which `boomboom_hits` shipped encoded in the flag key
+//! but absent from the web schema (fixed in 8077c5d): the option existed on
+//! both sides of the wire, so nothing in Rust noticed, and no one was watching
+//! the console. This file mirrors those two checks over the file itself so the
+//! same drift fails a build instead.
+//!
+//! Rust remains the source of truth. This only asserts that the JS agrees with
+//! it; when the two disagree, the schema is what changes.
+//!
+//! **On parsing JavaScript with regex:** the checks below extract a handful of
+//! literal keys from a file with a very regular shape. The real hazard is not a
+//! wrong answer but a *vacuous* one — a parser that quietly matches nothing
+//! still passes every comparison it is asked to make. `parser_still_matches_the
+//! _file` guards that directly, and every extractor asserts it found a plausible
+//! number of items before its results are used.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+
+use smb3_rs::{Options, flag_key_fields};
+
+const OPTIONS_JS: &str = "web/options.js";
+
+/// Lower bounds that only a broken parser can trip. They are deliberately far
+/// below the real counts — this is a "did the regex stop matching" tripwire,
+/// not a second copy of the schema that has to be maintained.
+const MIN_SCHEMA_ENTRIES: usize = 40;
+const MIN_PRESETS: usize = 3;
+const MIN_CONSTANT_FIELDS: usize = 1;
+
+fn options_js() -> String {
+    fs::read_to_string(OPTIONS_JS)
+        .unwrap_or_else(|e| panic!("{OPTIONS_JS} must be readable from the crate root: {e}"))
+}
+
+/// The body of a `export const NAME = [ … ];` array literal.
+fn array_block<'a>(src: &'a str, name: &str) -> &'a str {
+    let head = format!("export const {name} = [");
+    let start = src
+        .find(&head)
+        .unwrap_or_else(|| panic!("{OPTIONS_JS}: no `{head}` — did the export get renamed?"))
+        + head.len();
+    let rest = &src[start..];
+    let end = rest
+        .find("\n];")
+        .unwrap_or_else(|| panic!("{OPTIONS_JS}: `{name}` has no closing `\\n];`"));
+    &rest[..end]
+}
+
+/// Split an array block into one string per `\n\t{ id: ` entry. Every entry in
+/// both `SCHEMA` and `PRESETS` is written this way; `parser_still_matches_the
+/// _file` fails if that ever stops being true.
+fn entries(block: &str) -> Vec<&str> {
+    block.split("\n\t{ id: ").skip(1).collect()
+}
+
+/// The `"…"` immediately opening an entry.
+fn entry_id(entry: &str) -> &str {
+    let rest = entry.strip_prefix('"').expect("entry does not open with a quoted id");
+    let end = rest.find('"').expect("entry id is not terminated");
+    &rest[..end]
+}
+
+/// `SCHEMA` as `id -> inFlagKey`. Every entry carries an explicit marking; a
+/// missing one is a schema bug, not something to guess a default for.
+fn schema() -> BTreeMap<String, bool> {
+    let src = options_js();
+    let out: BTreeMap<String, bool> = entries(array_block(&src, "SCHEMA"))
+        .into_iter()
+        .map(|e| {
+            let id = entry_id(e);
+            let flag = if e.contains("inFlagKey: true") {
+                true
+            } else if e.contains("inFlagKey: false") {
+                false
+            } else {
+                panic!("{OPTIONS_JS}: SCHEMA entry `{id}` has no `inFlagKey` marking");
+            };
+            (id.to_string(), flag)
+        })
+        .collect();
+    assert!(
+        out.len() >= MIN_SCHEMA_ENTRIES,
+        "parsed only {} SCHEMA entries from {OPTIONS_JS} — the parser has almost \
+         certainly stopped matching the file, not the schema shrunk",
+        out.len(),
+    );
+    out
+}
+
+/// `CONSTANT_FIELDS` — options the app pins rather than exposing a control for.
+/// They are real `Options` fields with no schema entry, so the field-set
+/// comparison has to know about them.
+fn constant_fields() -> BTreeSet<String> {
+    let src = options_js();
+    let start = src
+        .find("const CONSTANT_FIELDS = {")
+        .expect("no `const CONSTANT_FIELDS = {` in options.js")
+        + "const CONSTANT_FIELDS = {".len();
+    let rest = &src[start..];
+    let end = rest.find("\n};").expect("CONSTANT_FIELDS has no closing `\\n};`");
+    let out: BTreeSet<String> = rest[..end]
+        .lines()
+        .filter_map(|l| l.trim().split(':').next())
+        .map(str::trim)
+        .filter(|k| !k.is_empty() && k.chars().all(|c| c.is_ascii_lowercase() || c == '_'))
+        .map(str::to_string)
+        .collect();
+    assert!(
+        out.len() >= MIN_CONSTANT_FIELDS,
+        "parsed no CONSTANT_FIELDS from {OPTIONS_JS} — parser drift",
+    );
+    out
+}
+
+/// Every `overrides:` key across all presets, tagged with its preset id.
+/// Override values are primitives and arrays only — no nested objects and no
+/// colons inside strings — which is what makes the flat key scan below safe.
+fn preset_overrides() -> Vec<(String, String)> {
+    let src = options_js();
+    let block = array_block(&src, "PRESETS");
+    let presets = entries(block);
+    assert!(
+        presets.len() >= MIN_PRESETS,
+        "parsed only {} presets from {OPTIONS_JS} — parser drift",
+        presets.len(),
+    );
+
+    let mut out = Vec::new();
+    for entry in presets {
+        let pid = entry_id(entry);
+        let at = entry
+            .find("overrides:")
+            .unwrap_or_else(|| panic!("preset `{pid}` has no `overrides:`"));
+        let open = entry[at..].find('{').expect("overrides has no `{`") + at;
+
+        let mut depth = 0usize;
+        let mut close = None;
+        for (i, c) in entry[open..].char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(open + i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let close = close.unwrap_or_else(|| panic!("preset `{pid}` overrides never close"));
+        let body = &entry[open + 1..close];
+        assert!(
+            !body.contains('{'),
+            "preset `{pid}` has a nested object in its overrides — the flat key \
+             scan in this test no longer describes the file",
+        );
+
+        for key in flat_keys(body) {
+            out.push((pid.to_string(), key));
+        }
+    }
+    out
+}
+
+/// Identifiers immediately followed by `:`, skipping anything inside a string
+/// literal so a colon in a value can never be read as a key.
+fn flat_keys(body: &str) -> Vec<String> {
+    let bytes = body.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    let mut in_str = false;
+    let mut word_start: Option<usize> = None;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_str = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' => {
+                in_str = true;
+                word_start = None;
+            }
+            // Uppercase counts: a key is only "not an id we know" if we saw it
+            // at all, so the scan must accept any identifier shape, not just
+            // the lower_snake_case the schema happens to use today.
+            b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'0'..=b'9' => {
+                if word_start.is_none() && !c.is_ascii_digit() {
+                    word_start = Some(i);
+                }
+            }
+            b':' => {
+                if let Some(s) = word_start {
+                    out.push(body[s..i].to_string());
+                }
+                word_start = None;
+            }
+            _ => word_start = None,
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Every `Options` field name, as serde spells it on the wire — the same set
+/// the WASM `default_options_json()` export ships to the web app.
+fn options_fields() -> BTreeSet<String> {
+    let value = serde_json::to_value(Options::default()).expect("Options serializes");
+    value
+        .as_object()
+        .expect("Options serializes to an object")
+        .keys()
+        .cloned()
+        .collect()
+}
+
+/// The tripwire. Everything else compares sets that this file extracts; if the
+/// extraction silently matched nothing, those comparisons would pass while
+/// checking nothing at all. Assert the shapes the extractors depend on are
+/// still there.
+#[test]
+fn parser_still_matches_the_file() {
+    let src = options_js();
+    let schema_entries = entries(array_block(&src, "SCHEMA"));
+    let preset_entries = entries(array_block(&src, "PRESETS"));
+
+    assert!(
+        schema_entries.len() >= MIN_SCHEMA_ENTRIES,
+        "SCHEMA parse found {} entries",
+        schema_entries.len(),
+    );
+    assert!(
+        preset_entries.len() >= MIN_PRESETS,
+        "PRESETS parse found {} entries",
+        preset_entries.len(),
+    );
+
+    // Every `id: "…"` inside the SCHEMA block must be an entry opener. If a
+    // nested `id:` ever appears, `entries()` silently under-counts and the
+    // field-set check below would start passing for the wrong reason.
+    let block = array_block(&src, "SCHEMA");
+    assert_eq!(
+        block.matches("id: \"").count(),
+        schema_entries.len(),
+        "SCHEMA has an `id:` that is not an entry opener — `entries()` is \
+         under-counting and every check built on it is unreliable",
+    );
+
+    assert!(!constant_fields().is_empty(), "CONSTANT_FIELDS parse is empty");
+    assert!(!preset_overrides().is_empty(), "preset override parse is empty");
+}
+
+/// Mirrors the first half of `assertSchemaParity`: the schema must offer a
+/// control for every `Options` field except the ones the app pins itself.
+///
+/// A field missing here is invisible in the web app — it silently takes its
+/// default for every player, which is exactly what happened to `boomboom_hits`.
+#[test]
+fn schema_covers_every_options_field() {
+    let schema: BTreeSet<String> = schema().into_keys().collect();
+    let constants = constant_fields();
+    let expected: BTreeSet<String> = options_fields().difference(&constants).cloned().collect();
+
+    let missing_in_js: Vec<&String> = expected.difference(&schema).collect();
+    let missing_in_rust: Vec<&String> = schema.difference(&expected).collect();
+
+    assert!(
+        missing_in_js.is_empty() && missing_in_rust.is_empty(),
+        "web/options.js SCHEMA has drifted from Options.\n  \
+         in Rust, no web control: {missing_in_js:?}\n  \
+         in the schema, not an Options field: {missing_in_rust:?}",
+    );
+}
+
+/// Mirrors the second half of `assertSchemaParity`: `inFlagKey` must say what
+/// Rust actually encodes.
+///
+/// The marking is not documentation — it drives `applyOptions` and
+/// `applyPreset`, so a wrong one means a shared flag key silently fails to
+/// apply that option.
+#[test]
+fn in_flag_key_markings_match_what_rust_encodes() {
+    let schema = schema();
+    let encoded: BTreeSet<String> = flag_key_fields().into_iter().collect();
+
+    let claimed_but_not_encoded: Vec<&String> = schema
+        .iter()
+        .filter(|(id, marked)| **marked && !encoded.contains(*id))
+        .map(|(id, _)| id)
+        .collect();
+    let encoded_but_not_claimed: Vec<&String> = schema
+        .iter()
+        .filter(|(id, marked)| !**marked && encoded.contains(*id))
+        .map(|(id, _)| id)
+        .collect();
+
+    assert!(
+        claimed_but_not_encoded.is_empty() && encoded_but_not_claimed.is_empty(),
+        "inFlagKey drift.\n  \
+         marked shareable, not in the flag key: {claimed_but_not_encoded:?}\n  \
+         in the flag key, not marked: {encoded_but_not_claimed:?}",
+    );
+}
+
+/// Mirrors `assertPresetParity`: a preset override naming an id that is not a
+/// flag-key schema entry is a silent no-op, so the preset quietly stops
+/// delivering the setting it advertises.
+#[test]
+fn preset_overrides_name_live_flag_key_fields() {
+    let schema = schema();
+    let bad: Vec<String> = preset_overrides()
+        .into_iter()
+        .filter_map(|(preset, key)| match schema.get(&key) {
+            None => Some(format!("{preset}.{key} (not a schema id)")),
+            Some(false) => Some(format!("{preset}.{key} (schema id, but inFlagKey: false)")),
+            Some(true) => None,
+        })
+        .collect();
+
+    assert!(bad.is_empty(), "presets reference ids they cannot apply: {bad:?}");
+}

--- a/tests/web_schema_parity.rs
+++ b/tests/web_schema_parity.rs
@@ -16,11 +16,14 @@
 //! Rust remains the source of truth. This only asserts that the JS agrees with
 //! it; when the two disagree, the schema is what changes.
 //!
-//! **On parsing JavaScript with regex:** the checks below extract a handful of
+//! **On hand-parsing JavaScript:** the scanners below extract a handful of
 //! literal keys from a file with a very regular shape. The real hazard is not a
 //! wrong answer but a *vacuous* one — a parser that quietly matches nothing
-//! still passes every comparison it is asked to make. `parser_still_matches_the
-//! _file` guards that directly, and every extractor asserts it found a plausible
+//! still passes every comparison it is asked to make, which is worse than no
+//! check at all because it looks like one. `parser_still_matches_the_file`
+//! guards that directly: it asserts every `id: "` in each block is an entry
+//! opener, so an entry written any other way fails loudly instead of dropping
+//! out of the comparison. Each extractor also asserts it found a plausible
 //! number of items before its results are used.
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -159,17 +162,67 @@ fn preset_overrides() -> Vec<(String, String)> {
             }
         }
         let close = close.unwrap_or_else(|| panic!("preset `{pid}` overrides never close"));
-        let body = &entry[open + 1..close];
+        // Comments first: `// TODO: revisit` would otherwise read as an override
+        // key named `TODO`, failing the build with a message that blames the
+        // presets for a parser problem. The JS check ignores comments too.
+        let body = strip_comments(&entry[open + 1..close]);
         assert!(
             !body.contains('{'),
             "preset `{pid}` has a nested object in its overrides — the flat key \
              scan in this test no longer describes the file",
         );
 
-        for key in flat_keys(body) {
+        for key in flat_keys(&body) {
             out.push((pid.to_string(), key));
         }
     }
+    out
+}
+
+/// Drop `//` and `/* … */` comments. String literals are tracked so a `//`
+/// inside one (a URL, say) is never mistaken for a comment start.
+///
+/// Only the result's *content* matters — nothing downstream maps an offset back
+/// to the original — so this copies kept spans wholesale rather than trying to
+/// preserve length.
+fn strip_comments(body: &str) -> String {
+    let b = body.as_bytes();
+    let mut out = String::with_capacity(body.len());
+    let mut i = 0;
+    let mut kept = 0;
+    let mut in_str = false;
+
+    while i < b.len() {
+        if in_str {
+            match b[i] {
+                b'\\' => i += 2,
+                b'"' => {
+                    in_str = false;
+                    i += 1;
+                }
+                _ => i += 1,
+            }
+            continue;
+        }
+        match b[i] {
+            b'"' => {
+                in_str = true;
+                i += 1;
+            }
+            b'/' if b.get(i + 1) == Some(&b'/') => {
+                out.push_str(&body[kept..i]);
+                i += body[i..].find('\n').unwrap_or(body.len() - i);
+                kept = i;
+            }
+            b'/' if b.get(i + 1) == Some(&b'*') => {
+                out.push_str(&body[kept..i]);
+                i += body[i..].find("*/").map_or(body.len() - i, |e| e + 2);
+                kept = i;
+            }
+            _ => i += 1,
+        }
+    }
+    out.push_str(&body[kept..]);
     out
 }
 
@@ -254,16 +307,19 @@ fn parser_still_matches_the_file() {
         preset_entries.len(),
     );
 
-    // Every `id: "…"` inside the SCHEMA block must be an entry opener. If a
-    // nested `id:` ever appears, `entries()` silently under-counts and the
-    // field-set check below would start passing for the wrong reason.
-    let block = array_block(&src, "SCHEMA");
-    assert_eq!(
-        block.matches("id: \"").count(),
-        schema_entries.len(),
-        "SCHEMA has an `id:` that is not an entry opener — `entries()` is \
-         under-counting and every check built on it is unreliable",
-    );
+    // Every `id: "…"` in a block must be an entry opener. An entry written any
+    // other way is silently skipped by `entries()`, and every check built on it
+    // then passes for the wrong reason — a preset reformatted this way takes its
+    // whole override list out of the parity check with nothing to show for it.
+    for name in ["SCHEMA", "PRESETS"] {
+        let block = array_block(&src, name);
+        assert_eq!(
+            block.matches("id: \"").count(),
+            entries(block).len(),
+            "{name} has an `id:` that is not an entry opener — `entries()` is \
+             under-counting and every check built on it is unreliable",
+        );
+    }
 
     assert!(!constant_fields().is_empty(), "CONSTANT_FIELDS parse is empty");
     assert!(!preset_overrides().is_empty(), "preset override parse is empty");


### PR DESCRIPTION
Cuts **1.2.1**. Eleven commits since 1.2.0, of which two are player-visible.

## Fixed

- **Super Princess Peach drew a band of garbage tiles across the title
  screen.** Peach needs room in PRG025 for its logo and, like any hack looking
  for space, took it from the first `$FF` run in that bank — five 36-byte VRAM
  upload blocks at `0x33530..0x336A7`. `FS_TITLE_MUTE`, the 22-byte
  press-B-to-mute routine, was sited at `0x33529`, the start of that same run.
  The web app applies the visual patch *before* randomization, so the
  randomizer wrote last and overwrote the first 15 bytes of Peach's first
  block: its PPU address, its length byte, and 13 tiles. That block targets
  `$22C0`, low on the screen, which is where the garbage showed up. Nothing
  errored, because a patch overwriting patched bytes is indistinguishable from
  a patch overwriting filler.

  The routine moved to `0x33FF0` — the far end of the same filler run,
  deliberately at the end, since a third-party title hack goes hunting from the
  beginning. `bundled_visual_patches_clear_the_free_space_registry` now checks
  every shipped `.ips` record against every `FREE_SPACE_ALLOCATIONS` row; it
  needs no ROM, so it runs in CI. Peach was the only collision across all six
  bundled patches.

- **Autoscroll removal skipped four enemies.** A `SPOILED_SEGMENT_RANGES` row
  ended one byte past the next stream's page byte, so the enemy walker resumed
  mid-entry and stayed 18 slots out of phase — pinning 4-1's two Big Berthas
  and 5-4's two para-troopas to vanilla in every seed. Nothing was ever written
  to a wrong byte. (#181, #192)

## Also on this range, not player-visible

- CI now checks `web/options.js` against the Rust option schema, so a Rust
  option cannot ship without its web control — and a follow-up fix stops that
  test passing vacuously when its own parser finds nothing. (#191)
- Dead `want_paths` and `cross_world` flags dropped from the route measure and
  the writer. (#189, #190)
- **Deploy concurrency scoped by branch, and `versions.json` takes `current`
  from the newest archived version instead of `Cargo.toml`.** (#188) This is
  the pair that cost the v1.2.0 archive entry: a `beta/next` push landing
  seconds after a release merge cancelled the release run before its archive
  step, and the replacement run published a `current` the archive could not
  serve. `main` still has the version with both defects until this merges — so
  the runbook still applies for *this* release, and protects the next one.

## Verification

- Full suite green (391 unit + integration), `clippy --all-targets` clean, and
  the wasm32 `clippy --lib` pass CI runs separately is clean too.
- Overworld baseline recaptured twice on this branch, each attributed. For the
  Peach fix: seeds 1-3 before and after differ in exactly 46 bytes across three
  runs — the 2-byte `JSR` operand, the old 22 bytes returning to `$FF`, and the
  byte-identical routine at its new home; the seeded music byte is unchanged
  per seed, so no RNG draw shifted. For the bump: 1.2.0 on the same tree
  reproduces the previous array exactly and 1.2.1 the new one, and the only
  bytes that move live in `FS_SEED_HASH_DATA`.
- The Peach fix was verified end-to-end by layering the patch and the
  randomizer the way the web app does: `0x33530..0x336A7` now survives
  randomization byte-for-byte.

Headed with `release/1.2.1` rather than `beta/next` so auto-delete-on-merge
takes the throwaway branch and leaves the integration branch alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW
