### PR TITLE
fix: give screen 2's Big [?] room a way back to its block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ deploys.
 
 ### Fixed
 
+- One of the new Big [?] Block bonus rooms could take your powerup and give
+  nothing back. Its block sits across the room from where the pipe drops you,
+  reachable only by steering mid-fall; miss that and you land in a pit with
+  nothing to climb and no way to try again — the room is spent. Two coins in
+  the shaft are music blocks now, so the floor is a setback instead of a dead
+  end. Only affects seeds with Big [?] room shuffle turned on.
+
 - A randomized Hammer Bro encounter can no longer trap you in the floor. The
   flying red Paratroopa ignores level geometry and sinks about seven tiles
   below where it starts, so on a Bro's ground row it spent half its cycle

--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -600,6 +600,18 @@ rooms, one per screen 0-7, every block a Tanooki Suit ($98).
 | Layout | 0x2B764 | $B754 | PRG021 (fortress tileset 2) | 294 |
 | Objects | 0x0D411 | $D401 | PRG006 | 26 |
 
+**Screen 2 is shipped modified.** Its two `Coin` commands at 0x2B7C0 and
+0x2B7C3 are retyped to note blocks (`LoadLevel_BlockRun`, byte2 `$80` → `$60`)
+and moved to rows 20/15 whenever a Big [?] host draws an Unused Level 5 room —
+see `SCREEN2_NOTES` in `big_q_rooms.rs`. Vanilla screen 2 arrives down a shaft
+(columns 1-4) that runs unbroken to the floor while its block sits at row 10,
+column 10, so a player who does not drift right through the rows 8-10 gap during
+the fall lands with nothing to climb and leaves the room unspendable. The note
+blocks are the climb. `$2E` is solid here because solidity is
+`tile >= Tile_AttrTable[quadrant]` and tileset 2's quadrant-0 root is `$11`;
+`Level_ActionTiles` handles the bounce and is tileset-independent. No vanilla
+fortress-tileset level places one, so this is the first.
+
 Neither address appears in the world pointer tables (0x19438–0x19C00) or as a
 header alt pointer. Loaded normally its pipes exit to the world map, which is
 what TCRF describes; reached through a Big [?] junction the flag rule above

--- a/src/bin/testrom.rs
+++ b/src/bin/testrom.rs
@@ -161,6 +161,13 @@ struct Cli {
     #[arg(long, value_name = "COL,YIDX")]
     bigq_aim: Option<String>,
 
+    /// Retype screen 2's two coins as note blocks, so a player who rides its
+    /// shaft to the floor can still climb to the Big [?] block instead of
+    /// spending the room. Optionally takes their positions as "ROW,COL;ROW,COL";
+    /// bare, it uses what a randomized ROM ships. Needs --bigq-unused5.
+    #[arg(long, value_name = "ROW,COL;ROW,COL", num_args = 0..=1)]
+    bigq_notes: Option<Option<String>>,
+
     /// List valid --starting-items names and exit.
     #[arg(long)]
     list_items: bool,
@@ -323,6 +330,24 @@ fn main() {
         (col, y_idx)
     });
 
+    // "ROW,COL;ROW,COL" -> the two note-block positions --bigq-notes writes over
+    // screen 2's coins. Ranges are checked in testrom.rs, next to the write.
+    let big_q_notes = cli.bigq_notes.as_ref().map(|given| {
+        let Some(n) = given.as_deref() else { return testrom::unused5_screen2_notes() };
+        let pair = |p: &str| -> (u8, u8) {
+            p.split_once(',')
+                .and_then(|(r, c)| Some((r.trim().parse().ok()?, c.trim().parse().ok()?)))
+                .unwrap_or_else(|| die(format!("--bigq-notes wants \"ROW,COL\", got \"{p}\"")))
+        };
+        let (a, b) = n
+            .split_once(';')
+            .unwrap_or_else(|| die(format!("--bigq-notes wants two ROW,COL pairs, got \"{n}\"")));
+        [pair(a), pair(b)]
+    });
+    if big_q_notes.is_some() && cli.bigq_unused5.is_none() {
+        die("--bigq-notes needs --bigq-unused5".to_string());
+    }
+
     let placements: Vec<Placement> =
         cli.place.iter().map(|s| parse_placement(s).unwrap_or_else(|e| die(e))).collect();
 
