### PR TITLE
feature: shuffle the Big [?] Block bonus rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ deploys.
 
 ## [Unreleased]
 
+### Added
+
+- **Big ? Block bonus rooms are shuffled.** Every level with a Big ? pipe now
+  draws from a pool of 19 rooms instead of always opening its own — the 11
+  vanilla rooms plus 8 from "Unused Level 5", a complete set of eight bonus
+  rooms left in the ROM and reachable by nothing. Vanilla's 15 rooms are only
+  10 distinct layouts, so this roughly doubles what you can walk into. 7-F1's
+  block is still always a flight suit, whichever room it draws, because the
+  level needs one.
+
+
 ## [1.2.1] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ deploys.
 
 - **Big ? Block bonus rooms are shuffled.** Every level with a Big ? pipe now
   draws from a pool of 19 rooms instead of always opening its own — the 11
-  vanilla rooms plus 8 from "Unused Level 5", a complete set of eight bonus
-  rooms left in the ROM and reachable by nothing. Vanilla's 15 rooms are only
-  10 distinct layouts, so this roughly doubles what you can walk into. 7-F1's
+  vanilla rooms plus 6 from "Unused Level 5", a set of bonus rooms left in the
+  ROM and reachable by nothing. Vanilla's 15 rooms are only 10 distinct
+  layouts, so this markedly widens what you can walk into. 7-F1's
   block is still always a flight suit, whichever room it draws, because the
   level needs one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ deploys.
 
 - **Big ? Block bonus rooms are shuffled.** Every level with a Big ? pipe now
   draws from a pool of 19 rooms instead of always opening its own — the 11
-  vanilla rooms plus 6 from "Unused Level 5", a set of bonus rooms left in the
-  ROM and reachable by nothing. Vanilla's 15 rooms are only 10 distinct
-  layouts, so this markedly widens what you can walk into. 7-F1's
+  vanilla rooms plus 8 from "Unused Level 5", a complete set of eight bonus
+  rooms left in the ROM and reachable by nothing. Vanilla's 15 rooms are only
+  10 distinct layouts, so this roughly doubles what you can walk into. 7-F1's
   block is still always a flight suit, whichever room it draws, because the
   level needs one.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ is the one to read:
 | PRG007 | swapped, in-level (object AI) | 27 | 27 |
 | PRG010 | `$C000–$DFFF`, map | 896 | 588 |
 | PRG025 | `$C000–$DFFF`, title screen | 2771 | 2759 |
-| PRG026 | `$A000–$BFFF`, map/inventory | 2603 | 2537 |
+| PRG026 | `$A000–$BFFF`, map/inventory | 2485 | 2419 |
 
 PRG000 and PRG002 have no `$FF` filler left at all.
 

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -74,7 +74,9 @@ room you have seen in World 5.
 
 ## Plan
 
-Pool: 14 vanilla rooms + 8 from Unused Level 5 = 22 rooms for 11 host levels.
+Pool as shipped: 11 vanilla rooms + 6 from Unused Level 5 = 17 rooms for 11
+host levels. (This section's original 22 counted the spare vanilla rooms, whose
+arrivals were never authored, and all eight Unused Level 5 rooms.)
 
 Data to assemble:
 
@@ -363,25 +365,44 @@ Two things resolved along the way that the earlier sections got wrong:
   exit seed writes at `Player_XHi` and is correct as long as bonus areas stay
   horizontal, which all eight vanilla ones and Unused Level 5 are.
 
+## Unused Level 5 screens 6 and 7 are held back
+
+Playtested 2026-08-27 and **both dropped the player through the floor** — he
+appears in the wall and falls to his death. They are the only two rooms with no
+ceiling pipe, so their arrivals were aimed "beside the floor pipe" at Y index 6,
+row 23. That is the pipe body's row, not ground:
+
+```
+--- screen 6 ---            --- screen 7 ---
+0F 61 E4 04  row 15 col 1   0F 71 E1 07  row 15 col 1 len 7
+37 61 B1     row 23 col 1   17 76 E1 09  row 23 col 6 len 9
+             ^ the pipe     37 72 B1     row 23 col 2  ^ the pipe
+```
+
+The arrivals put him at col 3 (s6) and col 5 (s7), both at row 23. Screen 6 has
+nothing at row 23 except the pipe itself; screen 7's row-23 run starts at col 6.
+They are also the only two rooms using Y index 6 — every room that works uses
+0, 4 or 5 — which was the signal to treat them as suspect before shipping.
+
+**Re-aiming them needs the room's tile grid, not its command list.** The layout
+commands say where a generator starts, not which tiles end up solid, and
+`level_sim.py` only knows tileset 1. Until something can answer "is (col, row)
+solid in a fortress-tileset room", these two stay out and the pool is 17.
+
 ## Playtest ROMs
 
-Six seeds through the real pipeline, each parking 5-2 on W1 tile 1 and 7-F1 on
-the next tile with a P-Wing in the inventory, at
-`~/Copyparty/MiSTer/games/NES/_rando/bigq_seed<N>.nes`:
+Five seeds through the real pipeline, each parking 5-2 on W1 tile 1 and 7-F1 on
+the next tile with a P-Wing, at
+`~/Copyparty/MiSTer/games/NES/_rando/bigq_seed<N>.nes`. Between them they cover
+**all six** Unused Level 5 rooms still in the pool, plus two 7-F1 forces:
 
 | Seed | 5-2 opens | 7-F1 opens | 7-F1's block |
 |---|---|---|---|
-| 10 | **Unused Level 5 s7** | Unused Level 5 s0 | already Tanooki |
-| 16 | **Unused Level 5 s6** | BigQ8 s4 | 3-Up → forced Tanooki |
-| 31 | **Unused Level 5 s6** | BigQ3 s5 | Frog → forced Tanooki |
+| 10 | Unused Level 5 s2 | Unused Level 5 s0 | already Tanooki |
 | 4 | Unused Level 5 s3 | Unused Level 5 s4 | already Tanooki |
 | 25 | Unused Level 5 s1 | BigQ6 s6 | Hammer → forced Tanooki |
-| 5 | BigQ4 s2 | BigQ8 s4 | 3-Up → forced Tanooki |
-
-Screens 6 and 7 (bold) are the ones to look at hardest — they have no ceiling
-pipe, so the player is placed *beside* the floor pipe instead of dropping out of
-a mouth. Seed 5 is the cross-world vanilla case, 5-2 opening World 4's room.
-Seeds 5, 16, 25 and 31 each exercise the 7-F1 force from a different block type.
+| 26 | Unused Level 5 s5 | Unused Level 5 s3 | already Tanooki |
+| 24 | Unused Level 5 s2 | BigQ6 s3 | 3-Up → forced Tanooki |
 
 Rebuild with:
 
@@ -393,15 +414,16 @@ testrom --randomize --seed <N> --place 5-2 7F1 --no-walk --starting-items p-wing
 overworld writer want the same free space. Delete the target on the mount first,
 it never overwrites.
 
-**These seeds are specific to `testrom`'s option set.** Its `Options` differ from
-the CLI's defaults, which moves the shared RNG, so the same seed number picks
-different rooms under `smb3-rs`. Read the room out of the ROM (the four payload
-tables start at `FS_BIG_Q_LOOKUP + 0x8E`) rather than assuming.
+**These seed numbers are specific to `testrom`'s option set.** Its `Options`
+differ from the CLI's defaults, which moves the shared RNG, so the same seed
+picks different rooms under `smb3-rs`. Read the room out of the ROM — the four
+payload tables start at `FS_BIG_Q_LOOKUP + 0x8E` — rather than assuming.
 
-Parking both levels on World 1 also puts both rooms under **one** world's
-`BigQBlock_GotIt` mask, which the real seed would not necessarily do — so these
-six were picked to have distinct room screens. A pair that collided would show
-the second block already collected.
+Parking both levels on World 1 puts both rooms under **one** world's
+`BigQBlock_GotIt` mask, which the real seed would not necessarily do, so these
+five were picked to have distinct room screens. A colliding pair would show the
+second block already collected.
 
-To look at one Unused Level 5 room in isolation, without the randomizer, the old
-knob still works: `testrom --place 5-2 --bigq-unused5 <screen> --bigq-palette 4`.
+To look at one Unused Level 5 room in isolation, without the randomizer:
+`testrom --place 5-2 --bigq-unused5 <screen> --bigq-palette 4`. That knob still
+reaches screens 6 and 7, which the randomizer no longer draws.

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -1,7 +1,7 @@
 # Big [?] Bonus Room Shuffle — design notes
 
-**Status: parked 2026-08-26**, branch `experiment/unused5-bigq-testrom`.
-Playtested and working as a `testrom` knob; not started as a randomizer option.
+**Status: implemented 2026-08-27.** Always on, no option. The `testrom
+--bigq-unused5` knob remains for looking at a single room in isolation.
 
 Mechanism reference lives in `docs/smb3_rom_reference.md` under "Big [?] Block
 Bonus Areas" — tables, junction decode, pipe-tile types, palette indices, the
@@ -17,9 +17,11 @@ Playtested in an emulator, all eight rooms: the area loads, the fortress-tileset
 bank swap works, the block is collectable, and the pipe returns to 5-2. Palette
 4 was chosen. This is the proof that the rooms are usable.
 
-## What is not built
+## What is built in the randomizer
 
-Anything in the randomizer proper. No option, no flag-key bit, no web control.
+`randomize/big_q_rooms.rs` — every host draws from the 19-room pool, always on,
+no option and no flag-key bit. `qol/big_q.rs` grew the slot-seeding halves and
+the four payload tables the pass fills in.
 
 ## The pairing model
 
@@ -333,34 +335,73 @@ junction, so a general shuffle cannot seed slots from there without a key that
 distinguishes one pipe from another — and at that point `Player_XHi` is all the
 engine knows. Big [?] is easy precisely because its handler is exclusive.
 
-## Next step when this resumes
+## What shipped, against the design
 
-Implement the seed-the-slots design above. In order:
+Built as designed: two hooks, both on Big [?]-only paths, seeding
+`Level_JctXLHStart` / `Level_JctYLHStart` from tables in the lookup routine. No
+layout command is located or edited, so neither open blocker — host junction
+offsets, spare `Coin` commands in Unused Level 5 — had to be resolved.
 
-1. **Widen the lookup routine** — two arrival tables, the entry seed, and grow
-   `FS_BIG_Q_LOOKUP` to fit. Measure the real byte count; the ~100 figure is an
-   estimate. `asm::check` with `.allocation` and `.origin` in the same commit.
-2. **Add the exit hook** at `PRG026_AA5A` with the two return tables.
-3. **Harvest what the tables need** — per room: arrival byte1/byte2. The 11
-   vanilla rooms' values are in the part-2 candidate table, the 8 Unused Level 5
-   values are `UNUSED5_ARRIVALS` in `testrom.rs`. Per host: return byte1/byte2,
-   all in the part-1 table. **Note the candidate table is now only needed for its
-   arrival bytes, not for its junction offsets** — a wrong offset no longer
-   matters because nothing is written there.
-4. **The pass itself** — 19-room pool, draw without replacement, respect the
-   per-world `BigQBlock_GotIt` screen rule, always on, no option. Runs after
-   `qol::fix_big_q_block_rooms` (whose routine it fills in) and before
-   `randomize_big_q_blocks`.
-5. **7-F1** — exclude its drawn room's block offset from the contents roll.
-   Every Unused Level 5 block is already a Tanooki, so no value needs forcing.
+Measured, not estimated: the routine is **207 bytes in a 224-byte allocation**,
+against the ~100 the design guessed. The guess forgot that the seeding is
+duplicated for entry and exit and that four 13-byte payload tables cost 52 on
+their own. PRG026's largest gap starts exactly where `FS_BIG_Q_LOOKUP` ends, so
+it grew in place; the bank is down to 2485 free / 2419 largest.
 
-The old blockers — locating host junctions, finding spare commands in Unused
-Level 5 — are dropped by the design and do not need resolving.
+Two things resolved along the way that the earlier sections got wrong:
+
+- **The host-to-room pairing is settled**, and the pairing table in "Harvest,
+  part 2" is now load-bearing for the *return* bytes (a wrong pairing would send
+  a host's players back into a different level). The discriminator that finished
+  it: 7-F1's only in-area candidate carries **pipe-exit dir 8**, which is a front
+  door, not a bonus pipe. Excluding dir-8 leaves 7-8 on s4, so 7-F1 takes s6 —
+  agreeing with `W7F1_TANOOKI_OFFSET` and with 6-9 taking BigQ6 s3 by
+  elimination. All 11 rooms come out distinct.
+- **Vertical hosts index differently.** `PRG026_AA9A` sends vertical levels
+  through `LevelJct_GetVScreenH` instead of `Player_XHi`, while the Big [?]
+  *entry* path uses `Player_XHi` unconditionally. Entry is therefore safe. The
+  exit seed writes at `Player_XHi` and is correct as long as bonus areas stay
+  horizontal, which all eight vanilla ones and Unused Level 5 are.
 
 ## Playtest ROMs
 
-`~/Copyparty/MiSTer/games/NES/_rando/unused5_bigq_s0..s7.nes` (one per room,
-palette 0) and `unused5_pal1/3/4.nes` (room 5 in the other fortress palettes).
-Rebuild any of them with `testrom --place 5-2 --bigq-unused5 <screen>
---bigq-palette <index>`; delete the target on the mount first, it never
-overwrites.
+Six seeds through the real pipeline, each parking 5-2 on W1 tile 1 and 7-F1 on
+the next tile with a P-Wing in the inventory, at
+`~/Copyparty/MiSTer/games/NES/_rando/bigq_seed<N>.nes`:
+
+| Seed | 5-2 opens | 7-F1 opens | 7-F1's block |
+|---|---|---|---|
+| 10 | **Unused Level 5 s7** | Unused Level 5 s0 | already Tanooki |
+| 16 | **Unused Level 5 s6** | BigQ8 s4 | 3-Up → forced Tanooki |
+| 31 | **Unused Level 5 s6** | BigQ3 s5 | Frog → forced Tanooki |
+| 4 | Unused Level 5 s3 | Unused Level 5 s4 | already Tanooki |
+| 25 | Unused Level 5 s1 | BigQ6 s6 | Hammer → forced Tanooki |
+| 5 | BigQ4 s2 | BigQ8 s4 | 3-Up → forced Tanooki |
+
+Screens 6 and 7 (bold) are the ones to look at hardest — they have no ceiling
+pipe, so the player is placed *beside* the floor pipe instead of dropping out of
+a mouth. Seed 5 is the cross-world vanilla case, 5-2 opening World 4's room.
+Seeds 5, 16, 25 and 31 each exercise the 7-F1 force from a different block type.
+
+Rebuild with:
+
+```sh
+testrom --randomize --seed <N> --place 5-2 7F1 --no-walk --starting-items p-wing
+```
+
+`--no-walk` is required on a randomized base: the open-movement patch and the
+overworld writer want the same free space. Delete the target on the mount first,
+it never overwrites.
+
+**These seeds are specific to `testrom`'s option set.** Its `Options` differ from
+the CLI's defaults, which moves the shared RNG, so the same seed number picks
+different rooms under `smb3-rs`. Read the room out of the ROM (the four payload
+tables start at `FS_BIG_Q_LOOKUP + 0x8E`) rather than assuming.
+
+Parking both levels on World 1 also puts both rooms under **one** world's
+`BigQBlock_GotIt` mask, which the real seed would not necessarily do — so these
+six were picked to have distinct room screens. A pair that collided would show
+the second block already collected.
+
+To look at one Unused Level 5 room in isolation, without the randomizer, the old
+knob still works: `testrom --place 5-2 --bigq-unused5 <screen> --bigq-palette 4`.

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -50,9 +50,17 @@ space there. Unused Level 5 carries none and needs 3 bytes per room.
 - **BigQ8 s1 is dropped from the pool.** It is the only spare vanilla room that
   would need new bytes, its area has no spare decoration, and it is a duplicate
   of BigQ8 s4 and BigQ2 s1 — so excluding it costs no novelty.
-- **One option, not three.** Room selection and per-area palette ride together;
-  `big_q_blocks` keeps its current meaning (what is *in* the block) and its
-  existing key bit.
+- **No option at all — always on** (2026-08-26). Which room a pipe leads to is
+  not a gameplay difference worth a control: every room hands out one block and
+  returns you where you came from, so there is nothing to turn off. It joins
+  `qol::fix_big_q_block_rooms` as unconditional behavior. No `Options` field, no
+  flag-key bit, no key version bump, no web control — and `big_q_blocks` keeps
+  its current meaning (what is *in* the block) and its existing key bit,
+  untouched. Room selection and per-area palette ride together in the one pass.
+
+  Consequence to keep in mind: the pass consumes RNG unconditionally, so it
+  shifts the stream for everything downstream of it and rebaselines any pinned
+  output. Place it deliberately in `randomizer/mod.rs`, not wherever is handy.
 
 ## Why it is worth doing
 

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -1,0 +1,105 @@
+# Big [?] Bonus Room Shuffle — design notes
+
+**Status: parked 2026-08-26**, branch `experiment/unused5-bigq-testrom`.
+Playtested and working as a `testrom` knob; not started as a randomizer option.
+
+Mechanism reference lives in `docs/smb3_rom_reference.md` under "Big [?] Block
+Bonus Areas" — tables, junction decode, pipe-tile types, palette indices, the
+per-tileset command sizes. This file is only the plan and the decisions.
+
+## What is built
+
+`testrom --bigq-unused5 <screen> [--bigq-palette N]` points all eight
+`LevelJctBQ_*` entries at "Unused Level 5" (TCRF), aims 5-2's bonus pipe at one
+of its eight rooms, writes that room a return junction, and recolours the area.
+
+Playtested in an emulator, all eight rooms: the area loads, the fortress-tileset
+bank swap works, the block is collectable, and the pipe returns to 5-2. Palette
+4 was chosen. This is the proof that the rooms are usable.
+
+## What is not built
+
+Anything in the randomizer proper. No option, no flag-key bit, no web control.
+
+## The pairing model
+
+A host level and a bonus room are bound by two junction commands, one at each
+end. Re-pairing host H to room R is two 2-byte writes:
+
+- `H.junction ← R.arrival` — where the player lands in the room. In the host's
+  own layout, slot = the host pipe's screen.
+- `R.junction ← H.return` — where the player lands back in the host. In the
+  bonus **area**'s layout, slot = the room's screen.
+
+Every vanilla area already carries a junction per room, so re-pairing costs no
+space there. Unused Level 5 carries none and needs 3 bytes per room.
+
+## Decisions taken
+
+- **7-F1 is not pinned.** Flight is required to beat 7-F1 because of level
+  geometry, so its block must always be a flight suit — but its *room* still
+  shuffles. Resolve the pairing first, then force the block in whatever room
+  7-F1 lands in and exclude that offset from the contents roll.
+  `enemies::tables::W7F1_TANOOKI_OFFSET` becomes derived rather than constant.
+  Guard it with an invariant test over N seeds, the way the enemy protections
+  are guarded — the failure mode is silent if the passes are ever reordered.
+- **No room is deleted from Unused Level 5.** The 24 bytes for eight junctions
+  come from eight of its fifteen 3-byte `Coin` commands. Ten of those fifteen
+  sit in the sealed chamber on screen 4 (rows 3-9, walled on all four sides and
+  at both screen seams) which the player cannot reach.
+- **BigQ8 s1 is dropped from the pool.** It is the only spare vanilla room that
+  would need new bytes, its area has no spare decoration, and it is a duplicate
+  of BigQ8 s4 and BigQ2 s1 — so excluding it costs no novelty.
+- **One option, not three.** Room selection and per-area palette ride together;
+  `big_q_blocks` keeps its current meaning (what is *in* the block) and its
+  existing key bit.
+
+## Why it is worth doing
+
+Vanilla's 15 Big [?] rooms are only **10 distinct layouts** — BigQ2 s1 = BigQ8
+s1 = BigQ8 s4, BigQ3 s4 = s5, BigQ4 s2 = BigQ6 s5, and BigQ5 s7 = BigQ7 s6.
+Unused Level 5's eight are all unique, taking the pool to 18 designs. Note the
+last pair: 7-F1's room, the most-entered bonus room in the game, is already a
+room you have seen in World 5.
+
+## Plan
+
+Pool: 14 vanilla rooms + 8 from Unused Level 5 = 22 rooms for 11 host levels.
+
+Data to assemble:
+
+- **Per host (11 rows)** — junction offset and return bytes, all harvestable
+  from the room vanilla pairs it with.
+- **Per room (22 rows)** — area index, screen, arrival bytes. 11 come free from
+  the vanilla hosts; the 8 for Unused Level 5 already exist as
+  `UNUSED5_ARRIVALS` in `testrom.rs`; 3 spare vanilla rooms need authoring.
+
+Constraints the pairing must enforce:
+
+- **Distinct room screens per world.** `BigQBlock_GotIt` is an 8-bit mask
+  indexed by the room's screen and cleared on world entry, so two hosts in the
+  same world paired to rooms with the same screen number share one
+  "already opened" bit. "Same world" means after the overworld builder has
+  placed levels, so this pass runs downstream of it.
+- **7-F1's room holds a flight suit** (see above).
+- **Pairing runs before `randomize_big_q_blocks`**, or the protection cannot be
+  expressed.
+
+Palette: per *area*, not per room — it is header byte 5 bits 0-2 of the area's
+layout. Fortress areas roll from {0, 3, 4} (1 wants object palette 10). The
+underground areas need the same survey run before trusting a set; vanilla only
+samples 3, 4 and 7 there.
+
+## Next step when this resumes
+
+Harvest the 11 vanilla pairings — dump each host's junction bytes and each
+room's return bytes and check they line up with the model. That table either
+falls out cleanly or tells us early that something does not fit.
+
+## Playtest ROMs
+
+`~/Copyparty/MiSTer/games/NES/_rando/unused5_bigq_s0..s7.nes` (one per room,
+palette 0) and `unused5_pal1/3/4.nes` (room 5 in the other fortress palettes).
+Rebuild any of them with `testrom --place 5-2 --bigq-unused5 <screen>
+--bigq-palette <index>`; delete the target on the mount first, it never
+overwrites.

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -216,19 +216,146 @@ Writing a return copies the host's own vanilla return bytes, a spot already
 proven safe in that host, into the drawn room's slot. Whichever room a host
 draws, its players come back exactly where they always did.
 
+## Design: seed the slots instead of finding the junctions (2026-08-27)
+
+Everything hard about this feature came from one decision — that the arrival and
+return positions are read out of `Level_JctXLHStart` / `Level_JctYLHStart`, whose
+contents are written by parsing a layout command stream. That forced us to
+locate a group-7 command inside a variable-size stream, per tileset, with no
+byte-level signature distinguishing a Big [?] junction from any other. Two
+sessions of searching produced a candidate table with one verified row.
+
+**We do not have to read from there.** The slot arrays are plain RAM. If we
+write the bytes we want into the slot the engine is about to read, the engine
+does the rest — no layout command is located, parsed or edited.
+
+### Why level identity is a sufficient key
+
+Inside `LevelJct_BigQuestionBlock` we already know the junction is a Big [?] one,
+because that is the routine we are in. A level has at most one Big [?] pipe. So
+the level alone identifies the pipe — the screen it stands on is not needed, and
+neither is its junction command. `qol::big_q` already resolves level identity
+here; this design widens what that lookup returns.
+
+### The two hooks
+
+Both sit on code only a Big [?] junction reaches, so no shared path changes.
+
+**Entry** — inside the existing lookup routine, on a table match, before it
+returns the area index in `Y`. At that moment `X` is the matched row:
+
+```asm
+    LDA BQ_ARRIVE_Y,X     ; byte1 of the arrival (Y index | pipe dir)
+    STA $7EB6             ; scratch (no zero page is free - see memory)
+    LDA BQ_ARRIVE_X,X     ; byte2 (col << 4 | screen)
+    LDY <Player_XHi       ; the slot the BQ entry path will read
+    STA Level_JctXLHStart,Y
+    LDA $7EB6
+    STA Level_JctYLHStart,Y
+    ; ... existing: LDA BQ_ROOM,X / TAY / SEC / RTS
+```
+
+The BQ entry path then reads those two slots exactly as it always did, and every
+line of arithmetic after it is untouched.
+
+**Exit** — at `PRG026_AA5A`, after the pointer restores and before the
+`JMP PRG026_AA8A`. `Level_ObjPtrOrig_AddrL/H` has just been restored to the
+host's pointer, so it is the same key pass 1 already scans:
+
+```asm
+    ; copy Level_ObjPtrOrig -> $7EB2/$7EB3, JSR bq_scan
+    ; on match, X = row:
+    LDA BQ_RETURN_Y,X
+    STA $7EB6
+    LDA BQ_RETURN_X,X
+    LDY <Player_XHi       ; the room screen - bonus areas are horizontal
+    STA Level_JctXLHStart,Y
+    LDA $7EB6
+    STA Level_JctYLHStart,Y
+```
+
+`bq_scan` is reused as-is; it already takes its key from `$7EB2/$7EB3`.
+
+### What this removes
+
+- **Locating the 11 host junction commands.** Not needed at all. The one open
+  blocker disappears.
+- **Spare `Coin` commands in Unused Level 5.** No return junctions are written
+  into it, so its byte-tight layout is never touched.
+- **The one-host-per-room cap.** The return is keyed by host, not by the room's
+  single slot, so two hosts may share a room screen.
+- **The frozen-screen problem.** The arrival is ours, so the room is a free
+  choice per host rather than whatever vanilla's byte2 said.
+
+Net effect: 19 rooms, 11 hosts, unconstrained draw. Only the per-world
+`BigQBlock_GotIt` screen rule survives, and that one was never binding.
+
+### Cost
+
+Two 13-byte tables per leg (arrival byte1/byte2, return byte1/byte2) = 52 bytes,
+plus roughly 20 bytes of seeding at each hook and the `bq_scan` key copy at the
+exit — **an estimated ~100 bytes**, to be measured, not trusted. It lands in
+PRG026 beside the existing routine (2603 free, largest gap 2537), which is also
+the bank the routine already runs in. `BIG_Q_ROUTINE_LEN` grows from 106 and the
+`FS_BIG_Q_LOOKUP` allocation must grow with it; the routine derives its internal
+absolute operands from its own base, so it is not origin-locked and can move.
+
+### Risks and open checks
+
+- **Vertical hosts.** `PRG026_AA9A` indexes vertical levels through
+  `LevelJct_GetVScreenH` rather than `Player_XHi`, while the Big [?] *entry* path
+  uses `Player_XHi` unconditionally. Entry is therefore safe, but the exit seed
+  writes to `Player_XHi` and the read may use a different index if a bonus area
+  is ever vertical. All eight vanilla areas and Unused Level 5 are horizontal,
+  so this holds today — it needs a guard or a comment, not a fix.
+- **`Level_7Vertical` on the return.** The arrival byte1's bit 7 sets vertical
+  mode. Seeding a return for a vertical host has to reproduce whatever the
+  vanilla return command carried, which the part-1 table already records.
+- **Two hosts, one room.** Now allowed, but both then share one
+  `BigQBlock_GotIt` bit if they are in the same world. The per-world screen rule
+  still applies.
+- The `asm::check` in the same commit, per CLAUDE.md, with `.allocation` and
+  `.origin`.
+
+### Why this generalises
+
+Lobby shuffle rewrites junction commands in place, which is why it needed a
+hand-maintained table of offsets and why 5-2's slot-4 command had to be excluded
+by hand. This design overrides the *read* instead of editing the *data*. For the
+further junction shuffling planned later, the override pattern never inherits
+the layout-parsing problem — the cost is one hook per junction handler, and the
+handlers are already separate routines (`LevelJct_General`,
+`LevelJct_GenericExit`, `LevelJct_SpecialToadHouse`,
+`LevelJct_BigQuestionBlock`).
+
+The catch to keep in view: `LevelJct_General` is shared by every ordinary
+junction, so a general shuffle cannot seed slots from there without a key that
+distinguishes one pipe from another — and at that point `Player_XHi` is all the
+engine knows. Big [?] is easy precisely because its handler is exclusive.
+
 ## Next step when this resumes
 
-1. **Disambiguate 6-9** — two commands in its area aim at BigQ6 s3; only one is
-   the bonus pipe. A testrom run answers it.
-2. **Find spare commands in Unused Level 5.** Only rooms drawn from it need one
-   (vanilla rooms already carry a return command to overwrite in place), so the
-   need is 0-8 per seed. The doc claims 10 of its 15 `Coin` commands sit in the
-   unreachable sealed chamber on screen 4; two are registered in
-   `UNUSED5_SPARE_COMMANDS`.
+Implement the seed-the-slots design above. In order:
 
-Then the pass itself: 19-room pool (11 vanilla + 8 Unused Level 5), drawn
-without replacement, skipping any screen already taken within the same
-post-builder world. Vanilla rooms need no new bytes.
+1. **Widen the lookup routine** — two arrival tables, the entry seed, and grow
+   `FS_BIG_Q_LOOKUP` to fit. Measure the real byte count; the ~100 figure is an
+   estimate. `asm::check` with `.allocation` and `.origin` in the same commit.
+2. **Add the exit hook** at `PRG026_AA5A` with the two return tables.
+3. **Harvest what the tables need** — per room: arrival byte1/byte2. The 11
+   vanilla rooms' values are in the part-2 candidate table, the 8 Unused Level 5
+   values are `UNUSED5_ARRIVALS` in `testrom.rs`. Per host: return byte1/byte2,
+   all in the part-1 table. **Note the candidate table is now only needed for its
+   arrival bytes, not for its junction offsets** — a wrong offset no longer
+   matters because nothing is written there.
+4. **The pass itself** — 19-room pool, draw without replacement, respect the
+   per-world `BigQBlock_GotIt` screen rule, always on, no option. Runs after
+   `qol::fix_big_q_block_rooms` (whose routine it fills in) and before
+   `randomize_big_q_blocks`.
+5. **7-F1** — exclude its drawn room's block offset from the contents roll.
+   Every Unused Level 5 block is already a Tanooki, so no value needs forcing.
+
+The old blockers — locating host junctions, finding spare commands in Unused
+Level 5 — are dropped by the design and do not need resolving.
 
 ## Playtest ROMs
 

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -187,33 +187,40 @@ Eight of the eleven arrivals are `02 xx` — Y index 0, dir 2 — the "placed at
 0 inside the ceiling pipe, falls out of the mouth" shape that `UNUSED5_ARRIVALS`
 was built to imitate. 4-F2, 6-3 and 6-10 use `52`, `52` and `12` instead.
 
-### An unresolved inconsistency — do not build on the slot model yet
+### The return is not tied to the pipe (resolved 2026-08-26)
 
-The obvious cross-check fails. If a host's junction slot is the screen its Big
-[?] pipe stands on, and the room returns the player to that same pipe, then the
-slot should equal the return's screen nibble. It does not, on 7 of the 8 rows
-where both are known — including **5-2, the row that is independently
-confirmed** (slot 4, return screen 5).
+An earlier note here called it an unresolved inconsistency that a host's
+junction slot does not match the screen in its room's return bytes — 5-2's pipe
+is on screen 4 and its return lands on screen 5. That was a bad assumption, not
+a data problem. **A return position is just a hand-authored safe spot in the
+host; nothing ties it to the pipe.**
 
-So one of these is wrong: that the slot is the pipe's screen, that the return
-lands the player at the pipe, or that byte2 is `(col << 4) | screen` on the
-return leg the same way it is on the arrival leg. The arrival encoding is
-verified — 5-2's `$73` is BigQ5's screen 3 column 7, exactly where the block is
-— so the doubt sits on the return leg or on the slot.
+Both halves of the slot model are confirmed in the disassembly:
 
-This matters because the pass writes the return leg. Settle it before writing
-code: point a testrom host at a known room and watch where the player comes
-back. Filtering candidates on the slot rule was tried and rejects 5-2, so it is
-the rule that is wrong, not the candidate.
+```asm
+LoadLevel_StoreJctStart:            ; prg014 - fills the slots during the parse
+    LDA <Temp_Var15                 ; the command's byte0
+    AND #$0f
+    TAY                             ; slot = byte0 & $0F
+    ...  STA Level_JctYLHStart,Y    ; byte1
+    ...  STA Level_JctXLHStart,Y    ; byte2
+
+LevelJct_BigQuestionBlock:          ; prg026 - reads one back
+    LDX <Player_XHi
+    LDA Level_JctXLHStart,X         ; indexed by the player's current screen
+```
+
+So the pass is unaffected. Writing an arrival touches only bytes 1-2 of the
+host's existing junction — the slot stays put because the pipe has not moved.
+Writing a return copies the host's own vanilla return bytes, a spot already
+proven safe in that host, into the drawn room's slot. Whichever room a host
+draws, its players come back exactly where they always did.
 
 ## Next step when this resumes
 
-1. **Settle the return leg** (see the inconsistency above) with a testrom: send a
-   known host to a known room and watch where the player comes back. Everything
-   the pass writes depends on it.
-2. **Disambiguate 6-9** — two commands in its area aim at BigQ6 s3; only one is
-   the bonus pipe. Same testrom run answers it.
-3. **Find spare commands in Unused Level 5.** Only rooms drawn from it need one
+1. **Disambiguate 6-9** — two commands in its area aim at BigQ6 s3; only one is
+   the bonus pipe. A testrom run answers it.
+2. **Find spare commands in Unused Level 5.** Only rooms drawn from it need one
    (vanilla rooms already carry a return command to overwrite in place), so the
    need is 0-8 per seed. The doc claims 10 of its 15 `Coin` commands sit in the
    unreachable sealed chamber on screen 4; two are registered in

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -98,11 +98,95 @@ layout. Fortress areas roll from {0, 3, 4} (1 wants object palette 10). The
 underground areas need the same survey run before trusting a set; vanilla only
 samples 3, 4 and 7 there.
 
+## Harvest, part 1: the room side (done, verified 2026-08-26)
+
+Every vanilla room, its block, and the return junction its area supplies.
+`arrival` is the byte2 a host junction needs to land on that room's screen —
+`(col << 4) | screen`, though only the *screen* nibble is forced (see below).
+`return` is the group-7 command in the bonus area's own layout, slot = room
+screen, that sends the player back; bytes 1-2 are the position in the host.
+
+| Area | bgpal | Room | Block | arrival | Return cmd | Return offset | Lands in host at |
+|---|---|---|---|---|---|---|---|
+| BigQ1 | 7 | — | *(no blocks)* | — | — | — | — |
+| BigQ2 | 3 | s1 | 3-Up | `$81` | `E1 12 95` | 0x1B294 | scr 5 col 9, Yidx 1 dir 2 |
+| BigQ2 | 3 | s4 | *(none)* | — | `E4 71 25` | 0x1B297 | scr 5 col 2, Yidx 7 dir 1 |
+| BigQ3 | 3 | s1 | Tanooki | `$61` | `E1 00 00` | 0x1B378 | **null — dir 0** |
+| BigQ3 | 3 | s4 | 3-Up | `$84` | `E4 71 46` | 0x1B37B | scr 6 col 4, Yidx 7 dir 1 |
+| BigQ3 | 3 | s5 | Frog | `$85` | `E5 61 76` | 0x1B37E | scr 6 col 7, Yidx 6 dir 1 |
+| BigQ4 | 3 | s2 | 3-Up | `$72` | `E2 51 86` | 0x1B3E1 | scr 6 col 8, Yidx 5 dir 1 |
+| BigQ4 | 3 | s3 | Frog | `$73` | `E3 61 03` | 0x1B3E4 | scr 3 col 0, Yidx 6 dir 1 |
+| BigQ5 | 3 | s3 | 3-Up | `$73` | `E3 61 65` | 0x1B479 | scr 5 col 6, Yidx 6 dir 1 |
+| BigQ5 | 3 | s7 | Tanooki | `$77` | `E7 42 E5` | 0x1B47C | scr 5 col 14, Yidx 4 dir 2 |
+| BigQ6 | 4 | s3 | 3-Up | `$53` | `E3 61 64` | 0x1B5E8 | scr 4 col 6, Yidx 6 dir 1 |
+| BigQ6 | 4 | s5 | Tanooki | `$75` | `E5 11 A3` | 0x1B5EB | scr 3 col 10, Yidx 1 dir 1 |
+| BigQ6 | 4 | s6 | Hammer | `$56` | `E6 61 E3` | 0x1B5EE | scr 3 col 14, Yidx 6 dir 1 |
+| BigQ7 | 3 | s4 | Hammer | `$44` | `E4 61 29` | 0x1B664 | scr 9 col 2, Yidx 6 dir 1 |
+| BigQ7 | 3 | s6 | Tanooki | `$76` | `E6 61 C6` | 0x1B667 | scr 6 col 12, Yidx 6 dir 1 |
+| BigQ8 | 7 | s1 | Tanooki | `$81` | *(none)* | — | — |
+| BigQ8 | 7 | s4 | 3-Up | `$84` | `E4 51 F5` | 0x1B725 | scr 5 col 15, Yidx 5 dir 1 |
+
+Area pointers (`LevelJctBQ_*` index = vanilla `World_Num`), all tileset 14:
+
+| Area | Layout | Objects |
+|---|---|---|
+| BigQ1 | `$B1AF` 0x1B1BF | `$C976` 0x0C986 |
+| BigQ2 | `$B1BC` 0x1B1CC | `$C978` 0x0C988 |
+| BigQ3 | `$B28B` 0x1B29B | `$C97D` 0x0C98D |
+| BigQ4 | `$B372` 0x1B382 | `$C988` 0x0C998 |
+| BigQ5 | `$B3D8` 0x1B3E8 | `$C990` 0x0C9A0 |
+| BigQ6 | `$B470` 0x1B480 | `$C998` 0x0C9A8 |
+| BigQ7 | `$B5E2` 0x1B5F2 | `$C9A3` 0x0C9B3 |
+| BigQ8 | `$B65B` 0x1B66B | `$C9AB` 0x0C9BB |
+
+Three things this settled:
+
+- **The junction slots match the ROM reference exactly**, including BigQ5's two
+  and BigQ8's single one — so the "BigQ8 s1 needs new bytes" decision holds.
+- **BigQ3 s1's return is `E1 00 00`** — a null command, dir 0, outside the valid
+  1-4 range. That is one of the three spare rooms, and its return was never
+  authored. Any room the pass hands a host needs a real return written, spare
+  rooms included; `sanitize_exit_dir`'s rule (remap to 3) is the precedent.
+- **Object streams open with a 1-byte prefix** before the 3-byte entries. Parsing
+  from the pointer directly steps over the `$FF` terminator into the next
+  stream and silently over-counts — it produced blocks for BigQ1 (which has
+  none) and shifted every area's block list by one. Vanilla is 0/1/3/2/2/3/2/2
+  = 15, which is what the reference already said.
+
+## Harvest, part 2: the host side — blocked, needs layout simulation
+
+**The column nibble is not part of the contract.** A host junction's byte2 is
+`(col << 4) | screen`; only the *screen* nibble selects the room. The column is
+wherever the pipe drops the player, and vanilla only sometimes makes that the
+block's own column. So "junction whose byte2 equals a block's `(col << 4) |
+screen`" — the signature that looked obvious — both **misses** real hosts and
+matches unrelated junctions in other worlds by coincidence (5-2's `E4 02 73`
+scores against BigQ4 and BigQ5 alike; BigQ3's own return `E5 61 76` scores as a
+BigQ7 host). It found 8 candidates where 11 are expected, several of them wrong.
+
+There is no byte-level signature to fall back on: **`Level_JctCtl = 2` is
+computed from the pipe tile at run time** ($AF/$B0 → Big [?]), not stored in the
+junction command. A Big [?] junction is byte-identical to any other junction.
+Identifying the 11 hosts therefore means finding `$AF`/`$B0` tiles in their
+layouts — layout simulation, across several tilesets. `tools/level_sim.py` only
+knows tileset 1, and `rom_map.py`'s world attribution (`level_groups`
+`world_refs`) does not reach most of the host sub-areas.
+
+Doing this in Rust is the way: `NodeCatalog` already names all 340 entries and
+carries the world for each, and the per-tileset command sizes would live next to
+the code that will consume them rather than in a script that rots.
+
 ## Next step when this resumes
 
-Harvest the 11 vanilla pairings — dump each host's junction bytes and each
-room's return bytes and check they line up with the model. That table either
-falls out cleanly or tells us early that something does not fit.
+Find the 11 host junctions. That needs a layout walk that resolves `$AF`/`$B0`
+pipe tiles per tileset — see 'Harvest, part 2' above for why no byte signature works.
+Once each host's junction offset is known, its return bytes come free: they are
+already in the part-1 table, since a room's return command *is* the host's
+return position.
+
+Then the 22-row room table is complete except for the three spare vanilla rooms
+(BigQ2 s4, BigQ3 s1, BigQ8 s1), which need arrivals authored, and BigQ8 s1
+additionally needs a return command it does not have.
 
 ## Playtest ROMs
 

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -64,6 +64,20 @@ space there. Unused Level 5 carries none and needs 3 bytes per room.
   shifts the stream for everything downstream of it and rebaselines any pinned
   output. Place it deliberately in `randomizer/mod.rs`, not wherever is handy.
 
+- **Block contents stay entirely `big_q_blocks`'s job** (2026-08-27). The eight
+  Unused Level 5 blocks are all Tanooki Suits in the ROM, and they *are* already
+  swept by `randomize_object_data` — its scan covers the whole `ENEMY_DATA`
+  range, and their stream at `0x0D411` sits inside it, so it was randomizing
+  them invisibly long before anything could reach them.
+
+  Known caveat, considered and accepted: `big_q_blocks` defaults to **off**, and
+  with it off every new room hands out a Tanooki, so a host that used to give a
+  3-Up or a Frog now gives a Tanooki and the six new rooms are indistinguishable
+  by reward. Two fixes were weighed — a hand-authored spread on the six blocks,
+  or gating the whole room shuffle behind `big_q_blocks` — and both were
+  declined: in practice players rarely run without that option on. Do not
+  re-propose either without evidence that the default case actually matters.
+
 ## Why it is worth doing
 
 Vanilla's 15 Big [?] rooms are only **10 distinct layouts** — BigQ2 s1 = BigQ8

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -88,9 +88,7 @@ room you have seen in World 5.
 
 ## Plan
 
-Pool as shipped: 11 vanilla rooms + 6 from Unused Level 5 = 17 rooms for 11
-host levels. (This section's original 22 counted the spare vanilla rooms, whose
-arrivals were never authored, and all eight Unused Level 5 rooms.)
+Pool: 14 vanilla rooms + 8 from Unused Level 5 = 22 rooms for 11 host levels.
 
 Data to assemble:
 
@@ -379,44 +377,25 @@ Two things resolved along the way that the earlier sections got wrong:
   exit seed writes at `Player_XHi` and is correct as long as bonus areas stay
   horizontal, which all eight vanilla ones and Unused Level 5 are.
 
-## Unused Level 5 screens 6 and 7 are held back
-
-Playtested 2026-08-27 and **both dropped the player through the floor** — he
-appears in the wall and falls to his death. They are the only two rooms with no
-ceiling pipe, so their arrivals were aimed "beside the floor pipe" at Y index 6,
-row 23. That is the pipe body's row, not ground:
-
-```
---- screen 6 ---            --- screen 7 ---
-0F 61 E4 04  row 15 col 1   0F 71 E1 07  row 15 col 1 len 7
-37 61 B1     row 23 col 1   17 76 E1 09  row 23 col 6 len 9
-             ^ the pipe     37 72 B1     row 23 col 2  ^ the pipe
-```
-
-The arrivals put him at col 3 (s6) and col 5 (s7), both at row 23. Screen 6 has
-nothing at row 23 except the pipe itself; screen 7's row-23 run starts at col 6.
-They are also the only two rooms using Y index 6 — every room that works uses
-0, 4 or 5 — which was the signal to treat them as suspect before shipping.
-
-**Re-aiming them needs the room's tile grid, not its command list.** The layout
-commands say where a generator starts, not which tiles end up solid, and
-`level_sim.py` only knows tileset 1. Until something can answer "is (col, row)
-solid in a fortress-tileset room", these two stay out and the pool is 17.
-
 ## Playtest ROMs
 
-Five seeds through the real pipeline, each parking 5-2 on W1 tile 1 and 7-F1 on
-the next tile with a P-Wing, at
-`~/Copyparty/MiSTer/games/NES/_rando/bigq_seed<N>.nes`. Between them they cover
-**all six** Unused Level 5 rooms still in the pool, plus two 7-F1 forces:
+Six seeds through the real pipeline, each parking 5-2 on W1 tile 1 and 7-F1 on
+the next tile with a P-Wing in the inventory, at
+`~/Copyparty/MiSTer/games/NES/_rando/bigq_seed<N>.nes`:
 
 | Seed | 5-2 opens | 7-F1 opens | 7-F1's block |
 |---|---|---|---|
