### PR TITLE
fix: raise the floor-ignoring flyer in closed bro rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@ deploys.
   Flag keys shared during the beta, when this ran unconditionally, now decode
   with it **off** — tick the box to get those seeds back.
 
+### Fixed
+
+- A randomized Hammer Bro encounter can no longer trap you in the floor. The
+  flying red Paratroopa ignores level geometry and sinks about seven tiles
+  below where it starts, so on a Bro's ground row it spent half its cycle
+  inside the floor — and hitting it as it climbed back out could leave you
+  stuck in the ground, in a room whose exit only appears once it is cleared.
+  It now starts high enough that the bottom of its dive lands *on* the floor.
+
 
 ## [1.2.1] - 2026-08-26
 

--- a/src/randomize/enemies/mod.rs
+++ b/src/randomize/enemies/mod.rs
@@ -158,12 +158,13 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
         }
 
         // A treasure box in the room means `Level_Event = 7`, which arms the
-        // Hammer Bro placeholder rewrite. Decided once from the segment's own
-        // vanilla contents, before any pick, so both paths below agree.
-        let no_hammer_bro = rewrites_hammer_bro(
-            seg_file_offset,
-            entries.iter().any(|e| e.obj_id == TREASURE_BOX_APPEAR),
-        );
+        // Hammer Bro placeholder rewrite — and also that the room is *closed*:
+        // the player cannot leave until it is empty, which is what makes a
+        // floor-ignoring enemy a softlock rather than a nuisance (see
+        // `place_hb_pick`). Decided once from the segment's own vanilla
+        // contents, before any pick, so every path below agrees.
+        let closed_room = entries.iter().any(|e| e.obj_id == TREASURE_BOX_APPEAR);
+        let no_hammer_bro = rewrites_hammer_bro(seg_file_offset, closed_room);
 
         // HB Wild: batch-assign enemies with stompability constraints.
         if is_hb_segment && opts.hb_encounters == EnemyMode::Wild && !big_q_only {
@@ -174,7 +175,7 @@ fn randomize_object_data<R: Rng>(rom: &mut Rom, rng: &mut R, big_q_only: bool, o
             // to measure "introduced" against since the room is composed from
             // scratch.
             let limits = SegmentLimits { cap_full: false, no_hammer_bro, hazard_cap_full: false };
-            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, limits, rng);
+            randomize_hb_wild_segment(&mut data, &entries, &hb_modes, limits, closed_room, rng);
             continue;
         }
 

--- a/src/randomize/enemies/segments.rs
+++ b/src/randomize/enemies/segments.rs
@@ -117,11 +117,28 @@ pub(super) fn chr_groups(entries: &[SegmentEntry]) -> Vec<Vec<usize>> {
 /// 2-enemy segments: `HB_NONSTOMPABLE_ODDS` chance for the non-stompable path
 /// (one from HB_NEEDS_SHELL_ENEMIES + one from SHELL_ENEMIES), otherwise both
 /// stompable.
+/// Write one HB Wild pick, raising the single enemy in the pool whose AI
+/// ignores the floor. See [`HB_FLYER_RAISE_ROWS`] for why 7 rows.
+///
+/// `closed_room` gates it: the raise exists to keep a treasure-box room
+/// clearable, and applying it to W8's open 7-7 layout would only leave its
+/// enemies floating.
+fn place_hb_pick(data: &mut [u8], id_index: usize, id: u8, closed_room: bool) {
+    swap_enemy(data, id_index, id);
+    if closed_room && id == FLYING_RED_PARATROOPA {
+        // The y byte is the absolute tile row as (page << 4) | row, so a plain
+        // subtraction moves it. Saturating is belt-and-braces: every bro room
+        // spawns its enemies on row 20 or below.
+        data[id_index + 2] = data[id_index + 2].saturating_sub(HB_FLYER_RAISE_ROWS);
+    }
+}
+
 pub(super) fn randomize_hb_wild_segment<R: Rng>(
     data: &mut [u8],
     entries: &[SegmentEntry],
     hb_modes: &ClassModes,
     limits: SegmentLimits,
+    closed_room: bool,
     rng: &mut R,
 ) {
     // A Hammer Bro is a placeholder the engine rewrites into something
@@ -152,7 +169,7 @@ pub(super) fn randomize_hb_wild_segment<R: Rng>(
 
     if swappable.len() == 1 {
         if let Some(chosen) = pick_compatible(&stompable, slot4, slot5, rng) {
-            swap_enemy(data, entries[swappable[0]].data_index, chosen);
+            place_hb_pick(data, entries[swappable[0]].data_index, chosen, closed_room);
         }
     } else if swappable.len() == 2 {
         // Roll whether this segment gets a non-stompable enemy
@@ -168,23 +185,23 @@ pub(super) fn randomize_hb_wild_segment<R: Rng>(
                     let (di0, di1) =
                         (entries[swappable[0]].data_index, entries[swappable[1]].data_index);
                     if rng.random_range(..2u32) == 0 {
-                        swap_enemy(data, di0, ns);
-                        swap_enemy(data, di1, shell);
+                        place_hb_pick(data, di0, ns, closed_room);
+                        place_hb_pick(data, di1, shell, closed_room);
                     } else {
-                        swap_enemy(data, di0, shell);
-                        swap_enemy(data, di1, ns);
+                        place_hb_pick(data, di0, shell, closed_room);
+                        place_hb_pick(data, di1, ns, closed_room);
                     }
                 }
             }
         } else {
             // Both from stompable pool
             if let Some(first) = pick_compatible(&stompable, slot4, slot5, rng) {
-                swap_enemy(data, entries[swappable[0]].data_index, first);
+                place_hb_pick(data, entries[swappable[0]].data_index, first, closed_room);
                 let mut s4 = slot4;
                 let mut s5 = slot5;
                 commit_chr_page(first, &mut s4, &mut s5);
                 if let Some(second) = pick_compatible(&stompable, s4, s5, rng) {
-                    swap_enemy(data, entries[swappable[1]].data_index, second);
+                    place_hb_pick(data, entries[swappable[1]].data_index, second, closed_room);
                 }
             }
         }

--- a/src/randomize/enemies/tables.rs
+++ b/src/randomize/enemies/tables.rs
@@ -382,6 +382,27 @@ pub(super) const WILD_INJECTION_CHANCE: u8 = 102;
 /// of two stompables. 5/31 ≈ 16%.
 pub(super) const HB_NONSTOMPABLE_ODDS: (u32, u32) = (5, 31);
 
+/// `OBJ_FLYINGREDPARATROOPA`. Its AI (`ObjNorm_FlyingRedTroopa`, prg004) moves
+/// it by Y velocity alone and never calls `Object_Move`, so no floor stops it.
+pub(super) const FLYING_RED_PARATROOPA: u8 = 0x6F;
+
+/// Rows to raise a [`FLYING_RED_PARATROOPA`] dealt into a closed bro room.
+///
+/// Its flight is asymmetric: from where it spawns it only ever *descends*,
+/// accelerating 1 unit every 4th frame to a $10 (1px/frame) limit, holding
+/// that for $30 frames, then reversing — 111px, just under 7 tiles, before it
+/// returns to the spawn row and repeats. It never rises above where it started.
+///
+/// Left on the row a bro stood on it therefore sinks through the floor, and a
+/// player who collides with it as it climbs back out can be pushed into the
+/// floor tile and stuck there — a softlock, since a bro room's exit only
+/// appears once the room is cleared. Raising the spawn 7 rows puts the *bottom*
+/// of that cycle back on the vanilla bro's row, which is a standing position by
+/// construction. Every bro room places its enemies on rows 20-24 with the floor
+/// at row 26, so the raised spawn (rows 13-17) is still inside the visible
+/// window and the enemy stays fightable at the bottom of each dive.
+pub(super) const HB_FLYER_RAISE_ROWS: u8 = 7;
+
 /// Large "Big Bertha" fish that exhaust sprite slots when stacked: the leaping
 /// eater (0x2D, the injected "Boss Bass") and the cheep-spitting birther (0x63).
 /// Both are sprite-heavy, so the per-segment cap counts them together.

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1558,7 +1558,9 @@ fn flyer_raise_covers_its_full_dive() {
 #[test]
 fn closed_bro_rooms_raise_the_floor_ignoring_flyer() {
     let Some(base) = load_reference_rom() else {
-        eprintln!("reference ROM absent — skipping closed_bro_rooms_raise_the_floor_ignoring_flyer");
+        eprintln!(
+            "reference ROM absent — skipping closed_bro_rooms_raise_the_floor_ignoring_flyer"
+        );
         return;
     };
 

--- a/src/randomize/enemies/tests.rs
+++ b/src/randomize/enemies/tests.rs
@@ -1485,6 +1485,145 @@ fn treasure_box_rooms_never_get_a_hammer_bro() {
     }
 }
 
+/// [`HB_FLYER_RAISE_ROWS`] has to cover the flyer's whole dive, so pin it to
+/// the engine rather than to arithmetic done once in a comment: run
+/// `ObjNorm_FlyingRedTroopa` (prg004) and measure.
+///
+/// The routine is a self-contained integrator — it reads no level state, so it
+/// can be executed here the way `stomp_fairness` executes its patch. Each
+/// frame: the object loop decrements `Objects_Timer` (prg000, `PRG000_C975`),
+/// the routine applies Y velocity, and while that timer is expired every 4th
+/// frame accelerates by `ParaTroopaFly_Accel[Var3 & 1]` until Y velocity hits
+/// `ParaTroopaFly_Limit[Var3 & 1]`, which flips the direction and reloads the
+/// timer with $30. Nothing ever consults the floor.
+#[test]
+fn flyer_raise_covers_its_full_dive() {
+    const ACCEL: [i8; 2] = [1, -1];
+    const LIMIT: [u8; 2] = [0x10, 0xF0];
+
+    // Sub-pixel position (1/16 px), relative to the spawn row. A fresh object
+    // slot starts every one of these at zero.
+    let (mut pos, mut vel, mut timer, mut var3, mut var4) = (0i32, 0u8, 0u8, 0u8, 0u8);
+    let (mut lowest, mut highest) = (0i32, 0i32);
+    for _ in 0..4000 {
+        timer = timer.saturating_sub(1);
+        pos += i32::from(vel as i8);
+        lowest = lowest.max(pos);
+        highest = highest.min(pos);
+        if timer != 0 {
+            continue;
+        }
+        var4 = var4.wrapping_add(1);
+        if var4 & 3 != 0 {
+            continue;
+        }
+        let dir = usize::from(var3 & 1);
+        vel = vel.wrapping_add_signed(ACCEL[dir]);
+        if vel == LIMIT[dir] {
+            var3 = var3.wrapping_add(1);
+            timer = 0x30;
+        }
+    }
+
+    // The flight is one-sided: it only ever descends from where it spawned.
+    // That is what makes raising the spawn a complete fix — a symmetric
+    // flyer would poke through the ceiling instead.
+    assert_eq!(highest, 0, "flyer rose above its spawn row — a raise cannot bound it");
+
+    let dive_rows = lowest.div_euclid(16 * 16); // 1/16 px -> 16px tile rows
+    let raise = i32::from(HB_FLYER_RAISE_ROWS);
+    assert!(
+        raise > dive_rows,
+        "HB_FLYER_RAISE_ROWS = {raise} does not clear a {}px dive — the flyer still \
+         reaches the floor",
+        lowest / 16,
+    );
+    assert!(
+        raise <= dive_rows + 1,
+        "HB_FLYER_RAISE_ROWS = {raise} overshoots a {}px dive; it wastes room height",
+        lowest / 16,
+    );
+}
+
+/// A closed bro room's exit only appears once the room is empty, so an enemy
+/// the player cannot reach is a softlock. `OBJ_FLYINGREDPARATROOPA` ($6F) is
+/// the one member of the HB pools whose AI never calls `Object_Move`: it
+/// descends up to 111px from its spawn row, straight through the floor, and a
+/// player who collides with it on the way back up can end up stuck in the
+/// floor tile. `place_hb_pick` raises it [`HB_FLYER_RAISE_ROWS`] so the bottom
+/// of that dive lands back on the row the vanilla bro stood on.
+///
+/// Checks all three halves: the raise happens, it is the *only* y byte the HB
+/// pass writes in those rooms, and the case actually occurs over the sweep.
+#[test]
+fn closed_bro_rooms_raise_the_floor_ignoring_flyer() {
+    let Some(base) = load_reference_rom() else {
+        eprintln!("reference ROM absent — skipping closed_bro_rooms_raise_the_floor_ignoring_flyer");
+        return;
+    };
+
+    // Vanilla (segment start, entry id-byte offsets) for every closed bro
+    // room: an HB-ruled segment whose enemy data holds the treasure box.
+    let mut rooms: Vec<(usize, Vec<usize>)> = Vec::new();
+    let data = base.read_range(ENEMY_DATA_START, ENEMY_DATA_END - ENEMY_DATA_START).to_vec();
+    let mut i = 0;
+    while i < data.len() {
+        if data[i] == 0xFF {
+            i += 1;
+            continue;
+        }
+        let start = ENEMY_DATA_START + i;
+        i += 1;
+        let mut ids = Vec::new();
+        while i + 2 < data.len() && data[i] != 0xFF {
+            ids.push(ENEMY_DATA_START + i);
+            i += 3;
+        }
+        let closed = ids.iter().any(|&o| base.read_range(o, 1)[0] == TREASURE_BOX_APPEAR);
+        if closed && walker_segment_rule_at(start) == WalkerSegmentRule::HammerBro {
+            rooms.push((start, ids));
+        }
+    }
+    assert!(rooms.len() >= 7, "expected the vanilla bro rooms, got {}", rooms.len());
+
+    // The raise must not compound with the tall-enemy nudge `swap_enemy`
+    // applies, or the flyer would end up a row higher than the cycle needs.
+    assert!(
+        !TALL_ENEMIES.contains(&FLYING_RED_PARATROOPA),
+        "flyer became tall — the raise now stacks with the tall nudge",
+    );
+
+    let mut opts = preset_recommended();
+    opts.hb_encounters = EnemyMode::Wild;
+    let mut flyers_seen = 0usize;
+    for seed in 0..200u64 {
+        let mut rom = base.clone();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        randomize(&mut rom, &mut rng, &opts);
+        for (start, ids) in &rooms {
+            for &off in ids {
+                let new_id = rom.read_range(off, 1)[0];
+                let raise = if new_id == FLYING_RED_PARATROOPA {
+                    flyers_seen += 1;
+                    HB_FLYER_RAISE_ROWS
+                } else {
+                    0
+                };
+                // The only other y write in these rooms is `swap_enemy`'s
+                // one-row nudge for a tall pick.
+                let tall = u8::from(TALL_ENEMIES.contains(&new_id));
+                assert_eq!(
+                    rom.read_range(off + 2, 1)[0],
+                    base.read_range(off + 2, 1)[0] - tall - raise,
+                    "seed {seed}: 0x{new_id:02X} at {off:#07X} in bro room {start:#07X} sits on \
+                     the wrong row — a flyer left on the bro's row sinks through the floor",
+                );
+            }
+        }
+    }
+    assert!(flyers_seen > 0, "no flyer was ever dealt into a bro room — the test proves nothing");
+}
+
 /// Every cannon-fire family member carries the CHR bank its engine
 /// behavior demands (see the cfire arm in `sprite_bank`): bills and
 /// goomba pipes spawn $4F/+5 children; the cannonball family (plus the


### PR DESCRIPTION
A randomized Hammer Bro encounter could trap the player inside the floor.

`OBJ_FLYINGREDPARATROOPA` (`$6F`) is the one member of the HB Wild pools whose AI never calls `Object_Move`. `ObjNorm_FlyingRedTroopa` (prg004) integrates Y velocity alone, so nothing stops it at the floor: from its spawn row it descends 111px (6.94 tiles) and climbs back, forever. Dealt onto the row a Hammer Bro stood on, it spends half its cycle inside the floor — and a player who collides with it as it climbs back out can end up stuck in the floor tile. In a bro room that is a softlock, since the exit only appears once the room is cleared.

## The fix

Every HB Wild pick now routes through `place_hb_pick`, which raises a `$6F` by `HB_FLYER_RAISE_ROWS` (7). The y byte is the absolute tile row as `(page << 4) | row`, so a plain subtraction moves it.

The flight is **one-sided** — it never rises above where it spawned — which is what makes raising a complete fix rather than a mitigation. A 7-row raise puts the *bottom* of the dive back on the vanilla bro's row, a standing position by construction, and the whole 112px cycle stays anchored to a spot that is on-screen by definition, so it cannot hide off the top either.

Gated on the treasure box already read for `rewrites_hammer_bro`: it applies to the seven closed bro rooms and leaves W8's open 7-7 layout alone.

Verified end-to-end over a seed sweep — vanilla rows 20/22/23/24 become 13/15/16/17 in every room.

## Tests

Both mutation-checked.

- **`flyer_raise_covers_its_full_dive`** executes the routine the way `stomp_fairness` executes its patch — it reads no level state — and measures the dive instead of trusting arithmetic in a comment. 7 is the only value that passes: 0 and 6 fail *"does not clear a 111px dive"*, 8 fails *"overshoots"*. It also asserts the flight never rises above spawn, since that one-sidedness is load-bearing.
- **`closed_bro_rooms_raise_the_floor_ignoring_flyer`** sweeps 200 seeds over every closed bro room, checks the raise lands, and checks the only other y write is `swap_enemy`'s existing tall-enemy nudge. Deleting the raise fails it on seed 0.

The first version of the sweep test passed with the constant mutated to 0 — it checked the constant against itself. The simulation test is what actually pins the value.

## Deliberately not changed

- `$80` FlyingGreenParatroopa flies **left/right**, not up/down (its Y is a ±2 bob). It drifts ~7 tiles off the side of a non-scrolling room for a few seconds and returns; no free chest, since the delete bound is `scroll+$180`. Left alone by decision.
- `$7E` BigGreenHopper is not a flyer at all — it dispatches to `ObjNorm_GroundTroop` despite the name. Neither are `$6E`/`$73`/`$74`, which all call `Object_Move` and bounce off the floor.

## Checks

`cargo test` green (406 lib tests), `cargo clippy --all-targets` and the wasm32 pass both clean. No ROM free space claimed. Playtested from `--seed 41 --hb-encounters wild`, where W1's bro room is a lone flyer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW