### PR TITLE
feature: three new king rescue quotes

### DIFF
--- a/src/randomize/king_quotes.rs
+++ b/src/randomize/king_quotes.rs
@@ -600,6 +600,22 @@ const QUOTES: &[[&str; 6]] = &[
         "",
         "",
     ],
+    [
+        "Don't have negative",
+        "thoughts.",
+        "",
+        "Remember your",
+        "mantra.",
+        "",
+    ],
+    [
+        "If you listen",
+        "closely, you can",
+        "hear DemonBattler",
+        "screaming in the",
+        "distance.",
+        "",
+    ],
 ];
 
 /// Suit-specific quotes: shown when Mario visits the king wearing frog suit.
@@ -708,6 +724,14 @@ const FROG_QUOTES: &[[&str; 6]] = &[
         "Wait.Bad example.",
         "",
         "",
+    ],
+    [
+        "Don't forget to",
+        "start your timer,",
+        "HumanMustard.",
+        "",
+        "Oh, too late.",
+        "Sorry, viewers!",
     ],
 ];
 


### PR DESCRIPTION
Adds three quotes to the king rescue pool.

Standard `QUOTES`:

```
|Don't have negative |      |If you listen       |
|thoughts.           |      |closely, you can    |
|                    |      |hear DemonBattler   |
|Remember your       |      |screaming in the    |
|mantra.             |      |distance.           |
|                    |      |                    |
```

`FROG_QUOTES`:

```
|Don't forget to     |
|start your timer,   |
|HumanMustard.       |
|                    |
|Oh, too late.       |
|Sorry, viewers!     |
```

`cargo test king_quotes` passes (line-width and encoder round-trip constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)