@@ -381,6 +406,7 @@ fn main() {
         include_beta: cli.beta,
         big_q_unused5: cli.bigq_unused5,
         big_q_palette: Some(cli.bigq_palette),
+        big_q_notes,
         big_q_aim,
         set_enemies,
     };

--- a/src/randomize/big_q_rooms.rs
+++ b/src/randomize/big_q_rooms.rs
@@ -85,10 +85,14 @@ const VANILLA_ROOMS: [Room; 11] = [
 /// The Y index is into `LevelJct_YLHStarts`, which has only eight entries —
 /// rows 0, 4, 7, 11, 15, 20, 23, 24 — so a landing spot cannot be nudged by a
 /// row or two. That coarseness is why screens 6 and 7 took a playtest round:
-/// see their comment below.
+/// see their comment below. Screen 2 needed a change to the room instead of the
+/// arrival, which is what `SCREEN2_NOTES` is.
 const UNUSED5_ROOMS: [Room; 8] = [
     room(0, 0, (0x02, 0x20), true), // ceiling pipe col 2, rows 0-1
     room(0, 1, (0x42, 0x11), true), // ceiling pipe col 1, rows 12-16
+    // Screen 2's shaft used to be a one-way trip past the block; its two coins
+    // are note blocks now, so the floor is no longer a dead end. See
+    // `SCREEN2_NOTES`.
     room(0, 2, (0x02, 0x22), true), // ceiling pipe col 2, rows 0-1
     room(0, 3, (0x52, 0x13), true), // ceiling pipe col 1, rows 16-21
     room(0, 4, (0x52, 0x24), true), // ceiling pipe col 2, rows 16-21
@@ -239,6 +243,81 @@ fn point_slot0_at_unused5(rom: &mut Rom) {
         rom_data::prg_bank_cpu_to_file(rom_data::UNUSED5_LAYOUT_BANK, rom_data::UNUSED5_LAYOUT_PTR);
     let byte5 = rom.read_byte(hdr + 5);
     rom.write_byte(hdr + 5, (byte5 & 0xF8) | UNUSED5_BGPAL);
+
+    write_screen2_notes(rom, SCREEN2_NOTES);
+}
+
+/// Screen 2's two `Coin` commands, which [`write_screen2_notes`] retypes.
+///
+/// Screen 2 is the one room a player can be locked out of. You arrive through
+/// its ceiling pipe at column 2, and the shaft below (columns 1-4) runs unbroken
+/// to the floor at row 25 while the block sits at row 10, column 10 — reachable
+/// only by drifting right through the rows 8-10 gap on the way down. Ride the
+/// shaft to the floor instead and there is nothing to climb: the exit pipe is
+/// still reachable, so the player leaves having spent the room for nothing.
+///
+/// Both coins sit in that shaft, which makes them the two tiles worth spending
+/// on a way back up.
+const SCREEN2_COINS: [(usize, [u8; 3]); 2] =
+    [(0x2B7C0, [0x2A, 0x22, 0x80]), (0x2B7C3, [0x2B, 0x21, 0x80])];
+
+/// Where the note blocks go, as `(row, column)`, tuned by playtest 2026-08-30.
+///
+/// Row 20 column 1 stands over the low floor at the bottom of the shaft, within
+/// a running jump of it and of the row 23 platform to its right. Row 15 column 4
+/// is one row under the top of the big columns 5-12 platform, so the bounce off
+/// the first lands beside it and the last move is a step up rather than a climb;
+/// from that platform the block is two tiles over the player's head.
+///
+/// Earlier positions were higher (19/12, then 19/13, then 20/14) and all read as
+/// out of reach in play — the bounce is shorter than the geometry suggests.
+const SCREEN2_NOTES: [(u8, u8); 2] = [(20, 1), (15, 4)];
+
+/// Retype screen 2's two coins as note blocks at `at`.
+///
+/// A note block (`TILEA_NOTE`, $2E) is solid in this tileset — solidity is
+/// `tile >= Tile_AttrTable[quadrant]`, and tileset 2's quadrant-0 root is $11 —
+/// and `Level_ActionTiles` bounces the player off it from above regardless of
+/// tileset, so nothing here needs a patch to go with it. Retyping is a one-
+/// nibble edit: byte2's high nibble picks the block out of `LoadLevel_Blocks`,
+/// $8 = coin, $6 = note block. Both commands are rewritten whole rather than
+/// patched in place, because the position lives in bytes 0 and 1.
+///
+/// Costs no ROM space: these are three-byte commands overwritten in place.
+fn write_screen2_notes(rom: &mut Rom, at: [(u8, u8); 2]) {
+    for (i, &(off, _)) in SCREEN2_COINS.iter().enumerate() {
+        let (row, col) = at[i];
+        // byte0: group 1, bit 4 selects the lower half of screen memory and the
+        // low nibble the row within that half. byte1: screen 2, column.
+        // byte2: $60 = note block, run length 1.
+        rom.write_range(off, &[0x20 | (row & 0x10) | (row & 0x0F), 0x20 | col, 0x60]);
+    }
+}
+
+/// The vanilla bytes at [`SCREEN2_COINS`], for callers that verify their base
+/// before writing over it.
+///
+/// Native-only, like its one caller `testrom` — the web build never assembles a
+/// ROM from an unverified base, and an unconditional accessor trips CI's
+/// wasm32 `-D warnings` pass as dead code.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn screen2_coins() -> [(usize, [u8; 3]); 2] {
+    SCREEN2_COINS
+}
+
+/// Where [`point_slot0_at_unused5`] puts the note blocks, so `testrom` can
+/// reproduce the shipped layout rather than a variant of it. Native-only for
+/// the same reason as [`screen2_coins`].
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn screen2_notes() -> [(u8, u8); 2] {
+    SCREEN2_NOTES
+}
+
+/// Lay the note blocks at an arbitrary `at`, for `testrom`'s position override.
+/// The shipped positions go in through [`point_slot0_at_unused5`].
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn place_screen2_notes(rom: &mut Rom, at: [(u8, u8); 2]) {
+    write_screen2_notes(rom, at);
 }
 
 /// File offset of the Big [?] Block object entry in a room, or `None` if the
@@ -298,5 +377,47 @@ mod tests {
         let pairs: Vec<(usize, usize)> =
             HOSTS.iter().filter_map(|h| h.mirror.map(|m| (h.row, m))).collect();
         assert_eq!(pairs, big_q::BQ_MIRROR_ROWS.to_vec());
+    }
+
+    /// The reason the note blocks exist is that a player who lands on screen 2's
+    /// floor is otherwise stuck, so the write has to be wired into the one
+    /// function that runs when a host actually draws an Unused Level 5 room.
+    /// Deleting that call would leave every other test here passing.
+    #[test]
+    fn opening_unused5_lays_the_screen_2_note_blocks() {
+        let Some(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok() else {
+            return;
+        };
+        let mut rom = Rom::from_bytes_lax(&bytes, true).unwrap();
+
+        // Vanilla first: a moved offset would silently retype another room.
+        for (off, expect) in SCREEN2_COINS {
+            assert_eq!(rom.read_range(off, 3), &expect, "screen 2 coin at {off:#07X}");
+        }
+
+        point_slot0_at_unused5(&mut rom);
+
+        for (i, (off, _)) in SCREEN2_COINS.into_iter().enumerate() {
+            let (row, col) = SCREEN2_NOTES[i];
+            let cmd = rom.read_range(off, 3);
+            // Group 1 with byte2 $60 is LoadLevel_BlockRun's note block, run of
+            // one; a different group decodes as some other generator entirely.
+            assert_eq!(cmd[0] >> 5, 1, "generator group at {off:#07X}");
+            assert_eq!(cmd[2], 0x60, "block type at {off:#07X}");
+            // Round-trip the position back out of bytes 0 and 1.
+            assert_eq!((cmd[0] & 0x0F) + 16 * ((cmd[0] >> 4) & 1), row, "row at {off:#07X}");
+            assert_eq!(cmd[1] >> 4, 2, "screen at {off:#07X}");
+            assert_eq!(cmd[1] & 0x0F, col, "column at {off:#07X}");
+        }
+    }
+
+    /// Both note blocks have to sit in the shaft the player falls down —
+    /// columns 1-4, below the rows 8-10 gap — or they are decoration.
+    #[test]
+    fn the_note_blocks_are_in_the_shaft() {
+        for (row, col) in SCREEN2_NOTES {
+            assert!((1..=4).contains(&col), "column {col} is outside the shaft");
+            assert!((11..=24).contains(&row), "row {row} is not between the gap and the floor");
+        }
     }
 }

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -12,6 +12,7 @@
 //! testing, and lock testing are all combinations rather than named modes.
 
 use crate::ips;
+use crate::randomize::big_q_rooms;
 use crate::randomize::node_catalog::{EntryView, NodeCatalog};
 use crate::randomize::rom_data::{self, LevelEntry, WORLDS};
 use crate::randomize::world_order::WORLD_INIT_OPERAND;
@@ -375,6 +376,9 @@ pub struct TestRomSpec {
     /// Y indices are into `LevelJct_YLHStarts`: 0 = row 0, 4 = row 15,
     /// 5 = row 20, 6 = row 23.
     pub big_q_aim: Option<(u8, u8)>,
+    /// Turn screen 2's two coins into note blocks at these `(row, col)`
+    /// positions. Only read when `big_q_unused5` is set.
+    pub big_q_notes: Option<[(u8, u8); 2]>,
     /// Enemy slots to overwrite outright. Applied last, so they win over the
     /// randomizer's own choices on a `--randomize` base.
     pub set_enemies: Vec<EnemyOverride>,
@@ -462,8 +466,9 @@ fn numbered_slots(rom: &Rom, world_idx: usize, include_beta: bool) -> Vec<(u8, u
 const UNUSED5_ARRIVALS: [(u8, u8); 8] = [
     (2, 0), // screen 0: ceiling pipe col 2, rows 0-1
     (1, 4), // screen 1: ceiling pipe col 1, rows 12-16
-    (2, 0), // screen 2: ceiling pipe col 2, rows 0-1 (drift right at rows 8-9
-    //           to reach the block; the shaft drops past it otherwise)
+    (2, 0), // screen 2: ceiling pipe col 2, rows 0-1. Drifting right at rows
+    //           8-9 reaches the block directly; ride the shaft to the floor
+    //           instead and the note blocks are the way back up.
     (1, 5), // screen 3: ceiling pipe col 1, rows 16-21
     (2, 5), // screen 4: ceiling pipe col 2, rows 16-21
     (7, 0), // screen 5: ceiling pipe col 7, rows 0-2
@@ -484,8 +489,45 @@ const UNUSED5_ARRIVALS: [(u8, u8); 8] = [
 /// extend the stream. Both of these are a single `Coin` generator (fortress
 /// generator 22), the cheapest thing in the level to lose, and the caller picks
 /// one that is not in the room being tested so the room itself is untouched.
+///
+/// The second spare is one of screen 4's ten decorative coins rather than one of
+/// screen 2's two, because a randomized ROM spends screen 2's pair on note
+/// blocks — see `big_q_rooms::write_screen2_notes`.
 const UNUSED5_SPARE_COMMANDS: [(usize, [u8; 3], u8); 2] =
-    [(0x2B78D, [0x2C, 0x03, 0x80], 0), (0x2B7C3, [0x2B, 0x21, 0x80], 2)];
+    [(0x2B78D, [0x2C, 0x03, 0x80], 0), (0x2B813, [0x27, 0x4C, 0x80], 4)];
+
+/// The positions `--bigq-notes` uses when given none — what a randomized ROM
+/// ships, so a bare `--bigq-notes` reproduces the real thing rather than a
+/// testrom-only variant.
+pub fn unused5_screen2_notes() -> [(u8, u8); 2] {
+    big_q_rooms::screen2_notes()
+}
+
+/// Retype screen 2's two coins as note blocks and move them to `at`.
+///
+/// The write itself is `big_q_rooms`, which is what a randomized ROM runs; this
+/// only adds the base check and the range check, because a test ROM is built
+/// from whatever base the caller passed and should say so rather than corrupt
+/// a stream it did not recognise.
+fn big_q_screen2_notes(rom: &mut Rom, at: [(u8, u8); 2]) -> Result<Vec<String>, String> {
+    for (off, expect) in big_q_rooms::screen2_coins() {
+        if rom.read_range(off, 3) != expect {
+            return Err(format!(
+                "0x{off:05X} is not the expected Coin command {expect:02X?} — \
+                 Unused Level 5's layout is not vanilla here"
+            ));
+        }
+    }
+    for (row, col) in at {
+        if row > 26 || col > 15 {
+            return Err(format!("--bigq-notes: row is 0-26, column 0-15, got {row},{col}"));
+        }
+    }
+    big_q_rooms::place_screen2_notes(rom, at);
+    Ok(vec![format!(
+        "  screen 2: coins -> note blocks at (row, col) {at:?}; block is at row 10, col 10"
+    )])
+}
 
 /// Repoint every Big [?] Block bonus area at "Unused Level 5", aim 5-2's bonus
 /// pipe at one of its eight rooms, and give that room a return junction.
@@ -871,6 +913,10 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
     // 3a. Big [?] Block bonus rooms from the unreferenced test level.
     if let Some(screen) = spec.big_q_unused5 {
         report.extend(big_q_unused5(&mut rom, screen, spec.big_q_palette, spec.big_q_aim)?);
+        // After the return junction, which never claims a screen 2 command.
+        if let Some(at) = spec.big_q_notes {
+            report.extend(big_q_screen2_notes(&mut rom, at)?);
+        }
     }
 
     // 4. Open the map up.
@@ -1027,6 +1073,7 @@ mod tests {
             big_q_unused5: None,
             big_q_palette: None,
             big_q_aim: None,
+            big_q_notes: None,
             set_enemies: Vec::new(),
         }
     }
@@ -1154,6 +1201,19 @@ mod tests {
         // Every spare command really is where it claims to be in vanilla.
         for (off, bytes, _) in UNUSED5_SPARE_COMMANDS {
             assert_eq!(src.read_range(off, 3), &bytes, "spare command at {off:#07X}");
+        }
+        // ...and so are the two coins --bigq-notes overwrites. A wrong offset
+        // here would silently retype some other room's tile.
+        for (off, bytes) in big_q_rooms::screen2_coins() {
+            assert_eq!(src.read_range(off, 3), &bytes, "screen 2 coin at {off:#07X}");
+        }
+        // The return junction must never land on one of them, or the note
+        // blocks and the way home would fight over the same three bytes.
+        for (coin, _) in big_q_rooms::screen2_coins() {
+            assert!(
+                UNUSED5_SPARE_COMMANDS.iter().all(|&(spare, ..)| spare != coin),
+                "spare command {coin:#07X} is also a screen 2 coin"
+            );
         }
         // byte0 is untouched — its slot nibble names 5-2's own pipe screen,
         // which is a property of 5-2 and not of the destination.
@@ -1461,5 +1521,45 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("start") || err.contains("unknown"), "got: {err}");
+    }
+
+    #[test]
+    fn big_q_notes_retypes_screen_2s_coins_as_note_blocks() {
+        let Some(van) = vanilla() else { return };
+        let built = build(
+            &van,
+            &TestRomSpec {
+                big_q_unused5: Some(2),
+                big_q_notes: Some(big_q_rooms::screen2_notes()),
+                ..spec()
+            },
+        )
+        .unwrap();
+        let out = Rom::from_bytes_lax(&built.bytes, true).unwrap();
+
+        for (i, (off, _)) in big_q_rooms::screen2_coins().into_iter().enumerate() {
+            let (row, col) = big_q_rooms::screen2_notes()[i];
+            let cmd = out.read_range(off, 3);
+            // byte2 $60 is LoadLevel_BlockRun's note block, run length 1.
+            assert_eq!(cmd[2], 0x60, "block type at {off:#07X}");
+            // Round-trip the position back out of bytes 0 and 1.
+            assert_eq!((cmd[0] & 0x0F) + 16 * ((cmd[0] >> 4) & 1), row, "row at {off:#07X}");
+            assert_eq!(cmd[1] & 0x0F, col, "column at {off:#07X}");
+            assert_eq!(cmd[1] >> 4, 2, "screen at {off:#07X}");
+            // Group 1 — the group whose variable-size base makes $6 a note
+            // block. A different group would decode as another generator.
+            assert_eq!(cmd[0] >> 5, 1, "generator group at {off:#07X}");
+        }
+    }
+
+    #[test]
+    fn big_q_notes_refuses_a_position_off_the_screen() {
+        let Some(van) = vanilla() else { return };
+        let err = build(
+            &van,
+            &TestRomSpec { big_q_unused5: Some(2), big_q_notes: Some([(27, 1), (12, 4)]), ..spec() },
+        )
+        .unwrap_err();
+        assert!(err.contains("row is 0-26"), "{err}");
     }
 }

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -1557,7 +1557,11 @@ mod tests {
         let Some(van) = vanilla() else { return };
         let err = build(
             &van,
-            &TestRomSpec { big_q_unused5: Some(2), big_q_notes: Some([(27, 1), (12, 4)]), ..spec() },
+            &TestRomSpec {
+                big_q_unused5: Some(2),
+                big_q_notes: Some([(27, 1), (12, 4)]),
+                ..spec()
+            },
         )
         .unwrap_err();
         assert!(err.contains("row is 0-26"), "{err}");


### PR DESCRIPTION
## The problem

Screen 2 of Unused Level 5 — one of the eight rooms the Big [?] room shuffle added — can take a player's powerup and give nothing back.

You arrive through its ceiling pipe at column 2. The shaft below (columns 1–4) runs unbroken to the floor at row 25, while the block sits at row 10, column 10, reachable only by steering right through the rows 8–10 gap during the fall. Ride the shaft down instead and there is nothing to climb. The exit pipe is still reachable, so you leave — and a Big [?] room is one-shot, so the powerup is gone.

`testrom.rs` had already noticed the hazard in a comment ("drift right at rows 8-9 to reach the block; the shaft drops past it otherwise") without treating it as a bug.

```
     0123456789012345
r 1  X.{}.##########X   drop in, col 2
r10  X.........*....X   the block
r14  X....########..X
r15  X...N########..X   note block  <- new
r20  XN.............X   note block  <- new
r23  X......########X   upper floor
r25  ################   lower floor
```

## The fix

The room's two coins become note blocks at rows 20 and 15, forming a climb out of the dead end. They already sat in the shaft, which is what made them the two tiles worth spending.

No 6502 and no ROM space:

- `$2E` is **solid** in the fortress tileset — solidity is `tile >= Tile_AttrTable[quadrant]`, and tileset 2's quadrant-0 root is `$11`. The same test correctly says coin `$40` is not solid and brick `$67` is.
- `Level_ActionTiles` handles the **bounce** on a flat tile-ID compare, independent of tileset (hit-enable `%0011`, top and bottom).
- The **art** is present: the metatile definition (`B8 B9 BA BB`, CHR page `$60`) is byte-identical in the fortress and plains banks.
- Retyping is **one nibble** in byte2 of a `LoadLevel_BlockRun` command, written in place over the existing coins — `$80` coin to `$60` note block.

No vanilla fortress-tileset level places a note block, so this is the first; verified in game.

## Tuning

Positions are playtested, not derived. Geometry suggested rows 19 and 12; three rounds of play walked them down to 20 and 15 — the bounce is shorter than the tile counts imply. That history is in the `SCREEN2_NOTES` doc comment so the next person doesn't re-derive the optimistic numbers.

## Scope

Gated on a host actually drawing an Unused Level 5 room, so a seed without the Big [?] room shuffle is byte-identical to before. Confirmed: with `--big-q-blocks` alone the coins stay vanilla; with `--shuffle-big-q-rooms` the note blocks land.

## testrom

Gains `--bigq-notes`, driving the same write and optionally taking positions, so the next tuning round needs no rebuild. Its second spare layout command moves off screen 2 onto one of screen 4's ten decorative coins, since screen 2's pair is now load-bearing — a test asserts the return junction and the note blocks can never claim the same three bytes.

## Verification

- `cargo test` — 413 pass, 0 fail (4 new)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --lib --target wasm32-unknown-unknown -- -D warnings` — clean (the two native-only accessors are `cfg`-gated; the unguarded version tripped this gate)
- `tools/offset_dups.py` — no constants bypassed
- Real seeds 1, 2, 3, 7 with `--shuffle-big-q-rooms` carry `34 21 60 / 2f 24 60`

A regression test calls `point_slot0_at_unused5` directly and asserts the note blocks land, because deleting that one call would otherwise leave every other test here passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJFT6nNwJpvMVxaqqh3XoW