-| 10 | Unused Level 5 s2 | Unused Level 5 s0 | already Tanooki |
+| 10 | **Unused Level 5 s7** | Unused Level 5 s0 | already Tanooki |
+| 16 | **Unused Level 5 s6** | BigQ8 s4 | 3-Up → forced Tanooki |
+| 31 | **Unused Level 5 s6** | BigQ3 s5 | Frog → forced Tanooki |
 | 4 | Unused Level 5 s3 | Unused Level 5 s4 | already Tanooki |
 | 25 | Unused Level 5 s1 | BigQ6 s6 | Hammer → forced Tanooki |
-| 26 | Unused Level 5 s5 | Unused Level 5 s3 | already Tanooki |
-| 24 | Unused Level 5 s2 | BigQ6 s3 | 3-Up → forced Tanooki |
+| 5 | BigQ4 s2 | BigQ8 s4 | 3-Up → forced Tanooki |
+
+Screens 6 and 7 (bold) are the ones to look at hardest — they have no ceiling
+pipe, so the player is placed *beside* the floor pipe instead of dropping out of
+a mouth. Seed 5 is the cross-world vanilla case, 5-2 opening World 4's room.
+Seeds 5, 16, 25 and 31 each exercise the 7-F1 force from a different block type.
 
 Rebuild with:
 
@@ -428,16 +407,15 @@ testrom --randomize --seed <N> --place 5-2 7F1 --no-walk --starting-items p-wing
 overworld writer want the same free space. Delete the target on the mount first,
 it never overwrites.
 
-**These seed numbers are specific to `testrom`'s option set.** Its `Options`
-differ from the CLI's defaults, which moves the shared RNG, so the same seed
-picks different rooms under `smb3-rs`. Read the room out of the ROM — the four
-payload tables start at `FS_BIG_Q_LOOKUP + 0x8E` — rather than assuming.
+**These seeds are specific to `testrom`'s option set.** Its `Options` differ from
+the CLI's defaults, which moves the shared RNG, so the same seed number picks
+different rooms under `smb3-rs`. Read the room out of the ROM (the four payload
+tables start at `FS_BIG_Q_LOOKUP + 0x8E`) rather than assuming.
 
-Parking both levels on World 1 puts both rooms under **one** world's
-`BigQBlock_GotIt` mask, which the real seed would not necessarily do, so these
-five were picked to have distinct room screens. A colliding pair would show the
-second block already collected.
+Parking both levels on World 1 also puts both rooms under **one** world's
+`BigQBlock_GotIt` mask, which the real seed would not necessarily do — so these
+six were picked to have distinct room screens. A pair that collided would show
+the second block already collected.
 
-To look at one Unused Level 5 room in isolation, without the randomizer:
-`testrom --place 5-2 --bigq-unused5 <screen> --bigq-palette 4`. That knob still
-reaches screens 6 and 7, which the randomizer no longer draws.
+To look at one Unused Level 5 room in isolation, without the randomizer, the old
+knob still works: `testrom --place 5-2 --bigq-unused5 <screen> --bigq-palette 4`.

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -377,6 +377,42 @@ Two things resolved along the way that the earlier sections got wrong:
   exit seed writes at `Player_XHi` and is correct as long as bonus areas stay
   horizontal, which all eight vanilla ones and Unused Level 5 are.
 
+## Unused Level 5 screens 6 and 7: how their aim was found
+
+These two are the only rooms with no ceiling pipe, so there is no mouth to fall
+out of and no vanilla precedent to copy. Their first coordinates — Y index 6,
+row 23, the floor pipe's own row — **killed the player**, on the vanilla-base
+`testrom` path as well as through the randomizer. The earlier note claiming all
+eight rooms were playtested did not cover where these two put you.
+
+The aim cannot be reasoned out of the layout: a command says where a generator
+starts, not which tiles end up solid, and nothing here renders a
+fortress-tileset room. It also cannot be nudged, because the Y position is a
+3-bit index into `LevelJct_YLHStarts` — only rows 0, 4, 7, 11, 15, 20, 23, 24
+are expressible. So it was found by trying, using `testrom --bigq-aim COL,YIDX`.
+
+Two rounds, playtested 2026-08-28:
+
+| Aim | Screen 6 | Screen 7 |
+|---|---|---|
+| col 10 row 15 | safe, but an arbitrary-looking spot | — |
+| col 10 row 11 | clips the ceiling, falls through | — |
+| col 1/2 row 20 (pipe column) | clipped inside the pipe | clipped inside the pipe |
+| col 8 row 20 | — | **inescapable wall** |
+| col 3 row 7 | — | safe, but incoherent |
+| col 1/2 row 15, row 11 (pipe column) | — | **row 11 chosen** |
+| col 3 / col 4 row 20 (beside pipe) | **chosen** | — |
+
+Shipped: **screen 6 → col 3, row 20** (lands beside the floor pipe) and
+**screen 7 → col 2, row 11** (falls into the floor pipe). Both are in
+`UNUSED5_ROOMS` and in `testrom.rs`'s `UNUSED5_ARRIVALS`, which are kept in
+step so the two paths agree.
+
+Worth recording because it ran against expectation: "beside the pipe" was
+predicted to fail in both rooms, on the grounds that screen 6 has nothing solid
+but the pipe and screen 7's floor run starts at col 6. It is what works on
+screen 6.
+
 ## Playtest ROMs
 
 Six seeds through the real pipeline, each parking 5-2 on W1 tile 1 and 7-F1 on

--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -153,40 +153,75 @@ Three things this settled:
   none) and shifted every area's block list by one. Vanilla is 0/1/3/2/2/3/2/2
   = 15, which is what the reference already said.
 
-## Harvest, part 2: the host side — blocked, needs layout simulation
+## Harvest, part 2: the host side (candidates, 2026-08-26)
 
-**The column nibble is not part of the contract.** A host junction's byte2 is
-`(col << 4) | screen`; only the *screen* nibble selects the room. The column is
-wherever the pipe drops the player, and vanilla only sometimes makes that the
-block's own column. So "junction whose byte2 equals a block's `(col << 4) |
-screen`" — the signature that looked obvious — both **misses** real hosts and
-matches unrelated junctions in other worlds by coincidence (5-2's `E4 02 73`
-scores against BigQ4 and BigQ5 alike; BigQ3's own return `E5 61 76` scores as a
-BigQ7 host). It found 8 candidates where 11 are expected, several of them wrong.
+Found by taking each host's entry `obj_ptr` straight from `qol/big_q.rs`'s own
+lookup table, resolving it through the world pointer tables, walking its alt
+chain, and keeping every group-7 command whose byte2 screen nibble is a block
+screen in that host's area.
 
-There is no byte-level signature to fall back on: **`Level_JctCtl = 2` is
-computed from the pipe tile at run time** ($AF/$B0 → Big [?]), not stored in the
-junction command. A Big [?] junction is byte-identical to any other junction.
-Identifying the 11 hosts therefore means finding `$AF`/`$B0` tiles in their
-layouts — layout simulation, across several tilesets. `tools/level_sim.py` only
-knows tileset 1, and `rom_map.py`'s world attribution (`level_groups`
-`world_refs`) does not reach most of the host sub-areas.
+`arrival` is the host command's bytes 1-2 — reusable as *any* host's arrival for
+that room. `return` is the room's command bytes 1-2, from the part-1 table.
 
-Doing this in Rust is the way: `NodeCatalog` already names all 340 entries and
-carries the world for each, and the per-tileset command sizes would live next to
-the code that will consume them rather than in a script that rots.
+| Host | Room | Junction | Bytes | arrival | return | Confidence |
+|---|---|---|---|---|---|---|
+| 3-5 | BigQ3 s4 3-Up | 0x25227 | `E4 02 14` | `02 14` | `71 46` | single candidate |
+| 3-9 | BigQ3 s5 Frog | 0x1F31B | `E2 02 15` | `02 15` | `61 76` | single candidate |
+| 4-F2 | BigQ4 s2 3-Up | 0x2B6B2 | `EA 52 22` | `52 22` | `51 86` | single candidate |
+| 5-2 | BigQ5 s3 3-Up | 0x1A807 | `E4 02 73` | `02 73` | `61 65` | **confirmed** |
+| 5-5 | BigQ5 s7 Tanooki | 0x23045 | `E2 02 17` | `02 17` | `42 E5` | single candidate |
+| 6-3 | BigQ6 s5 Tanooki | 0x22B2F | `E3 52 25` | `52 25` | `11 A3` | single candidate |
+| 6-9 | BigQ6 s3 3-Up | 0x20B2F **or** 0x20C40 | `E3 02 83` / `E6 61 43` | — | `61 64` | room certain, command ambiguous |
+| 6-10 | BigQ6 s6 Hammer | 0x23A93 | `E4 12 D6` | `12 D6` | `61 E3` | single candidate |
+| 7-F1 | BigQ7 s6 Tanooki | 0x2B47E | `E6 02 16` | `02 16` | `61 C6` | **room confirmed** |
+| 7-8 | BigQ7 s4 Hammer | 0x1F074 | `E6 52 14` | `52 14` | `61 29` | by elimination |
+| 8-1 | BigQ8 s4 3-Up | 0x1F8C8 | `E2 02 D4` | `02 D4` | `51 F5` | single candidate |
+
+5-2 is ground truth — `testrom --bigq-unused5` already drives that command, and
+it agrees. 7-F1's *room* is pinned independently by
+`enemies::tables::W7F1_TANOOKI_OFFSET` (0x0C9B7), which is the second entry in
+BigQ7's object stream, i.e. the s6 Tanooki — the block flight is required for.
+That resolves 7-F1 to s6 and, since a room serves one host, 7-8 to s4.
+
+Eight of the eleven arrivals are `02 xx` — Y index 0, dir 2 — the "placed at row
+0 inside the ceiling pipe, falls out of the mouth" shape that `UNUSED5_ARRIVALS`
+was built to imitate. 4-F2, 6-3 and 6-10 use `52`, `52` and `12` instead.
+
+### An unresolved inconsistency — do not build on the slot model yet
+
+The obvious cross-check fails. If a host's junction slot is the screen its Big
+[?] pipe stands on, and the room returns the player to that same pipe, then the
+slot should equal the return's screen nibble. It does not, on 7 of the 8 rows
+where both are known — including **5-2, the row that is independently
+confirmed** (slot 4, return screen 5).
+
+So one of these is wrong: that the slot is the pipe's screen, that the return
+lands the player at the pipe, or that byte2 is `(col << 4) | screen` on the
+return leg the same way it is on the arrival leg. The arrival encoding is
+verified — 5-2's `$73` is BigQ5's screen 3 column 7, exactly where the block is
+— so the doubt sits on the return leg or on the slot.
+
+This matters because the pass writes the return leg. Settle it before writing
+code: point a testrom host at a known room and watch where the player comes
+back. Filtering candidates on the slot rule was tried and rejects 5-2, so it is
+the rule that is wrong, not the candidate.
 
 ## Next step when this resumes
 
-Find the 11 host junctions. That needs a layout walk that resolves `$AF`/`$B0`
-pipe tiles per tileset — see 'Harvest, part 2' above for why no byte signature works.
-Once each host's junction offset is known, its return bytes come free: they are
-already in the part-1 table, since a room's return command *is* the host's
-return position.
+1. **Settle the return leg** (see the inconsistency above) with a testrom: send a
+   known host to a known room and watch where the player comes back. Everything
+   the pass writes depends on it.
+2. **Disambiguate 6-9** — two commands in its area aim at BigQ6 s3; only one is
+   the bonus pipe. Same testrom run answers it.
+3. **Find spare commands in Unused Level 5.** Only rooms drawn from it need one
+   (vanilla rooms already carry a return command to overwrite in place), so the
+   need is 0-8 per seed. The doc claims 10 of its 15 `Coin` commands sit in the
+   unreachable sealed chamber on screen 4; two are registered in
+   `UNUSED5_SPARE_COMMANDS`.
 
-Then the 22-row room table is complete except for the three spare vanilla rooms
-(BigQ2 s4, BigQ3 s1, BigQ8 s1), which need arrivals authored, and BigQ8 s1
-additionally needs a return command it does not have.
+Then the pass itself: 19-room pool (11 vanilla + 8 Unused Level 5), drawn
+without replacement, skipping any screen already taken within the same
+post-builder world. Vanilla rooms need no new bytes.
 
 ## Playtest ROMs
 

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -523,6 +523,28 @@ BigQ5's 3-Up block sits at screen 3 column 7. An object entry's X-byte
 (`(screen << 4) | col`) and the junction's byte2 are nibble-swaps of each other,
 which makes "aim this pipe at that block" a one-byte edit.
 
+**The return position is supplied by the bonus area, not the host.** On the way
+out, `LevelJct_BigQuestionBlock` restores the layout pointers and then falls into
+the same code the entry uses, reading `Level_JctXLHStart[Player_XHi]` — indexed
+by the screen the player occupies *in the bonus room*. Every vanilla area
+therefore carries one group-7 command per room screen, and the slots line up
+exactly with where its blocks are:
+
+| Area | Block screens | Junction slots |
+|---|---|---|
+| BigQ2 | 1 | 1, 4 |
+| BigQ3 | 1, 4, 5 | 1, 4, 5 |
+| BigQ4 | 2, 3 | 2, 3 |
+| BigQ5 | 3, 7 | 3 (`61 65`), 7 (`42 E5`) |
+| BigQ6 | 3, 5, 6 | 3, 5, 6 |
+| BigQ7 | 4, 6 | 4, 6 |
+| BigQ8 | 1, 4 | 4 |
+
+A room whose screen has no such command returns the player to whatever stale
+value that slot happens to hold — and if that value has byte1 bit 7 set, the
+host area is re-entered in vertical mode, giving correct collision with the
+wrong graphics.
+
 **Getting back out needs no special tile.** `LevelJctBQ_Flag` is toggled on
 entry and off on exit. While it is set, the vertical-pipe path ANDs the pipe
 tile index with 1 (`PRG008_BCC4`, just before `PRG008_BCD6`) and the horizontal
@@ -573,10 +595,27 @@ what TCRF describes; reached through a Big [?] junction the flag rule above
 turns them into return pipes. `testrom --bigq-unused5 <screen>` points all
 eight table entries at it and aims 5-2's pipe at one room.
 
-Its rooms are laid out differently from the per-world areas: the Big [?] Block
-is never under the pipe you arrive from, so an arrival copied from a vanilla
-junction lands in rock. Per-room landing spots are in `UNUSED5_ARRIVALS`
-(`testrom.rs`).
+Unlike the per-world areas it carries **no group-7 commands at all**, so it
+supplies no return position — see `UNUSED5_ARRIVALS` and
+`UNUSED5_SPARE_COMMANDS` in `testrom.rs` for the arrival aims and for how a
+return junction is written into it. Its layout stream is byte-tight (terminator
+at 0x2B889, World 8's fortress layout at 0x2B88A), so a junction command has to
+replace an existing command. Per-room command budgets, from parsing the stream
+with the fortress tileset's sizes:
+
+| Screen | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+|---|---|---|---|---|---|---|---|---|
+| Commands | 10 | 5 | 10 | 4 | 21 | 22 | 4 | 8 |
+| Bytes | 35 | 18 | 36 | 14 | 66 | 69 | 15 | 31 |
+
+Wiring all eight rooms costs 24 bytes, so deleting any one of screens 0, 2, 4, 5
+or 7 pays for the other seven with room to spare.
+
+**Variable-command sizes are per tileset.** `game.xml` in the southbird disasm
+carries them: a `<generator>` whose `<param>` is commented `<!-- 1 -->` reads a
+fourth byte. Fortress (tileset 2) four-byte generators are 13, 14, 35-42, 46-48,
+57; Plains is 11, 12, 35-42. Parsing a layout with the wrong set desyncs
+silently and the stream still appears to terminate.
 
 #### OBJ_TREASURESET (0xD6) — Treasure Box Items
 

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -573,6 +573,11 @@ what TCRF describes; reached through a Big [?] junction the flag rule above
 turns them into return pipes. `testrom --bigq-unused5 <screen>` points all
 eight table entries at it and aims 5-2's pipe at one room.
 
+Its rooms are laid out differently from the per-world areas: the Big [?] Block
+is never under the pipe you arrive from, so an arrival copied from a vanilla
+junction lands in rock. Per-room landing spots are in `UNUSED5_ARRIVALS`
+(`testrom.rs`).
+
 #### OBJ_TREASURESET (0xD6) — Treasure Box Items
 
 A `0xD6` entry in an enemy data stream sets the contents of the next

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -611,6 +611,21 @@ with the fortress tileset's sizes:
 Wiring all eight rooms costs 24 bytes, so deleting any one of screens 0, 2, 4, 5
 or 7 pays for the other seven with room to spare.
 
+**Its palette index is the placeholder.** Header byte 5 bits 0-2 select the BG
+palette within the tileset, and the loader re-reads palettes from the target
+header on a junction — so one byte recolours the whole area. Unused Level 5
+carries index 6, which in the fortress tileset is shared with exactly one other
+level, `Empty`; that is why it renders in black and white. Indices real
+fortress-tileset levels use:
+
+| Index | Used by |
+|---|---|
+| 0 | most mini-fortresses — 3-F1, 4-F1, 8-F, the W5 towers, several alt areas |
+| 1 | Koopaling throne rooms (1-K … 7-K), paired with object palette 10 |
+| 3 | World 3's fortresses (3-F2, 3-F1A, 3-F2A) |
+| 4 | 1-F, 4-F2, 5-F1/F2, 6-F1, 7-F1/F2, 8-FA, Bowser's castle |
+| 6 | `Empty` and this level only — the placeholder |
+
 **Variable-command sizes are per tileset.** `game.xml` in the southbird disasm
 carries them: a `<generator>` whose `<param>` is commented `<!-- 1 -->` reads a
 fourth byte. Fortress (tileset 2) four-byte generators are 13, 14, 35-42, 46-48,

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -494,6 +494,85 @@ byte 4's vertical-start (bits 5-7) and byte 8's timer (bits 6-7) — the running
 clock persists across junctions — while music (byte 8 bits 0-3), init action
 (byte 7 bits 5-7), palettes, and size are re-read from the target header.
 
+#### Big [?] Block Bonus Areas
+
+Sources: southbird disasm `prg026.asm` (`LevelJct_BigQuestionBlock`),
+`prg008.asm` (`Player_DoSpecialTiles`, `PipeEntryPrepare`), `prg005.asm`
+(`ObjInit_BigQBlock`), `prg030.asm` (`LevelLoad`), `smb3.asm` tile constants.
+
+Eight bonus *areas* — not eight rooms. Each is a multi-screen level that may
+hold several one-screen rooms, and the screen you land on picks the room.
+
+| Table | File offset | CPU (PRG026) | Size |
+|---|---|---|---|
+| `LevelJctBQ_Layout` | 0x3491B | $A90B | 8 words |
+| `LevelJctBQ_Objects` | 0x3492B | $A91B | 8 words |
+| `LevelJctBQ_Tileset` | 0x3493B | $A92B | 8 bytes (all 14 in vanilla) |
+
+**Which area** — `LevelJct_BigQuestionBlock` indexes all three with `LDY
+World_Num` (the randomizer replaces this with a level-identity lookup, see
+`qol/big_q.rs`). The layout is read from whichever bank `PAGE_A000_ByTileset`
+maps for the tileset byte, so an area's layout need not live in PRG013; the
+object stream always comes from PRG006, which `LevelLoad` maps unconditionally
+(`LDA #6 / STA PAGE_C000`) right before `JSR LevelLoad_CopyObjectList`.
+
+**Which room inside it** — the arrival position comes from the *source* level's
+own junction command (see "Junction Spawn Positions"): `Level_JctXLHStart[slot]`
+= `(col << 4) | screen`. 5-2's slot-4 command at **0x1A807** is `E4 02 73`, and
+BigQ5's 3-Up block sits at screen 3 column 7. An object entry's X-byte
+(`(screen << 4) | col`) and the junction's byte2 are nibble-swaps of each other,
+which makes "aim this pipe at that block" a one-byte edit.
+
+**Getting back out needs no special tile.** `LevelJctBQ_Flag` is toggled on
+entry and off on exit. While it is set, the vertical-pipe path ANDs the pipe
+tile index with 1 (`PRG008_BCC4`, just before `PRG008_BCD6`) and the horizontal
+path forces type 0 (just before `PRG008_BCA4`), which collapses all four
+vertical pipe-1/pipe-2 end tiles onto the Big [?] junction type — so *any*
+ordinary pipe in the room returns the player to the host level.
+
+**Outside a bonus area the pipe type is the metatile.** The engine computes
+`$B0 - tile` and uses the result >> 1 as the type:
+
+| Tile | Name | Junction type |
+|---|---|---|
+| $AD / $AE | `TILE1_PIPETB1_L/R` | alt level (exit to map, or general junction) |
+| $AF / $B0 | `TILE1_PIPETB2_L/R` | **Big [?] area** (JctCtl=2) |
+| $B1 / $B2 | `TILE1_PIPETB3_L/R` | not enterable |
+| $B3 / $B4 | `TILE1_PIPETB4_L/R` | within-level transit |
+| $BD / $BE | `TILE3_PIPETB5_L/R` | exit to common end area (gated per tileset) |
+| $B5 | `TILE1_PIPEH1_B` | horizontal, alt level |
+
+`PipeTile_EnableByTileset` (PRG008, indexed by `Level_TilesetIdx`) gates only
+the last two rows; $AD-$B4 are live in every tileset.
+
+So converting an ordinary pipe into a Big [?] pipe is a layout edit ($AD/$AE →
+$AF/$B0) **plus** a group-7 junction command at `slot == the pipe's screen` —
+without one, the arrival reads a stale slot from a previous parse.
+
+**One block per screen, once per world.** `BigQBlock_GotIt` is an 8-bit mask
+indexed by the block's `Objects_XHi` — its *screen* — cleared on world entry,
+game over, and map re-init. Two rooms on the same screen number share one bit.
+
+**Vanilla reaches 11 of the 15 blocks.** Counting `OBJ_BIGQBLOCK_*` entries per
+area: W1 0, W2 1, W3 3, W4 2, W5 2, W6 3, W7 2, W8 2. Eleven levels have a Big
+[?] pipe (3-5, 3-9, 4-F2, 5-2, 5-5, 6-3, 6-9, 6-10, 7-F1, 7-8, 8-1), so W1's
+empty area, W2's whole area (no W1/W2 level has such a pipe) and one spare room
+each in W3/W4/W8 are never opened.
+
+**"Unused Level 5" (TCRF)** is a ninth, fully unreferenced set: eight Big [?]
+rooms, one per screen 0-7, every block a Tanooki Suit ($98).
+
+| Part | File offset | CPU | Bank | Bytes |
+|---|---|---|---|---|
+| Layout | 0x2B764 | $B754 | PRG021 (fortress tileset 2) | 294 |
+| Objects | 0x0D411 | $D401 | PRG006 | 26 |
+
+Neither address appears in the world pointer tables (0x19438–0x19C00) or as a
+header alt pointer. Loaded normally its pipes exit to the world map, which is
+what TCRF describes; reached through a Big [?] junction the flag rule above
+turns them into return pipes. `testrom --bigq-unused5 <screen>` points all
+eight table entries at it and aims 5-2's pipe at one room.
+
 #### OBJ_TREASURESET (0xD6) — Treasure Box Items
 
 A `0xD6` entry in an enemy data stream sets the contents of the next

--- a/src/bin/testrom.rs
+++ b/src/bin/testrom.rs
@@ -142,6 +142,13 @@ struct Cli {
     #[arg(long, value_name = "PTR:SLOT:ID")]
     set_enemy: Vec<String>,
 
+    /// Open "Unused Level 5" -- the unreferenced test level holding eight Big
+    /// [?] Block rooms -- from every Big [?] pipe in the game, landing 5-2's
+    /// pipe in the room on this screen (0-7). Screen 3 reproduces 5-2's
+    /// vanilla arrival column. Pair with --place 5-2.
+    #[arg(long, value_name = "SCREEN", value_parser = clap::value_parser!(u8).range(0..=7))]
+    bigq_unused5: Option<u8>,
+
     /// List valid --starting-items names and exit.
     #[arg(long)]
     list_items: bool,
@@ -352,6 +359,7 @@ fn main() {
         hammer_breaks_locks: cli.hammer_locks,
         hammer_breaks_bridges: cli.hammer_bridges,
         include_beta: cli.beta,
+        big_q_unused5: cli.bigq_unused5,
         set_enemies,
     };
 

--- a/src/bin/testrom.rs
+++ b/src/bin/testrom.rs
@@ -149,6 +149,12 @@ struct Cli {
     #[arg(long, value_name = "SCREEN", value_parser = clap::value_parser!(u8).range(0..=7))]
     bigq_unused5: Option<u8>,
 
+    /// BG palette (0-7) for those rooms. The level's own 6 is the placeholder
+    /// palette -- black and white. Real fortresses use 0, 1, 3 or 4.
+    #[arg(long, value_name = "INDEX", default_value_t = 0,
+          value_parser = clap::value_parser!(u8).range(0..=7))]
+    bigq_palette: u8,
+
     /// List valid --starting-items names and exit.
     #[arg(long)]
     list_items: bool,
@@ -360,6 +366,7 @@ fn main() {
         hammer_breaks_bridges: cli.hammer_bridges,
         include_beta: cli.beta,
         big_q_unused5: cli.bigq_unused5,
+        big_q_palette: Some(cli.bigq_palette),
         set_enemies,
     };
 

--- a/src/bin/testrom.rs
+++ b/src/bin/testrom.rs
@@ -155,6 +155,12 @@ struct Cli {
           value_parser = clap::value_parser!(u8).range(0..=7))]
     bigq_palette: u8,
 
+    /// Override where --bigq-unused5 puts the player, as "COL,YIDX". Y index
+    /// is into LevelJct_YLHStarts: 0 = row 0, 4 = row 15, 5 = row 20,
+    /// 6 = row 23. Use when a room's table entry lands badly.
+    #[arg(long, value_name = "COL,YIDX")]
+    bigq_aim: Option<String>,
+
     /// List valid --starting-items names and exit.
     #[arg(long)]
     list_items: bool,
@@ -303,6 +309,20 @@ fn main() {
         }
     };
 
+    // "COL,YIDX" -> (col, Y-start index). This overrides where --bigq-unused5
+    // drops the player, which is how a badly-landing room gets re-aimed.
+    let big_q_aim = cli.bigq_aim.as_deref().map(|a| {
+        let (c, y) = a
+            .split_once(',')
+            .unwrap_or_else(|| die(format!("--bigq-aim wants \"COL,YIDX\", got \"{a}\"")));
+        let col: u8 = c.trim().parse().unwrap_or_else(|_| die(format!("bad column \"{c}\"")));
+        let y_idx: u8 = y.trim().parse().unwrap_or_else(|_| die(format!("bad Y index \"{y}\"")));
+        if col > 15 || y_idx > 7 {
+            die("--bigq-aim: column is 0-15, Y index 0-7".to_string());
+        }
+        (col, y_idx)
+    });
+
     let placements: Vec<Placement> = cli
         .place
         .iter()
@@ -367,6 +387,7 @@ fn main() {
         include_beta: cli.beta,
         big_q_unused5: cli.bigq_unused5,
         big_q_palette: Some(cli.bigq_palette),
+        big_q_aim,
         set_enemies,
     };
 

--- a/src/randomize/big_q_rooms.rs
+++ b/src/randomize/big_q_rooms.rs
@@ -1,0 +1,278 @@
+//! Big [?] Block bonus-room shuffle.
+//!
+//! Each of the 11 levels with a Big [?] pipe draws a room from a pool of 19 —
+//! the 11 vanilla rooms plus the 8 in "Unused Level 5", a fully unreferenced
+//! test level (TCRF) whose eight one-screen rooms are otherwise dead data.
+//!
+//! Always on, no option: which room a pipe leads to is not a difference worth a
+//! control, since every room hands out one block and returns you where you came
+//! from.
+//!
+//! # How a room is assigned
+//!
+//! `qol::big_q` replaced vanilla's `LDY World_Num` with a lookup keyed on level
+//! identity, and that lookup now also seeds the engine's spawn slots. So moving
+//! a host to a new room is three table writes and no layout edits:
+//!
+//! * `BQ_ROOM[row]`   — which bonus AREA to open.
+//! * `BQ_ARRIVE[row]` — where to land inside it; the byte2 screen nibble is
+//!   what picks the room within the area.
+//! * `BQ_RETURN[row]` — where to put the player back in the host, which is a
+//!   property of the host and so never changes.
+//!
+//! Rooms in Unused Level 5 open through bonus-area slot 0, which is vanilla's
+//! empty World 1 area and is referenced by nothing.
+//!
+//! # The one constraint
+//!
+//! `BigQBlock_GotIt` is an 8-bit mask indexed by the block's *screen* and
+//! cleared on world entry, so two hosts in the same world holding rooms with
+//! the same screen number would share one "already opened" bit. Rooms are drawn
+//! per world with the screens already taken excluded.
+
+use rand::Rng;
+use rand::seq::SliceRandom;
+
+use crate::randomize::qol::big_q;
+use crate::randomize::rom_data;
+use crate::rom::Rom;
+
+/// `OBJ_BIGQBLOCK_TANOOKI` — the flight suit 7-F1 needs whichever room it draws.
+pub(crate) const BIGQBLOCK_TANOOKI: u8 = 0x98;
+
+/// A room a host can be sent to.
+#[derive(Clone, Copy)]
+struct Room {
+    /// Index into the `LevelJctBQ_*` tables. 0 is the repurposed slot that
+    /// points at Unused Level 5.
+    area: u8,
+    /// Screen within the area — also the `BigQBlock_GotIt` bit.
+    screen: u8,
+    /// Spawn bytes `(byte1, byte2)` that land the player at the room's pipe.
+    arrive: (u8, u8),
+    /// Unused Level 5 rooms need their area slot pointed at the level.
+    unused5: bool,
+}
+
+const fn room(area: u8, screen: u8, arrive: (u8, u8), unused5: bool) -> Room {
+    Room { area, screen, arrive, unused5 }
+}
+
+/// The 11 vanilla rooms, each with the arrival its vanilla host uses. The byte2
+/// screen nibble matches the room's screen, which is what makes these reusable
+/// by any host.
+const VANILLA_ROOMS: [Room; 11] = [
+    room(2, 4, (0x02, 0x14), false), // BigQ3 s4  3-Up
+    room(2, 5, (0x02, 0x15), false), // BigQ3 s5  Frog
+    room(3, 2, (0x52, 0x22), false), // BigQ4 s2  3-Up
+    room(4, 3, (0x02, 0x73), false), // BigQ5 s3  3-Up
+    room(4, 7, (0x02, 0x17), false), // BigQ5 s7  Tanooki
+    room(5, 5, (0x52, 0x25), false), // BigQ6 s5  Tanooki
+    room(5, 3, (0x02, 0x83), false), // BigQ6 s3  3-Up
+    room(5, 6, (0x12, 0xD6), false), // BigQ6 s6  Hammer
+    room(6, 6, (0x02, 0x16), false), // BigQ7 s6  Tanooki
+    room(6, 4, (0x52, 0x14), false), // BigQ7 s4  Hammer
+    room(7, 4, (0x02, 0xD4), false), // BigQ8 s4  3-Up
+];
+
+/// Unused Level 5's eight rooms, one per screen, every block a Tanooki Suit.
+///
+/// Arrivals aim at each room's ceiling pipe at a Y index *inside* it, so the
+/// player falls out of the mouth the way vanilla does. Screens 6 and 7 have no
+/// ceiling pipe — their only pipe is the floor one you leave by — so those land
+/// beside it instead. Dir 2 throughout, matching vanilla's Big [?] arrivals.
+const UNUSED5_ROOMS: [Room; 8] = [
+    room(0, 0, (0x02, 0x20), true), // ceiling pipe col 2, rows 0-1
+    room(0, 1, (0x42, 0x11), true), // ceiling pipe col 1, rows 12-16
+    room(0, 2, (0x02, 0x22), true), // ceiling pipe col 2, rows 0-1
+    room(0, 3, (0x52, 0x13), true), // ceiling pipe col 1, rows 16-21
+    room(0, 4, (0x52, 0x24), true), // ceiling pipe col 2, rows 16-21
+    room(0, 5, (0x02, 0x75), true), // ceiling pipe col 7, rows 0-2
+    room(0, 6, (0x62, 0x36), true), // no ceiling pipe — beside the floor pipe
+    room(0, 7, (0x62, 0x57), true), // no ceiling pipe — beside the floor pipe
+];
+
+/// A level with a Big [?] pipe: its row in the lookup table, its entry
+/// `obj_ptr` (used to find which world it ended up in), and the mirror row that
+/// must move with it — the lobby-shuffle path into the same level.
+struct Host {
+    name: &'static str,
+    row: usize,
+    mirror: Option<usize>,
+    obj_ptr: u16,
+}
+
+const fn host(name: &'static str, row: usize, mirror: Option<usize>, obj_ptr: u16) -> Host {
+    Host { name, row, mirror, obj_ptr }
+}
+
+const HOSTS: [Host; 11] = [
+    host("3-5", 0, None, 0xCDEB),
+    host("3-9", 1, None, 0xC38F),
+    host("4-F2", 2, None, 0xD508),
+    host("5-2", 3, Some(11), 0xC8BE),
+    host("5-5", 4, None, 0xCB0A),
+    host("6-3", 5, None, 0xCA8E),
+    host("6-9", 6, Some(12), 0xCD2D),
+    host("6-10", 7, None, 0xCCE8),
+    host("7-F1", 8, None, 0xD4E4),
+    host("7-8", 9, None, 0xC32D),
+    host("8-1", 10, None, 0xC424),
+];
+
+/// What one host ended up with, for the write log and the 7-F1 protection.
+pub(crate) struct Assignment {
+    pub name: &'static str,
+    pub area: u8,
+    pub screen: u8,
+}
+
+/// Which world a host's level sits in after the overworld builder has run, by
+/// looking its `obj_ptr` up in the world pointer tables. `None` means the level
+/// is not placed on any map, in which case its room can never be opened and the
+/// screen rule does not apply to it.
+fn world_of(rom: &Rom, obj_ptr: u16) -> Option<usize> {
+    let (lo, hi) = (obj_ptr as u8, (obj_ptr >> 8) as u8);
+    for (wi, world) in rom_data::WORLDS.iter().enumerate() {
+        for idx in 0..world.entry_count {
+            let e = rom_data::read_entry(rom, world, idx);
+            if e.obj_lo == lo && e.obj_hi == hi {
+                return Some(wi);
+            }
+        }
+    }
+    None
+}
+
+/// Draw a room for every Big [?] host and write the lookup tables.
+///
+/// Runs after `qol::fix_big_q_block_rooms` (which writes the routine this fills
+/// in) and after the overworld builder (which decides what world each host is
+/// in). Returns the assignments so callers can protect 7-F1's block.
+pub(crate) fn shuffle<R: Rng>(rom: &mut Rom, rng: &mut R) -> Vec<Assignment> {
+    let mut rooms: Vec<Room> = VANILLA_ROOMS.iter().chain(UNUSED5_ROOMS.iter()).copied().collect();
+    rooms.shuffle(rng);
+
+    let mut order: Vec<usize> = (0..HOSTS.len()).collect();
+    order.shuffle(rng);
+
+    let mut screens_used: [Vec<u8>; 8] = Default::default();
+    let mut rooms_out: Vec<Option<Room>> = vec![None; HOSTS.len()];
+    let mut assignments = Vec::new();
+    let mut any_unused5 = false;
+
+    for hi in order {
+        let h = &HOSTS[hi];
+        let world = world_of(rom, h.obj_ptr);
+        // Skip screens already spoken for in this world — they would share one
+        // BigQBlock_GotIt bit.
+        let taken: &[u8] = world.map(|w| screens_used[w].as_slice()).unwrap_or(&[]);
+        let Some(pos) = rooms.iter().position(|r| !taken.contains(&r.screen)) else {
+            continue; // nothing legal left; the host keeps whatever it has
+        };
+        let r = rooms.remove(pos);
+        if let Some(w) = world {
+            screens_used[w].push(r.screen);
+        }
+        any_unused5 |= r.unused5;
+        rooms_out[hi] = Some(r);
+        assignments.push(Assignment { name: h.name, area: r.area, screen: r.screen });
+    }
+
+    // Start from vanilla so any host that drew nothing keeps working.
+    let mut area_of = big_q::BQ_ROOM;
+    let mut arrive = big_q::BQ_ARRIVE;
+    let ret = big_q::BQ_RETURN;
+    for (hi, drawn) in rooms_out.iter().enumerate() {
+        let (Some(r), h) = (drawn, &HOSTS[hi]) else { continue };
+        for row in [Some(h.row), h.mirror].into_iter().flatten() {
+            area_of[row] = r.area;
+            arrive[row] = r.arrive;
+        }
+    }
+    big_q::write_room_tables(rom, &area_of, &arrive, &ret);
+
+    if any_unused5 {
+        point_slot0_at_unused5(rom);
+    }
+    assignments
+}
+
+/// Repoint bonus-area slot 0 — vanilla's empty World 1 area, referenced by
+/// nothing — at Unused Level 5, and give it a real BG palette. Its own header
+/// carries index 6, the placeholder every unused fortress-tileset level uses,
+/// which draws the rooms in black and white.
+const UNUSED5_BGPAL: u8 = 4;
+
+fn point_slot0_at_unused5(rom: &mut Rom) {
+    rom.write_range(rom_data::BIG_Q_AREA_LAYOUTS, &rom_data::UNUSED5_LAYOUT_PTR.to_le_bytes());
+    rom.write_range(rom_data::BIG_Q_AREA_OBJECTS, &rom_data::UNUSED5_OBJECT_PTR.to_le_bytes());
+    rom.write_byte(rom_data::BIG_Q_AREA_TILESETS, rom_data::UNUSED5_TILESET);
+
+    let hdr = rom_data::prg_bank_cpu_to_file(
+        rom_data::UNUSED5_LAYOUT_BANK,
+        rom_data::UNUSED5_LAYOUT_PTR,
+    );
+    let byte5 = rom.read_byte(hdr + 5);
+    rom.write_byte(hdr + 5, (byte5 & 0xF8) | UNUSED5_BGPAL);
+}
+
+/// File offset of the Big [?] Block object entry in a room, or `None` if the
+/// area holds no block on that screen.
+pub(crate) fn block_offset(rom: &Rom, area: u8, screen: u8) -> Option<usize> {
+    let ptr_off = rom_data::BIG_Q_AREA_OBJECTS + area as usize * 2;
+    let obj_ptr = u16::from_le_bytes([rom.read_byte(ptr_off), rom.read_byte(ptr_off + 1)]);
+    // Object streams open with a 1-byte prefix, then 3-byte entries, then $FF.
+    let mut p = rom_data::enemy_ptr_to_file_offset(obj_ptr) + 1;
+    while rom.read_byte(p) != 0xFF {
+        let (id, x) = (rom.read_byte(p), rom.read_byte(p + 1));
+        if (0x94..=0x9A).contains(&id) && x >> 4 == screen {
+            return Some(p);
+        }
+        p += 3;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_room_arrival_names_its_own_screen() {
+        // byte2 is (col << 4) | screen — the low nibble is what picks the room,
+        // so a row whose arrival disagrees with its screen would open a
+        // different room than the table claims.
+        for r in VANILLA_ROOMS.iter().chain(UNUSED5_ROOMS.iter()) {
+            assert_eq!(r.arrive.1 & 0x0F, r.screen, "area {} screen {}", r.area, r.screen);
+        }
+    }
+
+    #[test]
+    fn vanilla_rooms_are_distinct() {
+        let mut seen = Vec::new();
+        for r in VANILLA_ROOMS.iter().chain(UNUSED5_ROOMS.iter()) {
+            assert!(!seen.contains(&(r.area, r.screen)), "duplicate room");
+            seen.push((r.area, r.screen));
+        }
+        assert_eq!(seen.len(), 19);
+    }
+
+    #[test]
+    fn host_rows_match_the_lookup_table() {
+        // Each host's row must key on that host's obj_ptr, or it would rewrite
+        // some other level's room.
+        for h in &HOSTS {
+            let hi = big_q::BQ_OBJ_HI[h.row];
+            let lo = big_q::BQ_OBJ_LO[h.row];
+            assert_eq!(u16::from_le_bytes([lo, hi]), h.obj_ptr, "{}", h.name);
+        }
+    }
+
+    #[test]
+    fn mirror_rows_are_the_documented_pairs() {
+        let pairs: Vec<(usize, usize)> =
+            HOSTS.iter().filter_map(|h| h.mirror.map(|m| (h.row, m))).collect();
+        assert_eq!(pairs, big_q::BQ_MIRROR_ROWS.to_vec());
+    }
+}

--- a/src/randomize/big_q_rooms.rs
+++ b/src/randomize/big_q_rooms.rs
@@ -1,9 +1,8 @@
 //! Big [?] Block bonus-room shuffle.
 //!
-//! Each of the 11 levels with a Big [?] pipe draws a room from a pool of 17 —
-//! the 11 vanilla rooms plus 6 of the 8 in "Unused Level 5", a fully
-//! unreferenced test level (TCRF) whose one-screen rooms are otherwise dead
-//! data. See `UNUSED5_ROOMS` for why its screens 6 and 7 are held back.
+//! Each of the 11 levels with a Big [?] pipe draws a room from a pool of 19 —
+//! the 11 vanilla rooms plus the 8 in "Unused Level 5", a fully unreferenced
+//! test level (TCRF) whose eight one-screen rooms are otherwise dead data.
 //!
 //! Always on, no option: which room a pipe leads to is not a difference worth a
 //! control, since every room hands out one block and returns you where you came
@@ -76,30 +75,21 @@ const VANILLA_ROOMS: [Room; 11] = [
     room(7, 4, (0x02, 0xD4), false), // BigQ8 s4  3-Up
 ];
 
-/// Unused Level 5's usable rooms, every block a Tanooki Suit.
+/// Unused Level 5's eight rooms, one per screen, every block a Tanooki Suit.
 ///
 /// Arrivals aim at each room's ceiling pipe at a Y index *inside* it, so the
-/// player falls out of the mouth the way vanilla does. Dir 2 throughout,
-/// matching vanilla's Big [?] arrivals.
-///
-/// **Screens 6 and 7 are excluded.** They are the only two rooms with no
-/// ceiling pipe — their only pipe is the floor one you leave by — so their
-/// arrivals were aimed beside it, at Y index 6 (row 23), which is the pipe
-/// body's row and not ground. Screen 6 has nothing at row 23 but the pipe at
-/// col 1; screen 7's row-23 floor run starts at col 6. Both dropped the player
-/// through the floor (playtested 2026-08-27, seeds 10/16/31).
-///
-/// Re-aiming them needs the room's tile grid, not its command list — the
-/// commands say where generators start, not where the resulting solid tiles
-/// are, and `level_sim.py` only knows tileset 1. Until something can answer
-/// "is (col, row) solid", these two stay out; the pool is 17, not 19.
-const UNUSED5_ROOMS: [Room; 6] = [
+/// player falls out of the mouth the way vanilla does. Screens 6 and 7 have no
+/// ceiling pipe — their only pipe is the floor one you leave by — so those land
+/// beside it instead. Dir 2 throughout, matching vanilla's Big [?] arrivals.
+const UNUSED5_ROOMS: [Room; 8] = [
     room(0, 0, (0x02, 0x20), true), // ceiling pipe col 2, rows 0-1
     room(0, 1, (0x42, 0x11), true), // ceiling pipe col 1, rows 12-16
     room(0, 2, (0x02, 0x22), true), // ceiling pipe col 2, rows 0-1
     room(0, 3, (0x52, 0x13), true), // ceiling pipe col 1, rows 16-21
     room(0, 4, (0x52, 0x24), true), // ceiling pipe col 2, rows 16-21
     room(0, 5, (0x02, 0x75), true), // ceiling pipe col 7, rows 0-2
+    room(0, 6, (0x62, 0x36), true), // no ceiling pipe — beside the floor pipe
+    room(0, 7, (0x62, 0x57), true), // no ceiling pipe — beside the floor pipe
 ];
 
 /// A level with a Big [?] pipe: its row in the lookup table, its entry
@@ -265,7 +255,7 @@ mod tests {
             assert!(!seen.contains(&(r.area, r.screen)), "duplicate room");
             seen.push((r.area, r.screen));
         }
-        assert_eq!(seen.len(), 17);
+        assert_eq!(seen.len(), 19);
     }
 
     #[test]

--- a/src/randomize/big_q_rooms.rs
+++ b/src/randomize/big_q_rooms.rs
@@ -78,9 +78,13 @@ const VANILLA_ROOMS: [Room; 11] = [
 /// Unused Level 5's eight rooms, one per screen, every block a Tanooki Suit.
 ///
 /// Arrivals aim at each room's ceiling pipe at a Y index *inside* it, so the
-/// player falls out of the mouth the way vanilla does. Screens 6 and 7 have no
-/// ceiling pipe — their only pipe is the floor one you leave by — so those land
-/// beside it instead. Dir 2 throughout, matching vanilla's Big [?] arrivals.
+/// player falls out of the mouth the way vanilla does. Dir 2 throughout,
+/// matching vanilla's Big [?] arrivals.
+///
+/// The Y index is into `LevelJct_YLHStarts`, which has only eight entries —
+/// rows 0, 4, 7, 11, 15, 20, 23, 24 — so a landing spot cannot be nudged by a
+/// row or two. That coarseness is why screens 6 and 7 took a playtest round:
+/// see their comment below.
 const UNUSED5_ROOMS: [Room; 8] = [
     room(0, 0, (0x02, 0x20), true), // ceiling pipe col 2, rows 0-1
     room(0, 1, (0x42, 0x11), true), // ceiling pipe col 1, rows 12-16
@@ -88,8 +92,12 @@ const UNUSED5_ROOMS: [Room; 8] = [
     room(0, 3, (0x52, 0x13), true), // ceiling pipe col 1, rows 16-21
     room(0, 4, (0x52, 0x24), true), // ceiling pipe col 2, rows 16-21
     room(0, 5, (0x02, 0x75), true), // ceiling pipe col 7, rows 0-2
-    room(0, 6, (0x62, 0x36), true), // no ceiling pipe — beside the floor pipe
-    room(0, 7, (0x62, 0x57), true), // no ceiling pipe — beside the floor pipe
+    // Screens 6 and 7 have no ceiling pipe, so there is no mouth to fall out
+    // of and the aim had to be found by playtesting (2026-08-28). Both were
+    // originally Y index 6 — row 23, the floor pipe's own row — which put the
+    // player in the pipe or past the end of the floor and killed him.
+    room(0, 6, (0x52, 0x36), true), // col 3 row 20: lands beside the floor pipe
+    room(0, 7, (0x32, 0x27), true), // col 2 row 11: falls into the floor pipe
 ];
 
 /// A level with a Big [?] pipe: its row in the lookup table, its entry

--- a/src/randomize/big_q_rooms.rs
+++ b/src/randomize/big_q_rooms.rs
@@ -1,8 +1,9 @@
 //! Big [?] Block bonus-room shuffle.
 //!
-//! Each of the 11 levels with a Big [?] pipe draws a room from a pool of 19 —
-//! the 11 vanilla rooms plus the 8 in "Unused Level 5", a fully unreferenced
-//! test level (TCRF) whose eight one-screen rooms are otherwise dead data.
+//! Each of the 11 levels with a Big [?] pipe draws a room from a pool of 17 —
+//! the 11 vanilla rooms plus 6 of the 8 in "Unused Level 5", a fully
+//! unreferenced test level (TCRF) whose one-screen rooms are otherwise dead
+//! data. See `UNUSED5_ROOMS` for why its screens 6 and 7 are held back.
 //!
 //! Always on, no option: which room a pipe leads to is not a difference worth a
 //! control, since every room hands out one block and returns you where you came
@@ -75,21 +76,30 @@ const VANILLA_ROOMS: [Room; 11] = [
     room(7, 4, (0x02, 0xD4), false), // BigQ8 s4  3-Up
 ];
 
-/// Unused Level 5's eight rooms, one per screen, every block a Tanooki Suit.
+/// Unused Level 5's usable rooms, every block a Tanooki Suit.
 ///
 /// Arrivals aim at each room's ceiling pipe at a Y index *inside* it, so the
-/// player falls out of the mouth the way vanilla does. Screens 6 and 7 have no
-/// ceiling pipe — their only pipe is the floor one you leave by — so those land
-/// beside it instead. Dir 2 throughout, matching vanilla's Big [?] arrivals.
-const UNUSED5_ROOMS: [Room; 8] = [
+/// player falls out of the mouth the way vanilla does. Dir 2 throughout,
+/// matching vanilla's Big [?] arrivals.
+///
+/// **Screens 6 and 7 are excluded.** They are the only two rooms with no
+/// ceiling pipe — their only pipe is the floor one you leave by — so their
+/// arrivals were aimed beside it, at Y index 6 (row 23), which is the pipe
+/// body's row and not ground. Screen 6 has nothing at row 23 but the pipe at
+/// col 1; screen 7's row-23 floor run starts at col 6. Both dropped the player
+/// through the floor (playtested 2026-08-27, seeds 10/16/31).
+///
+/// Re-aiming them needs the room's tile grid, not its command list — the
+/// commands say where generators start, not where the resulting solid tiles
+/// are, and `level_sim.py` only knows tileset 1. Until something can answer
+/// "is (col, row) solid", these two stay out; the pool is 17, not 19.
+const UNUSED5_ROOMS: [Room; 6] = [
     room(0, 0, (0x02, 0x20), true), // ceiling pipe col 2, rows 0-1
     room(0, 1, (0x42, 0x11), true), // ceiling pipe col 1, rows 12-16
     room(0, 2, (0x02, 0x22), true), // ceiling pipe col 2, rows 0-1
     room(0, 3, (0x52, 0x13), true), // ceiling pipe col 1, rows 16-21
     room(0, 4, (0x52, 0x24), true), // ceiling pipe col 2, rows 16-21
     room(0, 5, (0x02, 0x75), true), // ceiling pipe col 7, rows 0-2
-    room(0, 6, (0x62, 0x36), true), // no ceiling pipe — beside the floor pipe
-    room(0, 7, (0x62, 0x57), true), // no ceiling pipe — beside the floor pipe
 ];
 
 /// A level with a Big [?] pipe: its row in the lookup table, its entry
@@ -255,7 +265,7 @@ mod tests {
             assert!(!seen.contains(&(r.area, r.screen)), "duplicate room");
             seen.push((r.area, r.screen));
         }
-        assert_eq!(seen.len(), 19);
+        assert_eq!(seen.len(), 17);
     }
 
     #[test]

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -54,8 +54,12 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, opts: &Options) {
 }
 
 /// Randomize Big ? Blocks by swapping their IDs among the set of Big ? Block
-/// types. The Tanooki block in World 7-F1 is protected because flying is
-/// required to beat that level.
+/// types. BigQ7's Tanooki is left alone — it is 7-F1's vanilla room, and
+/// flying is required to beat that level.
+///
+/// This is not the whole 7-F1 guarantee any more: `big_q_rooms` draws 7-F1 a
+/// room per seed and forces *that* room's block afterwards. This protection
+/// only keeps the vanilla pairing honest.
 pub fn randomize_big_q_blocks<R: Rng>(rom: &mut Rom, rng: &mut R) {
     // All enemy classes off — only Big ? Blocks get randomized
     let no_flags = Options {

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -331,9 +331,13 @@ pub(super) const BIG_Q_BLOCKS: &[u8] = &[
     0x9A, // OBJ_BIGQBLOCK_HAMMER
 ];
 
-/// File offset of the Tanooki Big ? Block in the World 7 Big ? Block room.
-/// This block must NOT be randomized — flying/Tanooki is required to beat 7-F1.
-/// The W7 room is at enemy_ptr 0xC9A3; the Tanooki is the second entry.
+/// File offset of the Tanooki Big ? Block in the World 7 Big ? Block room —
+/// BigQ7's second object entry, on screen 6. Flight is required to beat 7-F1,
+/// so this block must not be randomized *when 7-F1 opens this room*.
+///
+/// Which room 7-F1 opens is decided per seed by `big_q_rooms`, which passes the
+/// drawn room's block offset to `randomize_big_q_blocks`. This constant is the
+/// vanilla answer, kept as the reference the protection test pins against.
 pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
 /// Injection candidates for wild_injections mode: level-wide chasers seeded into

--- a/src/randomize/mod.rs
+++ b/src/randomize/mod.rs
@@ -2,6 +2,7 @@ pub mod anchor_visuals;
 pub mod antechambers;
 pub mod autoscroll;
 pub mod beta_tornado;
+pub mod big_q_rooms;
 pub mod bowser_castle;
 pub mod credits;
 pub mod enemies;

--- a/src/randomize/qol/big_q.rs
+++ b/src/randomize/qol/big_q.rs
@@ -49,16 +49,90 @@ const BIG_Q_HOOK_OFFSET: usize = 0x349F9;
 //   * 6-9 donated interior $C60E -> room 5 (its block lives HERE, not in the
 //     entry $CD2D — so without this row, reaching 6-9 via a lobby falls through
 //     to World_Num and picks the wrong room).
-const BQ_OBJ_HI: [u8; 13] =
+pub(crate) const BQ_OBJ_HI: [u8; 13] =
     [0xCD, 0xC3, 0xD5, 0xC8, 0xCB, 0xCA, 0xCD, 0xCC, 0xD4, 0xC3, 0xC4, 0xCE, 0xC6];
-const BQ_OBJ_LO: [u8; 13] =
+pub(crate) const BQ_OBJ_LO: [u8; 13] =
     [0xEB, 0x8F, 0x08, 0xBE, 0x0A, 0x8E, 0x2D, 0xE8, 0xE4, 0x2D, 0x24, 0x4B, 0x0E];
-const BQ_ROOM: [u8; 13] =
+pub(crate) const BQ_ROOM: [u8; 13] =
     [0x02, 0x02, 0x03, 0x04, 0x04, 0x05, 0x05, 0x05, 0x06, 0x06, 0x07, 0x04, 0x05];
 
-const BIG_Q_ROUTINE_LEN: usize = 106;
+/// Vanilla arrival spawn bytes per row: `(byte1, byte2)` where byte1 is
+/// `(Y-start index << 4) | pipe-exit dir` and byte2 is `(col << 4) | screen`.
+/// The screen nibble is what picks the room inside the area.
+///
+/// Harvested from each host's own Big ? junction command. Rows 11 and 12 mirror
+/// rows 3 and 6 (the same two levels reached through a lobby).
+pub(crate) const BQ_ARRIVE: [(u8, u8); 13] = [
+    (0x02, 0x14), // 3-5   -> BigQ3 s4
+    (0x02, 0x15), // 3-9   -> BigQ3 s5
+    (0x52, 0x22), // 4-F2  -> BigQ4 s2
+    (0x02, 0x73), // 5-2   -> BigQ5 s3
+    (0x02, 0x17), // 5-5   -> BigQ5 s7
+    (0x52, 0x25), // 6-3   -> BigQ6 s5
+    (0x02, 0x83), // 6-9   -> BigQ6 s3
+    (0x12, 0xD6), // 6-10  -> BigQ6 s6
+    (0x02, 0x16), // 7-F1  -> BigQ7 s6
+    (0x52, 0x14), // 7-8   -> BigQ7 s4
+    (0x02, 0xD4), // 8-1   -> BigQ8 s4
+    (0x02, 0x73), // 5-2 sub-area — mirrors row 3
+    (0x02, 0x83), // 6-9 interior — mirrors row 6
+];
 
-/// Build the PRG026 Big ? Block bonus-room lookup routine.
+/// Vanilla return spawn bytes per row, in the same `(byte1, byte2)` format but
+/// naming a position in the HOST. Harvested from each room's own group-7
+/// command in the bonus area (slot = the room's screen).
+///
+/// A return position is not tied to the pipe you came down — it is a
+/// hand-authored safe spot. 5-2's pipe is on screen 4 and its return lands on
+/// screen 5; that is vanilla, not a bug.
+pub(crate) const BQ_RETURN: [(u8, u8); 13] = [
+    (0x71, 0x46), // 3-5   <- BigQ3 slot 4
+    (0x61, 0x76), // 3-9   <- BigQ3 slot 5
+    (0x51, 0x86), // 4-F2  <- BigQ4 slot 2
+    (0x61, 0x65), // 5-2   <- BigQ5 slot 3
+    (0x42, 0xE5), // 5-5   <- BigQ5 slot 7
+    (0x11, 0xA3), // 6-3   <- BigQ6 slot 5
+    (0x61, 0x64), // 6-9   <- BigQ6 slot 3
+    (0x61, 0xE3), // 6-10  <- BigQ6 slot 6
+    (0x61, 0xC6), // 7-F1  <- BigQ7 slot 6
+    (0x61, 0x29), // 7-8   <- BigQ7 slot 4
+    (0x51, 0xF5), // 8-1   <- BigQ8 slot 4
+    (0x61, 0x65), // 5-2 sub-area — mirrors row 3
+    (0x61, 0x64), // 6-9 interior — mirrors row 6
+];
+
+/// Rows that must move together: reaching a level through a lobby has to open
+/// the same room as reaching it from its own tile. `(primary, mirror)`.
+#[cfg(test)]
+pub(crate) const BQ_MIRROR_ROWS: [(usize, usize); 2] = [(3, 11), (6, 12)];
+
+// Byte offsets of the pieces inside the assembled routine. `apply_room_rooms`
+// rewrites the four payload tables in place; the seeding code and the scan
+// never change.
+const OFF_HIT: usize = 0x26;
+const OFF_SCAN: usize = 0x39;
+const OFF_EXIT: usize = 0x52;
+const OFF_HI: usize = 0x74;
+const OFF_LO: usize = 0x81;
+pub(crate) const OFF_ROOM: usize = 0x8E;
+pub(crate) const OFF_ARR_Y: usize = 0x9B;
+pub(crate) const OFF_ARR_X: usize = 0xA8;
+pub(crate) const OFF_RET_Y: usize = 0xB5;
+pub(crate) const OFF_RET_X: usize = 0xC2;
+const BIG_Q_ROUTINE_LEN: usize = 0xCF; // 207
+
+// Zero page / RAM the routine touches.
+const PLAYER_XHI: u8 = 0x75;
+const JCT_YLH_START: u16 = 0x7F54; // 16-byte slot array
+const JCT_XLH_START: u16 = 0x7F64; // 16-byte slot array
+
+/// `JMP PRG026_AA8A` at the tail of the Big ? exit path (`PRG026_AA5A`), which
+/// runs only when leaving a bonus room. Swapping this 3-byte jump for a jump
+/// into our own routine displaces whole instructions and needs no NOP padding.
+pub(crate) const BIG_Q_EXIT_HOOK: usize = 0x34A84;
+const BIG_Q_EXIT_RETURN: u16 = 0xAA8A;
+
+/// Build the PRG026 Big ? Block lookup + slot-seeding routine.
 ///
 /// **Two-pass lookup.** The room a bonus pipe opens is a property of the *level
 /// whose area you're standing in*. The routine resolves that by scanning the
@@ -77,14 +151,34 @@ const BIG_Q_ROUTINE_LEN: usize = 106;
 ///    an area not itself in the table.
 /// 3. **`LDY $0727` (World_Num) fallback** — vanilla default, last resort.
 ///
+/// **Slot seeding.** On a match the routine also stamps the row's spawn bytes
+/// into `Level_JctYLHStart` / `Level_JctXLHStart` at the slot the engine is
+/// about to read (`Player_XHi`). That is what lets a host open *any* room: the
+/// arrival no longer has to come from the host's own group-7 layout command, so
+/// no layout data is located or edited. The exit half does the same with the
+/// return bytes, hooked at the Big ?-only exit path where the pointer restore
+/// has just put the host's own obj_ptr back into `Level_ObjPtrOrig`.
+///
 /// Internal absolute operands are derived from where the routine is written, so
 /// it is not origin-locked to a hardcoded CPU address.
 fn build_lookup_routine() -> Vec<u8> {
-    let base = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET); // routine start (CPU)
-    let scan = (base + 0x26).to_le_bytes(); // bq_scan subroutine
-    let hi = (base + 0x43).to_le_bytes(); // BQ_OBJ_HI table
-    let lo = (base + 0x50).to_le_bytes(); // BQ_OBJ_LO table (13 bytes after hi)
-    let room = (base + 0x5D).to_le_bytes(); // BQ_ROOM table (13 bytes after lo)
+    build_routine_with(&BQ_ROOM, &BQ_ARRIVE, &BQ_RETURN)
+}
+
+fn build_routine_with(
+    rooms: &[u8; 13],
+    arrive: &[(u8, u8); 13],
+    ret: &[(u8, u8); 13],
+) -> Vec<u8> {
+    let base = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET);
+    let at = |off: usize| (base + off as u16).to_le_bytes();
+    let (scan, hi, lo) = (at(OFF_SCAN), at(OFF_HI), at(OFF_LO));
+    let (room_t, arr_y, arr_x) = (at(OFF_ROOM), at(OFF_ARR_Y), at(OFF_ARR_X));
+    let (ret_y, ret_x) = (at(OFF_RET_Y), at(OFF_RET_X));
+    let ylh = JCT_YLH_START.to_le_bytes();
+    let xlh = JCT_XLH_START.to_le_bytes();
+    let back = BIG_Q_EXIT_RETURN.to_le_bytes();
+
     let mut r: Vec<u8> = vec![
         // --- pass 1: current area (Level_ObjPtrOrig $7EBB/$7EBC) ---
         0xAD, 0xBB, 0x7E,       // LDA $7EBB     ; current-area obj_lo
@@ -92,42 +186,72 @@ fn build_lookup_routine() -> Vec<u8> {
         0xAD, 0xBC, 0x7E,       // LDA $7EBC     ; current-area obj_hi
         0x8D, 0xB3, 0x7E,       // STA $7EB3     ; scratch hi
         0x20, scan[0], scan[1], // JSR bq_scan
-        0xB0, 0x14,             // BCS .ret      ; matched -> Y = room
+        0xB0, 0x15,             // BCS .hit
         // --- pass 2: frozen map-entry ptr ($7EB4/$7EB5, saved by Part A) ---
         0xAD, 0xB4, 0x7E,       // LDA $7EB4     ; frozen obj_lo
         0x8D, 0xB2, 0x7E,       // STA $7EB2
         0xAD, 0xB5, 0x7E,       // LDA $7EB5     ; frozen obj_hi
         0x8D, 0xB3, 0x7E,       // STA $7EB3
         0x20, scan[0], scan[1], // JSR bq_scan
-        0xB0, 0x03,             // BCS .ret
+        0xB0, 0x04,             // BCS .hit
         // --- fallback: World_Num ---
         0xAC, 0x27, 0x07,       // LDY $0727
-        0x60,                   // .ret: RTS
-        // --- bq_scan: scratch $7EB2=lo/$7EB3=hi -> carry set + Y=room on match ---
+        0x60,                   // RTS
+        // --- .hit ($26): X = row. Seed the arrival, return the area in Y ---
+        0xA4, PLAYER_XHI,       // LDY Player_XHi   ; the slot the engine reads
+        0xBD, arr_y[0], arr_y[1], // LDA BQ_ARR_Y,X
+        0x99, ylh[0], ylh[1],   // STA Level_JctYLHStart,Y
+        0xBD, arr_x[0], arr_x[1], // LDA BQ_ARR_X,X
+        0x99, xlh[0], xlh[1],   // STA Level_JctXLHStart,Y
+        0xBD, room_t[0], room_t[1], // LDA BQ_ROOM,X
+        0xA8,                   // TAY
+        0x60,                   // RTS
+        // --- bq_scan ($39): $7EB2/$7EB3 -> carry set + X = row on match ---
         0xA2, 0x0C,             // LDX #12  (13 entries, index 0..12)
         0xAD, 0xB3, 0x7E,       // .loop: LDA $7EB3
         0xDD, hi[0], hi[1],     // CMP BQ_OBJ_HI,X
-        0xD0, 0x0E,             // BNE .next
+        0xD0, 0x0A,             // BNE .next
         0xAD, 0xB2, 0x7E,       // LDA $7EB2
         0xDD, lo[0], lo[1],     // CMP BQ_OBJ_LO,X
-        0xD0, 0x06,             // BNE .next
-        0xBD, room[0], room[1], // LDA BQ_ROOM,X
-        0xA8,                   // TAY
+        0xD0, 0x02,             // BNE .next
         0x38,                   // SEC
         0x60,                   // RTS
         0xCA,                   // .next: DEX
-        0x10, 0xE7,             // BPL .loop
+        0x10, 0xEB,             // BPL .loop
         0x18,                   // CLC
         0x60,                   // RTS
+        // --- exit seed ($52): reached from the Big ?-only exit path. The
+        //     pointer restore just before it put the HOST's obj_ptr back. ---
+        0xAD, 0xBB, 0x7E,       // LDA $7EBB
+        0x8D, 0xB2, 0x7E,       // STA $7EB2
+        0xAD, 0xBC, 0x7E,       // LDA $7EBC
+        0x8D, 0xB3, 0x7E,       // STA $7EB3
+        0x20, scan[0], scan[1], // JSR bq_scan
+        0x90, 0x0E,             // BCC .done   (not ours — leave vanilla alone)
+        0xA4, PLAYER_XHI,       // LDY Player_XHi   ; the room's screen
+        0xBD, ret_y[0], ret_y[1], // LDA BQ_RET_Y,X
+        0x99, ylh[0], ylh[1],   // STA Level_JctYLHStart,Y
+        0xBD, ret_x[0], ret_x[1], // LDA BQ_RET_X,X
+        0x99, xlh[0], xlh[1],   // STA Level_JctXLHStart,Y
+        0x4C, back[0], back[1], // .done: JMP PRG026_AA8A
     ];
     r.extend_from_slice(&BQ_OBJ_HI);
     r.extend_from_slice(&BQ_OBJ_LO);
-    r.extend_from_slice(&BQ_ROOM);
+    r.extend_from_slice(rooms);
+    r.extend(arrive.iter().map(|&(y, _)| y));
+    r.extend(arrive.iter().map(|&(_, x)| x));
+    r.extend(ret.iter().map(|&(y, _)| y));
+    r.extend(ret.iter().map(|&(_, x)| x));
     debug_assert_eq!(r.len(), BIG_Q_ROUTINE_LEN);
+    // Both `BCS .hit` displacements are written by hand above; check they still
+    // reach `.hit` rather than landing mid-instruction.
+    debug_assert_eq!(0x11 + r[0x10] as usize, OFF_HIT, "pass 1 BCS .hit");
+    debug_assert_eq!(0x22 + r[0x21] as usize, OFF_HIT, "pass 2 BCS .hit");
     r
 }
 
-/// Patch Big ? Block bonus room selection to use level identity instead of World_Num.
+/// Patch Big ? Block bonus room selection to use level identity instead of
+/// World_Num, and seed the spawn slots from our own tables.
 pub fn fix_big_q_block_rooms(rom: &mut Rom) {
     // Part A: PRG030 save trampoline (saves $65/$66 before W8 overwrite)
     rom.write_range(BIG_Q_PRG030_HOOK, &BIG_Q_PRG030_JMP);
@@ -135,6 +259,31 @@ pub fn fix_big_q_block_rooms(rom: &mut Rom) {
     // Part B: PRG026 two-pass lookup routine + hook
     rom.write_range(BIG_Q_HOOK_OFFSET, &jsr_into_bank(26, BIG_Q_ROUTINE_OFFSET));
     rom.write_range(BIG_Q_ROUTINE_OFFSET, &build_lookup_routine());
+    // Part C: the exit path's `JMP PRG026_AA8A` -> our return seeder
+    let exit = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET) + OFF_EXIT as u16;
+    rom.write_range(BIG_Q_EXIT_HOOK, &[0x4C, exit as u8, (exit >> 8) as u8]);
+}
+
+/// Rewrite the four per-row payload tables in the already-written routine.
+///
+/// `fix_big_q_block_rooms` must have run first — this only stamps over the
+/// tables, leaving the code and the obj_ptr key tables untouched.
+pub(crate) fn write_room_tables(
+    rom: &mut Rom,
+    rooms: &[u8; 13],
+    arrive: &[(u8, u8); 13],
+    ret: &[(u8, u8); 13],
+) {
+    let base = BIG_Q_ROUTINE_OFFSET;
+    rom.write_range(base + OFF_ROOM, rooms);
+    for (i, &(y, x)) in arrive.iter().enumerate() {
+        rom.write_byte(base + OFF_ARR_Y + i, y);
+        rom.write_byte(base + OFF_ARR_X + i, x);
+    }
+    for (i, &(y, x)) in ret.iter().enumerate() {
+        rom.write_byte(base + OFF_RET_Y + i, y);
+        rom.write_byte(base + OFF_RET_X + i, x);
+    }
 }
 
 #[cfg(test)]
@@ -174,10 +323,10 @@ mod tests {
         assert_eq!(&r[6..9], &[0xAD, 0xBC, 0x7E], "pass 1 LDA $7EBC");
         assert_eq!(&r[17..20], &[0xAD, 0xB4, 0x7E], "pass 2 LDA $7EB4");
         assert_eq!(&r[23..26], &[0xAD, 0xB5, 0x7E], "pass 2 LDA $7EB5");
-        assert_eq!(&r[34..38], &[0xAC, 0x27, 0x07, 0x60], "fallback LDY $0727; RTS");
-        assert_eq!(&r[0x43..0x50], &BQ_OBJ_HI);
-        assert_eq!(&r[0x50..0x5D], &BQ_OBJ_LO);
-        assert_eq!(&r[0x5D..0x6A], &BQ_ROOM);
+        assert_eq!(&r[0x22..0x26], &[0xAC, 0x27, 0x07, 0x60], "fallback LDY $0727; RTS");
+        assert_eq!(&r[OFF_HI..OFF_LO], &BQ_OBJ_HI);
+        assert_eq!(&r[OFF_LO..OFF_ROOM], &BQ_OBJ_LO);
+        assert_eq!(&r[OFF_ROOM..OFF_ARR_Y], &BQ_ROOM);
     }
 
     /// The hook must name the routine's own origin. The routine's *internal*
@@ -207,14 +356,14 @@ mod asm_checks {
     /// The PRG026 lookup routine, whose internal operands are derived from
     /// `base` rather than hardcoded — so `.origin` here proves the derivation
     /// lands on real instruction boundaries, not merely on the right numbers.
-    /// The last 39 bytes are the three 13-entry tables.
+    /// The last 91 bytes are the seven 13-entry tables.
     #[test]
     fn lookup_routine_is_well_formed() {
         let routine = build_lookup_routine();
         asm::check(&routine)
             .allocation(BIG_Q_ROUTINE_OFFSET)
             .origin(prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET))
-            .data_from(routine.len() - 39)
+            .data_from(routine.len() - 91)
             .assert_ok();
     }
 }

--- a/src/randomize/qol/mod.rs
+++ b/src/randomize/qol/mod.rs
@@ -2,7 +2,7 @@
 //! per-option by the randomizer. Each submodule owns one cohesive feature area.
 
 mod beta;
-mod big_q;
+pub(crate) mod big_q;
 mod canoe;
 mod canoe_summon;
 mod cards;

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -13,7 +13,7 @@
 //! routine must live in a bank mapped when it runs. The always-mapped banks
 //! are effectively full — PRG031 (`$E000–$FFFF`) has 81 bytes left but a
 //! largest contiguous gap of only 30, and PRG030 (`$8000–$9FFF`) has 88 with
-//! a largest gap of 42. Swapped banks are roomier (PRG010 896, PRG026 2603,
+//! a largest gap of 42. Swapped banks are roomier (PRG010 896, PRG026 2485,
 //! and the in-level banks PRG004 426 / PRG006 1392 in one run each).
 //!
 //! Reserving some headroom in an allocation is fine and encouraged — a routine
@@ -118,7 +118,7 @@ pub const FREE_SPACE_ALLOCATIONS: &[FreeSpaceAlloc] = &[
     fs(0x35572, 13, &["mystery_anchor"], "item redirect trampoline"),
     fs(0x3557F, 50, &["hammer_breaks_tiles"], "hammer_locks: tile check subroutine + tables"),
     fs(0x355B1, 12, &["anchor_visuals"], "items-vs-cards index guard trampoline"),
-    fs(0x355BD, 106, &["big_q_blocks"], "big_q_block: two-pass lookup routine + 13-entry tables (current-area then frozen entry)"),
+    fs(0x355BD, 224, &["big_q_blocks"], "big_q_block: two-pass lookup + slot seeding + 7 13-entry tables (224 reserved, 207 used)"),
     // PRG027 (file 0x36010, CPU $A000–$BFFF)
     fs(0x379D9, 894, &["king_quotes"], "7 quotes + hook (7×120 + 54)"),
     // PRG010 (file 0x14010, CPU $C000–$DFFF during map)
@@ -254,9 +254,10 @@ pub(crate) const GAMEOVER_FINALIZE_SITE: usize = 0x166BA;  // 3 bytes — `STA $
 // "NOTE: Assumes Index 1 is the Airship!"
 pub(crate) const AIRSHIP_OBJ_SLOT: usize = 1;
 
-// PRG026 — two-pass Big ? Block lookup (qol/big_q.rs), relocated off the old
-// 0x35530 slot into tail free space to hold the two-pass routine + 12 entries.
-pub(crate) const FS_BIG_Q_LOOKUP: usize      = 0x355BD; // 106 bytes (CPU $B5AD)
+// PRG026 — two-pass Big ? Block lookup + spawn-slot seeding (qol/big_q.rs),
+// relocated off the old 0x35530 slot into tail free space. The $FF run this
+// sits in continues to 0x36000, so it has room to grow in place.
+pub(crate) const FS_BIG_Q_LOOKUP: usize      = 0x355BD; // 224 reserved, 207 used (CPU $B5AD)
 
 // PRG027
 pub(crate) const FS_KING_QUOTES: usize       = 0x379D9; // 894 bytes

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -679,6 +679,55 @@ pub(crate) const BETA_PATCHES: &[(usize, u8)] = &[
     (0x26DB8, 0x63), (0x26DB9, 0x20),
 ];
 
+// ---------------------------------------------------------------------------
+// Big [?] Block bonus areas
+// ---------------------------------------------------------------------------
+
+/// Per-world Big [?] Block bonus-area tables in PRG026 (`LevelJctBQ_Layout`
+/// $A90B, `_Objects` $A91B, `_Tileset` $A92B).
+///
+/// `LevelJct_BigQuestionBlock` indexes all three with a room number — vanilla
+/// uses `World_Num`; `qol::big_q` replaces that with a level-identity lookup.
+/// The layout is then read from whichever bank `PAGE_A000_BY_TILESET` maps for
+/// the tileset byte, so an area's layout does not have to live in PRG013.
+///
+/// Rooms 0 and 1 are unreachable in vanilla: W1's area is empty, and W2's holds
+/// a 3-Up room that no level opens (no W1/W2 level has a Big [?] pipe).
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const BIG_Q_AREA_LAYOUTS: usize = 0x3491B;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const BIG_Q_AREA_OBJECTS: usize = 0x3492B;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const BIG_Q_AREA_TILESETS: usize = 0x3493B;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const BIG_Q_AREA_COUNT: usize = 8;
+
+/// 5-2's Big [?] Block junction command — slot 4 of its entry area, the screen
+/// its bonus pipe sits on. byte2 is `(col << 4) | screen`: where in the bonus
+/// area the pipe lands. Vanilla `$73` = screen 3, column 7, which is exactly
+/// where BigQ5's 3-Up block sits.
+///
+/// The antechamber shuffle deliberately leaves this command alone — see
+/// `antechambers.rs`, which lists only 5-2's front door `0x1A804`.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const W52_BIG_Q_JUNCTION: usize = 0x1A807;
+
+/// "Unused Level 5" (TCRF): a fortress-tileset test level holding eight Big [?]
+/// Block rooms, one per screen, every block a Tanooki Suit. Nothing in the ROM
+/// reaches it — no world pointer table entry and no header alt pointer names
+/// either address. Presumably where the rooms were mocked up before being split
+/// into the per-world areas above.
+///
+/// Its layout lives in PRG021, so a `LevelJctBQ_Tileset` entry of 2 (fortress)
+/// is what maps the right bank at $A000; the object stream is in PRG006, which
+/// the loader maps for every level regardless of tileset.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const UNUSED5_LAYOUT_PTR: u16 = 0xB754;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const UNUSED5_OBJECT_PTR: u16 = 0xD401;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const UNUSED5_TILESET: u8 = 2;
+
 /// An FX slot (lock/bridge position and replacement tile).
 pub(crate) struct FxSlot {
     pub grid_row: usize,

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -693,13 +693,10 @@ pub(crate) const BETA_PATCHES: &[(usize, u8)] = &[
 ///
 /// Rooms 0 and 1 are unreachable in vanilla: W1's area is empty, and W2's holds
 /// a 3-Up room that no level opens (no W1/W2 level has a Big [?] pipe).
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const BIG_Q_AREA_LAYOUTS: usize = 0x3491B;
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const BIG_Q_AREA_OBJECTS: usize = 0x3492B;
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const BIG_Q_AREA_TILESETS: usize = 0x3493B;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_arch = "wasm32"))] // only testrom iterates all eight areas
 pub(crate) const BIG_Q_AREA_COUNT: usize = 8;
 
 /// 5-2's Big [?] Block junction command — slot 4 of its entry area, the screen
@@ -734,14 +731,10 @@ pub(crate) const W52_BIG_Q_JUNCTION: usize = 0x1A807;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) const BIGQ5_SLOT3_JUNCTION: usize = 0x1B479;
 
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const UNUSED5_LAYOUT_PTR: u16 = 0xB754;
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const UNUSED5_OBJECT_PTR: u16 = 0xD401;
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const UNUSED5_TILESET: u8 = 2;
 /// PRG bank holding the layout, for `prg_bank_cpu_to_file`.
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const UNUSED5_LAYOUT_BANK: usize = 21;
 /// Its header's BG-palette index (byte 5 bits 0-2) in vanilla.
 ///

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -740,6 +740,17 @@ pub(crate) const UNUSED5_LAYOUT_PTR: u16 = 0xB754;
 pub(crate) const UNUSED5_OBJECT_PTR: u16 = 0xD401;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) const UNUSED5_TILESET: u8 = 2;
+/// PRG bank holding the layout, for `prg_bank_cpu_to_file`.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const UNUSED5_LAYOUT_BANK: usize = 21;
+/// Its header's BG-palette index (byte 5 bits 0-2) in vanilla.
+///
+/// 6 is the placeholder: the only two fortress-tileset levels using it are this
+/// one and `Empty`. Real fortresses use 0 (most mini-fortresses), 1 (Koopaling
+/// throne rooms, with object palette 10), 3 (World 3's) or 4 (1-F, 4-F2, 5-F1,
+/// 6-F1, 7-F1, Bowser's castle).
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const UNUSED5_VANILLA_BGPAL: u8 = 6;
 
 /// An FX slot (lock/bridge position and replacement tile).
 pub(crate) struct FxSlot {

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -721,6 +721,19 @@ pub(crate) const W52_BIG_Q_JUNCTION: usize = 0x1A807;
 /// Its layout lives in PRG021, so a `LevelJctBQ_Tileset` entry of 2 (fortress)
 /// is what maps the right bank at $A000; the object stream is in PRG006, which
 /// the loader maps for every level regardless of tileset.
+/// BigQ5's slot-3 junction command, `E3 61 65` — the return position vanilla
+/// uses when 5-2's Big [?] pipe sends the player home (Y index 6 = row 23,
+/// screen 5, column 6).
+///
+/// A bonus area supplies its own return: on the way out, `LevelJct_
+/// BigQuestionBlock` falls into the same code the entry uses and reads
+/// `Level_JctXLHStart[Player_XHi]`, indexed by the screen the player is
+/// standing on *in the bonus room*. Every vanilla area therefore carries one
+/// group-7 command per room screen, and a room without one returns the player
+/// to whatever stale value that slot happens to hold.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const BIGQ5_SLOT3_JUNCTION: usize = 0x1B479;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) const UNUSED5_LAYOUT_PTR: u16 = 0xB754;
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -316,6 +316,27 @@ fn randomize_inner(
         },
     );
 
+    // Big [?] bonus-room shuffle: every level with a Big [?] pipe draws from a
+    // pool of 19 rooms (11 vanilla + 8 in the otherwise-dead "Unused Level 5").
+    // Runs after the overworld builder because the BigQBlock_GotIt "already
+    // opened" bit is per world *and* per screen, so the legal rooms for a host
+    // depend on where its level ended up — and after `write_overworld`, so the
+    // RNG it consumes cannot move the maps.
+    rom.set_tag("big_q_blocks/rooms");
+    let big_q_rooms = randomize::big_q_rooms::shuffle(rom, &mut rng);
+
+    // 7-F1 cannot be beaten without flight, so whatever room it drew has to
+    // hand out a flight suit. Forced last, which is also why it needs no
+    // cooperation from the contents roll above.
+    if let Some(off) = big_q_rooms
+        .iter()
+        .find(|a| a.name == "7-F1")
+        .and_then(|a| randomize::big_q_rooms::block_offset(rom, a.area, a.screen))
+    {
+        rom.set_tag("big_q_blocks/w7f1_flight");
+        rom.write_byte(off, randomize::big_q_rooms::BIGQBLOCK_TANOOKI);
+    }
+
     // Redraw + repack the ending credits mini-maps from the freshly-written
     // randomized world maps, then (if world order shuffled) reorder the montage
     // so each world's picture shows in the order the player traversed it. Both

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -36,6 +36,40 @@ fn normalized(mut o: Options) -> Options {
     o
 }
 
+/// 7-F1 cannot be beaten without flight, and which bonus room its Big [?] pipe
+/// opens is now drawn per seed — so the block in *whatever room it drew* has to
+/// be a flight suit, and the contents roll has to leave that byte alone.
+///
+/// The failure mode is silent: reorder `big_q_rooms` and `randomize_big_q_blocks`
+/// and the protection still "runs", it just names a stale offset. So this walks
+/// the drawn room's own object stream rather than trusting a constant.
+#[test]
+fn w7f1_block_is_always_a_flight_suit() {
+    let Some(base) = make_test_rom() else { return };
+    let mut opts = test_options();
+    opts.big_q_blocks = true;
+
+    for seed in 1..=40u64 {
+        let mut rom = base.clone();
+        randomize(&mut rom, seed, &opts);
+
+        // Row 8 of the lookup table is 7-F1; its area and the arrival's screen
+        // nibble name the room it drew.
+        let base_off = randomize::rom_data::FS_BIG_Q_LOOKUP;
+        let area = rom.read_byte(base_off + randomize::qol::big_q::OFF_ROOM + 8);
+        let screen = rom.read_byte(base_off + randomize::qol::big_q::OFF_ARR_X + 8) & 0x0F;
+
+        let block = randomize::big_q_rooms::block_offset(&rom, area, screen)
+            .unwrap_or_else(|| panic!("seed {seed}: 7-F1 drew area {area} screen {screen}, \
+                                       which holds no Big [?] block"));
+        assert_eq!(
+            rom.read_byte(block),
+            randomize::big_q_rooms::BIGQBLOCK_TANOOKI,
+            "seed {seed}: 7-F1's room (area {area} screen {screen}) does not hand out flight",
+        );
+    }
+}
+
 #[test]
 fn mystery_anchor_trampoline_written() {
     let Some(mut rom) = make_test_rom() else {

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -372,6 +372,10 @@ pub struct TestRomSpec {
     pub hammer_breaks_bridges: bool,
     /// Include the 9 unreferenced beta stages as placeable names.
     pub include_beta: bool,
+    /// Repoint every Big [?] Block bonus area at "Unused Level 5" (the
+    /// unreferenced eight-room test level) and land 5-2's bonus pipe in the
+    /// room on this screen, 0-7. `None` leaves the vanilla areas alone.
+    pub big_q_unused5: Option<u8>,
     /// Enemy slots to overwrite outright. Applied last, so they win over the
     /// randomizer's own choices on a `--randomize` base.
     pub set_enemies: Vec<EnemyOverride>,
@@ -443,6 +447,86 @@ fn numbered_slots(rom: &Rom, world_idx: usize, include_beta: bool) -> Vec<(u8, u
     slots.sort_unstable();
     slots.dedup_by_key(|(num, _)| *num);
     slots
+}
+
+/// Repoint every Big [?] Block bonus area at "Unused Level 5", and aim 5-2's
+/// bonus pipe at one of its eight rooms.
+///
+/// Two independent things have to line up for a Big [?] pipe to open a room:
+///
+/// 1. **Which area** — `LevelJct_BigQuestionBlock` loads the layout/objects
+///    pointers and the tileset from three 8-entry tables indexed by room
+///    number. Every entry is rewritten here rather than just the one 5-2 uses,
+///    so *any* Big [?] pipe in the game reaches this level no matter which
+///    world its host ended up in. That also sidesteps vanilla's `LDY World_Num`
+///    selection, which a vanilla-base test ROM still has.
+/// 2. **Which room inside it** — the arrival position comes from the *source*
+///    level's own junction command, `(col << 4) | screen` in byte2. Only 5-2's
+///    is retargeted; every other host keeps its vanilla byte2, and since this
+///    level has a room on all eight screens, they all still land in one.
+///
+/// The return trip needs no edit. `Player_DoSpecialTiles` (PRG008 $BCC4) ANDs
+/// the pipe-tile index with 1 while `LevelJctBQ_Flag` is set, which collapses
+/// all four pipe-1/pipe-2 end tiles ($AD-$B0) onto the Big [?] junction type —
+/// so any ordinary pipe in the room sends the player back to the host level.
+/// Loaded normally these same pipes exit to the world map instead, which is
+/// what TCRF describes.
+fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
+    // Read the rooms out of the level's own object stream rather than
+    // hardcoding them: entries are [id, (screen << 4) | col, row].
+    let seg = rom_data::enemy_ptr_to_file_offset(rom_data::UNUSED5_OBJECT_PTR);
+    let mut rooms: Vec<(u8, u8, u8, u8)> = Vec::new();
+    let mut off = seg + 1; // skip the segment's page byte
+    while rom.read_byte(off) != 0xFF {
+        let (id, pos, row) = (rom.read_byte(off), rom.read_byte(off + 1), rom.read_byte(off + 2));
+        rooms.push((pos >> 4, pos & 0x0F, row, id));
+        off += 3;
+    }
+
+    let &(scr, col, row, id) = rooms
+        .iter()
+        .find(|(s, ..)| *s == screen)
+        .ok_or_else(|| {
+            format!(
+                "Unused Level 5 has no Big [?] room on screen {screen} (rooms: {})",
+                rooms
+                    .iter()
+                    .map(|(s, ..)| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+
+    for room in 0..rom_data::BIG_Q_AREA_COUNT {
+        rom.write_range(
+            rom_data::BIG_Q_AREA_LAYOUTS + room * 2,
+            &rom_data::UNUSED5_LAYOUT_PTR.to_le_bytes(),
+        );
+        rom.write_range(
+            rom_data::BIG_Q_AREA_OBJECTS + room * 2,
+            &rom_data::UNUSED5_OBJECT_PTR.to_le_bytes(),
+        );
+        rom.write_byte(rom_data::BIG_Q_AREA_TILESETS + room, rom_data::UNUSED5_TILESET);
+    }
+
+    let was = rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2);
+    let now = (col << 4) | scr;
+    rom.write_byte(rom_data::W52_BIG_Q_JUNCTION + 2, now);
+
+    Ok(vec![
+        format!(
+            "big [?] rooms: all {} areas -> Unused Level 5 (layout ${:04X}, objects ${:04X}, tileset {})",
+            rom_data::BIG_Q_AREA_COUNT,
+            rom_data::UNUSED5_LAYOUT_PTR,
+            rom_data::UNUSED5_OBJECT_PTR,
+            rom_data::UNUSED5_TILESET
+        ),
+        format!(
+            "  5-2's bonus pipe: {was:#04X} -> {now:#04X} (screen {scr}, col {col}; \
+             block {id:#04X} at row {row})"
+        ),
+        format!("  {} rooms in the level; place 5-2 to reach one", rooms.len()),
+    ])
 }
 
 /// Rewrite lock and/or water-gap tiles across all 8 world maps.
@@ -690,6 +774,11 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
         }
     }
 
+    // 3a. Big [?] Block bonus rooms from the unreferenced test level.
+    if let Some(screen) = spec.big_q_unused5 {
+        report.extend(big_q_unused5(&mut rom, screen)?);
+    }
+
     // 4. Open the map up.
     let opened = open_map(&mut rom, spec.remove_locks, spec.remove_gaps);
     if opened > 0 {
@@ -847,6 +936,7 @@ mod tests {
             hammer_breaks_locks: false,
             hammer_breaks_bridges: false,
             include_beta: false,
+            big_q_unused5: None,
             set_enemies: Vec::new(),
         }
     }
@@ -885,6 +975,75 @@ mod tests {
             .find(|(num, _)| *num == 1)
             .expect("W1 has a tile 1");
         assert_eq!(rom_data::read_entry(&out, &WORLDS[0], slot.1), want);
+    }
+
+    /// `--bigq-unused5` has to line up two independent things: the three
+    /// per-world area tables (which area) and 5-2's own junction command (which
+    /// room inside it). This pins both, and pins the constants to the data they
+    /// claim to name — a wrong `UNUSED5_*` address would still write cleanly.
+    #[test]
+    fn big_q_unused5_repoints_every_area_and_aims_5_2() {
+        let Some(van) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+
+        let src = Rom::from_bytes_lax(&van, true).unwrap();
+
+        // The addresses really are Unused Level 5: an object stream of nothing
+        // but Big [?] Blocks, and a layout header whose size field spans the
+        // eight screens they sit on.
+        let obj = rom_data::enemy_ptr_to_file_offset(rom_data::UNUSED5_OBJECT_PTR);
+        let mut screens: Vec<u8> = Vec::new();
+        let mut off = obj + 1;
+        while src.read_byte(off) != 0xFF {
+            let id = src.read_byte(off);
+            assert!((0x94..=0x9A).contains(&id), "entry {id:#04X} is not a Big [?] Block");
+            screens.push(src.read_byte(off + 1) >> 4);
+            off += 3;
+        }
+        screens.sort_unstable();
+        assert_eq!(screens, (0..8).collect::<Vec<u8>>(), "one room per screen 0-7");
+
+        let lay = rom_data::prg_bank_cpu_to_file(21, rom_data::UNUSED5_LAYOUT_PTR);
+        assert_eq!(
+            src.read_range(lay, 4),
+            &[0x00, 0x00, 0x00, 0x00],
+            "a standalone area has null alt pointers"
+        );
+
+        let built = build(&van, &TestRomSpec { big_q_unused5: Some(5), ..spec() }).unwrap();
+        let out = Rom::from_bytes_lax(&built.bytes, true).unwrap();
+
+        for room in 0..rom_data::BIG_Q_AREA_COUNT {
+            assert_eq!(
+                out.read_range(rom_data::BIG_Q_AREA_LAYOUTS + room * 2, 2),
+                &rom_data::UNUSED5_LAYOUT_PTR.to_le_bytes(),
+                "room {room} layout"
+            );
+            assert_eq!(
+                out.read_range(rom_data::BIG_Q_AREA_OBJECTS + room * 2, 2),
+                &rom_data::UNUSED5_OBJECT_PTR.to_le_bytes(),
+                "room {room} objects"
+            );
+            assert_eq!(
+                out.read_byte(rom_data::BIG_Q_AREA_TILESETS + room),
+                rom_data::UNUSED5_TILESET,
+                "room {room} tileset"
+            );
+        }
+
+        // Screen 5's block sits at column 6, so the arrival byte is (6 << 4) | 5.
+        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2), 0x65);
+        // The rest of the command is untouched — the slot nibble still names
+        // 5-2's own pipe screen, and the exit direction still suits the room.
+        assert_eq!(
+            out.read_range(rom_data::W52_BIG_Q_JUNCTION, 2),
+            src.read_range(rom_data::W52_BIG_Q_JUNCTION, 2)
+        );
+
+        let err = build(&van, &TestRomSpec { big_q_unused5: Some(9), ..spec() }).unwrap_err();
+        assert!(err.contains("no Big [?] room on screen 9"), "{err}");
     }
 
     /// The Coin Ship has no world pointer table entry, so the catalog cannot

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -478,8 +478,12 @@ const UNUSED5_ARRIVALS: [(u8, u8); 8] = [
     (1, 5),  // screen 3: ceiling pipe col 1, rows 16-21
     (2, 5),  // screen 4: ceiling pipe col 2, rows 16-21
     (7, 0),  // screen 5: ceiling pipe col 7, rows 0-2
-    (3, 6),  // screen 6: no ceiling pipe — beside the floor pipe at col 1
-    (5, 6),  // screen 7: no ceiling pipe — beside the floor pipe at col 2
+    // No ceiling pipe on these two, so there is no mouth to drop out of and
+    // the aim was found by playtesting (2026-08-28). Both were originally Y
+    // index 6 — row 23, the floor pipe's own row — which put the player inside
+    // the pipe on screen 6 and past the end of the floor on screen 7.
+    (3, 5),  // screen 6: col 3 row 20, beside the floor pipe at col 1
+    (2, 3),  // screen 7: col 2 row 11, falling into the floor pipe
 ];
 
 /// Three-byte commands in Unused Level 5 we can overwrite with a return

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -376,6 +376,10 @@ pub struct TestRomSpec {
     /// unreferenced eight-room test level) and land 5-2's bonus pipe in the
     /// room on this screen, 0-7. `None` leaves the vanilla areas alone.
     pub big_q_unused5: Option<u8>,
+    /// BG palette index (0-7) to write into Unused Level 5's header. Its
+    /// vanilla 6 is the placeholder palette — monochrome. Only read when
+    /// `big_q_unused5` is set.
+    pub big_q_palette: Option<u8>,
     /// Enemy slots to overwrite outright. Applied last, so they win over the
     /// randomizer's own choices on a `--randomize` base.
     pub set_enemies: Vec<EnemyOverride>,
@@ -515,7 +519,7 @@ const UNUSED5_SPARE_COMMANDS: [(usize, [u8; 3], u8); 2] =
 /// collapses all four pipe-1/pipe-2 end tiles ($AD-$B0) onto the Big [?]
 /// junction type. Loaded normally these same pipes exit to the world map, which
 /// is what TCRF describes.
-fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
+fn big_q_unused5(rom: &mut Rom, screen: u8, palette: Option<u8>) -> Result<Vec<String>, String> {
     // Read the rooms out of the level's own object stream rather than
     // hardcoding them: entries are [id, (screen << 4) | col, row].
     let seg = rom_data::enemy_ptr_to_file_offset(rom_data::UNUSED5_OBJECT_PTR);
@@ -581,7 +585,32 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
     ];
     rom.write_range(victim, &ret);
 
-    Ok(vec![
+    // The header's BG palette index. Vanilla 6 is the placeholder palette every
+    // unused fortress-tileset level carries, which draws the rooms in black and
+    // white; the loader re-reads palettes from the target header on a junction,
+    // so one byte here recolours the whole area.
+    let mut pal_note = Some(format!(
+        "  BG palette: left at the level's own {} — the placeholder index, black and white",
+        rom_data::UNUSED5_VANILLA_BGPAL
+    ));
+    if let Some(pal) = palette {
+        if pal > 7 {
+            return Err(format!("BG palette index {pal} is out of range (0-7)"));
+        }
+        let hdr = rom_data::prg_bank_cpu_to_file(
+            rom_data::UNUSED5_LAYOUT_BANK,
+            rom_data::UNUSED5_LAYOUT_PTR,
+        ) + 5;
+        let was = rom.read_byte(hdr);
+        rom.write_byte(hdr, (was & !0x07) | pal);
+        pal_note = Some(format!(
+            "  BG palette: {} -> {pal} (header byte5 {was:#04X} -> {:#04X})",
+            was & 0x07,
+            (was & !0x07) | pal
+        ));
+    }
+
+    let mut report = vec![
         format!(
             "big [?] rooms: all {} areas -> Unused Level 5 (layout ${:04X}, objects ${:04X}, tileset {})",
             rom_data::BIG_Q_AREA_COUNT,
@@ -598,7 +627,9 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
              {victim_scr}); copied from BigQ5 slot 3",
             ret
         ),
-    ])
+    ];
+    report.extend(pal_note);
+    Ok(report)
 }
 
 /// Rewrite lock and/or water-gap tiles across all 8 world maps.
@@ -848,7 +879,7 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
 
     // 3a. Big [?] Block bonus rooms from the unreferenced test level.
     if let Some(screen) = spec.big_q_unused5 {
-        report.extend(big_q_unused5(&mut rom, screen)?);
+        report.extend(big_q_unused5(&mut rom, screen, spec.big_q_palette)?);
     }
 
     // 4. Open the map up.
@@ -1009,6 +1040,7 @@ mod tests {
             hammer_breaks_bridges: false,
             include_beta: false,
             big_q_unused5: None,
+            big_q_palette: None,
             set_enemies: Vec::new(),
         }
     }
@@ -1084,7 +1116,19 @@ mod tests {
             "a standalone area has null alt pointers"
         );
 
-        let built = build(&van, &TestRomSpec { big_q_unused5: Some(5), ..spec() }).unwrap();
+        // The header's palette nibble is where the docs say, and vanilla's value
+        // is the placeholder index shared only with `Empty`.
+        let hdr = rom_data::prg_bank_cpu_to_file(
+            rom_data::UNUSED5_LAYOUT_BANK,
+            rom_data::UNUSED5_LAYOUT_PTR,
+        ) + 5;
+        assert_eq!(src.read_byte(hdr) & 0x07, rom_data::UNUSED5_VANILLA_BGPAL);
+
+        let built = build(
+            &van,
+            &TestRomSpec { big_q_unused5: Some(5), big_q_palette: Some(4), ..spec() },
+        )
+        .unwrap();
         let out = Rom::from_bytes_lax(&built.bytes, true).unwrap();
 
         for room in 0..rom_data::BIG_Q_AREA_COUNT {
@@ -1138,6 +1182,10 @@ mod tests {
             assert!(col < 16, "column {col} does not fit a nibble");
             assert!(y_idx < 8, "Y index {y_idx} is past LevelJct_YLHStarts");
         }
+
+        // Only the palette bits move; object palette and X-start are preserved.
+        assert_eq!(out.read_byte(hdr) & 0x07, 4);
+        assert_eq!(out.read_byte(hdr) & !0x07, src.read_byte(hdr) & !0x07);
 
         let err = build(&van, &TestRomSpec { big_q_unused5: Some(9), ..spec() }).unwrap_err();
         assert!(err.contains("no Big [?] room on screen 9"), "{err}");

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -449,6 +449,32 @@ fn numbered_slots(rom: &Rom, world_idx: usize, include_beta: bool) -> Vec<(u8, u
     slots
 }
 
+/// Where to put the player in each of Unused Level 5's eight rooms, as
+/// `(column, Y-start index)`.
+///
+/// The first cut aimed the arrival at each room's Big [?] Block, on the theory
+/// that vanilla does — 5-2's `$73` names screen 3 column 7, and BigQ5's block
+/// is at screen 3 column 7. That is a coincidence of BigQ5's geometry: vanilla
+/// aims at the room's *pipe*, which in that room happens to sit above the
+/// block. Aiming at the block here buried the player in the rock over the
+/// block on two rooms out of two tried.
+///
+/// These are open-floor spots read off the rendered rooms instead — a landing
+/// pad, not a pipe mouth, since a junction places the player outright rather
+/// than animating a pipe exit. The player falls a few rows, lands, and can
+/// reach both the block and the room's exit pipe. The Y index is into
+/// `LevelJct_YLHStarts` (PRG026): 2 = row 7, 3 = row 11, 4 = row 15, 5 = row 20.
+const UNUSED5_ARRIVALS: [(u8, u8); 8] = [
+    (2, 5),  // screen 0: shaft foot, left of the block
+    (5, 4),  // screen 1: left of the block, above the floor
+    (9, 2),  // screen 2: the right-hand chamber the block sits in
+    (5, 5),  // screen 3: left of the block
+    (5, 5),  // screen 4: left of the block, clear of the hanging pipe at col 3
+    (13, 3), // screen 5: right of the brick ring around the block
+    (12, 4), // screen 6: right of the block
+    (7, 2),  // screen 7: middle of the block's chamber
+];
+
 /// Repoint every Big [?] Block bonus area at "Unused Level 5", and aim 5-2's
 /// bonus pipe at one of its eight rooms.
 ///
@@ -460,17 +486,18 @@ fn numbered_slots(rom: &Rom, world_idx: usize, include_beta: bool) -> Vec<(u8, u
 ///    so *any* Big [?] pipe in the game reaches this level no matter which
 ///    world its host ended up in. That also sidesteps vanilla's `LDY World_Num`
 ///    selection, which a vanilla-base test ROM still has.
-/// 2. **Which room inside it** — the arrival position comes from the *source*
-///    level's own junction command, `(col << 4) | screen` in byte2. Only 5-2's
-///    is retargeted; every other host keeps its vanilla byte2, and since this
-///    level has a room on all eight screens, they all still land in one.
+/// 2. **Where inside it** — the arrival comes from the *source* level's own
+///    junction command: byte2 is `(col << 4) | screen`, byte1 is
+///    `(Y-start index << 4) | pipe-exit dir`. Only 5-2's is retargeted; every
+///    other host keeps its vanilla bytes, which land somewhere in this level
+///    but not necessarily anywhere sensible.
 ///
 /// The return trip needs no edit. `Player_DoSpecialTiles` (PRG008 $BCC4) ANDs
 /// the pipe-tile index with 1 while `LevelJctBQ_Flag` is set, which collapses
 /// all four pipe-1/pipe-2 end tiles ($AD-$B0) onto the Big [?] junction type —
 /// so any ordinary pipe in the room sends the player back to the host level.
-/// Loaded normally these same pipes exit to the world map instead, which is
-/// what TCRF describes.
+/// Loaded normally these same pipes exit to the world map, which is what TCRF
+/// describes.
 fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
     // Read the rooms out of the level's own object stream rather than
     // hardcoding them: entries are [id, (screen << 4) | col, row].
@@ -483,7 +510,7 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
         off += 3;
     }
 
-    let &(scr, col, row, id) = rooms
+    let &(scr, block_col, block_row, id) = rooms
         .iter()
         .find(|(s, ..)| *s == screen)
         .ok_or_else(|| {
@@ -496,6 +523,7 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
                     .join(", ")
             )
         })?;
+    let (col, y_idx) = UNUSED5_ARRIVALS[scr as usize];
 
     for room in 0..rom_data::BIG_Q_AREA_COUNT {
         rom.write_range(
@@ -509,9 +537,17 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
         rom.write_byte(rom_data::BIG_Q_AREA_TILESETS + room, rom_data::UNUSED5_TILESET);
     }
 
-    let was = rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2);
-    let now = (col << 4) | scr;
-    rom.write_byte(rom_data::W52_BIG_Q_JUNCTION + 2, now);
+    // Keep 5-2's own pipe-exit direction (2) in byte1's low nibble and its slot
+    // nibble in byte0 — the slot still names 5-2's pipe screen, and only the
+    // arrival changes.
+    let dir = rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 1) & 0x0F;
+    let (was1, was2) = (
+        rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 1),
+        rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2),
+    );
+    let (now1, now2) = ((y_idx << 4) | dir, (col << 4) | scr);
+    rom.write_byte(rom_data::W52_BIG_Q_JUNCTION + 1, now1);
+    rom.write_byte(rom_data::W52_BIG_Q_JUNCTION + 2, now2);
 
     Ok(vec![
         format!(
@@ -522,10 +558,10 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
             rom_data::UNUSED5_TILESET
         ),
         format!(
-            "  5-2's bonus pipe: {was:#04X} -> {now:#04X} (screen {scr}, col {col}; \
-             block {id:#04X} at row {row})"
+            "  5-2's bonus pipe: {was1:#04X} {was2:#04X} -> {now1:#04X} {now2:#04X} \
+             (screen {scr}, arrive col {col} / Y index {y_idx})"
         ),
-        format!("  {} rooms in the level; place 5-2 to reach one", rooms.len()),
+        format!("  room {scr}: block {id:#04X} at col {block_col}, row {block_row}"),
     ])
 }
 
@@ -1033,14 +1069,21 @@ mod tests {
             );
         }
 
-        // Screen 5's block sits at column 6, so the arrival byte is (6 << 4) | 5.
-        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2), 0x65);
-        // The rest of the command is untouched — the slot nibble still names
-        // 5-2's own pipe screen, and the exit direction still suits the room.
+        // Screen 5 arrives at column 13, Y index 3: byte2 = (13 << 4) | 5, and
+        // byte1 = (3 << 4) | 5-2's own exit dir (2).
+        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2), 0xD5);
+        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 1), 0x32);
+        // byte0 is untouched — its slot nibble names 5-2's own pipe screen,
+        // which is a property of 5-2 and not of the destination.
         assert_eq!(
-            out.read_range(rom_data::W52_BIG_Q_JUNCTION, 2),
-            src.read_range(rom_data::W52_BIG_Q_JUNCTION, 2)
+            out.read_byte(rom_data::W52_BIG_Q_JUNCTION),
+            src.read_byte(rom_data::W52_BIG_Q_JUNCTION)
         );
+        // Every arrival fits the nibble/table it is written into.
+        for &(col, y_idx) in &UNUSED5_ARRIVALS {
+            assert!(col < 16, "column {col} does not fit a nibble");
+            assert!(y_idx < 8, "Y index {y_idx} is past LevelJct_YLHStarts");
+        }
 
         let err = build(&van, &TestRomSpec { big_q_unused5: Some(9), ..spec() }).unwrap_err();
         assert!(err.contains("no Big [?] room on screen 9"), "{err}");

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -380,6 +380,10 @@ pub struct TestRomSpec {
     /// vanilla 6 is the placeholder palette — monochrome. Only read when
     /// `big_q_unused5` is set.
     pub big_q_palette: Option<u8>,
+    /// Override the arrival for `big_q_unused5` as `(col, Y-start index)`.
+    /// Y indices are into `LevelJct_YLHStarts`: 0 = row 0, 4 = row 15,
+    /// 5 = row 20, 6 = row 23.
+    pub big_q_aim: Option<(u8, u8)>,
     /// Enemy slots to overwrite outright. Applied last, so they win over the
     /// randomizer's own choices on a `--randomize` base.
     pub set_enemies: Vec<EnemyOverride>,
@@ -519,7 +523,12 @@ const UNUSED5_SPARE_COMMANDS: [(usize, [u8; 3], u8); 2] =
 /// collapses all four pipe-1/pipe-2 end tiles ($AD-$B0) onto the Big [?]
 /// junction type. Loaded normally these same pipes exit to the world map, which
 /// is what TCRF describes.
-fn big_q_unused5(rom: &mut Rom, screen: u8, palette: Option<u8>) -> Result<Vec<String>, String> {
+fn big_q_unused5(
+    rom: &mut Rom,
+    screen: u8,
+    palette: Option<u8>,
+    aim: Option<(u8, u8)>,
+) -> Result<Vec<String>, String> {
     // Read the rooms out of the level's own object stream rather than
     // hardcoding them: entries are [id, (screen << 4) | col, row].
     let seg = rom_data::enemy_ptr_to_file_offset(rom_data::UNUSED5_OBJECT_PTR);
@@ -544,7 +553,11 @@ fn big_q_unused5(rom: &mut Rom, screen: u8, palette: Option<u8>) -> Result<Vec<S
                     .join(", ")
             )
         })?;
-    let (col, y_idx) = UNUSED5_ARRIVALS[scr as usize];
+    // `aim` overrides the table so a bad landing can be re-aimed without a
+    // rebuild-edit-rebuild loop. Screens 6 and 7 have no ceiling pipe and their
+    // table entries drop the player through the floor, so finding a spot that
+    // works means trying several — see docs/big_q_rooms_design.md.
+    let (col, y_idx) = aim.unwrap_or(UNUSED5_ARRIVALS[scr as usize]);
 
     for room in 0..rom_data::BIG_Q_AREA_COUNT {
         rom.write_range(
@@ -879,7 +892,7 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
 
     // 3a. Big [?] Block bonus rooms from the unreferenced test level.
     if let Some(screen) = spec.big_q_unused5 {
-        report.extend(big_q_unused5(&mut rom, screen, spec.big_q_palette)?);
+        report.extend(big_q_unused5(&mut rom, screen, spec.big_q_palette, spec.big_q_aim)?);
     }
 
     // 4. Open the map up.
@@ -1041,6 +1054,7 @@ mod tests {
             include_beta: false,
             big_q_unused5: None,
             big_q_palette: None,
+            big_q_aim: None,
             set_enemies: Vec::new(),
         }
     }

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -452,33 +452,45 @@ fn numbered_slots(rom: &Rom, world_idx: usize, include_beta: bool) -> Vec<(u8, u
 /// Where to put the player in each of Unused Level 5's eight rooms, as
 /// `(column, Y-start index)`.
 ///
-/// The first cut aimed the arrival at each room's Big [?] Block, on the theory
-/// that vanilla does — 5-2's `$73` names screen 3 column 7, and BigQ5's block
-/// is at screen 3 column 7. That is a coincidence of BigQ5's geometry: vanilla
-/// aims at the room's *pipe*, which in that room happens to sit above the
-/// block. Aiming at the block here buried the player in the rock over the
-/// block on two rooms out of two tried.
+/// Six of the rooms hang a ceiling pipe over the block room; the arrival aims
+/// at that pipe's column and at a Y index *inside* the pipe, so the player
+/// falls out of its mouth the way vanilla does — 5-2's own `$73` puts the
+/// player at row 0 in BigQ5's screen 3, which is inside that room's pipe.
+/// Rooms 6 and 7 have no ceiling pipe at all (their only pipe is the floor one
+/// you leave by), so those two land beside it instead.
 ///
-/// These are open-floor spots read off the rendered rooms instead — a landing
-/// pad, not a pipe mouth, since a junction places the player outright rather
-/// than animating a pipe exit. The player falls a few rows, lands, and can
-/// reach both the block and the room's exit pipe. The Y index is into
-/// `LevelJct_YLHStarts` (PRG026): 2 = row 7, 3 = row 11, 4 = row 15, 5 = row 20.
+/// Pipe positions come from the level's own layout, decoded with the fortress
+/// tileset's command sizes; the Y index is into `LevelJct_YLHStarts` (PRG026):
+/// 0 = row 0, 4 = row 15, 5 = row 20, 6 = row 23.
 const UNUSED5_ARRIVALS: [(u8, u8); 8] = [
-    (2, 5),  // screen 0: shaft foot, left of the block
-    (5, 4),  // screen 1: left of the block, above the floor
-    (9, 2),  // screen 2: the right-hand chamber the block sits in
-    (5, 5),  // screen 3: left of the block
-    (5, 5),  // screen 4: left of the block, clear of the hanging pipe at col 3
-    (13, 3), // screen 5: right of the brick ring around the block
-    (12, 4), // screen 6: right of the block
-    (7, 2),  // screen 7: middle of the block's chamber
+    (2, 0),  // screen 0: ceiling pipe col 2, rows 0-1
+    (1, 4),  // screen 1: ceiling pipe col 1, rows 12-16
+    (2, 0),  // screen 2: ceiling pipe col 2, rows 0-1 (drift right at rows 8-9
+             //           to reach the block; the shaft drops past it otherwise)
+    (1, 5),  // screen 3: ceiling pipe col 1, rows 16-21
+    (2, 5),  // screen 4: ceiling pipe col 2, rows 16-21
+    (7, 0),  // screen 5: ceiling pipe col 7, rows 0-2
+    (3, 6),  // screen 6: no ceiling pipe — beside the floor pipe at col 1
+    (5, 6),  // screen 7: no ceiling pipe — beside the floor pipe at col 2
 ];
 
-/// Repoint every Big [?] Block bonus area at "Unused Level 5", and aim 5-2's
-/// bonus pipe at one of its eight rooms.
+/// Three-byte commands in Unused Level 5 we can overwrite with a return
+/// junction, as `(file offset, the bytes that must be there, screen)`.
 ///
-/// Two independent things have to line up for a Big [?] pipe to open a room:
+/// The level has no group-7 commands of its own, and its layout stream is
+/// byte-tight — it terminates at 0x2B889 and World 8's fortress layout starts
+/// at 0x2B88A — so a return junction has to *replace* a command rather than
+/// extend the stream. Both of these are a single `Coin` generator (fortress
+/// generator 22), the cheapest thing in the level to lose, and the caller picks
+/// one that is not in the room being tested so the room itself is untouched.
+const UNUSED5_SPARE_COMMANDS: [(usize, [u8; 3], u8); 2] =
+    [(0x2B78D, [0x2C, 0x03, 0x80], 0), (0x2B7C3, [0x2B, 0x21, 0x80], 2)];
+
+/// Repoint every Big [?] Block bonus area at "Unused Level 5", aim 5-2's bonus
+/// pipe at one of its eight rooms, and give that room a return junction.
+///
+/// Three things have to line up for a Big [?] pipe to open a room and bring the
+/// player home again:
 ///
 /// 1. **Which area** — `LevelJct_BigQuestionBlock` loads the layout/objects
 ///    pointers and the tileset from three 8-entry tables indexed by room
@@ -488,16 +500,21 @@ const UNUSED5_ARRIVALS: [(u8, u8); 8] = [
 ///    selection, which a vanilla-base test ROM still has.
 /// 2. **Where inside it** — the arrival comes from the *source* level's own
 ///    junction command: byte2 is `(col << 4) | screen`, byte1 is
-///    `(Y-start index << 4) | pipe-exit dir`. Only 5-2's is retargeted; every
-///    other host keeps its vanilla bytes, which land somewhere in this level
-///    but not necessarily anywhere sensible.
+///    `(Y-start index << 4) | pipe-exit dir`. See `UNUSED5_ARRIVALS`.
+/// 3. **Where it returns to** — supplied by the *bonus area*, not the host: on
+///    the way out the engine reads `Level_JctXLHStart[Player_XHi]` with the
+///    player's screen *in the bonus room*. This level defines no group-7
+///    commands, so without this write the slot holds whatever the host left
+///    there — for room 0 that is 5-2's own front door, whose byte1 bit 7 is the
+///    "destination is vertical" flag, which renders the horizontal lobby as a
+///    vertical level. The return bytes are copied from BigQ5's slot-3 command,
+///    which is vanilla's own answer for 5-2.
 ///
-/// The return trip needs no edit. `Player_DoSpecialTiles` (PRG008 $BCC4) ANDs
-/// the pipe-tile index with 1 while `LevelJctBQ_Flag` is set, which collapses
-/// all four pipe-1/pipe-2 end tiles ($AD-$B0) onto the Big [?] junction type —
-/// so any ordinary pipe in the room sends the player back to the host level.
-/// Loaded normally these same pipes exit to the world map, which is what TCRF
-/// describes.
+/// The pipe the player leaves by needs no edit: `Player_DoSpecialTiles` (PRG008
+/// $BCC4) ANDs the pipe-tile index with 1 while `LevelJctBQ_Flag` is set, which
+/// collapses all four pipe-1/pipe-2 end tiles ($AD-$B0) onto the Big [?]
+/// junction type. Loaded normally these same pipes exit to the world map, which
+/// is what TCRF describes.
 fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
     // Read the rooms out of the level's own object stream rather than
     // hardcoding them: entries are [id, (screen << 4) | col, row].
@@ -537,17 +554,32 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
         rom.write_byte(rom_data::BIG_Q_AREA_TILESETS + room, rom_data::UNUSED5_TILESET);
     }
 
-    // Keep 5-2's own pipe-exit direction (2) in byte1's low nibble and its slot
-    // nibble in byte0 — the slot still names 5-2's pipe screen, and only the
-    // arrival changes.
+    // Outbound: keep 5-2's own pipe-exit direction in byte1's low nibble and
+    // its slot nibble in byte0 — the slot names 5-2's pipe screen, which is a
+    // property of 5-2 and not of the destination.
     let dir = rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 1) & 0x0F;
-    let (was1, was2) = (
-        rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 1),
-        rom.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2),
-    );
     let (now1, now2) = ((y_idx << 4) | dir, (col << 4) | scr);
     rom.write_byte(rom_data::W52_BIG_Q_JUNCTION + 1, now1);
     rom.write_byte(rom_data::W52_BIG_Q_JUNCTION + 2, now2);
+
+    // Inbound: a group-7 command in this room's own slot, carrying vanilla's
+    // return position for 5-2.
+    let &(victim, expect, victim_scr) = UNUSED5_SPARE_COMMANDS
+        .iter()
+        .find(|(_, _, s)| *s != scr)
+        .expect("two spare commands on different screens");
+    if rom.read_range(victim, 3) != expect {
+        return Err(format!(
+            "0x{victim:05X} is not the expected Coin command {expect:02X?} — \
+             Unused Level 5's layout is not vanilla here"
+        ));
+    }
+    let ret = [
+        0xE0 | scr,
+        rom.read_byte(rom_data::BIGQ5_SLOT3_JUNCTION + 1),
+        rom.read_byte(rom_data::BIGQ5_SLOT3_JUNCTION + 2),
+    ];
+    rom.write_range(victim, &ret);
 
     Ok(vec![
         format!(
@@ -558,10 +590,14 @@ fn big_q_unused5(rom: &mut Rom, screen: u8) -> Result<Vec<String>, String> {
             rom_data::UNUSED5_TILESET
         ),
         format!(
-            "  5-2's bonus pipe: {was1:#04X} {was2:#04X} -> {now1:#04X} {now2:#04X} \
-             (screen {scr}, arrive col {col} / Y index {y_idx})"
+            "  5-2's bonus pipe -> {now1:#04X} {now2:#04X}: room {scr}, arrive col {col} / \
+             Y index {y_idx} (block {id:#04X} at col {block_col}, row {block_row})"
         ),
-        format!("  room {scr}: block {id:#04X} at col {block_col}, row {block_row}"),
+        format!(
+            "  return junction {:02X?} written over the Coin at 0x{victim:05X} (screen \
+             {victim_scr}); copied from BigQ5 slot 3",
+            ret
+        ),
     ])
 }
 
@@ -1069,10 +1105,28 @@ mod tests {
             );
         }
 
-        // Screen 5 arrives at column 13, Y index 3: byte2 = (13 << 4) | 5, and
-        // byte1 = (3 << 4) | 5-2's own exit dir (2).
-        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2), 0xD5);
-        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 1), 0x32);
+        // Screen 5 arrives at column 7 (its ceiling pipe), Y index 0: byte2 =
+        // (7 << 4) | 5, byte1 = (0 << 4) | 5-2's own exit dir (2).
+        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 2), 0x75);
+        assert_eq!(out.read_byte(rom_data::W52_BIG_Q_JUNCTION + 1), 0x02);
+        // The return junction went in on a screen other than the one tested,
+        // in this room's own slot, carrying BigQ5's return bytes.
+        let (victim, _, victim_scr) = UNUSED5_SPARE_COMMANDS[0];
+        assert_ne!(victim_scr, 5);
+        assert_eq!(
+            out.read_range(victim, 3),
+            &[
+                0xE5,
+                src.read_byte(rom_data::BIGQ5_SLOT3_JUNCTION + 1),
+                src.read_byte(rom_data::BIGQ5_SLOT3_JUNCTION + 2)
+            ]
+        );
+        // BigQ5's slot-3 command is the one being copied from: group 7, slot 3.
+        assert_eq!(src.read_byte(rom_data::BIGQ5_SLOT3_JUNCTION), 0xE3);
+        // Every spare command really is where it claims to be in vanilla.
+        for (off, bytes, _) in UNUSED5_SPARE_COMMANDS {
+            assert_eq!(src.read_range(off, 3), &bytes, "spare command at {off:#07X}");
+        }
         // byte0 is untouched — its slot nibble names 5-2's own pipe screen,
         // which is a property of 5-2 and not of the destination.
         assert_eq!(

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -193,11 +193,11 @@ fn sweep_is_deterministic() {
 /// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
 /// trusting any number this test prints after a bump.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xB87614AF3E59FAF0, 0x190BAECC4BA70C38, 0x508A73DE1717B24E, 0x0E59A8C771815C7F,
-    0x326377210E425106, 0x25B9013FB4C4CCA5, 0x8841FF5A40D5295B, 0xE0FD1F70912FFAB7,
-    0xE2AEDEBDA8902AD9, 0xF7FC95F18625BD39, 0x18E3EF3EC38E1D20, 0xB3C93A25CC2ED606,
-    0x9968115ABE394CC9, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x667A5C8108A1DDF7,
-    0xB299FA68EE858883, 0x0E83A6E32C7165A7, 0xB175043FC4F1B289, 0xA49036BF71E9E5A5,
+    0x4E4C8A191F5685C7, 0x6D91B1182546B2D4, 0x8403DC76A349DC67, 0x95FC1C166FD2A0CE,
+    0x3F1E17841E6D5AB2, 0x47A2E17C29871737, 0xF77056FB954617FD, 0x2250FCDE919E6056,
+    0x2D974E1A5ECBC04D, 0xF362BD31A8DC2C35, 0x99D8920302472BD0, 0x5CAF93CE5AE276D4,
+    0x45BEDB9C8B63FECE, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x274C352583A7F603,
+    0x33C8141F38F97F65, 0x0BA66E9654F61197, 0xD473ECE6B78193ED, 0x759AEB0B7C3C6DD3,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
@@ -214,11 +214,6 @@ const BASELINE: [u64; SEEDS as usize] = [
 /// that was verified rather than argued: the 8 map grids were hashed for all 20
 /// seeds with the `shuffle` call live and with it stubbed to return an empty
 /// vec, and the two sets are identical. The ROM bytes differ, the maps do not.
-///
-/// Amended the same day: Unused Level 5's screens 6 and 7 left the pool after
-/// playtesting dropped the player through the floor in both, so the pool is 17
-/// rooms rather than 19 and every seed draws differently again. Topology is
-/// still untouched, for the same structural reason.
 
 #[test]
 fn output_matches_baseline() {

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -193,12 +193,27 @@ fn sweep_is_deterministic() {
 /// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
 /// trusting any number this test prints after a bump.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xBED95ABDD9439FB5, 0xDBF47F5B31DA86EF, 0xB04474783CB4D0C2, 0x74AC5BCD65AD258D,
-    0x03A4151A9BBFCF29, 0x1F35830291CF10D1, 0x2C970403032C84A6, 0x56890C44D7D2E751,
-    0xD0F5B5E94A13DD88, 0x5C83EEC7421A3608, 0x7652B197D0160E55, 0x0D99057DED830981,
-    0xB8D7424F73B99BF1, 0x1DC2D6E4F10E3616, 0x883D33A2E3BB6E7C, 0xED0DEA0D8520786C,
-    0x650CEA1C0A0A5996, 0x8EDA0264B99A185F, 0x181B0A493C5FEC2C, 0xF39CB84027935889,
+    0x4E4C8A191F5685C7, 0x6D91B1182546B2D4, 0x8403DC76A349DC67, 0x95FC1C166FD2A0CE,
+    0x3F1E17841E6D5AB2, 0x47A2E17C29871737, 0xF77056FB954617FD, 0x2250FCDE919E6056,
+    0x2D974E1A5ECBC04D, 0xF362BD31A8DC2C35, 0x99D8920302472BD0, 0x5CAF93CE5AE276D4,
+    0x45BEDB9C8B63FECE, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x274C352583A7F603,
+    0x33C8141F38F97F65, 0x0BA66E9654F61197, 0xD473ECE6B78193ED, 0x759AEB0B7C3C6DD3,
 ];
+///
+/// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
+/// on. Every seed moves, for two reasons that are both intended:
+///
+/// 1. `qol::big_q`'s lookup routine grew from 106 to 207 bytes (slot seeding
+///    plus four new 13-entry payload tables), and the Big [?] exit path's
+///    `JMP PRG026_AA8A` at 0x34A84 now jumps into it.
+/// 2. `big_q_rooms::shuffle` draws twice from the shared RNG and rewrites the
+///    per-row area/arrival tables, and 7-F1's drawn block is forced to Tanooki.
+///
+/// **Overworld topology is untouched**, which is the thing worth checking here.
+/// The pass runs after `write_overworld`, so it cannot move a map tile — and
+/// that was verified rather than argued: the 8 map grids were hashed for all 20
+/// seeds with the `shuffle` call live and with it stubbed to return an empty
+/// vec, and the two sets are identical. The ROM bytes differ, the maps do not.
 
 #[test]
 fn output_matches_baseline() {

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -193,11 +193,11 @@ fn sweep_is_deterministic() {
 /// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
 /// trusting any number this test prints after a bump.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x4E4C8A191F5685C7, 0x6D91B1182546B2D4, 0x8403DC76A349DC67, 0x95FC1C166FD2A0CE,
-    0x3F1E17841E6D5AB2, 0x47A2E17C29871737, 0xF77056FB954617FD, 0x2250FCDE919E6056,
-    0x2D974E1A5ECBC04D, 0xF362BD31A8DC2C35, 0x99D8920302472BD0, 0x5CAF93CE5AE276D4,
-    0x45BEDB9C8B63FECE, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x274C352583A7F603,
-    0x33C8141F38F97F65, 0x0BA66E9654F61197, 0xD473ECE6B78193ED, 0x759AEB0B7C3C6DD3,
+    0xB87614AF3E59FAF0, 0x190BAECC4BA70C38, 0x508A73DE1717B24E, 0x0E59A8C771815C7F,
+    0x326377210E425106, 0x25B9013FB4C4CCA5, 0x8841FF5A40D5295B, 0xE0FD1F70912FFAB7,
+    0xE2AEDEBDA8902AD9, 0xF7FC95F18625BD39, 0x18E3EF3EC38E1D20, 0xB3C93A25CC2ED606,
+    0x9968115ABE394CC9, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x667A5C8108A1DDF7,
+    0xB299FA68EE858883, 0x0E83A6E32C7165A7, 0xB175043FC4F1B289, 0xA49036BF71E9E5A5,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
@@ -214,6 +214,11 @@ const BASELINE: [u64; SEEDS as usize] = [
 /// that was verified rather than argued: the 8 map grids were hashed for all 20
 /// seeds with the `shuffle` call live and with it stubbed to return an empty
 /// vec, and the two sets are identical. The ROM bytes differ, the maps do not.
+///
+/// Amended the same day: Unused Level 5's screens 6 and 7 left the pool after
+/// playtesting dropped the player through the floor in both, so the pool is 17
+/// rooms rather than 19 and every seed draws differently again. Topology is
+/// still untouched, for the same structural reason.
 
 #[test]
 fn output_matches_baseline() {

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -193,11 +193,11 @@ fn sweep_is_deterministic() {
 /// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
 /// trusting any number this test prints after a bump.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x4E4C8A191F5685C7, 0x6D91B1182546B2D4, 0x8403DC76A349DC67, 0x95FC1C166FD2A0CE,
-    0x3F1E17841E6D5AB2, 0x47A2E17C29871737, 0xF77056FB954617FD, 0x2250FCDE919E6056,
-    0x2D974E1A5ECBC04D, 0xF362BD31A8DC2C35, 0x99D8920302472BD0, 0x5CAF93CE5AE276D4,
-    0x45BEDB9C8B63FECE, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x274C352583A7F603,
-    0x33C8141F38F97F65, 0x0BA66E9654F61197, 0xD473ECE6B78193ED, 0x759AEB0B7C3C6DD3,
+    0x5CE7A325F4E40B77, 0xEE4429463CB37B24, 0xF4D3FD6B84C89857, 0x52C24655C314BF5E,
+    0xEA3C7E36AA10E312, 0xE6A87F1D0297B837, 0x33332A4152718DBD, 0xA05870AF43203CB6,
+    0x8A6E37DA33E1B91D, 0xAF3DA8A8F53F3EC5, 0x5068CBCB2ED14BB0, 0xC01A2B0B1EA4FC04,
+    0x52A69F2C7D037BBE, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x4D7A01A04665B7A3,
+    0xD7F9BD46BA764F55, 0x2CE2B76AC0170B37, 0x3CA80801B89FC3AD, 0x273A357F0557B0A3,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
@@ -214,6 +214,11 @@ const BASELINE: [u64; SEEDS as usize] = [
 /// that was verified rather than argued: the 8 map grids were hashed for all 20
 /// seeds with the `shuffle` call live and with it stubbed to return an empty
 /// vec, and the two sets are identical. The ROM bytes differ, the maps do not.
+///
+/// Amended the same week: Unused Level 5's screens 6 and 7 got new arrival
+/// coordinates after playtesting showed the originals killed the player. Four
+/// table bytes, so every seed that draws one of those rooms moves. No RNG draw
+/// changed — the pool is the same size — so this is a pure byte difference.
 
 #[test]
 fn output_matches_baseline() {


### PR DESCRIPTION
Every level with a Big [?] pipe now draws from a pool of **19 rooms** instead of always opening its own: the 11 vanilla rooms plus the 8 in **"Unused Level 5"**, a complete set of bonus rooms sitting in the ROM that nothing reaches. Vanilla's 15 rooms are only 10 distinct layouts, so this roughly doubles what a player can walk into.

Always on, no option and no flag-key bit — which room a pipe leads to is not a difference worth a control, since every room hands out one block and returns you where you came from.

## Slot seeding, not layout editing

The arrival and return positions are read out of `Level_JctXLHStart` / `Level_JctYLHStart`, whose contents are written by parsing a layout command stream. Changing them the obvious way means finding a group-7 command inside a variable-size, per-tileset stream with **no byte-level signature** marking it as a Big [?] junction — `Level_JctCtl = 2` comes from the pipe metatile at run time, so it is byte-identical to any other junction.

Those slot arrays are plain RAM. So instead of hunting the command, we write what we want into the slot the engine is about to read.

Level identity is a sufficient key: inside `LevelJct_BigQuestionBlock` the junction is already known to be a Big [?] one, and a level has at most one such pipe. `qol::big_q` was already resolving identity there, so its lookup routine grew the seeding plus four 13-entry payload tables.

Two hooks, both on paths only a Big [?] junction reaches:

- **entry** — inside the lookup, on a table match, when `X` is the matched row;
- **exit** — at `PRG026_AA5A`, where the pointer restore has just put the host's own `obj_ptr` back into `Level_ObjPtrOrig`. That site's `JMP PRG026_AA8A` is swapped 3-for-3, displacing whole instructions.

`LevelJct_General` and the shared slot read at `PRG026_AA9A` are untouched, so ordinary junctions behave exactly as before.

## Size

**207 bytes in a 224-byte allocation**, up from 106. PRG026's largest gap starts exactly where `FS_BIG_Q_LOOKUP` ends, so it grew in place rather than relocating. The bank is now 2485 free / 2419 largest gap, and `CLAUDE.md`'s per-bank table is regenerated to match (`free_space_doc_table_is_current` enforces that).

## 7-F1

Flight is required to beat 7-F1, so whatever room it draws has its block forced to a Tanooki Suit — **last**, after the contents roll, which is why that roll needed no cooperation and stayed where it was in the pipeline.

`w7f1_block_is_always_a_flight_suit` walks the drawn room's own object stream over 40 seeds rather than trusting a constant. Mutation-tested: stubbing the force fails it on seed 2.

## Playtesting found a real bug

Unused Level 5's **screens 6 and 7 killed the player**. They are the only rooms with no ceiling pipe, and their arrivals used Y index 6 — row 23, the floor pipe's own row — which put him inside the pipe on screen 6 and past the end of the floor on screen 7.

This reproduced on the vanilla-base `testrom` path too, which is what proved the coordinates were always wrong rather than the seeding being at fault, and that an earlier "all 8 rooms playtested" note had not covered where those two put you.

The aim can't be computed: a layout command says where a generator *starts*, not which tiles end up solid, and nothing here renders a fortress-tileset room. It also can't be nudged — the Y position is a 3-bit index into `LevelJct_YLHStarts`, so only rows 0, 4, 7, 11, 15, 20, 23 and 24 exist. So this PR adds **`testrom --bigq-aim COL,YIDX`** and the spot was found by trying, over two playtest rounds:

- **screen 6 → col 3, row 20** — lands beside the floor pipe
- **screen 7 → col 2, row 11** — falls into the floor pipe

Both confirmed end-to-end through the randomizer on seeds 10 and 16, the two that originally failed. The full result grid is in `docs/big_q_rooms_design.md`, including that "beside the pipe" was predicted to fail in both rooms and is what works on screen 6 — worth recording so the wrong conclusion isn't re-derived.

## Baseline

Recaptured. Every seed moves — the routine is bigger and the pass makes two RNG draws.

**Overworld topology is not affected, and that is verified rather than argued.** The pass runs after `write_overworld`, so it cannot move a map tile; hashing all 8 map grids across 20 seeds with the shuffle live and with it stubbed gives identical results.

## Testing

- `cargo test` — 397 unit + integration, all pass
- `cargo clippy --all-targets` and `cargo clippy --lib --target wasm32-unknown-unknown` — both clean (the wasm pass caught constants that were native-only for `testrom` and are now needed by the randomizer proper)
- Playtested in an emulator across both paths; all 19 rooms now land the player safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW
