### PR TITLE
fix: drop the vestigial BigQ7 exemption, correct two stale comments

### DIFF
--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -40,11 +40,25 @@ space there. Unused Level 5 carries none and needs 3 bytes per room.
 
 - **7-F1 is not pinned.** Flight is required to beat 7-F1 because of level
   geometry, so its block must always be a flight suit — but its *room* still
-  shuffles. Resolve the pairing first, then force the block in whatever room
-  7-F1 lands in and exclude that offset from the contents roll.
-  `enemies::tables::W7F1_TANOOKI_OFFSET` becomes derived rather than constant.
-  Guard it with an invariant test over N seeds, the way the enemy protections
-  are guarded — the failure mode is silent if the passes are ever reordered.
+  shuffles. As shipped: the contents roll runs first and exempts nothing, then
+  the room draw forces the drawn room's block to a Tanooki. Because the force is
+  the **last** write to that byte it needs no cooperation from the roll, which is
+  also why the roll could stay where it was in the pipeline rather than moving
+  below the overworld builder and shifting every seed's map.
+
+  `enemies::tables::W7F1_TANOOKI_OFFSET` is gone. It exempted BigQ7's screen-6
+  block from the roll, which made sense when 7-F1 always opened that room — but
+  under the shuffle 7-F1 usually opens something else, so the exemption was
+  pinning a room for a reason that no longer applied. Measured over 15 seeds:
+  that block was Tanooki in every one regardless of who opened it, and most seeds
+  ended up with two guaranteed Tanooki rooms (that one, plus 7-F1's actual
+  room). Removed 2026-08-28.
+
+  The guard is `w7f1_block_is_always_a_flight_suit`, which reads the lookup table
+  to learn which room 7-F1 drew and walks that room's own object stream, so it
+  cannot be fooled by a stale offset. The failure mode is silent — if the room
+  draw ever moved back above the contents roll, the roll would overwrite the
+  forced byte while everything still appeared to run.
 - **No room is deleted from Unused Level 5.** The 24 bytes for eight junctions
   come from eight of its fifteen 3-byte `Coin` commands. Ten of those fifteen
   sit in the sealed chamber on screen 4 (rows 3-9, walled on all four sides and

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -54,12 +54,11 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, opts: &Options) {
 }
 
 /// Randomize Big ? Blocks by swapping their IDs among the set of Big ? Block
-/// types. BigQ7's Tanooki is left alone — it is 7-F1's vanilla room, and
-/// flying is required to beat that level.
+/// types. Every block rolls, including the eight in Unused Level 5.
 ///
-/// This is not the whole 7-F1 guarantee any more: `big_q_rooms` draws 7-F1 a
-/// room per seed and forces *that* room's block afterwards. This protection
-/// only keeps the vanilla pairing honest.
+/// Nothing is exempt. 7-F1 needs flight, but which room its pipe opens is drawn
+/// per seed by `big_q_rooms`, which runs after this and forces *that* room's
+/// block — so the guarantee does not depend on any offset being skipped here.
 pub fn randomize_big_q_blocks<R: Rng>(rom: &mut Rom, rng: &mut R) {
     // All enemy classes off — only Big ? Blocks get randomized
     let no_flags = Options {
@@ -245,7 +244,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                 // Big ? blocks and Boom-Booms swap among their own kind and skip
                 // the class machinery entirely.
                 if big_q_only {
-                    if BIG_Q_BLOCKS.contains(&entry.obj_id) && file_offset != W7F1_TANOOKI_OFFSET {
+                    if BIG_Q_BLOCKS.contains(&entry.obj_id) {
                         data[entry.data_index] = *BIG_Q_BLOCKS.choose(rng).unwrap();
                     }
                     continue;

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -335,9 +335,12 @@ pub(super) const BIG_Q_BLOCKS: &[u8] = &[
 /// BigQ7's second object entry, on screen 6. Flight is required to beat 7-F1,
 /// so this block must not be randomized *when 7-F1 opens this room*.
 ///
-/// Which room 7-F1 opens is decided per seed by `big_q_rooms`, which passes the
-/// drawn room's block offset to `randomize_big_q_blocks`. This constant is the
-/// vanilla answer, kept as the reference the protection test pins against.
+/// This is only half the guarantee, and no longer the load-bearing half. Which
+/// room 7-F1 opens is decided per seed by `big_q_rooms`, which runs *after* this
+/// roll and forces the drawn room's block to a Tanooki outright — so 7-F1 is
+/// covered whichever room it gets. What this constant still buys is that BigQ7's
+/// screen-6 block keeps its vanilla contents, which is what
+/// `test_7f1_tanooki_protected` pins.
 pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
 /// Injection candidates for wild_injections mode: level-wide chasers seeded into

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -331,17 +331,6 @@ pub(super) const BIG_Q_BLOCKS: &[u8] = &[
     0x9A, // OBJ_BIGQBLOCK_HAMMER
 ];
 
-/// File offset of the Tanooki Big ? Block in the World 7 Big ? Block room —
-/// BigQ7's second object entry, on screen 6. Flight is required to beat 7-F1,
-/// so this block must not be randomized *when 7-F1 opens this room*.
-///
-/// This is only half the guarantee, and no longer the load-bearing half. Which
-/// room 7-F1 opens is decided per seed by `big_q_rooms`, which runs *after* this
-/// roll and forces the drawn room's block to a Tanooki outright — so 7-F1 is
-/// covered whichever room it gets. What this constant still buys is that BigQ7's
-/// screen-6 block keeps its vanilla contents, which is what
-/// `test_7f1_tanooki_protected` pins.
-pub(super) const W7F1_TANOOKI_OFFSET: usize = 0x0C9B7;
 
 /// Injection candidates for wild_injections mode: level-wide chasers seeded into
 /// a level's first enemy. CHR compatibility checked via `sprite_bank()` at filter

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -130,21 +130,6 @@
         ];
         data[seg1_start..seg1_start + seg1.len()].copy_from_slice(seg1);
 
-        // Place the protected W7 Big Q Tanooki at its exact file offset
-        // W7F1_TANOOKI_OFFSET = 0x0C9B7, which is the ID byte of the entry.
-        // We need: [FF] [page] [0x98, x, y] [0x41, x, y] [FF]
-        // So page byte at 0x0C9B6, entry at 0x0C9B7
-        let w7f1_seg_start = W7F1_TANOOKI_OFFSET - 2; // FF + page byte before the entry
-        data[w7f1_seg_start] = 0xFF;
-        data[w7f1_seg_start + 1] = 0x01; // page flag
-        data[W7F1_TANOOKI_OFFSET] = 0x98; // BIGQBLOCK_TANOOKI
-        data[W7F1_TANOOKI_OFFSET + 1] = 0x0A;
-        data[W7F1_TANOOKI_OFFSET + 2] = 0x13;
-        data[W7F1_TANOOKI_OFFSET + 3] = 0x41; // ENDLEVELCARD
-        data[W7F1_TANOOKI_OFFSET + 4] = 0x48;
-        data[W7F1_TANOOKI_OFFSET + 5] = 0x15;
-        data[W7F1_TANOOKI_OFFSET + 6] = 0xFF;
-
         Rom::from_bytes_lax(&data, true).unwrap()
     }
 
@@ -281,21 +266,6 @@
         assert!(
             saw_slot4_0a_in_seg2 && saw_slot4_0b_in_seg2,
             "Segment 2 should not be constrained by segment 1's CHR choice"
-        );
-    }
-
-    #[test]
-    fn test_7f1_tanooki_protected() {
-        let mut rom = make_bigq_test_rom();
-        let mut rng = ChaCha8Rng::seed_from_u64(99);
-        randomize_big_q_blocks(&mut rom, &mut rng);
-
-        // The 7-F1 Tanooki must remain 0x98
-        let protected = rom.read_byte(W7F1_TANOOKI_OFFSET);
-        assert_eq!(
-            protected, 0x98,
-            "7-F1 Tanooki was changed to 0x{:02X}!",
-            protected
         );
     }
 

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -40,9 +40,10 @@ fn normalized(mut o: Options) -> Options {
 /// opens is now drawn per seed — so the block in *whatever room it drew* has to
 /// be a flight suit, and the contents roll has to leave that byte alone.
 ///
-/// The failure mode is silent: reorder `big_q_rooms` and `randomize_big_q_blocks`
-/// and the protection still "runs", it just names a stale offset. So this walks
-/// the drawn room's own object stream rather than trusting a constant.
+/// The failure mode is silent: the force has to be the LAST write to that byte,
+/// and if `big_q_rooms` ever moved back above `randomize_big_q_blocks` the roll
+/// would overwrite it while everything still appeared to run. So this walks the
+/// drawn room's own object stream rather than trusting any fixed offset.
 #[test]
 fn w7f1_block_is_always_a_flight_suit() {
     let Some(base) = make_test_rom() else { return };


### PR DESCRIPTION
Follow-up to #194, from reading the 7-F1 protection back.

## The exemption is vestigial

`randomize_big_q_blocks` skipped one offset — `W7F1_TANOOKI_OFFSET`, BigQ7's screen-6 block — because flight is required to beat 7-F1 and, in vanilla, that is the room 7-F1's pipe opens. Under the room shuffle it usually isn't.

Measured over 15 seeds, that block came out **Tanooki in every one**, whoever opened it:

```
seed  BigQ7 s6   opened by   7-F1 drew
1     Tanooki    nobody      BigQ5 s3
2     Tanooki    5-2         BigQ6 s5
4     Tanooki    3-9         U5 s0
13    Tanooki    8-1         BigQ7 s4
```

Two consequences, neither intended:

- One of the 19 rooms never rolled its block, even with `big_q_blocks` on. If 5-2 drew it, 5-2 always got a Tanooki.
- Most seeds carried **two** guaranteed Tanooki rooms — that one plus 7-F1's actual forced room. Tanooki is already over-represented, since all eight Unused Level 5 blocks are Tanooki by default.

7-F1 never depended on the skip: `big_q_rooms` runs *after* the roll and forces the drawn room's block, so the force is the last write to that byte either way. After the change the same scan shows BigQ7 s6 rolling freely (Frog, Hammer, Fire, Leaf…), with the one seed where 7-F1 actually drew it still coming out Tanooki.

Removed with it: the constant, `test_7f1_tanooki_protected`, and the fixture segment that existed only to feed that test. `w7f1_block_is_always_a_flight_suit` is the guard that matters — it reads the lookup table for the room 7-F1 drew and walks that room's own object stream, so a stale offset can't fool it.

## Two stale comments

Both described a shape of the code that didn't ship — an earlier version where the drawn offset was threaded into `randomize_big_q_blocks` as a parameter, reverted so the roll could stay above the overworld builder and not shift every seed's map.

- `W7F1_TANOOKI_OFFSET`'s doc claimed the roll receives that offset. It took no such argument.
- The invariant test's doc named reordering as the silent failure but described it as "naming a stale offset". The real hazard is ordering alone: the force has to be the last write.

## Testing

- `cargo test` — 396 + integration, all pass
- `cargo clippy --all-targets` and `--lib --target wasm32-unknown-unknown` — clean
- **No baseline change**, which is the check that this touches nothing on the default path: `randomize_big_q_blocks` only runs when `big_q_blocks` is on, and the baseline sweep uses default options, where it's off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW
