### PR TITLE
feature: Limit Hazards and Friendlier Levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ deploys.
 
 ### Added
 
+- **Limit Hazards** (new option: Off / Some / All, off by default). Stops enemy
+  swaps from dropping a hazard into a level that wasn't built for one — nippers,
+  Ptooies, thwomps, Hot Foots and Bros. Hazards Nintendo placed are always kept,
+  and a slot that held one can still shuffle within its own kind, so this only
+  ever removes surprises the randomizer added. **Some** allows the occasional
+  one so you still learn to handle them; **All** allows none. Measured over 250
+  seeds of the Max Chaos preset, the unfiltered game gains ~140 hazards a seed
+  with as many as 25 in a single stretch of level; Some cuts that to ~52 and
+  never more than one.
+
+  Only in-level enemies are affected. Hammer Bro mini-battles keep their own
+  curated pools, and Wild Injections are unchanged.
+
+- **Beginner Friendly** preset now uses Limit Hazards (All) and has its Ghosts
+  class turned back on. The class was previously disabled outright just to stop
+  Boo → Hot Foot; blocking that directly brings Boo ↔ Dry Bones variety back.
+
 - **Shuffle Big ? Rooms** (new option, off by default). Every level with a Big ?
   pipe draws from a pool of 19 rooms instead of always opening its own — the 11
   vanilla rooms plus 8 from "Unused Level 5", a complete set of eight bonus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ deploys.
   donated to a door you can still open, while whatever was donated to the
   blocked door became unreachable, quietly costing you an unrelated level.
 
+  It also makes two fortresses — 7F2, then 8F1 — optional rather than absent.
+  They stay on the map and stay beatable, but land behind a lock the world can
+  be finished without, so you can walk past them. Forts can't be held out of the
+  pool the way levels can (every fort needs a lock, and the full roster is an
+  invariant), and there has to be a spare bypassable lock going: 1-F always
+  claims the first one, since its secret exit can leave a lock shut forever.
+  Measured over 300 seeds, 99% have room for both; in the rest 8F1 stays
+  required.
+
 - **Beginner Friendly** preset now uses Limit Hazards (All) and Friendlier
   Levels, and has its Ghosts class turned back on. The class was previously
   disabled outright just to stop Boo → Hot Foot; blocking that directly brings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,21 @@ deploys.
   Only in-level enemies are affected. Hammer Bro mini-battles keep their own
   curated pools, and Wild Injections are unchanged.
 
-- **Beginner Friendly** preset now uses Limit Hazards (All) and has its Ghosts
-  class turned back on. The class was previously disabled outright just to stop
-  Boo → Hot Foot; blocking that directly brings Boo ↔ Dry Bones variety back.
+- **Friendlier Levels** (new option, off by default). Keeps the roughest levels
+  out of the shuffle — 2-3, 5-3, 6-6, 7-5, 7-8 and 8-1. Their slots go to beta
+  stages when those are on, and otherwise to a second visit to a level already
+  in the seed, so the map is exactly as full as it always was.
+
+  With lobby shuffle on, the held-back levels sit that out too. Blocking a level
+  removes its *front door*, and the lobby shuffle moves *interiors*
+  independently — so a blocked level left in that pool would have its interior
+  donated to a door you can still open, while whatever was donated to the
+  blocked door became unreachable, quietly costing you an unrelated level.
+
+- **Beginner Friendly** preset now uses Limit Hazards (All) and Friendlier
+  Levels, and has its Ghosts class turned back on. The class was previously
+  disabled outright just to stop Boo → Hot Foot; blocking that directly brings
+  Boo ↔ Dry Bones variety back.
 
 - **Shuffle Big ? Rooms** (new option, off by default). Every level with a Big ?
   pipe draws from a pool of 19 rooms instead of always opening its own — the 11

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ use rom::Rom;
 
 pub use ips::apply_ips_patch;
 pub use randomizer::{
-    EnemyMode, FireFlowerMode, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY, ITEMS,
-    Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser, current_flag_key_version,
-    flag_key_fields, flag_key_version_of, item_display_name, item_id,
+    EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
+    ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser,
+    current_flag_key_version, flag_key_fields, flag_key_version_of, item_display_name, item_id,
 };
 
 /// Validate a ROM blob without doing any randomization. Returns Ok if the bytes

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,6 +413,11 @@ struct Cli {
     #[arg(long, default_value = "off", value_parser = parse_hazard_limit)]
     limit_hazards: HazardLimit,
 
+    /// Hold the harshest levels out of the shuffle pool (2-3, 5-3, 6-6, 7-5,
+    /// 7-8, 8-1), refilling with beta stages and duplicates of what remains
+    #[arg(long)]
+    friendlier_levels: bool,
+
     /// Seed a level-wide chaser into a fraction of levels. A comma-separated
     /// set of `sun`, `lakitu`, `bass`; or `all`; or `off` (default). A level
     /// whose CHR can't fit an allowed chaser is skipped rather than given one
@@ -575,6 +580,7 @@ fn build_options(cli: &Cli) -> Options {
             bros: cli.bros,
             hb_encounters: cli.hb_encounters,
             limit_hazards: cli.limit_hazards,
+            friendlier_levels: cli.friendlier_levels,
             wild_injections: cli.wild_injections.0.clone(),
             starting_lives: cli.starting_lives,
             starting_items,
@@ -608,6 +614,7 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
             HazardLimit::All => "all",
         }
     );
+    eprintln!("  Friendlier levels: {}", if options.friendlier_levels { "on" } else { "off" });
     eprintln!("  World order: {}", if options.world_order { "on" } else { "off" });
     if options.world_order && options.world_count < 7 {
         eprintln!("  World count: {}", options.world_count);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use std::process;
 
 use smb3_rs::{
-    EnemyMode, FireFlowerMode, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser,
-    item_display_name, item_id,
+    EnemyMode, FireFlowerMode, HazardLimit, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES,
+    Tri, WildChaser, item_display_name, item_id,
 };
 
 /// Human-readable label for a tri-state flag in the run summary.
@@ -65,6 +65,16 @@ fn parse_fire_flower(s: &str) -> Result<FireFlowerMode, String> {
         "on" => Ok(FireFlowerMode::On),
         "wild" => Ok(FireFlowerMode::Wild),
         _ => Err("valid values: off, on, wild".to_string()),
+    }
+}
+
+/// clap value parser for `--limit-hazards` (off/some/all).
+fn parse_hazard_limit(s: &str) -> Result<HazardLimit, String> {
+    match s {
+        "off" => Ok(HazardLimit::Off),
+        "some" => Ok(HazardLimit::Sparse),
+        "all" => Ok(HazardLimit::All),
+        _ => Err("valid values: off, some, all".to_string()),
     }
 }
 
@@ -398,6 +408,11 @@ struct Cli {
     #[arg(long, default_value = "off", value_parser = parse_enemy_mode)]
     hb_encounters: EnemyMode,
 
+    /// Stop swaps introducing hazards a level wasn't built with: off, some
+    /// (one per room), or all (default: off)
+    #[arg(long, default_value = "off", value_parser = parse_hazard_limit)]
+    limit_hazards: HazardLimit,
+
     /// Seed a level-wide chaser into a fraction of levels. A comma-separated
     /// set of `sun`, `lakitu`, `bass`; or `all`; or `off` (default). A level
     /// whose CHR can't fit an allowed chaser is skipped rather than given one
@@ -559,6 +574,7 @@ fn build_options(cli: &Cli) -> Options {
             water: cli.water,
             bros: cli.bros,
             hb_encounters: cli.hb_encounters,
+            limit_hazards: cli.limit_hazards,
             wild_injections: cli.wild_injections.0.clone(),
             starting_lives: cli.starting_lives,
             starting_items,
@@ -584,6 +600,14 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
     eprintln!("  World colors: {}", if options.palette_themed { "themed" } else { "vanilla" });
     eprintln!("  Remove flashing: {}", if options.remove_flashing { "on" } else { "off" });
     eprintln!("  Enemies:  {}", if options.any_enemies_active() { "on" } else { "off" });
+    eprintln!(
+        "  Limit hazards: {}",
+        match options.limit_hazards {
+            HazardLimit::Off => "off",
+            HazardLimit::Sparse => "some (the occasional one)",
+            HazardLimit::All => "all",
+        }
+    );
     eprintln!("  World order: {}", if options.world_order { "on" } else { "off" });
     if options.world_order && options.world_count < 7 {
         eprintln!("  World count: {}", options.world_count);

--- a/src/randomize/antechambers.rs
+++ b/src/randomize/antechambers.rs
@@ -29,6 +29,7 @@
 use rand::seq::SliceRandom;
 use rand_chacha::ChaCha8Rng;
 
+use super::rom_data;
 use crate::rom::Rom;
 
 /// One antechamber-pattern level. The vanilla entries are emitted by
@@ -153,12 +154,31 @@ fn sanitize_exit_dir(byte1: u8) -> u8 {
 /// Randomly permute which interior each antechamber level's entry pipe
 /// leads to. Identity assignments are allowed (a level may keep its own
 /// interior) and skip their writes entirely.
-pub fn shuffle(rom: &mut Rom, rng: &mut ChaCha8Rng, include_beta_stages: bool) {
+pub fn shuffle(
+    rom: &mut Rom,
+    rng: &mut ChaCha8Rng,
+    include_beta_stages: bool,
+    friendlier_levels: bool,
+) {
     // Beta antechambers only join the pool when their stages are placed. With
     // beta stages off the pool is the 11 vanilla levels and the output is
     // byte-identical to before β4 existed.
-    let pool: Vec<&Antechamber> =
-        ANTECHAMBERS.iter().filter(|a| include_beta_stages || !a.beta).collect();
+    //
+    // Friendlier Levels withdraws its blocked levels here as well, and that is
+    // a correctness requirement rather than tidiness. Blocking removes a
+    // level's *lobby* from the map; this pass moves *interiors*, and the
+    // assignment below is a full permutation. Leave a blocked level in and
+    // both halves go wrong at once: its interior is donated to a lobby the
+    // player can still reach, so it gets played anyway, and whatever was
+    // donated to the blocked lobby sits behind a door that was never placed,
+    // dropping an unrelated level from the seed. Three of the blocked levels
+    // (5-3, 6-6, 7-5) are in this pool, so the pool goes 11 -> 8, or 12 -> 9
+    // with beta stages on.
+    let pool: Vec<&Antechamber> = ANTECHAMBERS
+        .iter()
+        .filter(|a| include_beta_stages || !a.beta)
+        .filter(|a| !friendlier_levels || !rom_data::is_friendlier_blocked(a.name))
+        .collect();
 
     // Snapshot all vanilla interiors before any writes, so a permutation
     // never reads a value another assignment already overwrote.
@@ -272,7 +292,7 @@ mod tests {
         let vanilla: Vec<_> = ANTECHAMBERS.iter().map(|a| interior_tuple(&rom, a)).collect();
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        shuffle(&mut rom, &mut rng, true);
+        shuffle(&mut rom, &mut rng, true, false);
 
         let mut shuffled: Vec<_> = ANTECHAMBERS.iter().map(|a| interior_tuple(&rom, a)).collect();
         let mut expected = vanilla.clone();
@@ -285,7 +305,7 @@ mod tests {
     fn host_local_bytes_are_preserved() {
         let mut rom = make_test_rom();
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        shuffle(&mut rom, &mut rng, true);
+        shuffle(&mut rom, &mut rng, true, false);
 
         for (i, a) in ANTECHAMBERS.iter().enumerate() {
             let n = i as u8;
@@ -305,7 +325,7 @@ mod tests {
         let mut rom = make_test_rom();
         let vanilla: Vec<_> = ANTECHAMBERS.iter().map(|a| interior_tuple(&rom, a)).collect();
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        shuffle(&mut rom, &mut rng, true);
+        shuffle(&mut rom, &mut rng, true, false);
 
         for (a, before) in ANTECHAMBERS.iter().zip(&vanilla) {
             let moved = interior_tuple(&rom, a) != *before;
@@ -356,7 +376,7 @@ mod tests {
         // Force the permutation so some other level hosts this donor: shuffle
         // until a non-identity assignment lands the donor somewhere.
         let mut rng = ChaCha8Rng::seed_from_u64(3);
-        shuffle(&mut rom, &mut rng, true);
+        shuffle(&mut rom, &mut rng, true, false);
 
         // Wherever the donor's interior went, its junctions must read dir 3
         // (0xF3) — never the raw 0xF8 — and keep the arrival column 0x27.
@@ -380,8 +400,8 @@ mod tests {
         let mut rom_b = make_test_rom();
         let mut rng_a = ChaCha8Rng::seed_from_u64(42);
         let mut rng_b = ChaCha8Rng::seed_from_u64(42);
-        shuffle(&mut rom_a, &mut rng_a, true);
-        shuffle(&mut rom_b, &mut rng_b, true);
+        shuffle(&mut rom_a, &mut rng_a, true, false);
+        shuffle(&mut rom_b, &mut rng_b, true, false);
 
         for a in &ANTECHAMBERS {
             assert_eq!(rom_a.read_range(a.header, 9), rom_b.read_range(a.header, 9));
@@ -400,7 +420,7 @@ mod tests {
         let vanilla: Vec<_> = ANTECHAMBERS.iter().map(|a| interior_tuple(&rom, a)).collect();
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        shuffle(&mut rom, &mut rng, false);
+        shuffle(&mut rom, &mut rng, false, false);
 
         // Every beta entry is untouched.
         for (a, before) in ANTECHAMBERS.iter().zip(&vanilla) {
@@ -426,6 +446,52 @@ mod tests {
         shuffled.sort();
         expected.sort();
         assert_eq!(shuffled, expected, "vanilla interiors still permute");
+    }
+
+    /// Friendlier Levels withholds its blocked levels from this pool, and the
+    /// reason is correctness, not tidiness. Blocking removes a level's lobby
+    /// from the map while this pass moves interiors; leaving a blocked level
+    /// in would donate its interior to a reachable lobby (so it gets played
+    /// anyway) and strand whatever was donated to the blocked lobby behind a
+    /// door that was never placed (so an unrelated level vanishes).
+    #[test]
+    fn friendlier_blocked_levels_are_withheld() {
+        let mut rom = make_test_rom();
+        let vanilla: Vec<_> = ANTECHAMBERS.iter().map(|a| interior_tuple(&rom, a)).collect();
+
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        shuffle(&mut rom, &mut rng, true, true);
+
+        let blocked = |a: &Antechamber| rom_data::is_friendlier_blocked(a.name);
+
+        // At least one of the pool is actually blocked, or this test proves
+        // nothing — 5-3, 6-6 and 7-5 are in both lists today.
+        assert!(ANTECHAMBERS.iter().any(blocked), "no blocked level is in the antechamber pool");
+
+        for (a, before) in ANTECHAMBERS.iter().zip(&vanilla) {
+            if blocked(a) {
+                assert_eq!(
+                    interior_tuple(&rom, a),
+                    *before,
+                    "{}: blocked interior was reassigned",
+                    a.name
+                );
+            }
+        }
+
+        // What remains is still a permutation of itself: no interior is lost
+        // to a withheld host, and none is duplicated.
+        let mut shuffled: Vec<_> =
+            ANTECHAMBERS.iter().filter(|a| !blocked(a)).map(|a| interior_tuple(&rom, a)).collect();
+        let mut expected: Vec<_> = ANTECHAMBERS
+            .iter()
+            .zip(&vanilla)
+            .filter(|(a, _)| !blocked(a))
+            .map(|(_, before)| before.clone())
+            .collect();
+        shuffled.sort();
+        expected.sort();
+        assert_eq!(shuffled, expected, "remaining interiors still permute among themselves");
     }
 
     /// Guard the hardcoded offsets against the real ROM: every entry must

--- a/src/randomize/antechambers.rs
+++ b/src/randomize/antechambers.rs
@@ -36,7 +36,12 @@ use crate::rom::Rom;
 /// `tools/rom_map.py --antechamber`; beta stages are added by hand (that
 /// detector only scans pointer-table levels, so it can't see them).
 struct Antechamber {
-    /// Vanilla level name, for panic messages.
+    /// Vanilla level name. Used in panic messages, and **load-bearing**: it is
+    /// matched against `FRIENDLIER_BLOCKED_LEVELS` to decide whether Friendlier
+    /// Levels withholds this level from the pool. That makes it the same
+    /// namespace as `NodeCatalog` names — `antechamber_names_are_catalog_names`
+    /// enforces it, so adding a name to the blocklist reaches both the level
+    /// deck and this pool without any further wiring.
     name: &'static str,
     /// File offset of the entry area's 9-byte layout header.
     header: usize,
@@ -492,6 +497,36 @@ mod tests {
         shuffled.sort();
         expected.sort();
         assert_eq!(shuffled, expected, "remaining interiors still permute among themselves");
+    }
+
+    /// `Antechamber.name` and `NodeCatalog` names must be one namespace.
+    ///
+    /// Friendlier Levels reaches both the level deck and this pool by matching
+    /// `FRIENDLIER_BLOCKED_LEVELS` against a name — `CatalogEntry.name` on the
+    /// deck side, `Antechamber.name` here. Nothing in the type system ties
+    /// those two tables together, so a level spelled differently in the two
+    /// places would be dropped from the deck while its interior kept
+    /// circulating in this pool: blocked in name only, and costing an
+    /// unrelated level its interior. Asserting the whole pool resolves is what
+    /// lets the blocklist be extended without touching either filter.
+    #[test]
+    fn antechamber_names_are_catalog_names() {
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+        let rom = Rom::from_bytes(&bytes).unwrap();
+        // Beta stages on: β4 only exists as a catalog entry with that flag set.
+        let catalog = crate::randomize::node_catalog::NodeCatalog::build(&rom, true);
+
+        for a in &ANTECHAMBERS {
+            assert!(
+                catalog.entries.iter().any(|e| e.name == a.name),
+                "antechamber {:?} has no NodeCatalog entry of that name — the \
+                 Friendlier Levels blocklist could never match it",
+                a.name,
+            );
+        }
     }
 
     /// Guard the hardcoded offsets against the real ROM: every entry must

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -20,7 +20,7 @@ use crate::randomize::rom_data::{
     STOMPABLE_ENEMIES, TREASURE_BOX_APPEAR,
 };
 use crate::randomize::segment_writer::{self, SegmentEntry as WriterEntry, SortMode};
-use crate::randomizer::{EnemyMode, Options, WildChaser};
+use crate::randomizer::{EnemyMode, HazardLimit, Options, WildChaser};
 use crate::rom::Rom;
 
 mod class_modes;
@@ -167,7 +167,13 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
 
         // HB Wild: batch-assign enemies with stompability constraints.
         if is_hb_segment && opts.hb_encounters == EnemyMode::Wild && !big_q_only {
-            let limits = SegmentLimits { cap_full: false, no_hammer_bro };
+            // `hazard_cap_full: false` on purpose — `limit_hazards` is a
+            // levels-only filter. An HB room draws from its own curated pools
+            // (STOMPABLE_ENEMIES / HB_NEEDS_SHELL_ENEMIES), already chosen so
+            // the player can clear a closed room, and it has no vanilla enemy
+            // to measure "introduced" against since the room is composed from
+            // scratch.
+            let limits = SegmentLimits { cap_full: false, no_hammer_bro, hazard_cap_full: false };
             randomize_hb_wild_segment(&mut data, &entries, &hb_modes, limits, rng);
             continue;
         }
@@ -189,6 +195,15 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         // here — `entries` was updated in step with `data` above.
         let mut bertha_count: u8 =
             entries.iter().filter(|e| BERTHA_IDS.contains(&e.obj_id)).count() as u8;
+
+        // Hazards this pass has *added* to this segment, for HazardLimit::Sparse.
+        // Starts at zero rather than counting what's already here: the rule is
+        // additive-only, so a segment Nintendo filled with nippers keeps them and
+        // still has its full budget for one more. Monotonic — a pick that
+        // replaces an added hazard with a non-hazard doesn't refund it, which
+        // keeps the budget a ceiling on introductions rather than on the
+        // final count.
+        let mut added_hazards: u8 = 0;
 
         // Split entries into proximity groups by X-position. Each group gets
         // independent CHR slot tracking — enemies more than CHR_GROUP_GAP tiles
@@ -272,6 +287,11 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                     cap_full: bertha_count.saturating_sub(was_bertha as u8)
                         >= MAX_BERTHA_PER_SEGMENT,
                     no_hammer_bro,
+                    hazard_cap_full: match opts.limit_hazards {
+                        HazardLimit::Off => false,
+                        HazardLimit::Sparse => added_hazards >= MAX_ADDED_HAZARDS_PER_SEGMENT,
+                        HazardLimit::All => true,
+                    },
                 };
                 let chr = ChrCtx {
                     local: (committed_slot4, committed_slot5),
@@ -298,6 +318,11 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
                     bertha_count = bertha_count.saturating_sub(1);
                 } else if !was_bertha && chosen_is_bertha {
                     bertha_count = bertha_count.saturating_add(1);
+                }
+                // Same predicate `keep` blocks on, so under All this never
+                // fires and under Sparse it spends the segment's one budget.
+                if hazard_excluded(chosen, entry.obj_id) {
+                    added_hazards = added_hazards.saturating_add(1);
                 }
                 swap_enemy(&mut data, entry.data_index, chosen);
                 commit_chr_page(chosen, &mut committed_slot4, &mut committed_slot5);

--- a/src/randomize/enemies/picking.rs
+++ b/src/randomize/enemies/picking.rs
@@ -160,7 +160,12 @@ pub(super) fn pick_replacement<R: Rng>(
         // committed anywhere in the segment, not just this group — it
         // follows the player into all of them (see CHASER_IDS).
         let chaser_clash = CHASER_IDS.contains(&id) && !is_chr_compatible(id, seg4, seg5);
-        !(over_cap || bad_giant || chaser_clash || hb_rewritten)
+        // This segment's hazard budget is spent (always, under HazardLimit::All).
+        // Additive-only, exactly like the curated ExcludeHazards entries: a
+        // hazard sharing the vanilla enemy's category is still allowed, so
+        // designed-in hazards survive and thwomp-variant shuffle keeps working.
+        let added_hazard = limits.hazard_cap_full && hazard_excluded(id, entry.obj_id);
+        !(over_cap || bad_giant || chaser_clash || hb_rewritten || added_hazard)
     };
     // (A piranha slot can't become a hazard: the piranha pools are
     // self-contained and contain none — verified by the harness's

--- a/src/randomize/enemies/segments.rs
+++ b/src/randomize/enemies/segments.rs
@@ -22,9 +22,12 @@ pub(super) struct SegmentPins {
 }
 
 /// Placement limits that hold for every entry in one segment, whatever pool
-/// that entry draws from. Both are properties of the *room*, not the slot,
-/// which is why they ride alongside the per-entry protections rather than
-/// being expressed as `EntryRule`s.
+/// that entry draws from. The first two are properties of the *room*, not the
+/// slot, which is why they ride alongside the per-entry protections rather
+/// than being expressed as `EntryRule`s. `hazard_cap_full` is the one
+/// run-scoped member: it rides here because `pick_replacement`'s `keep` is the
+/// single place every pick funnels through, so one field there covers the
+/// class pools, the wild pool and all four protection paths at once.
 #[derive(Clone, Copy)]
 pub(super) struct SegmentLimits {
     /// The Big Bertha cap is already reached — no new bertha here.
@@ -32,6 +35,12 @@ pub(super) struct SegmentLimits {
     /// No `$81` here: this room rewrites one into an unkillable object. See
     /// `enemy_protections::rewrites_hammer_bro`.
     pub(super) no_hammer_bro: bool,
+    /// This segment's introduced-hazard budget is spent, so no pick may put a
+    /// hazard where the vanilla enemy wasn't already one of the same category.
+    /// Always true under `HazardLimit::All`, always false under
+    /// `HazardLimit::Off`, and under `Sparse` it flips once the segment has
+    /// gained [`MAX_ADDED_HAZARDS_PER_SEGMENT`] of them.
+    pub(super) hazard_cap_full: bool,
 }
 
 impl SegmentPins {

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -393,6 +393,22 @@ pub(super) const BERTHA_IDS: &[u8] = &[0x2D, 0x63];
 /// this was observed in 3-9 where the white block became unreachable.
 pub(super) const MAX_BERTHA_PER_SEGMENT: u8 = 2;
 
+/// Maximum number of *introduced* hazards allowed in a single enemy segment
+/// under `HazardLimit::Sparse`. Vanilla hazards don't count — only a pick that
+/// puts a hazard where the slot's vanilla enemy was a different category (see
+/// [`hazard_excluded`]), which is the same thing `HazardLimit::All` forbids
+/// outright.
+///
+/// One, so the player can still meet a Ptooie or a nipper and learn to handle
+/// it, but never walks into a wall of them.
+///
+/// The budget is per `$FF`-bounded enemy run, not per level. That is usually
+/// the same thing, but several levels can enter one run at different
+/// `enemy_ptr`s (see the `SortMode::Preserve` note in `mod.rs`), and there they
+/// share the one budget. Stricter than per-level, which is the safe direction
+/// for a flag whose whole job is "fewer surprises".
+pub(super) const MAX_ADDED_HAZARDS_PER_SEGMENT: u8 = 1;
+
 /// Maximum X-tile gap between consecutive enemies (sorted by X) before they
 /// are split into separate CHR groups. Enemies more than one screen apart
 /// can never be visible simultaneously, so they don't need compatible CHR pages.

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1033,6 +1033,16 @@ struct PlacementStats {
     /// bypass it), so this must stay 0 — any nonzero count is a violation.
     bertha_cap_exceeded: u64,
     max_berthas_in_seg: u8,
+    /// Hazards this run introduced: a pick that put a hazard where the
+    /// vanilla enemy was a different category. Must be 0 under
+    /// `HazardLimit::All`; under `Sparse` it is capped per segment, not
+    /// globally, so this is a diagnostic there rather than an invariant.
+    hazards_added: u64,
+    /// Segment-instances (seed × segment) that exceeded
+    /// `MAX_ADDED_HAZARDS_PER_SEGMENT` under `HazardLimit::Sparse`. Hard
+    /// invariant — must stay 0.
+    hazard_cap_exceeded: u64,
+    max_hazards_added_in_seg: u8,
     /// new_id -> times placed (only counts actual swaps)
     histogram: std::collections::BTreeMap<u8, u64>,
 }
@@ -1124,6 +1134,7 @@ fn check_invariants(
         };
 
         let mut bertha_in_seg = 0u8;
+        let mut hazards_added_in_seg = 0u8;
         for i in 0..b.entry_count {
             let off = b.file_offset + 1 + i * 3; // +1 skips the page flag
             let orig = vanilla[off];
@@ -1183,6 +1194,21 @@ fn check_invariants(
                     bad("HB-wild swap not in the HB wild pool".into());
                 }
                 continue;
+            }
+
+            // --- Limit Hazards (site A: in-level class swaps) ---
+            //
+            // Counted here, after the injectable and HB-batch branches have
+            // taken their exits: neither goes through `pick_replacement`'s
+            // `keep`, and an injectable slot's `orig` is the vanilla enemy
+            // rather than the injected id, so measuring it against `orig`
+            // would be meaningless. Chasers aren't hazards anyway.
+            if hazard_excluded(new, orig) {
+                stats.hazards_added += 1;
+                hazards_added_in_seg = hazards_added_in_seg.saturating_add(1);
+                if opts.limit_hazards == HazardLimit::All {
+                    bad("limit_hazards=all but a new hazard category was introduced".into());
+                }
             }
 
             let prot = entry_protection_at(fo);
@@ -1255,6 +1281,20 @@ fn check_invariants(
             }
         }
 
+        // Added-hazard cap, the Sparse rung's hard invariant. Only meaningful
+        // under Sparse: Off has no cap and All is checked per entry above.
+        stats.max_hazards_added_in_seg = stats.max_hazards_added_in_seg.max(hazards_added_in_seg);
+        if opts.limit_hazards == HazardLimit::Sparse
+            && hazards_added_in_seg > MAX_ADDED_HAZARDS_PER_SEGMENT
+        {
+            stats.hazard_cap_exceeded += 1;
+            out.push(format!(
+                "seed {seed} @ seg {:#07X}: {hazards_added_in_seg} added hazards, cap is {}",
+                ENEMY_DATA_START + b.file_offset,
+                MAX_ADDED_HAZARDS_PER_SEGMENT,
+            ));
+        }
+
         // Bertha cap: hard invariant now that the predicate pipeline applies
         // it to every pick (it used to be bypassed by the Force*/ExcludeHazards
         // branches — see PlacementStats::bertha_cap_exceeded).
@@ -1309,6 +1349,14 @@ fn run_preset(label: &str, opts: &Options, seeds: u64, base: &Rom, vanilla: &[u8
         "bertha-cap exceeded in {} segment-instances (max {} berthas/seg)",
         stats.bertha_cap_exceeded, stats.max_berthas_in_seg,
     );
+    eprintln!(
+        "hazards added: {} total ({}/seed), max {} in one segment; \
+         cap exceeded in {} segment-instances",
+        stats.hazards_added,
+        stats.hazards_added / stats.seeds.max(1),
+        stats.max_hazards_added_in_seg,
+        stats.hazard_cap_exceeded,
+    );
     eprintln!("placement histogram (id: total placements over all seeds):");
     for (id, n) in &stats.histogram {
         eprintln!("  0x{id:02X}: {n}");
@@ -1327,6 +1375,24 @@ fn enemy_invariant_baseline() {
     let mut violations = Vec::new();
     violations.extend(run_preset("Recommended", &preset_recommended(), 250, &base, &vanilla));
     violations.extend(run_preset("Max Chaos", &preset_max_chaos(), 250, &base, &vanilla));
+    // Both Limit Hazards rungs run the *whole* preset suite above, not a
+    // narrower one: the point is that turning the filter on doesn't cost any
+    // of the existing protections. Max Chaos is the arm that matters — every
+    // class Wild is what puts all 18 hazard ids in the pool to begin with.
+    violations.extend(run_preset(
+        "Max Chaos + limit_hazards=all",
+        &Options { limit_hazards: HazardLimit::All, ..preset_max_chaos() },
+        250,
+        &base,
+        &vanilla,
+    ));
+    violations.extend(run_preset(
+        "Max Chaos + limit_hazards=some",
+        &Options { limit_hazards: HazardLimit::Sparse, ..preset_max_chaos() },
+        250,
+        &base,
+        &vanilla,
+    ));
 
     assert!(
         violations.is_empty(),

--- a/src/randomize/node_catalog/tests.rs
+++ b/src/randomize/node_catalog/tests.rs
@@ -291,3 +291,30 @@ fn friendlier_blocklist_resolves() {
         );
     }
 }
+
+/// Same guard as `friendlier_blocklist_resolves`, for the fortress ladder.
+///
+/// Worth its own test because the naming convention differs and that is the
+/// easy mistake: forts are `7F2` / `8F1` (from the ordinal suffix), with no
+/// dash, while levels are `7-8`. A misspelled entry never matches any pool
+/// member, so the fort silently stays required and nothing else complains.
+#[test]
+fn friendlier_optional_forts_resolve() {
+    let Some(rom) = load_rom() else {
+        eprintln!("reference ROM not present — skipping friendlier_optional_forts_resolve");
+        return;
+    };
+    let catalog = NodeCatalog::build(&rom, false);
+
+    for &name in crate::randomize::rom_data::FRIENDLIER_OPTIONAL_FORTS {
+        let hits = catalog
+            .entries
+            .iter()
+            .filter(|e| e.name == name && matches!(e.kind, NodeKind::Fortress { .. }))
+            .count();
+        assert_eq!(
+            hits, 1,
+            "{name}: expected exactly one Fortress entry, found {hits} — typo, or not a fortress",
+        );
+    }
+}

--- a/src/randomize/node_catalog/tests.rs
+++ b/src/randomize/node_catalog/tests.rs
@@ -251,3 +251,43 @@ fn test_print_catalog() {
     }
     eprintln!("  Total:       {}", catalog.entries.len());
 }
+
+/// Every name in `FRIENDLIER_BLOCKED_LEVELS` must resolve, or the option
+/// silently blocks nothing. The list is written in catalog names (the ones
+/// `testrom --list` prints) precisely so it can be read against the game, and
+/// this is the guard that makes a typo fail loudly instead of quietly.
+///
+/// Chest and hand levels are barred outright: the player has to reach those to
+/// collect a one-off inventory item, so removing one from the pool would put
+/// the item out of reach entirely.
+#[test]
+fn friendlier_blocklist_resolves() {
+    let Some(rom) = load_rom() else {
+        eprintln!("reference ROM not present — skipping friendlier_blocklist_resolves");
+        return;
+    };
+    let catalog = NodeCatalog::build(&rom, false);
+
+    for &name in crate::randomize::rom_data::FRIENDLIER_BLOCKED_LEVELS {
+        let hits: Vec<&CatalogEntry> = catalog
+            .entries
+            .iter()
+            .filter(|e| e.name == name && matches!(e.kind, NodeKind::Level))
+            .collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "{name}: expected exactly one Level entry, found {} — typo, or the name is not a level",
+            hits.len(),
+        );
+        let e = hits[0];
+        assert!(
+            !crate::randomize::rom_data::is_chest_level(e.world_idx, e.entry_idx),
+            "{name} is a chest level — blocking it puts its inventory item out of reach",
+        );
+        assert!(
+            !crate::randomize::rom_data::is_hand_level(e.world_idx, e.entry_idx),
+            "{name} is a hand level — blocking it puts its item drop out of reach",
+        );
+    }
+}

--- a/src/randomize/overworld_writer/assign.rs
+++ b/src/randomize/overworld_writer/assign.rs
@@ -160,11 +160,45 @@ pub(super) fn assign_pool<R: Rng>(
     // that's fine — the player must use the normal exit (beat Boom-Boom)
     // to open the lock.
     let mut preassigned_forts: HashMap<(usize, usize), usize> = HashMap::new();
-    if let Some(&(safe_wi, safe_section)) = safe_slots.choose(rng) {
-        preassigned_forts.insert((safe_wi, safe_section), fort_1f_pi);
+    if let Some(&slot) = safe_slots.choose(rng) {
+        safe_slots.retain(|&s| s != slot);
+        preassigned_forts.insert(slot, fort_1f_pi);
     } else {
         // No safe slot available — return 1-F to the regular pool.
         fort_pool.push(fort_1f_pi);
+    }
+
+    // Friendlier Levels, fortress half: park the harshest forts on the safe
+    // slots 1-F did not take, so their locks can stay shut and the player can
+    // route around them.
+    //
+    // A ladder rather than a set, because supply is finite and 1-F has already
+    // taken one. `FRIENDLIER_OPTIONAL_FORTS` is walked in order and each entry
+    // takes a remaining safe slot; when they run out the rest of the ladder is
+    // simply left required. Measured over 300 seeds, 99% offer the three safe
+    // slots this wants and none offered fewer than two, so in practice only the
+    // tail ever misses.
+    //
+    // Unlike 1-F this is a preference, never a correctness requirement: these
+    // forts open their locks normally, so a missed slot costs the player a
+    // detour rather than the run. That is also why it is fine that
+    // `secret_exit_safe` is computed one lock at a time — two safe locks in one
+    // world are not *jointly* guaranteed safe, but nothing here is ever sealed
+    // permanently, so the player can always go back and beat one.
+    if friendlier_levels {
+        for &name in rom_data::FRIENDLIER_OPTIONAL_FORTS {
+            let Some(&slot) = safe_slots.choose(rng) else {
+                break; // no safe slots left — the rest of the ladder stays required
+            };
+            let Some(pos) = fort_pool
+                .iter()
+                .position(|&pi| catalog.entries[pickup.pool[pi].catalog_idx].name == name)
+            else {
+                continue; // not in the pool this run
+            };
+            safe_slots.retain(|&s| s != slot);
+            preassigned_forts.insert(slot, fort_pool.remove(pos));
+        }
     }
 
     // A level that hands out a one-off inventory item: the chest levels

--- a/src/randomize/overworld_writer/assign.rs
+++ b/src/randomize/overworld_writer/assign.rs
@@ -78,7 +78,7 @@ pub(super) fn assign_pool<R: Rng>(
     rng: &mut R,
     flags: WriteFlags,
 ) -> Vec<WorldAssignments> {
-    let WriteFlags { shuffle_hammer_bros, .. } = flags;
+    let WriteFlags { shuffle_hammer_bros, friendlier_levels, .. } = flags;
     let pickup = data.pickup;
     let catalog = data.catalog;
     // Partition pool by kind.
@@ -167,6 +167,48 @@ pub(super) fn assign_pool<R: Rng>(
         fort_pool.push(fort_1f_pi);
     }
 
+    // A level that hands out a one-off inventory item: the chest levels
+    // (rom_data::CHEST_LEVELS — 3-7 Cloud, 5-1 Music Box, 8-Tank Star; 1F is
+    // listed too but is a fortress and never fills a regular-level slot) and
+    // the W8 hand rooms (8-Hnd1/2/3). Two rules key off this:
+    //
+    //  - Never dealt twice. A second copy hands the item out twice.
+    //  - Never disguised as a troll pipe. Those don't clear when beaten, so
+    //    the hand rooms could be farmed for items, and a chest level hidden
+    //    behind a pipe tile is missed by players who skip them.
+    let holds_unique_item = |pi: usize| -> bool {
+        let ce = &catalog.entries[pickup.pool[pi].catalog_idx];
+        rom_data::is_hand_level(ce.world_idx, ce.entry_idx)
+            || rom_data::is_chest_level(ce.world_idx, ce.entry_idx)
+    };
+
+    // Friendlier Levels: hold the harshest levels out of the deck, then refill
+    // it so the draw still reaches VANILLA_LEVEL_COUNT.
+    //
+    // Refilling is mandatory, not cosmetic: the builder places exactly
+    // VANILLA_LEVEL_COUNT levels every seed and the draw below is a bare
+    // `pop_front().expect(...)`, so a short deck panics. Beta stages already
+    // leave the deck oversized (they are appended without raising the number
+    // drawn), so they absorb the removals first and only the shortfall becomes
+    // duplicates — which is why `short` is a saturating subtraction rather
+    // than the blocklist length.
+    //
+    // A duplicate is just the same pool index dealt twice. The writer reads
+    // the level entry through it, so both slots get the same level; nothing
+    // needs a synthetic catalog entry.
+    if friendlier_levels {
+        level_pool.retain(|&pi| {
+            !rom_data::is_friendlier_blocked(&catalog.entries[pickup.pool[pi].catalog_idx].name)
+        });
+        let sources: Vec<usize> =
+            level_pool.iter().copied().filter(|&pi| !holds_unique_item(pi)).collect();
+        let short = VANILLA_LEVEL_COUNT.saturating_sub(level_pool.len());
+        // Without replacement, so no level is dealt a third time. `sources` is
+        // far larger than `short` for any sane blocklist; the deck-length
+        // assertion in the tests is what holds that true.
+        level_pool.extend(sources.choose_multiple(rng, short).copied());
+    }
+
     // Shuffle remaining fortress and level pools.
     fort_pool.as_mut_slice().shuffle(rng);
     level_pool.as_mut_slice().shuffle(rng);
@@ -179,24 +221,6 @@ pub(super) fn assign_pool<R: Rng>(
 
     let mut fort_iter = fort_pool.into_iter();
     let mut level_pool: VecDeque<usize> = level_pool.into();
-
-    // Troll pipes don't clear when beaten, so a slot stamped as a troll pipe
-    // can be replayed infinitely. We exclude two families of levels from the
-    // troll-pipe assignment pool:
-    //
-    //  - W8 Hand levels (8-Hnd1/2/3): short bonus rooms that drop items, so
-    //    re-entering the pipe would let the player farm items.
-    //
-    //  - Chest levels (rom_data::CHEST_LEVELS): the player needs to find these
-    //    levels to collect the inventory item. Disguising them as pipes hides
-    //    them from players who skip pipe-look tiles. Includes 3-7 (Cloud),
-    //    5-1 (Music Box), 8-Tank (Star). 1F is also in the list but is a
-    //    fortress, never a regular-level slot.
-    let is_troll_pipe_ineligible = |pi: usize| -> bool {
-        let ce = &catalog.entries[pickup.pool[pi].catalog_idx];
-        rom_data::is_hand_level(ce.world_idx, ce.entry_idx)
-            || rom_data::is_chest_level(ce.world_idx, ce.entry_idx)
-    };
 
     let mut assignments: Vec<WorldAssignments> = Vec::with_capacity(8);
 
@@ -242,7 +266,7 @@ pub(super) fn assign_pool<R: Rng>(
 
         for slot in ordered {
             let (pi, demoted) =
-                take_level_slot(&mut level_pool, slot.is_troll_pipe, is_troll_pipe_ineligible);
+                take_level_slot(&mut level_pool, slot.is_troll_pipe, holds_unique_item);
             if demoted {
                 demoted_troll_pipes.insert(slot.pos);
             }

--- a/src/randomize/overworld_writer/mod.rs
+++ b/src/randomize/overworld_writer/mod.rs
@@ -11,7 +11,9 @@ use crate::PiranhaMode;
 use crate::rom::Rom;
 
 use super::node_catalog::NodeKind;
-use super::overworld_build::{BuildResult, BuiltWorld, OverworldData, SlotKind, bfs_ordered};
+use super::overworld_build::{
+    BuildResult, BuiltWorld, OverworldData, SlotKind, VANILLA_LEVEL_COUNT, bfs_ordered,
+};
 use super::overworld_helpers;
 use super::pipe_helpers;
 use super::rom_data::{
@@ -132,4 +134,7 @@ pub(crate) fn write_overworld<R: Rng>(
 pub(crate) struct WriteFlags {
     pub shuffle_hammer_bros: bool,
     pub piranha: PiranhaMode,
+    /// Friendlier Levels: drop `FRIENDLIER_BLOCKED_LEVELS` from the level deck
+    /// and refill it with duplicates of what remains.
+    pub friendlier_levels: bool,
 }

--- a/src/randomize/overworld_writer/tests.rs
+++ b/src/randomize/overworld_writer/tests.rs
@@ -248,6 +248,114 @@ fn test_friendlier_levels_blocks_and_refills() {
     }
 }
 
+/// Friendlier Levels' fortress half: 7F2 then 8F1 are parked on
+/// secret-exit-safe slots so their locks can stay shut, leaving them beatable
+/// but off the critical path.
+///
+/// Two invariants, and between them they pin the whole degradation story:
+///
+///  - Supply. 1-F takes a safe slot first and unconditionally (its secret exit
+///    makes a non-safe slot a softlock, not an inconvenience), so with `s` safe
+///    locks in the seed the ladder can place `min(2, s - 1)`. Asserting the
+///    exact count is what proves the ladder never steals 1-F's slot and never
+///    silently gives up while supply remains.
+///  - Order. 8F1 is only served once 7F2 is, so a short seed always costs the
+///    tail of the ladder rather than a random one of the two.
+#[test]
+fn test_friendlier_levels_fort_ladder() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+    let catalog = node_catalog::NodeCatalog::build(&rom, false);
+    let pickup = standard_pickup(&rom, &catalog);
+
+    let mut placed_hist = [0usize; 3];
+    for seed in 0u64..120 {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let build = overworld_build::build(
+            &rom,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            standard_build_flags(),
+        );
+
+        // Safe fort slots, as (world, section) — the same set assign_pool draws
+        // from. Every fort has a lock, so a fort NOT on one of these is
+        // required by construction.
+        let safe: HashSet<(usize, usize)> = (0..8)
+            .flat_map(|wi| {
+                build.worlds[wi]
+                    .locks
+                    .iter()
+                    .filter(|l| l.secret_exit_safe)
+                    .map(move |l| (wi, l.fort_section))
+            })
+            .collect();
+
+        let assignments = assign_pool(
+            &rom,
+            &build,
+            &OverworldData { pickup: &pickup, catalog: &catalog },
+            &mut rng,
+            WriteFlags { friendlier_levels: true, ..Default::default() },
+        );
+
+        // Which of the ladder forts landed on a safe slot.
+        let mut on_safe: HashSet<&str> = HashSet::new();
+        for (wi, wa) in assignments.iter().enumerate() {
+            for a in &wa.fortress {
+                let name = &catalog.entries[pickup.pool[a.pool_idx].catalog_idx].name;
+                let Some(slot) = build.worlds[wi]
+                    .slots
+                    .iter()
+                    .find(|s| s.kind == overworld_build::SlotKind::Fortress && s.pos == a.pos)
+                else {
+                    continue;
+                };
+                if safe.contains(&(wi, slot.section))
+                    && rom_data::FRIENDLIER_OPTIONAL_FORTS.contains(&name.as_str())
+                {
+                    on_safe.insert(
+                        rom_data::FRIENDLIER_OPTIONAL_FORTS
+                            .iter()
+                            .find(|n| *n == name)
+                            .expect("just matched"),
+                    );
+                }
+            }
+        }
+
+        let expected = safe.len().saturating_sub(1).min(rom_data::FRIENDLIER_OPTIONAL_FORTS.len());
+        assert_eq!(
+            on_safe.len(),
+            expected,
+            "seed {seed}: {} safe locks, so the ladder should place {expected}, placed {:?}",
+            safe.len(),
+            on_safe,
+        );
+
+        // Ladder order: nothing is served before the entry ahead of it.
+        for pair in rom_data::FRIENDLIER_OPTIONAL_FORTS.windows(2) {
+            if on_safe.contains(pair[1]) {
+                assert!(
+                    on_safe.contains(pair[0]),
+                    "seed {seed}: {} got a safe slot before {}",
+                    pair[1],
+                    pair[0],
+                );
+            }
+        }
+
+        placed_hist[on_safe.len()] += 1;
+    }
+
+    eprintln!(
+        "fort ladder over 120 seeds: both optional {}, one {}, neither {}",
+        placed_hist[2], placed_hist[1], placed_hist[0],
+    );
+}
+
 #[test]
 fn test_write_deterministic() {
     let rom = match load_rom() {

--- a/src/randomize/overworld_writer/tests.rs
+++ b/src/randomize/overworld_writer/tests.rs
@@ -166,6 +166,88 @@ fn test_troll_pipes_never_assigned_hand_levels() {
     }
 }
 
+/// Friendlier Levels must (a) actually keep the blocked levels off the map and
+/// (b) leave the deck long enough to deal. The draw is a bare
+/// `pop_front().expect(...)` against a fixed `VANILLA_LEVEL_COUNT` of slots, so
+/// a short deck panics rather than degrading — which makes the count assertion
+/// as load-bearing as the blocklist one.
+///
+/// Both beta arms are checked because they refill differently: with beta stages
+/// on the deck is already oversized and absorbs the removals, so no duplicate
+/// is needed; with them off every removal becomes a duplicate.
+#[test]
+fn test_friendlier_levels_blocks_and_refills() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+
+    for beta in [false, true] {
+        let catalog = node_catalog::NodeCatalog::build(&rom, beta);
+        let pickup = standard_pickup(&rom, &catalog);
+
+        for seed in 0u64..16 {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let build = overworld_build::build(
+                &rom,
+                &OverworldData { pickup: &pickup, catalog: &catalog },
+                &mut rng,
+                standard_build_flags(),
+            );
+            let assignments = assign_pool(
+                &rom,
+                &build,
+                &OverworldData { pickup: &pickup, catalog: &catalog },
+                &mut rng,
+                WriteFlags { friendlier_levels: true, ..Default::default() },
+            );
+
+            let placed: Vec<usize> =
+                assignments.iter().flat_map(|wa| wa.level.iter().map(|a| a.pool_idx)).collect();
+
+            assert_eq!(
+                placed.len(),
+                overworld_build::VANILLA_LEVEL_COUNT,
+                "beta={beta} seed {seed}: dealt {} levels, expected {}",
+                placed.len(),
+                overworld_build::VANILLA_LEVEL_COUNT,
+            );
+
+            let mut seen: HashMap<usize, usize> = HashMap::new();
+            for pi in &placed {
+                let ce = &catalog.entries[pickup.pool[*pi].catalog_idx];
+                assert!(
+                    !rom_data::is_friendlier_blocked(&ce.name),
+                    "beta={beta} seed {seed}: blocked level {} was placed",
+                    ce.name,
+                );
+                *seen.entry(*pi).or_insert(0) += 1;
+            }
+
+            // Nothing is dealt three times, and nothing holding a one-off item
+            // is dealt twice.
+            for (&pi, &n) in &seen {
+                let ce = &catalog.entries[pickup.pool[pi].catalog_idx];
+                assert!(n <= 2, "beta={beta} seed {seed}: {} dealt {n} times", ce.name);
+                if n > 1 {
+                    assert!(
+                        !rom_data::is_chest_level(ce.world_idx, ce.entry_idx)
+                            && !rom_data::is_hand_level(ce.world_idx, ce.entry_idx),
+                        "beta={beta} seed {seed}: {} holds a one-off item and was dealt twice",
+                        ce.name,
+                    );
+                }
+            }
+
+            // Beta stages absorb the removals; without them the shortfall is
+            // made up with duplicates, one per blocked level.
+            let dupes = placed.len() - seen.len();
+            let expected = if beta { 0 } else { rom_data::FRIENDLIER_BLOCKED_LEVELS.len() };
+            assert_eq!(dupes, expected, "beta={beta} seed {seed}: {dupes} duplicates");
+        }
+    }
+}
+
 #[test]
 fn test_write_deterministic() {
     let rom = match load_rom() {
@@ -877,7 +959,11 @@ fn test_march_veto_pipeline_writes_registry() {
         &build,
         &data,
         &mut rng,
-        WriteFlags { piranha: PiranhaMode::Wild, shuffle_hammer_bros: true },
+        WriteFlags {
+            piranha: PiranhaMode::Wild,
+            shuffle_hammer_bros: true,
+            friendlier_levels: false,
+        },
     );
 
     assert_veto_hook_installed(&out);

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -355,6 +355,26 @@ pub(crate) fn is_friendlier_blocked(name: &str) -> bool {
     FRIENDLIER_BLOCKED_LEVELS.contains(&name)
 }
 
+/// Fortresses **Friendlier Levels** tries to make optional, in the order it
+/// tries. Keyed by `NodeCatalog` name — note forts are named `7F2` / `8F1`,
+/// with no dash, unlike the levels above.
+///
+/// A fortress can't be held out of its pool the way a level can: every fort
+/// has a lock (asserted in `overworld_build::tests`) and the full roster is a
+/// redeal-screened invariant, so removals never ship. Instead these are parked
+/// on a slot whose lock is `secret_exit_safe` — one the world stays completable
+/// without — which leaves the fort on the map and beatable but no longer on the
+/// critical path.
+///
+/// **Ordered, and the order is the whole point.** 1-F claims a safe slot first
+/// and unconditionally: its secret exit permanently prevents the lock FX, so a
+/// non-safe slot is a softlock rather than an inconvenience. These two are only
+/// preferences — the fort works normally, and a player who skips it can always
+/// come back — so they take what is left, in this order. Measured over 300
+/// seeds, 99% have the three safe slots this wants; in the rest the tail of the
+/// ladder simply stays required.
+pub(crate) const FRIENDLIER_OPTIONAL_FORTS: &[&str] = &["7F2", "8F1"];
+
 /// True if the given vanilla `(world_idx, entry_idx)` is in [`CHEST_LEVELS`].
 pub(crate) fn is_chest_level(world_idx: usize, entry_idx: usize) -> bool {
     CHEST_LEVELS.iter().any(|&(w, e, _)| w == world_idx && e == entry_idx)

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -334,6 +334,27 @@ pub(crate) const CHEST_LEVELS: &[(usize, usize, &str)] = &[
     (7, 16, "8-Hnd3 (chest)"),
 ];
 
+/// Levels held back from the shuffle pool by the **Friendlier Levels** option:
+/// the ones judged too punishing to hand a newcomer at random. Keyed by
+/// `NodeCatalog` name, which is what `testrom --list` prints, so this list can
+/// be checked against the game by eye.
+///
+/// Every name must resolve to exactly one `NodeKind::Level` and must not be a
+/// chest or hand level — `friendlier_blocklist_resolves` asserts both, so a
+/// typo here fails a test rather than silently blocking nothing.
+///
+/// Three of these (5-3, 6-6, 7-5) are also antechamber hosts. Blocking a level
+/// removes its *lobby*; the lobby shuffle moves *interiors* independently, so
+/// these are withheld from that pool too (see `antechambers::shuffle`) — else
+/// the blocked interior gets donated to a reachable lobby and played anyway,
+/// while whatever was donated to the blocked lobby is lost from the seed.
+pub(crate) const FRIENDLIER_BLOCKED_LEVELS: &[&str] = &["2-3", "5-3", "6-6", "7-5", "7-8", "8-1"];
+
+/// True if `name` is in [`FRIENDLIER_BLOCKED_LEVELS`].
+pub(crate) fn is_friendlier_blocked(name: &str) -> bool {
+    FRIENDLIER_BLOCKED_LEVELS.contains(&name)
+}
+
 /// True if the given vanilla `(world_idx, entry_idx)` is in [`CHEST_LEVELS`].
 pub(crate) fn is_chest_level(world_idx: usize, entry_idx: usize) -> bool {
     CHEST_LEVELS.iter().any(|&(w, e, _)| w == world_idx && e == entry_idx)

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -401,9 +401,12 @@ mod payload {
         /// vanilla rooms — deliberate, and the reason this is a plain appended
         /// bit rather than an inverted one.
         pub(super) shuffle_big_q_rooms: bool,
+        /// Hazard-introduction limit. Zero is `Off`, so an older key decodes
+        /// to the unrestricted picks it was minted with.
+        pub(super) limit_hazards: HazardLimit,
 
         // --- Reserve ---
-        // 145 bits. Adding an option is: declare it immediately above this
+        // 143 bits. Adding an option is: declare it immediately above this
         // block, then take the same number of bits off `B19`. An older key
         // simply has those bits zero, which is "off" for a bool and the default
         // for every enum here, so it stays a correct key for the settings it
@@ -418,7 +421,7 @@ mod payload {
         #[skip]
         __: B128,
         #[skip]
-        __: B17,
+        __: B15,
     }
 }
 
@@ -459,7 +462,7 @@ impl Options {
             hammer_breaks_locks, hammer_breaks_bridges, more_hammer_rocks,
             eights_are_wild, troll_pipes, antechamber_shuffle,
             ground, shell, flying, piranhas, ghosts, thwomps, rotodiscs,
-            cannons, water, bros, hb_encounters,
+            cannons, water, bros, hb_encounters, limit_hazards,
             fire_flower, piranha_shuffle, wild_injections,
             starting_lives, world_count, starting_items,
             // Not encoded — see NOT_ENCODED for the reason on each.
@@ -522,6 +525,7 @@ impl Options {
             .with_water(*water)
             .with_bros(*bros)
             .with_hb_encounters(*hb_encounters)
+            .with_limit_hazards(*limit_hazards)
             .with_fire_flower(*fire_flower)
             .with_piranha_shuffle(*piranha_shuffle)
             .with_wild_sun(has(WildChaser::Sun))
@@ -610,6 +614,7 @@ impl Options {
             water: f.water_or_err().unwrap_or_default(),
             bros: f.bros_or_err().unwrap_or_default(),
             hb_encounters: f.hb_encounters_or_err().unwrap_or_default(),
+            limit_hazards: f.limit_hazards_or_err().unwrap_or_default(),
             fire_flower: f.fire_flower_or_err().unwrap_or_default(),
             piranha_shuffle: f.piranha_shuffle_or_err().unwrap_or_default(),
             wild_injections: chasers,

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -404,9 +404,11 @@ mod payload {
         /// Hazard-introduction limit. Zero is `Off`, so an older key decodes
         /// to the unrestricted picks it was minted with.
         pub(super) limit_hazards: HazardLimit,
+        /// Friendlier Levels: hold the harshest levels out of the shuffle pool.
+        pub(super) friendlier_levels: bool,
 
         // --- Reserve ---
-        // 143 bits. Adding an option is: declare it immediately above this
+        // 142 bits. Adding an option is: declare it immediately above this
         // block, then take the same number of bits off `B19`. An older key
         // simply has those bits zero, which is "off" for a bool and the default
         // for every enum here, so it stays a correct key for the settings it
@@ -421,7 +423,7 @@ mod payload {
         #[skip]
         __: B128,
         #[skip]
-        __: B15,
+        __: B14,
     }
 }
 
@@ -462,7 +464,7 @@ impl Options {
             hammer_breaks_locks, hammer_breaks_bridges, more_hammer_rocks,
             eights_are_wild, troll_pipes, antechamber_shuffle,
             ground, shell, flying, piranhas, ghosts, thwomps, rotodiscs,
-            cannons, water, bros, hb_encounters, limit_hazards,
+            cannons, water, bros, hb_encounters, limit_hazards, friendlier_levels,
             fire_flower, piranha_shuffle, wild_injections,
             starting_lives, world_count, starting_items,
             // Not encoded — see NOT_ENCODED for the reason on each.
@@ -526,6 +528,7 @@ impl Options {
             .with_bros(*bros)
             .with_hb_encounters(*hb_encounters)
             .with_limit_hazards(*limit_hazards)
+            .with_friendlier_levels(*friendlier_levels)
             .with_fire_flower(*fire_flower)
             .with_piranha_shuffle(*piranha_shuffle)
             .with_wild_sun(has(WildChaser::Sun))
@@ -615,6 +618,7 @@ impl Options {
             bros: f.bros_or_err().unwrap_or_default(),
             hb_encounters: f.hb_encounters_or_err().unwrap_or_default(),
             limit_hazards: f.limit_hazards_or_err().unwrap_or_default(),
+            friendlier_levels: f.friendlier_levels(),
             fire_flower: f.fire_flower_or_err().unwrap_or_default(),
             piranha_shuffle: f.piranha_shuffle_or_err().unwrap_or_default(),
             wild_injections: chasers,

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -17,8 +17,9 @@ use options::*;
 // Public API re-exported by the crate root (see lib.rs).
 pub use flag_key::{current_flag_key_version, flag_key_fields, flag_key_version_of};
 pub use options::{
-    EnemyMode, FireFlowerMode, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY, ITEMS,
-    Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser, item_display_name, item_id,
+    EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
+    ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser,
+    item_display_name, item_id,
 };
 
 #[cfg(test)]

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -212,7 +212,12 @@ fn randomize_inner(
     // of the overworld builder and the enemy/powerup passes.
     if antechamber_shuffle {
         rom.set_tag("levels/antechambers");
-        randomize::antechambers::shuffle(rom, &mut rng, options.include_beta_stages);
+        randomize::antechambers::shuffle(
+            rom,
+            &mut rng,
+            options.include_beta_stages,
+            options.friendlier_levels,
+        );
     }
 
     // Koopaling stability patches — needed whenever Koopalings may load in a
@@ -309,6 +314,7 @@ fn randomize_inner(
         randomize::overworld_writer::WriteFlags {
             shuffle_hammer_bros: options.shuffle_hammer_bros,
             piranha: options.piranha_shuffle,
+            friendlier_levels: options.friendlier_levels,
         },
     );
 

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -575,6 +575,11 @@ pub struct Options {
     /// wasn't designed with. See [`HazardLimit`].
     #[serde(default)]
     pub limit_hazards: HazardLimit,
+    /// Hold the harshest levels out of the shuffle pool, refilling it with
+    /// beta stages (when they are on) and then with duplicates of the levels
+    /// that remain. See `FRIENDLIER_BLOCKED_LEVELS` for the list.
+    #[serde(default)]
+    pub friendlier_levels: bool,
     /// Which level-wide chasers may be seeded into a fraction of real levels
     /// (CHR-compatible). Empty = off. See [`WildChaser`].
     #[serde(default)]
@@ -654,6 +659,7 @@ impl Default for Options {
             bros: EnemyMode::Shuffle,
             hb_encounters: EnemyMode::Off,
             limit_hazards: HazardLimit::Off,
+            friendlier_levels: false,
             wild_injections: Vec::new(),
             starting_lives: default_starting_lives(),
             starting_items: Vec::new(),

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -170,6 +170,48 @@ pub enum PiranhaMode {
     Wild,
 }
 
+/// How hard to stop the randomizer from *introducing* hazards.
+///
+/// A "hazard" is one of the `HAZARD_CATEGORIES` — thwomps, Lava Lotus,
+/// Ptooie, nippers, Hot Foot, bros — the same taxonomy the curated
+/// `ExcludeHazards` entries use. The rule is additive-only in every mode: a
+/// hazard is only blocked where the slot's *vanilla* enemy wasn't the same
+/// category, so designed-in hazards survive and within-category shuffle (e.g.
+/// thwomp variants) still works. Nothing is ever removed from vanilla.
+///
+/// `Sparse` is the trainer rung: a level may gain the occasional hazard, never
+/// a wall of them. `All` blocks every introduction.
+///
+/// Only affects in-level enemy picks. Hammer Bro map encounters draw from
+/// their own curated pools (see `randomize_hb_wild_segment`) and are left
+/// alone, as are wild-injection chasers, which aren't in the taxonomy.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    modular_bitfield::Specifier,
+)]
+#[bits = 2]
+#[serde(rename_all = "snake_case")]
+pub enum HazardLimit {
+    /// Vanilla behavior — the randomizer may introduce hazards freely.
+    #[default]
+    Off,
+    /// At most `MAX_ADDED_HAZARDS_PER_SEGMENT` introduced hazard per room.
+    ///
+    /// Named `Sparse` rather than `Some` so it never reads as `Option::Some`
+    /// at a match site; the serde/CLI/web value stays "some".
+    #[serde(rename = "some")]
+    Sparse,
+    /// Never introduce a hazard.
+    All,
+}
+
 /// A level-wide chaser the wild-injection pass can seed into a level. The
 /// option is the *set* of these the player allowed — an empty set is off.
 ///
@@ -529,6 +571,10 @@ pub struct Options {
     /// All enemies in Hammer Bro encounter segments
     #[serde(default = "default_off")]
     pub hb_encounters: EnemyMode,
+    /// How hard to stop the class swaps from introducing a hazard the level
+    /// wasn't designed with. See [`HazardLimit`].
+    #[serde(default)]
+    pub limit_hazards: HazardLimit,
     /// Which level-wide chasers may be seeded into a fraction of real levels
     /// (CHR-compatible). Empty = off. See [`WildChaser`].
     #[serde(default)]
@@ -607,6 +653,7 @@ impl Default for Options {
             water: EnemyMode::Shuffle,
             bros: EnemyMode::Shuffle,
             hb_encounters: EnemyMode::Off,
+            limit_hazards: HazardLimit::Off,
             wild_injections: Vec::new(),
             starting_lives: default_starting_lives(),
             starting_items: Vec::new(),

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1082,6 +1082,7 @@ fn fnv1a(data: &[u8]) -> u64 {
 fn all_off_options() -> Options {
     Options {
         fire_flower: FireFlowerMode::Off,
+        limit_hazards: HazardLimit::Off,
         piranha_shuffle: PiranhaMode::Off,
         powerups: false,
         palettes: false,
@@ -1151,6 +1152,7 @@ fn all_off_options() -> Options {
 fn all_on_options() -> Options {
     Options {
         fire_flower: FireFlowerMode::On,
+        limit_hazards: HazardLimit::All,
         piranha_shuffle: PiranhaMode::On,
         powerups: true,
         palettes: false,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1082,6 +1082,7 @@ fn fnv1a(data: &[u8]) -> u64 {
 fn all_off_options() -> Options {
     Options {
         fire_flower: FireFlowerMode::Off,
+        friendlier_levels: false,
         limit_hazards: HazardLimit::Off,
         piranha_shuffle: PiranhaMode::Off,
         powerups: false,
@@ -1153,6 +1154,7 @@ fn all_on_options() -> Options {
     Options {
         fire_flower: FireFlowerMode::On,
         limit_hazards: HazardLimit::All,
+        friendlier_levels: true,
         piranha_shuffle: PiranhaMode::On,
         powerups: true,
         palettes: false,

--- a/web/options.js
+++ b/web/options.js
@@ -351,7 +351,7 @@ export const SCHEMA = [
 		group: "enemies", inFlagKey: true },
 	{ id: "friendlier_levels", type: "bool", default: false,
 		label: "Friendlier Levels",
-		tip: "Keeps the roughest levels out of the shuffle — 2-3, 5-3, 6-6, 7-5, 7-8 and 8-1. Their slots go to beta stages if you have those on, otherwise to a second visit to a level already in the seed.",
+		tip: "Keeps the roughest levels out of the shuffle — 2-3, 5-3, 6-6, 7-5, 7-8 and 8-1. Their slots go to beta stages if you have those on, otherwise to a second visit to a level already in the seed. Two fortresses, 7F2 and 8F1, are usually made optional rather than removed: still there, still beatable, just not in your way.",
 		group: "map", inFlagKey: true },
 	{ id: "limit_hazards", type: "tri", options: OFF_SOME_ALL, default: "off",
 		label: "Limit Hazards",

--- a/web/options.js
+++ b/web/options.js
@@ -349,6 +349,10 @@ export const SCHEMA = [
 		label: "HB Encounters",
 		tip: "All enemies in overworld Hammer Bro mini-battles",
 		group: "enemies", inFlagKey: true },
+	{ id: "friendlier_levels", type: "bool", default: false,
+		label: "Friendlier Levels",
+		tip: "Keeps the roughest levels out of the shuffle — 2-3, 5-3, 6-6, 7-5, 7-8 and 8-1. Their slots go to beta stages if you have those on, otherwise to a second visit to a level already in the seed.",
+		group: "map", inFlagKey: true },
 	{ id: "limit_hazards", type: "tri", options: OFF_SOME_ALL, default: "off",
 		label: "Limit Hazards",
 		tip: "Stops swaps from dropping nippers, Ptooies, thwomps, Hot Foots or Bros into levels that weren't built for them. Some allows the occasional one, All allows none. Hazards that were always there stay put.",
@@ -552,7 +556,7 @@ export const PRESETS = [
 			hammer_vulnerable_koopalings: true,
 		} },
 	{ id: "beginner", label: "Beginner Friendly",
-		tip: "Gentler ruleset: extra lives and items, no added hazards, no game-over penalty, no hand traps or troll pipes.",
+		tip: "Gentler ruleset: extra lives and items, no added hazards, the roughest levels sat out, no game-over penalty, no hand traps or troll pipes.",
 		overrides: {
 			starting_lives: 20, starting_items: [1, 2, 3],
 			infinite_mushroom_houses: true, fast_mushroom_house: true,
@@ -567,6 +571,7 @@ export const PRESETS = [
 			// that directly, so the class goes back on and Boo <-> Dry Bones
 			// variety comes with it.
 			limit_hazards: "all", ghosts: "shuffle", hb_encounters: "shuffle",
+			friendlier_levels: true,
 			world_order: true, random_koopalings: true,
 			hammer_vulnerable_koopalings: true,
 		} },

--- a/web/options.js
+++ b/web/options.js
@@ -68,6 +68,15 @@ const WILD_INJECTION_TOGGLES = [
 	{ value: "bass", label: "Bass" },
 ];
 
+// Off / Some / All pill for Limit Hazards. Values match the Rust `HazardLimit`
+// enum's serde representation ("some" is the `Sparse` variant, renamed there
+// only so it never reads as `Option::Some`).
+const OFF_SOME_ALL = [
+	{ value: "off", label: "Off" },
+	{ value: "some", label: "Some" },
+	{ value: "all", label: "All" },
+];
+
 // Off / On / Wild pill for Random Fire Flower. "Wild" widens the pool to also
 // include the Small/Big downgrade outcomes. Values match the Rust
 // `FireFlowerMode` enum's serde representation.
@@ -340,6 +349,10 @@ export const SCHEMA = [
 		label: "HB Encounters",
 		tip: "All enemies in overworld Hammer Bro mini-battles",
 		group: "enemies", inFlagKey: true },
+	{ id: "limit_hazards", type: "tri", options: OFF_SOME_ALL, default: "off",
+		label: "Limit Hazards",
+		tip: "Stops swaps from dropping nippers, Ptooies, thwomps, Hot Foots or Bros into levels that weren't built for them. Some allows the occasional one, All allows none. Hazards that were always there stay put.",
+		group: "enemies", inFlagKey: true },
 	{ id: "wild_injections", type: "toggles", options: WILD_INJECTION_TOGGLES,
 		default: [],
 		label: "Wild Injections",
@@ -539,7 +552,7 @@ export const PRESETS = [
 			hammer_vulnerable_koopalings: true,
 		} },
 	{ id: "beginner", label: "Beginner Friendly",
-		tip: "Gentler ruleset: extra lives and items, no game-over penalty, no hand traps or troll pipes.",
+		tip: "Gentler ruleset: extra lives and items, no added hazards, no game-over penalty, no hand traps or troll pipes.",
 		overrides: {
 			starting_lives: 20, starting_items: [1, 2, 3],
 			infinite_mushroom_houses: true, fast_mushroom_house: true,
@@ -549,7 +562,11 @@ export const PRESETS = [
 			hands_levels: false, troll_pipes: "off",
 			shuffle_spade_games: false, more_hammer_rocks: "on",
 			hammer_breaks_locks: "on", big_q_blocks: true,
-			ghosts: "off", hb_encounters: "shuffle",
+			// `ghosts` was "off" purely to stop Boo -> Hot Foot, the only
+			// hazard that class can produce in Shuffle. limit_hazards blocks
+			// that directly, so the class goes back on and Boo <-> Dry Bones
+			// variety comes with it.
+			limit_hazards: "all", ghosts: "shuffle", hb_encounters: "shuffle",
 			world_order: true, random_koopalings: true,
 			hammer_vulnerable_koopalings: true,
 		} },


### PR DESCRIPTION
Two opt-in options aimed at newer players, plus a guard that came out of building them. Every commit is independently reviewable; the third is a test-only fix for a gap the second left.

## Limit Hazards (`off` / `some` / `all`)

Stops enemy swaps from introducing a hazard a level wasn't designed with. The rule is the additive-only one the curated `ExcludeHazards` entries already use — `hazard_excluded(candidate, vanilla_at_slot)` — applied to every pick instead of one offset. A hazard whose category matches the slot's vanilla enemy is kept, so designed-in hazards survive and within-category shuffle (thwomp variants) still works. **Nothing vanilla is ever removed.**

`all` blocks every introduction; `some` allows one per `$FF`-bounded enemy run, so a player still meets a nipper and learns to handle it but never walks into a wall of them.

The implementation is one clause in `pick_replacement`'s `keep` — the single place every pick funnels through, so it covers the class pools, the wild pool and all four protection paths at once, and composes with the bertha cap and giant-red/chaser guards via the existing re-pick fallback. `SegmentLimits` carries it as `hazard_cap_full`, parallel to `cap_full`, which keeps the enum out of `picking.rs` entirely.

Deliberately scoped to in-level picks. HB mini-battles pass `hazard_cap_full: false` — those rooms are composed from their own curated pools, so there is no vanilla enemy to measure "introduced" against. Wild-injection chasers are untouched. A class set to `Off` still yields no pool, so the filter never forces a swap, which is what keeps the CHR pin model (`is_fixed` / `segment_pins`) completely unchanged.

Measured over 250 seeds of Max Chaos:

| | hazards added/seed | max in one segment |
|---|---|---|
| `off` | 140 | 25 |
| `some` | 52 | 1 |
| `all` | 0 | 0 |

Recommended unfiltered is 73/seed with up to 24 in one segment.

## Friendlier Levels

Holds six levels out of the shuffle pool — 2-3, 5-3, 6-6, 7-5, 7-8, 8-1 — and refills the deck so the map stays as full as before.

Refilling is mandatory, not cosmetic: the builder places exactly `VANILLA_LEVEL_COUNT` levels every seed and the draw is a bare `pop_front().expect(...)`, so a short deck panics. Beta stages already leave the deck oversized, so they absorb the removals first and only the shortfall becomes duplicates — 6 duplicates with beta off, none with it on. A duplicate is the same pool index dealt twice; nothing needs a synthetic catalog entry.

Chest and hand levels are barred from both halves: blocking one puts its one-off item out of reach, duplicating one hands the item out twice. That is the same fact the troll-pipe rule keys off, so the two now share one predicate.

**The lobby-shuffle interaction is the part most worth reviewing.** Three of the six (5-3, 6-6, 7-5) are antechamber hosts, and they are withheld from that pool too. Blocking removes a level's *lobby*; `antechambers::shuffle` moves *interiors*, and its assignment is a full permutation. Leaving a blocked level in breaks both directions at once — its interior is donated to a lobby the player can still reach, so it gets played anyway, and whatever was donated to the blocked lobby sits behind a door that was never placed, dropping an unrelated level from the seed. Pool goes 11 → 8, or 12 → 9 with beta stages on.

It also makes two fortresses optional rather than absent, as a ladder: **7F2 then 8F1**. Forts can't be held out of their pool the way levels can — every fort has a lock and the full roster is a redeal-screened invariant — so they are parked on a lock the world stays completable without. Still on the map, still beatable, just off the critical path.

1-F has first claim, and the priority is load-bearing. Its secret exit permanently prevents the lock FX, so a non-safe slot is a *softlock*; these two only *prefer* one, since they open normally and a player who walks past can come back. That asymmetry is also why it does not matter that `secret_exit_safe` is computed one lock at a time — two safe locks in one world are not jointly guaranteed safe, but nothing here is ever sealed permanently.

Supply measured over 300 seeds: median 6 safe locks, range 2–11, three or more available in 99%. Over 120 seeds through the real assignment path: 118 both optional, 2 only 7F2, 0 neither. So in practice only 8F1 ever misses, in 1–2% of seeds, and then it simply stays required.

**Optional is not absent** — both forts stay enterable, so a player who walks into everything still plays them. The tooltip says so rather than implying removal.

## Namespace guard (test-only)

Friendlier Levels reaches both hooks by matching the blocklist against a *name*: `CatalogEntry.name` on the level deck, `Antechamber.name` in the lobby shuffle. That is what makes the list extensible without touching either filter — but nothing tied the two tables together, and `Antechamber.name` was documented as being "for panic messages", so a future entry could reasonably be spelled however read best.

A divergence there fails silently and asymmetrically: the level drops from the deck while its interior keeps circulating, so it is blocked in name only *and* an unrelated level loses its interior. The commit asserts the whole antechamber pool resolves to catalog names and marks the field load-bearing.

## Verification

- **404 tests pass**; zero clippy warnings on native *and* wasm32; `cargo fmt --check` clean.
- **Byte-identical output at defaults** against the pre-change build (seed 4242, `--no-palettes`, matching md5), so no existing seed moves. Pre-change flag keys decode to `off` and re-emit unchanged — zero is the default for both new fields, so no version bump.
- **Every guard mutation-tested**, since all these failure modes are silent:
  - neutering the hazard clause → 43,298 harness violations;
  - neutering the deck filter → 2-3 placed on seed 0;
  - neutering the antechamber filter → 5-3's interior reassigned;
  - serving the fort ladder in reverse → order assertion fires on seed 29;
  - dropping 1-F's slot reservation → the ladder overwrites it, fortress pool exhausts;
  - an en-dash in one antechamber name → namespace guard fires.
- The existing enemy protection suite runs in **both** Limit Hazards arms, so the point that turning the filter on costs none of the existing protections is checked rather than asserted.

## Presets

**Beginner Friendly** now uses Limit Hazards (`all`) and Friendlier Levels, and has its Ghosts class turned back on — it was disabled outright only to stop Boo → Hot Foot, which the filter now blocks directly, bringing Boo ↔ Dry Bones variety back. Flag me if you'd rather the preset stay as it was; the two options stand on their own.

## Not done

- The blocklist and the fort ladder are curated judgment calls, not measurements — worth a play before they settle.
- Nothing here touches pits, lava, munchers, autoscroll or bosses, which is why the enemy option is named for what it does rather than "Beginner".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW
