### PR TITLE
chore: close referenced issues when a PR merges to beta/next

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,78 @@
+name: Close referenced issues
+
+# GitHub only auto-closes issues when a PR merges into the *default* branch
+# (`main`). Feature work here targets `beta/next`, so a `Closes #N` line in a
+# PR body does nothing at merge time and the issue silently stays open —
+# confirmed on PR #175 / issue #48, and the reason issues #121-#124 were all
+# closed by hand. This restores the behaviour everyone expects.
+#
+# Nothing here touches the site: `ci.yml` owns `push` and gates its `build` and
+# `deploy` jobs on `github.event_name == 'push'`, and `pull_request: closed`
+# never fires those. Kept as its own file rather than folded into `ci.yml`
+# because it is the only workflow that needs `issues: write`.
+#
+# Known gap: a PR from a *fork* gets a read-only `GITHUB_TOKEN` whatever the
+# `permissions` block says, so its issues still need closing by hand. Fixing
+# that means `pull_request_target`, which runs with repo write access against
+# an untrusted head — not worth it while every PR here comes from this repo.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: ['beta/next']
+
+# Least privilege: this workflow only ever closes and comments on issues.
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  close:
+    # `types: [closed]` fires for abandoned PRs too — only a merge is a fix.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues this PR says it closes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          # Via env, not inlined into the script: a PR body is untrusted input
+          # and `${{ }}` interpolation would splice it into the shell.
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # GitHub's own closing keywords, applied to the PR body and to every
+          # commit message in the PR. Matches `Closes #12`, `fixed  #12`,
+          # `RESOLVES #12`. Cross-repo (`owner/repo#12`) and URL forms are
+          # deliberately not handled — `issues: write` is scoped to this repo.
+          keywords='close[sd]?|fix(e[sd])?|resolve[sd]?'
+
+          commits=$(gh pr view "$PR" --repo "$REPO" --json commits \
+                      --jq '.commits[] | .messageHeadline + "\n" + .messageBody')
+
+          issues=$(printf '%s\n%s\n' "$BODY" "$commits" \
+                     | grep -oEi "(${keywords})[[:space:]]+#[0-9]+" \
+                     | grep -oE '[0-9]+' \
+                     | sort -un || true)
+
+          if [ -z "$issues" ]; then
+            echo "No closing keywords in PR #${PR}."
+            exit 0
+          fi
+
+          for n in $issues; do
+            state=$(gh issue view "$n" --repo "$REPO" --json state --jq .state 2>/dev/null || echo MISSING)
+            # A pull request shares the issue number space, so `#12` may name a
+            # PR. Skipping anything that is not an open issue also covers an
+            # already-closed issue and a typo'd number.
+            if [ "$state" != "OPEN" ]; then
+              echo "Skipping #${n} (state: ${state})."
+              continue
+            fi
+            echo "Closing #${n}."
+            gh issue close "$n" --repo "$REPO" --reason completed \
+              --comment "Landed on \`beta/next\` in #${PR} (${SHA}). It ships with the next release."
+          done


### PR DESCRIPTION
`Closes #N` has never worked on this repo. GitHub only auto-closes issues when a PR merges into the **default** branch (`main`), and feature work targets `beta/next` — so the keyword silently does nothing at merge time. Confirmed on PR #175 / issue #48, and the reason issues #121–#124 were all closed by hand.

This restores the behaviour everyone expects.

## How

A workflow on `pull_request: types: [closed]` with `branches: ['beta/next']` (that filter is the *base* branch), gated on `merged == true` so an abandoned PR does nothing. It scans the PR body and every commit message for GitHub's own closing keywords — `close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved` — and closes each referenced issue with a comment naming the PR and merge sha.

Its own file rather than part of `ci.yml`: it's the only workflow that needs `issues: write`, and `ci.yml`'s `build`/`deploy` gating is delicate enough to leave alone. Nothing here can touch the site — those jobs gate on `github.event_name == 'push'`, and `pull_request: closed` never fires them.

Two guards worth naming:

- The PR body reaches the script through **env, not `${{ }}` interpolation**. A PR body is untrusted input and interpolation would splice it straight into the shell.
- A reference is skipped unless it names an **OPEN issue**. Issues and PRs share a number space, so `#200` is a PR, not an issue — this covers that, plus typos and already-closed issues.

## Verified before pushing

The parser was dry-run against live API data, not just eyeballed:

| case | result |
|---|---|
| PR #200's real body and commits | no keywords found → no-op |
| `fixes #44` / `RESOLVED #48` / `Close #200` / `closes #44` | all matched, case-insensitive, deduped |
| `#48` (already closed) | skipped, state `CLOSED` |
| `#200` (a PR, not an issue) | skipped, state `MERGED` |
| `mentions #121 without a keyword` | ignored |
| repo's own `fix:` commit prefix | no false match — a keyword must be followed by whitespace then `#N` |

YAML parses; the script passes `shellcheck`.

## Known gaps

- A PR from a **fork** gets a read-only `GITHUB_TOKEN` whatever the `permissions` block says, so those still need closing by hand. Fixing it means `pull_request_target`, which runs with repo write access against an untrusted head — not worth it while every PR here comes from this repo. Noted in a comment in the file.
- Cross-repo (`owner/repo#12`) and full-URL references are deliberately not handled, since `issues: write` is scoped to this repo.

What the dry run can't prove is that the trigger fires and that the token really carries `issues: write` — that needs one real merge. Happy to prove it with a throwaway issue and a trivial PR after this lands, or just let the next real fix be the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW