### PR TITLE
fix: exempt pipe travel from the left-edge crush death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ deploys.
   stuck in the ground, in a room whose exit only appears once it is cleared.
   It now starts high enough that the bottom of its dive lands *on* the floor.
 
+- Travelling through a pipe no longer kills you when the screen scrolls at the
+  same time. The game's "crushed against the left edge" check only looks at how
+  far left Mario's sprite has been pushed, and a pipe transition that squished
+  the view could push him far enough to trip it — a death with nothing on
+  screen to cause it. Pipe travel is now exempt, the same way vertical levels
+  and a finished level already were. (MaCobra52's "Pipe Screen Squish Fix".)
+
 
 ## [1.2.1] - 2026-08-26
 

--- a/src/randomize/qol/macobra.rs
+++ b/src/randomize/qol/macobra.rs
@@ -151,6 +151,47 @@ const TAIL_STAY_DEAD_ROUTINE: [u8; 8] = [0xA9, 0xFF, 0x9D, 0x59, 0x06, 0x4C, 0x0
 const TAIL_STAY_DEAD_HOOK_OFFSET: usize = 0x07E4A;
 const TAIL_STAY_DEAD_HOOK_BYTES: [u8; 2] = [0xF9, 0xA5]; // JMP $A5F9 operand
 
+// Pipe screen-squish fix (by MaCobra52) — "Pipe Screen Squish Fix.ips".
+// Bug: travelling through a pipe while the screen scrolls can shove
+// Player_SpriteX into $F8..$FF, which the in-level "crushed against the left
+// edge" check reads as a real crush and kills the player. That check lives in
+// the per-frame Player update (PRG008, CPU $A45A):
+//
+//     $A45A: LDA Player_SpriteX / CMP #$F8 / BCC $A472  ; not shoved left, done
+//     $A460: LDA Level_7Vertical
+//     $A463: ORA Player_EndLevel
+//     $A466: BNE $A472                                  ; exempt -> no death
+//     $A468: JSR Player_Die
+//
+// The fix adds a third exemption term, Player_InPipe ($058C in the gameplay
+// context), so pipe travel joins vertical levels and completed levels in being
+// exempt. This is the engine's own idiom for "suppress while in a pipe" —
+// vanilla already does the same `ORA Player_InPipe` in PRG007 and PRG026. The
+// flag is self-clearing: Player_DrawAndDoActions29 zeroes it every frame and
+// only re-INCs it when the pipe path returns normally.
+//
+// One 9-byte splice at file 0x10476 ($A466), reproduced verbatim from the IPS:
+//
+//     $A466: 0D 8C 05   ORA Player_InPipe   ; new
+//     $A469: D0 07      BNE $A472           ; was `D0 0A` at $A466
+//     $A46B: 20 7C DA   JSR Player_Die
+//     $A46E: EA         NOP                 ; slack
+//     ($A46F: JMP $A44D — untouched)
+//
+// The 3 bytes are paid for out of the vanilla `LDA #$01 / STA Player_IsDying`
+// that followed the JSR: Player_Die (PRG000) already sets Player_IsDying = 1
+// itself and nothing runs in between, so those 4 bytes were dead. Net cost to
+// the ROM free-space budget is zero — the patch never leaves PRG008's existing
+// footprint, so it claims no FREE_SPACE_ALLOCATIONS row.
+const PIPE_SQUISH_FIX_OFFSET: usize = 0x10476;
+#[rustfmt::skip]
+const PIPE_SQUISH_FIX_BYTES: [u8; 9] = [
+    0x0D, 0x8C, 0x05, // ORA Player_InPipe
+    0xD0, 0x07,       // BNE $A472
+    0x20, 0x7C, 0xDA, // JSR Player_Die
+    0xEA,             // NOP
+];
+
 // ---------------------------------------------------------------------------
 // MaCobra patches — opt-in features
 // Each apply_* below is gated by an individual option in randomizer.rs;
@@ -503,6 +544,10 @@ pub fn apply_macobra_patches(rom: &mut Rom) {
     rom.write_range(FS_TAIL_STAY_DEAD, &TAIL_STAY_DEAD_ROUTINE);
     rom.write_range(TAIL_STAY_DEAD_HOOK_OFFSET, &TAIL_STAY_DEAD_HOOK_BYTES);
 
+    // Pipe screen-squish fix: exempt pipe travel from the "crushed against the
+    // left edge" death check, so scrolling inside a pipe cannot fake a crush.
+    rom.write_range(PIPE_SQUISH_FIX_OFFSET, &PIPE_SQUISH_FIX_BYTES);
+
     // NOTE: MaCobra's "Bros don't stop on hands" (issue #14) used to live
     // here; it is subsumed by the overworld writer's march-veto trampoline
     // (overworld_writer/march_veto.rs), which rejects hand-trap landings
@@ -636,6 +681,39 @@ mod tests {
     }
 
     #[test]
+    fn test_macobra_pipe_squish_fix_writes() {
+        let mut rom = make_test_rom();
+        apply_macobra_patches(&mut rom);
+
+        assert_eq!(
+            rom.read_range(PIPE_SQUISH_FIX_OFFSET, PIPE_SQUISH_FIX_BYTES.len()),
+            &PIPE_SQUISH_FIX_BYTES
+        );
+    }
+
+    /// The splice starts at CPU $A466 and its `BNE` must reach $A472 (the
+    /// always-run tail), the same exit the two vanilla exemption terms take.
+    /// A miscounted operand here would land mid-instruction instead.
+    #[test]
+    fn test_pipe_squish_branch_reaches_the_tail() {
+        // PRG008 maps to $A000; file 0x10476 - 0x10 header - 0x10000 bank = $A466.
+        let splice_cpu = 0xA000 + (PIPE_SQUISH_FIX_OFFSET - 0x10 - 0x10000);
+        assert_eq!(splice_cpu, 0xA466);
+
+        // ORA abs (3) + BNE (2) => the branch's own PC-after is $A46B.
+        assert_eq!(PIPE_SQUISH_FIX_BYTES[0], 0x0D, "expected ORA abs");
+        assert_eq!(
+            u16::from_le_bytes([PIPE_SQUISH_FIX_BYTES[1], PIPE_SQUISH_FIX_BYTES[2]]),
+            0x058C,
+            "ORA operand must be Player_InPipe"
+        );
+        assert_eq!(PIPE_SQUISH_FIX_BYTES[3], 0xD0, "expected BNE");
+        let after_branch = splice_cpu + 5;
+        let target = after_branch + PIPE_SQUISH_FIX_BYTES[4] as usize;
+        assert_eq!(target, 0xA472, "BNE must land on PRG008_A472");
+    }
+
+    #[test]
     fn test_modern_powerups_writes() {
         let mut rom = make_test_rom();
         apply_modern_powerups(&mut rom);
@@ -693,6 +771,13 @@ mod asm_checks {
     #[test]
     fn no_game_over_is_well_formed() {
         asm::check(&NGO_ROUTINE).allocation(NGO_ROUTINE_OFFSET).assert_ok();
+    }
+
+    #[test]
+    fn pipe_squish_fix_is_well_formed() {
+        // Spliced in place over vanilla and continues into the untouched
+        // `JMP $A44D` that follows, so it is a fragment, not a whole routine.
+        asm::check(&PIPE_SQUISH_FIX_BYTES).fragment().assert_ok();
     }
 
     #[test]

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -192,27 +192,35 @@ fn sweep_is_deterministic() {
 /// `Cargo.toml` here, so the first recapture attempt printed a stale binary's
 /// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
 /// trusting any number this test prints after a bump.
+///
+/// Re-captured 2026-08-30 for the pipe screen-squish fix: the always-on
+/// MaCobra bundle gained a 9-byte splice at 0x10476 (PRG008 $A466) that exempts
+/// pipe travel from the left-edge crush death. It consumes no RNG, so nothing
+/// downstream shifted — verified rather than argued: for all 20 of these seeds
+/// the pre- and post-fix ROMs were diffed byte for byte (`--no-palettes
+/// --patched-rom`) and the diff is exactly 0x10476..0x1047F on every one of
+/// them, with no second span. No map tile, pointer table or level byte moved.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x10907FA9ADEAAF3F,
-    0x75A07E362568245D,
-    0x9F5B5BE6FD20755C,
-    0xD31EBA415DA9BAAB,
-    0xC832693B75377CB7,
-    0xA01F68AEE80254EF,
-    0x0F872B53E62D3760,
-    0x87D694E674CDF96F,
-    0x0D86E47E883FC7BA,
-    0x5D62A065ED55B22A,
-    0x062F138FE272DF5F,
-    0x22C3A5C39FCF738F,
-    0x140B2C424BA5E5AB,
-    0x1A191EF76661222C,
-    0x66E52614C84F60C6,
-    0x5E52087C914C8E1A,
-    0x848134F654C1572C,
-    0x36A081EC9E7DA639,
-    0xCBF672CBE2CF2F3A,
-    0x4769EB681AF3994F,
+    0x3926E260625D06D4,
+    0x0399EDF5AD3BF8B6,
+    0x03356435C6932BEF,
+    0xBE9CAE2B19A02134,
+    0xBC76F9C04B292A04,
+    0xC54586417213FADC,
+    0xFF69C69E11BC2ACF,
+    0xA33D0B6973781EBC,
+    0x2B66E3F87BAC7CA5,
+    0x070AD7D88A7E8209,
+    0x5D42687C16575B04,
+    0xE0ADF6480E23B948,
+    0x8B37FB382962FB68,
+    0x7DC91D42C5A48B5F,
+    0x8223703FC418305D,
+    0x8289DA9476BA4485,
+    0x1723298F6A43537F,
+    0xDF04A58F323073D2,
+    0xE8B54FB806F8D03D,
+    0xBB22752C7DB88528,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always


### PR DESCRIPTION
MaCobra52's **"Pipe Screen Squish Fix"**, brought into the always-on bundle.

## The bug

The in-level "crushed against the left edge" check only looks at how far left Mario's sprite has been pushed. A pipe transition that squishes the view can push `Player_SpriteX` into `$F8..$FF` on its own, so the game reads a normal pipe trip as a crush and kills you — a death with nothing on screen to cause it.

The check lives in the per-frame Player update, PRG008 `$A45A`:

```
$A45A: LDA Player_SpriteX / CMP #$F8 / BCC $A472  ; not shoved left, done
$A460: LDA Level_7Vertical
$A463: ORA Player_EndLevel
$A466: BNE $A472                                  ; exempt -> no death
$A468: JSR Player_Die
```

## The fix

A third exemption term, so pipe travel joins vertical levels and completed levels:

```
$A466: 0D 8C 05   ORA Player_InPipe   ; new
$A469: D0 07      BNE $A472           ; retargeted, was D0 0A at $A466
$A46B: 20 7C DA   JSR Player_Die
$A46E: EA         NOP
($A46F: JMP $A44D — untouched)
```

`$058C` is `Player_InPipe` in the gameplay context (derived from the RAM map: `Object_SprRAM` at `$058F`, counting back `Player_SprOff` / `Player_MushFall` / `Player_InPipe`). `ORA Player_InPipe` is the engine's own idiom for "suppress while in a pipe" — vanilla already does exactly that in PRG007 and PRG026. The flag is self-clearing: `Player_DrawAndDoActions29` zeroes it every frame and only re-`INC`s it when the pipe path returns normally.

## Size

**Net cost to the free-space budget is zero.** The 3 new bytes are paid for out of the vanilla `LDA #$01 / STA Player_IsDying` that followed the `JSR`, which was dead code — `Player_Die` (PRG000) already sets `Player_IsDying = 1` itself and nothing runs in between. Confirmed in the disassembly rather than taken on the strength of Southbird's "superfluous" comment.

The patch never leaves PRG008's existing footprint, so it claims no `FREE_SPACE_ALLOCATIONS` row. Nothing smaller is available: `Player_InPipe` is outside zero page, so `ORA abs` (3 bytes) is the floor for testing it; the leftover `NOP` is a 1-byte hole inside a live routine, not reusable space; and `JMP $A44D` can't shrink to a branch because after `JSR Player_Die` the flags come from `AND #$7F` on `Player_FlipBits`, which can be either.

## Verification

- The 9 bytes are byte-for-byte the upstream IPS — checked by applying `patches/Pipe Screen Squish Fix.ips` to vanilla independently and comparing against generated output. The IPS is a single record and touches nothing else.
- `asm::check(...).fragment()` on the splice, plus a test that pins the `BNE` operand to land on `PRG008_A472`. That guard was mutation-tested (`D0 07` → `D0 08` fails it).
- `overworld_baseline` recaptured in the same commit — it hashes the whole ROM, so any always-on patch trips it. Verified rather than argued: for all 20 baseline seeds the pre- and post-fix ROMs were diffed byte for byte (`--no-palettes --patched-rom`) and the diff is **exactly `0x10476..0x1047F` on every one, with no second span**. The patch consumes no RNG, so no map tile, pointer table or level byte moved.
- Full suite, both clippy passes (native + wasm32), `cargo fmt --check`, and `tools/offset_dups.py` all clean. No `--write-log` allocation warnings.

Not independently reproduced in an emulator — the "screen squish kills you" behavior is MaCobra's description of the bug. What is verified here is that the bytes are his, that they decode correctly, and that they change nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW