### PR TITLE
fix: the Big [?] exit path only ran half the level lookup

### DIFF
--- a/docs/big_q_rooms_design.md
+++ b/docs/big_q_rooms_design.md
@@ -370,11 +370,13 @@ Built as designed: two hooks, both on Big [?]-only paths, seeding
 layout command is located or edited, so neither open blocker — host junction
 offsets, spare `Coin` commands in Unused Level 5 — had to be resolved.
 
-Measured, not estimated: the routine is **207 bytes in a 224-byte allocation**,
-against the ~100 the design guessed. The guess forgot that the seeding is
-duplicated for entry and exit and that four 13-byte payload tables cost 52 on
-their own. PRG026's largest gap starts exactly where `FS_BIG_Q_LOOKUP` ends, so
-it grew in place; the bank is down to 2485 free / 2419 largest.
+Measured, not estimated: the routine is **199 bytes in a 224-byte allocation**,
+against the ~100 the design guessed. The guess forgot that four 13-byte payload
+tables cost 52 on their own. PRG026's largest gap starts exactly where
+`FS_BIG_Q_LOOKUP` ends, so it grew in place; the bank is down to 2485 free /
+2419 largest. (The first cut was 207, with the two-pass lookup written out twice;
+folding it into one `bq_lookup` subroutine fixed the 7-F1 bug below and returned
+8 bytes.)
 
 Two things resolved along the way that the earlier sections got wrong:
 
@@ -390,6 +392,46 @@ Two things resolved along the way that the earlier sections got wrong:
   *entry* path uses `Player_XHi` unconditionally. Entry is therefore safe. The
   exit seed writes at `Player_XHi` and is correct as long as bonus areas stay
   horizontal, which all eight vanilla ones and Unused Level 5 are.
+
+## 7-F1's bonus pipe is not in the area its tile enters
+
+Reported on the beta as "7-F1 crashes the player after they leave the Big ?
+room" (seed 4270776170103004, flags `SMB3R-3MMFZZVZ7T8T9ANAWSXMM28`, which draws
+Unused Level 5 s2 for 7-F1). Fixed 2026-08-29.
+
+The first cut wrote the lookup twice: the entry half scanned two sources
+(current area, then the frozen map-entry ptr), the exit half scanned only the
+current area. That asymmetry looked harmless and is not, because of one level:
+
+| | 7-F1 |
+|---|---|
+| map pointer entry | layout `$B28E`, objects `$D4E4` (W7 idx 5, tileset 2 → bank 21) |
+| that area's alt pointers | layout `$B3CB`, objects **`$C006`** (`Empty_ObjLayout`) |
+| Big ? junction command | `E6 02 16` at 0x2B47E → CPU `$B46E`, **inside `$B3CB`** |
+
+So the bonus pipe is in 7-F1's *alternate* area, and `Level_ObjPtrOrig` while
+standing there is the shared `Empty_ObjLayout`, which is no host's key. Entry
+still resolved — pass 2 reads the frozen `$D4E4` — but the exit scan missed,
+seeded nothing, and left the engine reading whatever
+`Level_JctXLHStart[Player_XHi]` happened to hold. 7-F1 is the only one of the
+eleven hosts shaped this way; every other host's pipe sits in an area whose
+object pointer is already a table key (6-9's donated interior `$C60E` is row 12).
+
+**Vanilla hid it.** Before the shuffle, 7-F1 always opened BigQ7 s6, so
+`Player_XHi` on the way out was 6 and BigQ7's own slot-6 group-7 command is
+exactly 7-F1's return. The seeding was redundant there. Point the host at any
+other room and the slot the engine reads is one nothing authored for 7-F1.
+
+The fix is `bq_lookup`: one two-pass subroutine that both halves `JSR`. Neither
+`$7EBB` nor `$7EB4` changes while a bonus room is open — `LevelJct_
+BigQuestionBlock` never calls `Level_JctInit` — so sharing it makes exit resolve
+the same row entry did, by construction rather than by matching code.
+
+**The lesson for the next junction shuffle:** a host's identity key is a
+property of the *area holding the pipe*, not of the level, and the two are not
+the same area for every level. Harvesting a junction command's offset (as the
+table above does) already tells you which area that is — compare it against the
+level's alt chain before assuming the entry pointer identifies it.
 
 ## Unused Level 5 screens 6 and 7: how their aim was found
 
@@ -460,7 +502,7 @@ it never overwrites.
 **These seeds are specific to `testrom`'s option set.** Its `Options` differ from
 the CLI's defaults, which moves the shared RNG, so the same seed number picks
 different rooms under `smb3-rs`. Read the room out of the ROM (the four payload
-tables start at `FS_BIG_Q_LOOKUP + 0x8E`) rather than assuming.
+tables start at `FS_BIG_Q_LOOKUP + 0x86`) rather than assuming.
 
 Parking both levels on World 1 also puts both rooms under **one** world's
 `BigQBlock_GotIt` mask, which the real seed would not necessarily do — so these

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -581,6 +581,17 @@ area: W1 0, W2 1, W3 3, W4 2, W5 2, W6 3, W7 2, W8 2. Eleven levels have a Big
 empty area, W2's whole area (no W1/W2 level has such a pipe) and one spare room
 each in W3/W4/W8 are never opened.
 
+**The pipe is not always in the area the level's map tile enters.** Ten of the
+eleven hosts carry their Big [?] pipe in their entry area, so `Level_ObjPtrOrig`
+at the pipe equals the pointer-table `obj_ptr`. **7-F1 does not:** its map entry
+is layout $B28E / objects $D4E4, and the junction command `E6 02 16` (0x2B47E,
+CPU $B46E) lies in the *alternate* area $B3CB, whose objects are the shared
+`Empty_ObjLayout` ($C006). Anything that identifies the host from
+`Level_ObjPtrOrig` alone therefore fails for 7-F1 and must fall back to the
+map-entry pointer saved at level init. (6-9's pipe is likewise outside its entry
+area, in the donated interior $C60E — but that pointer is distinct, so it still
+identifies the level.)
+
 **"Unused Level 5" (TCRF)** is a ninth, fully unreferenced set: eight Big [?]
 rooms, one per screen 0-7, every block a Tanooki Suit ($98).
 

--- a/src/randomize/qol/big_q.rs
+++ b/src/randomize/qol/big_q.rs
@@ -109,17 +109,18 @@ pub(crate) const BQ_MIRROR_ROWS: [(usize, usize); 2] = [(3, 11), (6, 12)];
 // Byte offsets of the pieces inside the assembled routine. `apply_room_rooms`
 // rewrites the four payload tables in place; the seeding code and the scan
 // never change.
-const OFF_HIT: usize = 0x26;
-const OFF_SCAN: usize = 0x39;
-const OFF_EXIT: usize = 0x52;
-const OFF_HI: usize = 0x74;
-const OFF_LO: usize = 0x81;
-pub(crate) const OFF_ROOM: usize = 0x8E;
-pub(crate) const OFF_ARR_Y: usize = 0x9B;
-pub(crate) const OFF_ARR_X: usize = 0xA8;
-pub(crate) const OFF_RET_Y: usize = 0xB5;
-pub(crate) const OFF_RET_X: usize = 0xC2;
-const BIG_Q_ROUTINE_LEN: usize = 0xCF; // 207
+const OFF_HIT: usize = 0x09;
+const OFF_EXIT: usize = 0x1C;
+const OFF_LOOKUP: usize = 0x32;
+const OFF_SCAN: usize = 0x53;
+const OFF_HI: usize = 0x6C;
+const OFF_LO: usize = 0x79;
+pub(crate) const OFF_ROOM: usize = 0x86;
+pub(crate) const OFF_ARR_Y: usize = 0x93;
+pub(crate) const OFF_ARR_X: usize = 0xA0;
+pub(crate) const OFF_RET_Y: usize = 0xAD;
+pub(crate) const OFF_RET_X: usize = 0xBA;
+const BIG_Q_ROUTINE_LEN: usize = 0xC7; // 199
 
 // Zero page / RAM the routine touches.
 const PLAYER_XHI: u8 = 0x75;
@@ -159,6 +160,15 @@ const BIG_Q_EXIT_RETURN: u16 = 0xAA8A;
 /// return bytes, hooked at the Big ?-only exit path where the pointer restore
 /// has just put the host's own obj_ptr back into `Level_ObjPtrOrig`.
 ///
+/// **Both halves share `bq_lookup`, and must.** 7-F1's bonus pipe is not in the
+/// area its map tile enters — it sits in the alternate area ($B3CB), whose
+/// `Level_ObjPtrOrig` is the shared `Empty_ObjLayout` ($C006). Pass 1 misses
+/// there and only pass 2 resolves it, so an exit half that scanned the current
+/// area alone would seed nothing and hand the player back a stale slot. Sharing
+/// the subroutine also makes the two halves resolve the same row by
+/// construction: neither `$7EBB` nor `$7EB4` changes while the bonus room is
+/// open, so exit sees exactly the inputs entry saw.
+///
 /// Internal absolute operands are derived from where the routine is written, so
 /// it is not origin-locked to a hardcoded CPU address.
 fn build_lookup_routine() -> Vec<u8> {
@@ -172,7 +182,7 @@ fn build_routine_with(
 ) -> Vec<u8> {
     let base = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET);
     let at = |off: usize| (base + off as u16).to_le_bytes();
-    let (scan, hi, lo) = (at(OFF_SCAN), at(OFF_HI), at(OFF_LO));
+    let (lookup, scan, hi, lo) = (at(OFF_LOOKUP), at(OFF_SCAN), at(OFF_HI), at(OFF_LO));
     let (room_t, arr_y, arr_x) = (at(OFF_ROOM), at(OFF_ARR_Y), at(OFF_ARR_X));
     let (ret_y, ret_x) = (at(OFF_RET_Y), at(OFF_RET_X));
     let ylh = JCT_YLH_START.to_le_bytes();
@@ -180,24 +190,13 @@ fn build_routine_with(
     let back = BIG_Q_EXIT_RETURN.to_le_bytes();
 
     let mut r: Vec<u8> = vec![
-        // --- pass 1: current area (Level_ObjPtrOrig $7EBB/$7EBC) ---
-        0xAD, 0xBB, 0x7E,       // LDA $7EBB     ; current-area obj_lo
-        0x8D, 0xB2, 0x7E,       // STA $7EB2     ; scratch lo
-        0xAD, 0xBC, 0x7E,       // LDA $7EBC     ; current-area obj_hi
-        0x8D, 0xB3, 0x7E,       // STA $7EB3     ; scratch hi
-        0x20, scan[0], scan[1], // JSR bq_scan
-        0xB0, 0x15,             // BCS .hit
-        // --- pass 2: frozen map-entry ptr ($7EB4/$7EB5, saved by Part A) ---
-        0xAD, 0xB4, 0x7E,       // LDA $7EB4     ; frozen obj_lo
-        0x8D, 0xB2, 0x7E,       // STA $7EB2
-        0xAD, 0xB5, 0x7E,       // LDA $7EB5     ; frozen obj_hi
-        0x8D, 0xB3, 0x7E,       // STA $7EB3
-        0x20, scan[0], scan[1], // JSR bq_scan
+        // --- entry ($00): reached from the replaced `LDY World_Num` ---
+        0x20, lookup[0], lookup[1], // JSR bq_lookup
         0xB0, 0x04,             // BCS .hit
         // --- fallback: World_Num ---
         0xAC, 0x27, 0x07,       // LDY $0727
         0x60,                   // RTS
-        // --- .hit ($26): X = row. Seed the arrival, return the area in Y ---
+        // --- .hit ($09): X = row. Seed the arrival, return the area in Y ---
         0xA4, PLAYER_XHI,       // LDY Player_XHi   ; the slot the engine reads
         0xBD, arr_y[0], arr_y[1], // LDA BQ_ARR_Y,X
         0x99, ylh[0], ylh[1],   // STA Level_JctYLHStart,Y
@@ -206,7 +205,32 @@ fn build_routine_with(
         0xBD, room_t[0], room_t[1], // LDA BQ_ROOM,X
         0xA8,                   // TAY
         0x60,                   // RTS
-        // --- bq_scan ($39): $7EB2/$7EB3 -> carry set + X = row on match ---
+        // --- exit seed ($1C): reached from the Big ?-only exit path. The
+        //     pointer restore just before it put the HOST's obj_ptr back. ---
+        0x20, lookup[0], lookup[1], // JSR bq_lookup
+        0x90, 0x0E,             // BCC .done   (not ours — leave vanilla alone)
+        0xA4, PLAYER_XHI,       // LDY Player_XHi   ; the room's screen
+        0xBD, ret_y[0], ret_y[1], // LDA BQ_RET_Y,X
+        0x99, ylh[0], ylh[1],   // STA Level_JctYLHStart,Y
+        0xBD, ret_x[0], ret_x[1], // LDA BQ_RET_X,X
+        0x99, xlh[0], xlh[1],   // STA Level_JctXLHStart,Y
+        0x4C, back[0], back[1], // .done: JMP PRG026_AA8A
+        // --- bq_lookup ($32): two passes -> carry set + X = row on match ---
+        // pass 1: current area (Level_ObjPtrOrig $7EBB/$7EBC)
+        0xAD, 0xBB, 0x7E,       // LDA $7EBB     ; current-area obj_lo
+        0x8D, 0xB2, 0x7E,       // STA $7EB2     ; scratch lo
+        0xAD, 0xBC, 0x7E,       // LDA $7EBC     ; current-area obj_hi
+        0x8D, 0xB3, 0x7E,       // STA $7EB3     ; scratch hi
+        0x20, scan[0], scan[1], // JSR bq_scan
+        0xB0, 0x0F,             // BCS .out
+        // pass 2: frozen map-entry ptr ($7EB4/$7EB5, saved by Part A)
+        0xAD, 0xB4, 0x7E,       // LDA $7EB4     ; frozen obj_lo
+        0x8D, 0xB2, 0x7E,       // STA $7EB2
+        0xAD, 0xB5, 0x7E,       // LDA $7EB5     ; frozen obj_hi
+        0x8D, 0xB3, 0x7E,       // STA $7EB3
+        0x4C, scan[0], scan[1], // JMP bq_scan   ; its RTS returns to our caller
+        0x60,                   // .out: RTS
+        // --- bq_scan ($53): $7EB2/$7EB3 -> carry set + X = row on match ---
         0xA2, 0x0C,             // LDX #12  (13 entries, index 0..12)
         0xAD, 0xB3, 0x7E,       // .loop: LDA $7EB3
         0xDD, hi[0], hi[1],     // CMP BQ_OBJ_HI,X
@@ -220,20 +244,6 @@ fn build_routine_with(
         0x10, 0xEB,             // BPL .loop
         0x18,                   // CLC
         0x60,                   // RTS
-        // --- exit seed ($52): reached from the Big ?-only exit path. The
-        //     pointer restore just before it put the HOST's obj_ptr back. ---
-        0xAD, 0xBB, 0x7E,       // LDA $7EBB
-        0x8D, 0xB2, 0x7E,       // STA $7EB2
-        0xAD, 0xBC, 0x7E,       // LDA $7EBC
-        0x8D, 0xB3, 0x7E,       // STA $7EB3
-        0x20, scan[0], scan[1], // JSR bq_scan
-        0x90, 0x0E,             // BCC .done   (not ours — leave vanilla alone)
-        0xA4, PLAYER_XHI,       // LDY Player_XHi   ; the room's screen
-        0xBD, ret_y[0], ret_y[1], // LDA BQ_RET_Y,X
-        0x99, ylh[0], ylh[1],   // STA Level_JctYLHStart,Y
-        0xBD, ret_x[0], ret_x[1], // LDA BQ_RET_X,X
-        0x99, xlh[0], xlh[1],   // STA Level_JctXLHStart,Y
-        0x4C, back[0], back[1], // .done: JMP PRG026_AA8A
     ];
     r.extend_from_slice(&BQ_OBJ_HI);
     r.extend_from_slice(&BQ_OBJ_LO);
@@ -243,10 +253,11 @@ fn build_routine_with(
     r.extend(ret.iter().map(|&(y, _)| y));
     r.extend(ret.iter().map(|&(_, x)| x));
     debug_assert_eq!(r.len(), BIG_Q_ROUTINE_LEN);
-    // Both `BCS .hit` displacements are written by hand above; check they still
-    // reach `.hit` rather than landing mid-instruction.
-    debug_assert_eq!(0x11 + r[0x10] as usize, OFF_HIT, "pass 1 BCS .hit");
-    debug_assert_eq!(0x22 + r[0x21] as usize, OFF_HIT, "pass 2 BCS .hit");
+    // The three hand-written branch displacements, checked against the labels
+    // they are meant to reach rather than against the byte that was typed.
+    debug_assert_eq!(0x05 + r[0x04] as usize, OFF_HIT, "entry BCS .hit");
+    debug_assert_eq!(0x21 + r[0x20] as usize, OFF_LOOKUP - 3, "exit BCC .done");
+    debug_assert_eq!(0x43 + r[0x42] as usize, OFF_SCAN - 1, "pass 1 BCS .out");
     r
 }
 
@@ -313,20 +324,42 @@ mod tests {
             rom.read_range(BIG_Q_ROUTINE_OFFSET, expected.len()),
             expected.as_slice()
         );
+        // Part C names `.exit`, not the origin — `asm::check` validates branches
+        // *inside* the routine and cannot see a hook that lands mid-instruction.
+        let exit = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET) + OFF_EXIT as u16;
+        assert_eq!(
+            rom.read_range(BIG_Q_EXIT_HOOK, 3),
+            &[0x4C, exit as u8, (exit >> 8) as u8]
+        );
     }
 
     #[test]
     fn routine_scans_current_area_before_frozen_entry() {
         let r = build_lookup_routine();
         assert_eq!(r.len(), BIG_Q_ROUTINE_LEN);
-        assert_eq!(&r[0..3], &[0xAD, 0xBB, 0x7E], "pass 1 LDA $7EBB");
-        assert_eq!(&r[6..9], &[0xAD, 0xBC, 0x7E], "pass 1 LDA $7EBC");
-        assert_eq!(&r[17..20], &[0xAD, 0xB4, 0x7E], "pass 2 LDA $7EB4");
-        assert_eq!(&r[23..26], &[0xAD, 0xB5, 0x7E], "pass 2 LDA $7EB5");
-        assert_eq!(&r[0x22..0x26], &[0xAC, 0x27, 0x07, 0x60], "fallback LDY $0727; RTS");
+        let l = OFF_LOOKUP;
+        assert_eq!(&r[l..l + 3], &[0xAD, 0xBB, 0x7E], "pass 1 LDA $7EBB");
+        assert_eq!(&r[l + 6..l + 9], &[0xAD, 0xBC, 0x7E], "pass 1 LDA $7EBC");
+        assert_eq!(&r[l + 17..l + 20], &[0xAD, 0xB4, 0x7E], "pass 2 LDA $7EB4");
+        assert_eq!(&r[l + 23..l + 26], &[0xAD, 0xB5, 0x7E], "pass 2 LDA $7EB5");
+        assert_eq!(&r[5..OFF_HIT], &[0xAC, 0x27, 0x07, 0x60], "fallback LDY $0727; RTS");
         assert_eq!(&r[OFF_HI..OFF_LO], &BQ_OBJ_HI);
         assert_eq!(&r[OFF_LO..OFF_ROOM], &BQ_OBJ_LO);
         assert_eq!(&r[OFF_ROOM..OFF_ARR_Y], &BQ_ROOM);
+    }
+
+    /// The bug that shipped in the first cut of the room shuffle: the exit half
+    /// scanned only the current area, so 7-F1 — whose bonus pipe lives in an
+    /// alternate area with a shared `Empty_ObjLayout` pointer — never got its
+    /// return bytes seeded and came back to a stale slot. Both halves must call
+    /// the same two-pass subroutine.
+    #[test]
+    fn entry_and_exit_share_the_two_pass_lookup() {
+        let r = build_lookup_routine();
+        let lookup = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET) + OFF_LOOKUP as u16;
+        let jsr = [0x20, lookup as u8, (lookup >> 8) as u8];
+        assert_eq!(&r[0..3], &jsr, "entry JSR bq_lookup");
+        assert_eq!(&r[OFF_EXIT..OFF_EXIT + 3], &jsr, "exit JSR bq_lookup");
     }
 
     /// The hook must name the routine's own origin. The routine's *internal*
@@ -364,6 +397,50 @@ mod asm_checks {
             .allocation(BIG_Q_ROUTINE_OFFSET)
             .origin(prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET))
             .data_from(routine.len() - 91)
+            .assert_ok();
+    }
+
+    fn vanilla() -> Option<Vec<u8>> {
+        std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()
+    }
+
+    /// All three hook sites, against the vanilla bytes they overwrite. The
+    /// structural checks above see only the routine; nothing there can tell
+    /// that a hook chopped a vanilla instruction in half and left its operand
+    /// for the CPU to run as an opcode. Split out because it needs the ROM.
+    ///
+    /// The exit hook is checked as a *fragment* starting at `OFF_EXIT`, because
+    /// `.hook` requires the hook to name the checked array's origin and this
+    /// one deliberately names a label partway into the routine.
+    #[test]
+    fn hooks_displace_whole_instructions() {
+        let Some(v) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+        let base = prg_bank_file_to_cpu(26, BIG_Q_ROUTINE_OFFSET);
+        let routine = build_lookup_routine();
+
+        // Part A: PRG030 save trampoline, reached by `JMP` over `CPY #$07`.
+        asm::check(&BIG_Q_PRG030_ROUTINE)
+            .allocation(BIG_Q_PRG030_OFFSET)
+            .origin(crate::randomize::rom_data::prg030_file_to_cpu(BIG_Q_PRG030_OFFSET))
+            .hook(&v, BIG_Q_PRG030_HOOK, &BIG_Q_PRG030_JMP)
+            .assert_ok();
+
+        // Part B: the entry hook, replacing `LDY World_Num`.
+        asm::check(&routine)
+            .origin(base)
+            .data_from(routine.len() - 91)
+            .hook(&v, BIG_Q_HOOK_OFFSET, &jsr_into_bank(26, BIG_Q_ROUTINE_OFFSET))
+            .assert_ok();
+
+        // Part C: the exit hook, replacing the tail `JMP PRG026_AA8A`.
+        let exit_cpu = base + OFF_EXIT as u16;
+        let exit_jmp = [0x4C, exit_cpu as u8, (exit_cpu >> 8) as u8];
+        asm::check(&routine[OFF_EXIT..OFF_LOOKUP])
+            .origin(exit_cpu)
+            .hook(&v, BIG_Q_EXIT_HOOK, &exit_jmp)
             .assert_ok();
     }
 }

--- a/src/randomize/rom_data/free_space.rs
+++ b/src/randomize/rom_data/free_space.rs
@@ -257,7 +257,7 @@ pub(crate) const AIRSHIP_OBJ_SLOT: usize = 1;
 // PRG026 — two-pass Big ? Block lookup + spawn-slot seeding (qol/big_q.rs),
 // relocated off the old 0x35530 slot into tail free space. The $FF run this
 // sits in continues to 0x36000, so it has room to grow in place.
-pub(crate) const FS_BIG_Q_LOOKUP: usize      = 0x355BD; // 224 reserved, 207 used (CPU $B5AD)
+pub(crate) const FS_BIG_Q_LOOKUP: usize      = 0x355BD; // 224 reserved, 199 used (CPU $B5AD)
 
 // PRG027
 pub(crate) const FS_KING_QUOTES: usize       = 0x379D9; // 894 bytes

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -193,11 +193,11 @@ fn sweep_is_deterministic() {
 /// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
 /// trusting any number this test prints after a bump.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x5CE7A325F4E40B77, 0xEE4429463CB37B24, 0xF4D3FD6B84C89857, 0x52C24655C314BF5E,
-    0xEA3C7E36AA10E312, 0xE6A87F1D0297B837, 0x33332A4152718DBD, 0xA05870AF43203CB6,
-    0x8A6E37DA33E1B91D, 0xAF3DA8A8F53F3EC5, 0x5068CBCB2ED14BB0, 0xC01A2B0B1EA4FC04,
-    0x52A69F2C7D037BBE, 0xB6F19EA114E6B2B7, 0xD16BE93B4EE4DC2F, 0x4D7A01A04665B7A3,
-    0xD7F9BD46BA764F55, 0x2CE2B76AC0170B37, 0x3CA80801B89FC3AD, 0x273A357F0557B0A3,
+    0x10A21459F3D382D4, 0xE3B9B230CB5E2FD7, 0x507C6DF8FECC0748, 0x2D1F63143211AF41,
+    0x059F26A00BD20859, 0xFFA931FD7213C6F8, 0x4AC4B084D5710E46, 0xBBC03D522F8D7B0D,
+    0x0E8A0C6DCF74974E, 0x145B0F2077100926, 0xE87B059AA0D229B3, 0xCE14C48FAD6340C3,
+    0x9CC0FFBB47133B59, 0x8840994638563498, 0x41230F8CD226BE50, 0xD6C8A68350419C68,
+    0xE07803C1078FD866, 0x15EDD16343473678, 0x314021376D017AC6, 0xE099549AF8F4640C,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
@@ -219,6 +219,15 @@ const BASELINE: [u64; SEEDS as usize] = [
 /// coordinates after playtesting showed the originals killed the player. Four
 /// table bytes, so every seed that draws one of those rooms moves. No RNG draw
 /// changed — the pool is the same size — so this is a pure byte difference.
+///
+/// Re-captured 2026-08-29 for the 7-F1 return fix: the entry and exit halves of
+/// the `qol::big_q` routine now share one `bq_lookup` subroutine, which moved
+/// every label and table after offset $09 and shrank it from 207 to 199 bytes.
+/// Again a pure byte difference, and again verified rather than argued — for
+/// each of these 20 seeds the pre- and post-fix ROMs were diffed byte for byte,
+/// and the only bytes that changed outside `FS_BIG_Q_LOOKUP`'s own 224-byte
+/// allocation were the exit hook's operand at 0x34A85. No map tile, pointer
+/// table or level byte moved.
 
 #[test]
 fn output_matches_baseline() {


### PR DESCRIPTION
Reported on the beta: **7-F1 crashes the player after they leave the Big [?] room** — seed `4270776170103004`, flags `SMB3R-3MMFZZVZ7T8T9ANAWSXMM28`.

## Root cause

7-F1's bonus pipe is not in the area its map tile enters:

| | 7-F1 |
|---|---|
| pointer-table entry | layout `$B28E`, objects `$D4E4` |
| that area's alt pointers | layout `$B3CB`, objects **`$C006`** = `Empty_ObjLayout` |
| junction command `E6 02 16` | 0x2B47E → CPU `$B46E`, **inside `$B3CB`** |

`$C006` is the alt-objects pointer of **eight** different areas, so it can never key a level — only the frozen map-entry pointer identifies 7-F1.

The routine wrote its lookup twice. The entry half scanned `Level_ObjPtrOrig` and then the frozen ptr; the exit half scanned only `Level_ObjPtrOrig`. Entering resolved on pass 2 and opened the right room; leaving missed, seeded nothing, and left the engine reading whatever `Level_JctXLHStart[Player_XHi]` held.

**Vanilla hid it.** 7-F1 always opened BigQ7 s6, so `Player_XHi` out was 6 and BigQ7's own slot-6 group-7 command *is* 7-F1's return — the seeding was redundant. The room shuffle promoted that dead path to load-bearing, and this seed sends 7-F1 to Unused Level 5 s2, which has no group-7 commands at all.

7-F1 is the only host shaped this way; the other ten have their pipe in an area whose object pointer is already a table key (6-9's donated interior `$C60E` is row 12).

## Fix

One `bq_lookup` subroutine that both halves `JSR`. Neither `$7EBB` nor `$7EB4` changes while a bonus room is open — `LevelJct_BigQuestionBlock` never calls `Level_JctInit` — so exit resolves the same row entry did by construction rather than by two code paths agreeing.

**No table row was added or changed.** Deduplicating returned 8 bytes: **207 → 199** in a 224-byte allocation.

## Testing gap closed

The three hook sites never went through `asm::check`, only plain byte asserts. `hooks_displace_whole_instructions` now runs `.hook()` against the vanilla ROM for all three (Part A / entry / exit). It immediately caught `prg_bank_file_to_cpu(30, ..)` being wrong for Part A — that helper hardcodes the `$A000` window, and PRG030 maps at `$8000`, which is what `prg030_file_to_cpu` exists for.

The exit hook is checked as a fragment at `OFF_EXIT`, since `.hook()` requires the hook to name the checked array's origin and this one deliberately names a mid-routine label.

## Baseline

Recaptured — every label and table past offset `$09` shifted. Verified as bytes-only rather than argued: for each of seeds 1–20 the pre- and post-fix ROMs were diffed byte for byte, and the only byte that changed outside `FS_BIG_Q_LOOKUP`'s own allocation was the exit hook's operand at 0x34A85. No map tile, pointer table or level byte moved.

## Checks

- `cargo test` — 398 passed, 0 failed
- `cargo clippy --all-targets` — 0 warnings
- `asm::check` on the routine: `.allocation` + `.origin` + `.data_from`, plus the three new hook checks
- playtest pair built from `testrom --randomize --seed 12 --place 7F1 --no-walk --starting-items p-wing`, which draws Unused Level 5 s2 for 7-F1 — the same room the reported seed gives it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW