### PR TITLE
feature: forts stay off the forced path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ deploys.
 
 ### Changed
 
+- **Fortresses no longer sit where you cannot walk around them.** A fortress in
+  the middle of the only road is a wasted lock — you play it because it is in
+  the way, and the lock it opens was never a decision. Fortresses now take a
+  spot you could have walked past, so going to find one is a choice you make.
+  Measured across 1000 seeds, unavoidable fortresses went from 22% to under
+  0.5%, and worlds came out with slightly more routes rather than fewer.
+
 - **The level clock now counts real seconds.** Vanilla steps the timer every 41
   frames, so a unit was 0.68 s and the clock ran about 47% fast — a "300" level
   was really about 3:25, not five minutes. The divider is now 60 frames, giving

--- a/docs/choice_first_charter.md
+++ b/docs/choice_first_charter.md
@@ -675,3 +675,155 @@ dealt floor either way. Reproduce with:
 CENSUS_SEEDS=3000 cargo test --release --lib w8_bridges_out -- --ignored --nocapture
 BRIDGES_OUT=3 CENSUS_SEEDS=600 cargo test --release --lib w8_bridges_out -- --ignored --nocapture
 ```
+
+## Forts on the forced path — the baseline (2026-08-31)
+
+"A fort on the mandatory walking path is a wasted lock" is the charter's
+cardinal sin (above) and issue #163's whole subject, but until now nothing
+measured it on the world the builder actually ships. Two columns now do, both
+in `test_builder_shaping_census` (and `forced%` also at placement time in
+`test_builder_forts_census`):
+
+- **`forced%`** — `WorldState::forced_forts`, the strict form. Wall the fort
+  off with **every lock in the world open** and ask whether the goal is still
+  reachable. If it is not, the fort tile is a cut vertex: the player plays it
+  because it is in the way, and its lock opens with no decision made.
+- **`onC1%`** — the fort merely sits on the cheapest route. The weaker
+  symptom: the player *could* have walked around and chose not to, so a cheap
+  decision did happen. This is the number the pre-rebuild builder scored ~53%
+  on.
+
+Locks open is what separates the geometry question from the key question. The
+first version of the metric kept the fort's lock shut and ran the
+completability fixpoint; it called **61-93%** of forts forced, because it
+counted every world whose goal gate that fort opens — which is the charter's
+*good* structure ("which fort is the key?"), already counted by `gGate`.
+
+**Baseline, 1000 seeds, realistic flag mix:**
+
+| World | forced% dumb | forced% shaped | onC1% dumb | onC1% shaped |
+|---|---|---|---|---|
+| W1 | 47 | 35 | 76 | 83 |
+| W2 | 30 | 28 | 60 | 67 |
+| W3 | 22 | 22 | 48 | 63 |
+| W4 | 17 | 22 | 50 | 77 |
+| W5 | 20 | 17 | 61 | 74 |
+| W6 | 37 | 35 | 58 | 59 |
+| W7 | 18 | 19 | 50 | 77 |
+| W8 | 13 | 12 | 56 | 64 |
+
+Fort-weighted, that is roughly **24% → 22% forced** and **57% → 70% on the
+cheapest route**: the shaping loop leaves the strict number about where
+uniform placement put it, and drives the weak one up by ~13 points. The second
+half is expected rather than surprising — cost mode raises C1 by moving
+content *onto* the trunk (`try_level_move` says so in its own doc), and
+`try_fort_lock` accepts on routes/C1, never on off-path-ness. Note also that
+the loop only ever runs while `routes_needy || cheap`: a world with two in-band
+routes above its floor breaks out "satisfied" with every fort on the trunk,
+because nothing in the diagnosis asks.
+
+W1 and W6 are the outliers at both ends of the pipeline, and W1 is the world
+with no pipe budget at all — the lever that would de-force a fort is the one
+it does not have.
+
+**Caveats.**
+
+- Rocks read as walls to the map walker, so a fort avoidable only by spending
+  a hammer counts as forced. Deliberately conservative — the scorer prices a
+  rock at 8 points but models no hammer supply — and the reason `forced%` can
+  exceed `onC1%` in rocky worlds (W1, W6). A cut vertex is otherwise on every
+  route by construction.
+- Neither number is a defect count, and neither has a target. Per "What the
+  map must communicate", a lock still reports its fort and the world's fort
+  count however the fort was reached, and terrain can leave no alternative.
+  This section is the starting point #163 asks for, not a goal.
+
+```sh
+CENSUS_SEEDS=1000 cargo test --release --lib test_builder_shaping_census -- --nocapture
+CENSUS_SEEDS=1000 cargo test --release --lib test_builder_forts_census -- --ignored --nocapture
+```
+
+### The ceiling: can placement even comply? (2026-08-31)
+
+`test_builder_forced_blanks_census` measures the pool rather than the draw —
+of the legal blanks the `Forts` phase actually sees (production order:
+connectivity → levels), how many are cut vertices, and are there enough
+non-forced ones to hold the world's forts? 1000 seeds:
+
+| World | forts | blanks | free | forcedB% | tight% | forcedB% +spares |
+|---|---|---|---|---|---|---|
+| W1 | 1.86 | 10.9 | 5.9 | 46 | 0 | 46 |
+| W2 | 1.85 | 30.7 | 19.5 | 37 | 0 | 29 |
+| W3 | 1.87 | 28.1 | 19.8 | 30 | 0 | 24 |
+| W4 | 1.85 | 16.6 | 13.5 | 19 | 0 | 16 |
+| W5 | 1.87 | 23.9 | 19.1 | 20 | 0 | 20 |
+| W6 | 1.86 | 37.4 | 21.1 | 44 | 0 | 37 |
+| W7 | 1.84 | 16.0 | 13.3 | 17 | 0 | 17 |
+| W8 | 4.00 | 20.1 | 17.7 | 12 | 0 | 13 |
+
+Three readings:
+
+1. **`forcedB%` tracks the dumb arm's `forced%` almost exactly** (46/47,
+   19/17, 20/20, 17/18, 12/13). Placement is behaving precisely like the dice,
+   which is the knob-free skeleton working as designed — and it means the
+   whole of `forced%` is placement, not some later phase's doing.
+2. **`tight%` is 0 in every world, every seed.** The free pool is never
+   smaller than the fort budget; even W1, the worst world at 46% forced and
+   the only one with no pipe budget to fix it, still averages 5.9 non-forced
+   blanks for 1.86 forts. **There is no structural floor.** An off-path
+   preference is not a nudge here — it can be a near-hard rule with a
+   deliberate rare exception, which is what "never say never" asks for anyway.
+3. **Spare pipes are a weak second lever.** Spending the full remaining budget
+   moves `forcedB%` by 6-8 points in W2/W3/W6 and by nothing at all in
+   W1/W5/W7/W8. Worth taking where it falls out; not worth reordering the
+   pipeline for.
+
+Risk to carry into the fix: a fort off the trunk stops contributing its +5 to
+C1, so worlds that currently reach the floor partly *because* a fort was in
+the way will lean harder on the shaping loop (more level moves onto the trunk,
+longer builds). Measure C1, linear%, and build time alongside `forced%`.
+
+### The fix, and what it cost (2026-08-31)
+
+`Forts` now refuses a blank the player cannot walk around: one call to
+`WorldState::forced_positions` over `legal_blanks()`, asked once per phase
+because the answer cannot change as content lands. `try_fort_lock` filters
+its relocation targets the same way (hoisted, since that rung never touches
+the pipe web) and `try_pipe_move` rejects a rewiring that strands a fort on
+the path — a pipe *added* can only remove a cut vertex, but a mouth *taken
+away* can create one under a fort that was safe when it was placed.
+
+No rate and no fallback rule: `tight%` = 0 says the safe pool is never empty,
+so the "place it anyway" branch exists only to keep a future map from
+deadlocking, and it logs when it fires.
+
+**Result, 1000 seeds:** `forced%` **22% → 0.0%** in six worlds, 0.4% in W4 and
+0.2% in W7. The residue is the pipe-web redeal, which restores the placement
+snapshot and re-runs `Connectivity` with the forts frozen, so a fresh web can
+force one — deliberately left unguarded at that rate rather than adding a term
+to the redeal key for one fort in 250. `onC1%` fell too without being targeted
+(70% → 64% fort-weighted), since a blank off the cut vertices tends to be off
+the cheapest route as well.
+
+**The cost, `test_route_census` at 1000 seeds, before → after:**
+
+| | before | after |
+|---|---|---|
+| mean routes/world | 2.537 | **2.595** |
+| linear% | 6.91 | **6.22** |
+| C1 mean | 19.4 | 19.2 |
+| below own dealt floor | 0.34% | 0.39% |
+| goal-open | 3.0% | 2.7% |
+| build time (shaped) | 52.1 ms/seed | 52.5 ms/seed |
+
+The feared trade did not materialise: C1 gives up 0.2 points, and choice
+improves rather than regressing (W1 linear 9% → 4% is the biggest single
+move). Per-world linear% is flat or better everywhere except W4 (12 → 14) and
+W3 (5 → 6). Build time absorbs the extra BFS inside noise — the walker was
+never the expensive part, route enumeration is.
+
+Two columns moved that are not targets and are recorded so a later reader
+does not rediscover them as a surprise: W1 `zero-gate%` 3 → 8, and W7
+`goal-open%` 14 → 19. Both are charter non-defects (a decorative lock still
+reports its fort; a goal-open world above its floor is fine), and both follow
+from the same cause — forts off the trunk gate less of the map.

--- a/src/randomize/overworld_build/builder_tests.rs
+++ b/src/randomize/overworld_build/builder_tests.rs
@@ -525,7 +525,10 @@ fn test_builder_levels_census() {
 /// levels → spare pipes → forts). The headline number is on-route%: how
 /// often a random fort lands on the cheapest route — where the player pays
 /// its 5 points no matter what, and its future lock gates nothing (the
-/// "on-path fort = decorative lock" thesis, baselined). Runs the realistic
+/// "on-path fort = decorative lock" thesis, baselined). forced% is the
+/// strict form of the same thesis (`WorldState::forced_forts`): the goal is
+/// unreachable without this fort, so no route choice could have avoided it.
+/// Runs the realistic
 /// flag mix (see [`census_ctx`]). `CENSUS_SEEDS` seeds (default 100).
 ///
 /// `#[ignore]`d (2026-08-07): a baseline instrument, not a gate — it
@@ -542,6 +545,7 @@ fn test_builder_forts_census() {
 
     let mut placed_sum = [0usize; 8];
     let mut on_route = [0usize; 8];
+    let mut forced = [0usize; 8];
     let mut fort_count = [0usize; 8];
     let mut c1_sum = [0u64; 8];
     let mut routes_sum = [0usize; 8];
@@ -569,6 +573,7 @@ fn test_builder_forts_census() {
                 let path: HashSet<Pos> = cheap.path.iter().copied().collect();
                 on_route[world_idx] += forts.iter().filter(|p| path.contains(p)).count();
             }
+            forced[world_idx] += state.forced_forts().len();
             fort_count[world_idx] += forts.len();
             c1_sum[world_idx] += u64::from(measure.c1);
             routes_sum[world_idx] += measure.routes_in_band;
@@ -579,18 +584,113 @@ fn test_builder_forts_census() {
     }
 
     println!("forts census ({seeds} seeds, uniform placement, full dumb pipeline, flag-mix arms)");
-    println!("world  budget  placed  on-route%  C1(mean)  routes  linear%");
+    println!("world  budget  placed  on-route%  forced%  C1(mean)  routes  linear%");
     let n = seeds as f64;
     for world_idx in 0..8 {
         println!(
-            "  W{}   {:>5} {:>7.2} {:>9.0}% {:>9.1} {:>7.2} {:>7.0}%",
+            "  W{}   {:>5} {:>7.2} {:>9.0}% {:>7.0}% {:>9.1} {:>7.2} {:>7.0}%",
             world_idx + 1,
             budget[world_idx],
             placed_sum[world_idx] as f64 / n,
             100.0 * on_route[world_idx] as f64 / fort_count[world_idx].max(1) as f64,
+            100.0 * forced[world_idx] as f64 / fort_count[world_idx].max(1) as f64,
             c1_sum[world_idx] as f64 / n,
             routes_sum[world_idx] as f64 / n,
             100.0 * linear[world_idx] as f64 / n,
+        );
+    }
+}
+
+/// Forced-blank ceiling: can fort placement even comply with the charter's
+/// "forts stay off the path" rule? A fort is forced exactly when it sits on
+/// a cut-vertex blank (see `WorldState::forced_positions` — the answer is a
+/// property of terrain + pipe web alone, decided before any content lands),
+/// so this measures the pool the Forts phase draws from rather than where it
+/// happened to draw.
+///
+/// Production order: connectivity → levels, then measure, because that is
+/// what `Forts` actually sees. The `+spares` columns re-measure with the
+/// full pipe budget spent — spare pipes run AFTER shaping in production, and
+/// a pipe can only ever remove a cut vertex, so the difference is what the
+/// world's own remaining budget would buy if the fort phase could see it.
+///
+/// Columns: blanks/free = mean legal blanks and mean NON-forced ones at fort
+/// time; forcedB% = share of the pool that is forced; tight% = seeds where
+/// the free blanks cannot cover the world's fort budget, so at least one
+/// fort MUST be forced whatever the builder prefers — the structural floor.
+/// Runs the realistic flag mix (see [`census_ctx`]). `CENSUS_SEEDS` seeds
+/// (default 100).
+///
+/// `#[ignore]`d: a baseline instrument, not a gate — no assertions.
+#[test]
+#[ignore]
+fn test_builder_forced_blanks_census() {
+    let Some(raw) = load_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
+    let seeds: u64 = std::env::var("CENSUS_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(100);
+
+    #[derive(Default, Clone, Copy)]
+    struct Tally {
+        blanks: usize,
+        forced: usize,
+        free_sum: usize,
+        tight: usize,
+    }
+
+    let mut pre = [Tally::default(); 8];
+    let mut post = [Tally::default(); 8];
+    let mut budget_sum = [0usize; 8];
+
+    let measure = |t: &mut Tally, state: &WorldState| -> usize {
+        let blanks = state.legal_blanks();
+        let forced = state.forced_positions(&blanks).len();
+        t.blanks += blanks.len();
+        t.forced += forced;
+        let free = blanks.len() - forced;
+        t.free_sum += free;
+        free
+    };
+
+    for seed in 0..seeds {
+        let ctx = census_ctx(&raw, seed);
+        for world_idx in 0..8 {
+            let mut state = ctx.world(world_idx);
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            budget_sum[world_idx] += state.fort_budget;
+
+            run_schedule(&mut state, &[&Connectivity, &Levels], &mut rng);
+            if measure(&mut pre[world_idx], &state) < state.fort_budget {
+                pre[world_idx].tight += 1;
+            }
+
+            run_schedule(&mut state, &[&SparePipes], &mut rng);
+            if measure(&mut post[world_idx], &state) < state.fort_budget {
+                post[world_idx].tight += 1;
+            }
+        }
+    }
+
+    println!("forced-blank census ({seeds} seeds, production order through levels, flag-mix arms)");
+    println!(
+        "world  forts  blanks  free  forcedB%  tight%  |  +spares: blanks  free  forcedB%  tight%"
+    );
+    let n = seeds as f64;
+    for world_idx in 0..8 {
+        let (a, b) = (&pre[world_idx], &post[world_idx]);
+        println!(
+            "  W{}   {:>5.2} {:>7.1} {:>5.1} {:>8.0}% {:>6.0}%  | {:>15.1} {:>5.1} {:>8.0}% {:>6.0}%",
+            world_idx + 1,
+            budget_sum[world_idx] as f64 / n,
+            a.blanks as f64 / n,
+            a.free_sum as f64 / n,
+            100.0 * a.forced as f64 / a.blanks.max(1) as f64,
+            100.0 * a.tight as f64 / n,
+            b.blanks as f64 / n,
+            b.free_sum as f64 / n,
+            100.0 * b.forced as f64 / b.blanks.max(1) as f64,
+            100.0 * b.tight as f64 / n,
         );
     }
 }
@@ -747,6 +847,15 @@ fn test_builder_shaping_census() {
         zero_gate: usize,
         goal_gates: usize,
         locks: usize,
+        // Forts, and the two on-path symptoms the charter's "forts stay off
+        // the path" rule is about: `forced` = the player cannot reach the
+        // goal without this fort, so its lock opens with no decision made;
+        // `on_c1` = it merely sits on the cheapest route (avoidable, so the
+        // player chose it). forced is a subset of on_c1 in practice, never
+        // by construction.
+        forts: usize,
+        forced: usize,
+        on_c1: usize,
         goal_open: usize,
         pipes: usize,
         // Adjacent-level pairs (orthogonal 2-tile neighbors — visually
@@ -775,6 +884,9 @@ fn test_builder_shaping_census() {
                 zero_gate: 0,
                 goal_gates: 0,
                 locks: 0,
+                forts: 0,
+                forced: 0,
+                on_c1: 0,
                 goal_open: 0,
                 pipes: 0,
                 adjacent_levels: 0,
@@ -812,6 +924,16 @@ fn test_builder_shaping_census() {
         t.zero_gate += state.zero_gate_locks().len();
         t.goal_gates += state.goal_gate_locks();
         t.locks += state.locks.len();
+        t.forts += state.fort_count();
+        t.forced += state.forced_forts().len();
+        if let Some(cheap) = m.rc.routes.first() {
+            let path: HashSet<Pos> = cheap.path.iter().copied().collect();
+            t.on_c1 += state
+                .slots
+                .iter()
+                .filter(|s| s.kind == SlotKind::Fortress && path.contains(&s.pos))
+                .count();
+        }
         t.pipes += state.pipe_pairs.len();
         let levels: Vec<Pos> =
             state.slots.iter().filter(|s| s.kind == SlotKind::Level).map(|s| s.pos).collect();
@@ -948,13 +1070,13 @@ fn test_builder_shaping_census() {
         "shaping A/B census ({seeds} seeds, dumb skeleton vs diagnosis-driven shaping, flag-mix arms)"
     );
     println!(
-        "world  arm     C1(mean)  C1min  C1<12%  routes  linear%  uniq  C2-C1  noalt%  zero-gate%  gGate  goal-open%  pipes  touched%  lr(acc:rej)  ab(acc:rej)  gs(acc:rej)  fl(acc:rej)  lm(acc:rej)  pm(acc:rej)  redeals"
+        "world  arm     C1(mean)  C1min  C1<12%  routes  linear%  uniq  C2-C1  noalt%  zero-gate%  forced%  onC1%  gGate  goal-open%  pipes  touched%  lr(acc:rej)  ab(acc:rej)  gs(acc:rej)  fl(acc:rej)  lm(acc:rej)  pm(acc:rej)  redeals"
     );
     let n = seeds as f64;
     for world_idx in 0..8 {
         for (arm, t) in [("dumb", &dumb[world_idx]), ("shaped", &shaped[world_idx])] {
             let base = format!(
-                "  W{}   {arm:<7} {:>7.1} {:>6} {:>6.0}% {:>7.2} {:>7.0}% {:>5.2} {:>6.2} {:>6.0}% {:>9.0}% {:>5.2} {:>9.0}% {:>6.2} adjL={:.2}",
+                "  W{}   {arm:<7} {:>7.1} {:>6} {:>6.0}% {:>7.2} {:>7.0}% {:>5.2} {:>6.2} {:>6.0}% {:>9.0}% {:>6.1}% {:>5.0}% {:>5.2} {:>9.0}% {:>6.2} adjL={:.2}",
                 world_idx + 1,
                 t.c1 as f64 / n,
                 t.c1_min,
@@ -965,6 +1087,8 @@ fn test_builder_shaping_census() {
                 t.gap_sum as f64 / t.gapped.max(1) as f64,
                 100.0 * t.noalt as f64 / n,
                 100.0 * t.zero_gate as f64 / t.locks.max(1) as f64,
+                100.0 * t.forced as f64 / t.forts.max(1) as f64,
+                100.0 * t.on_c1 as f64 / t.forts.max(1) as f64,
                 t.goal_gates as f64 / n,
                 100.0 * t.goal_open as f64 / n,
                 t.pipes as f64 / n,

--- a/src/randomize/overworld_build/forts.rs
+++ b/src/randomize/overworld_build/forts.rs
@@ -1,11 +1,25 @@
 //! Forts phase — place the world's fortresses.
 //!
-//! KNOB-FREE: each fort lands on a uniform-random legal blank, same shared
-//! rules as levels and pipe endpoints. None of the shipping builder's fort
-//! thinking (off-path preference, dead-end aesthetics, rescue duty) exists
-//! yet — the census measures where random forts land (notably: how often on
-//! the cheapest route, where their future lock would gate nothing) and the
-//! off-path preference gets argued from that number.
+//! Uniform-random over legal blanks, same shared rules as levels and pipe
+//! endpoints, with ONE preference: a fort may not take a blank the player
+//! cannot walk around. Everything else the shipping builder used to do here
+//! (dead-end aesthetics, rescue duty) still does not exist.
+//!
+//! **Why this one preference.** A fort the player is forced through is a
+//! wasted lock — they play it because it is in the way and its lock opens
+//! with no decision made (the charter's cardinal sin, issue #163). The
+//! forbidden blanks are exactly the cut vertices between start and goal, so
+//! [`WorldState::forced_positions`] answers it directly; it is asked once
+//! per phase because the answer depends on terrain and the pipe web alone,
+//! never on what has been placed.
+//!
+//! Argued from the census as this module promised, not assumed
+//! (`docs/choice_first_charter.md`, "Forts on the forced path"): uniform
+//! placement left 24% of forts forced and the shaping loop could not repair
+//! them, while the free pool covered every world's fort budget in 8000 out
+//! of 8000 world-builds. With no seed ever short of safe blanks the
+//! preference needs no rate and no fallback rule — the guard below fires
+//! only if a future map ever runs the pool dry.
 //!
 //! Forts carry a plain **fort id** in `SlotAssignment.section`, assigned in
 //! placement order. It exists only to pair each fort with its lock (a ROM
@@ -29,7 +43,17 @@ impl Phase for Forts {
     fn run(&self, state: &mut WorldState, rng: &mut dyn RngCore) -> PhaseReport {
         let mut actions = Vec::new();
 
+        // Asked once: placing content never changes who is a cut vertex.
         let mut candidates = state.legal_blanks();
+        let forced: HashSet<Pos> = state.forced_positions(&candidates).into_iter().collect();
+        if candidates.iter().any(|p| !forced.contains(p)) {
+            candidates.retain(|p| !forced.contains(p));
+        } else if !forced.is_empty() {
+            actions.push(format!(
+                "no unforced blank among {} candidates — placing on the path",
+                candidates.len(),
+            ));
+        }
         let mut placed = 0usize;
 
         while placed < state.fort_budget {
@@ -51,7 +75,11 @@ impl Phase for Forts {
             candidates.retain(|&c| c != pos && Some(c) != row78_partner(pos));
         }
 
-        actions.push(format!("done: {placed}/{} forts placed", state.fort_budget));
+        actions.push(format!(
+            "done: {placed}/{} forts placed, {} forced blanks excluded",
+            state.fort_budget,
+            forced.len(),
+        ));
         PhaseReport { phase: self.name(), actions }
     }
 }

--- a/src/randomize/overworld_build/shaping.rs
+++ b/src/randomize/overworld_build/shaping.rs
@@ -502,6 +502,11 @@ fn try_fort_lock(
     let trunk: HashSet<Pos> =
         before.rc.routes.first().map(|r| r.path.iter().copied().collect()).unwrap_or_default();
 
+    // Blanks the player could not walk around, hoisted out of both loops:
+    // this rung never touches terrain or the pipe web, and nothing else
+    // decides who is a cut vertex, so one answer serves every trial.
+    let no_go: HashSet<Pos> = state.forced_positions(&state.legal_blanks()).into_iter().collect();
+
     let mut fort_indices: Vec<usize> = state
         .slots
         .iter()
@@ -524,7 +529,8 @@ fn try_fort_lock(
             if evals >= FORTLOCK_TRIES {
                 break;
             }
-            let candidates = state.legal_blanks();
+            let candidates: Vec<Pos> =
+                state.legal_blanks().into_iter().filter(|p| !no_go.contains(p)).collect();
             let Some(&new_pos) = candidates.choose(rng) else { break };
             state.slots[fi].pos = new_pos;
             evals += 1;
@@ -685,7 +691,10 @@ fn try_pipe_move(
             state.pipe_pairs[pi] = if move_a { (new_pos, keep) } else { (keep, new_pos) };
             evals += 1;
 
-            if all_content_reachable(state) && place_locks_gating(state, rng, true) {
+            if all_content_reachable(state)
+                && !any_fort_forced(state)
+                && place_locks_gating(state, rng, true)
+            {
                 let after = measure_world(state);
                 // Cost-only rung: there is no choice gain to claim, so the
                 // verdict is `accepted`'s cost branch alone — exactly the
@@ -719,6 +728,16 @@ fn try_pipe_move(
 /// snake along the trunk.
 fn spaced(state: &WorldState, targets: Vec<Pos>) -> Vec<Pos> {
     targets.into_iter().filter(|&p| !super::levels::next_to_level(state, p)).collect()
+}
+
+/// True when some fort now sits where the player cannot walk around it. The
+/// [`Forts`] placement rule, re-checked after a move that REWIRES the pipe
+/// web: adding a pipe can only ever remove a cut vertex, but taking a mouth
+/// away can create one under a fort that was safe when it was placed.
+fn any_fort_forced(state: &WorldState) -> bool {
+    let forts: Vec<Pos> =
+        state.slots.iter().filter(|s| s.kind == SlotKind::Fortress).map(|s| s.pos).collect();
+    !state.forced_positions(&forts).is_empty()
 }
 
 /// Every slot and the goal walk-reachable from start on the all-open world

--- a/src/randomize/overworld_build/state.rs
+++ b/src/randomize/overworld_build/state.rs
@@ -199,6 +199,90 @@ impl WorldState {
         out
     }
 
+    /// Forts the player cannot walk around — the charter's "fort on the
+    /// forced path" in its strict form. Wall the fort off (the player
+    /// refuses to play it) with every lock in the world OPEN, and ask
+    /// whether the goal is still reachable. If it is not, the fort tile is
+    /// a cut vertex: no route avoids it, the player plays it because it is
+    /// in the way, and its lock opens as a side effect — no decision was
+    /// ever offered. Returns fort ids (`SlotAssignment::section`).
+    ///
+    /// **Every lock open is the point, not a shortcut.** It isolates the
+    /// GEOMETRY question from the key question. A fort the player must beat
+    /// because its lock is the only way through is the charter's good
+    /// structure — they had to go find the key — and the closed-lock
+    /// version of this test cannot tell the two apart (measured: it called
+    /// 61-93% of forts forced, mostly goal gates). That case is already
+    /// counted by [`Self::goal_gate_locks`].
+    ///
+    /// Distinct from a fort merely sitting on the CHEAPEST route: that one
+    /// could have been walked around, so taking it was a (cheap) decision.
+    /// Distinct again from [`Self::zero_gate_locks`] — a forced fort's lock
+    /// can wall off half the world and still be free to open.
+    ///
+    /// Rocks read as walls here, the map walker's model, so a fort avoidable
+    /// only by spending a hammer on a rock counts as forced — deliberately
+    /// conservative (the hammer is a real cost the scorer cannot price: it
+    /// does charge a rock 8 points but models no hammer supply). This is
+    /// why forced% can exceed the on-cheapest-route rate in rocky worlds.
+    ///
+    /// A census instrument, not a defect count: per the charter's "What the
+    /// map must communicate", a lock still reports its fort and its count
+    /// whatever the fort cost, and terrain (W1's zero pipe budget, a world
+    /// with no off-trunk blanks) can leave no alternative.
+    #[cfg(test)]
+    pub(crate) fn forced_forts(&self) -> Vec<usize> {
+        let forts: Vec<(usize, Pos)> = self
+            .slots
+            .iter()
+            .filter(|s| s.kind == SlotKind::Fortress)
+            .map(|s| (s.section, s.pos))
+            .collect();
+        let positions: Vec<Pos> = forts.iter().map(|&(_, pos)| pos).collect();
+        let forced: HashSet<Pos> = self.forced_positions(&positions).into_iter().collect();
+        forts.iter().filter(|(_, pos)| forced.contains(pos)).map(|&(id, _)| id).collect()
+    }
+
+    /// Which of `candidates` are cut vertices between the start and the
+    /// goal — the test [`Self::forced_forts`] is built from, exposed so a
+    /// census can ask it of empty blanks ("could a fort placed HERE have
+    /// been avoided?") as well as of placed forts.
+    ///
+    /// **The answer does not depend on what is placed.** Content only ever
+    /// occupies node tiles and every node tile is walkable to the map walker
+    /// (`VALID_BLANK_TILES` and the stamped slot tiles are all disjoint from
+    /// `BACKGROUND_TILES`); only locks change walkability, and they are held
+    /// open here. So this is a property of the terrain plus the pipe web
+    /// alone, fixed the moment connectivity finishes. Adding a pipe can only
+    /// ever REMOVE a cut vertex, never create one — which makes a fort
+    /// placed off a forced blank a guarantee that survives every later
+    /// phase, not a preference that decays. That invariance is what lets
+    /// [`Forts`] call this ONCE for the whole phase rather than per placement.
+    pub(crate) fn forced_positions(&self, candidates: &[Pos]) -> Vec<Pos> {
+        // Any BACKGROUND_TILES member reads as a wall to the walker. The
+        // wall is written into a scratch grid and taken back out again; no
+        // value here ever reaches the ROM.
+        const WALL: u8 = BACKGROUND_TILES[0];
+
+        let Some(target) = self.target else { return Vec::new() };
+        let mut g = self.grid.clone();
+        stamp_slots(&mut g, &self.slots);
+        for lock in &self.locks {
+            g.set(lock.pos.0, lock.pos.1, lock.replace_tile);
+        }
+
+        let mut out = Vec::new();
+        for &pos in candidates {
+            let was = g.get(pos.0, pos.1);
+            g.set(pos.0, pos.1, WALL);
+            if !walk_reachable(&g, &self.pipe_pairs, self.start, self.world_idx).contains(target) {
+                out.push(pos);
+            }
+            g.set(pos.0, pos.1, was);
+        }
+        out
+    }
+
     /// Order-free completability — the locks invariant. Close every lock,
     /// beat every fort the walker can reach, open those forts' locks,
     /// repeat to a fixpoint. Valid iff the goal is reached AND every fort

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -200,27 +200,46 @@ fn sweep_is_deterministic() {
 /// the pre- and post-fix ROMs were diffed byte for byte (`--no-palettes
 /// --patched-rom`) and the diff is exactly 0x10476..0x1047F on every one of
 /// them, with no second span. No map tile, pointer table or level byte moved.
+///
+/// Re-captured 2026-08-31 for the off-path fort rule (`Forts` may no longer
+/// take a blank the player cannot walk around; `try_fort_lock` and
+/// `try_pipe_move` hold the same line). Overworld topology changes on
+/// purpose. TWO causes are folded into this recapture and both are named
+/// here on purpose:
+///
+/// 1. The baseline was ALREADY stale at HEAD — PR #205 (three new king rescue
+///    quotes) rewrites quote text in every ROM and did not recapture, so all
+///    20 seeds had already moved before this change was written.
+/// 2. This change itself, which moves fortresses and therefore locks, C1, and
+///    the shaping decisions downstream of them.
+///
+/// Verified by pinning, the way the v28 and dealt-C1-floor recaptures were:
+/// neutralising all three guards (an empty forced set in `Forts` and in
+/// `try_fort_lock`, `any_fort_forced` returning false) reproduced the HEAD
+/// hashes EXACTLY, all 20 seeds. So cause 2 is the guards alone — the new
+/// `WorldState::forced_positions` and the census columns that read it change
+/// no output — and cause 1 is inherited, not created here.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x4E4FF90634A36EFE,
-    0x7EF158B7AB964F24,
-    0xBB1600149FDEE681,
-    0x19755D9D3A20D976,
-    0x6780286C3D945042,
-    0x32DCF84F7F8CC8CE,
-    0xAD44D169D22366F9,
-    0xDC4E49DFCA9316BA,
-    0x3ADFD185C3D96617,
-    0x85F50EE60B7813EB,
-    0x21C742BD48684712,
-    0xCDAAC2C715B4FD06,
-    0x8E4AE5BD2732E71E,
-    0x6F227C0E53E246CD,
-    0x87C947524987DD2B,
-    0x679C101E1A2CF5CB,
-    0xB8B5AB92808F8EDD,
-    0xEC8D879A476CE504,
-    0x0D55993F9D2E99CB,
-    0x5B841B69FF6AFAB6,
+    0x29A3EEA5BF4AE51F,
+    0xDF1B453A02F3E8CE,
+    0x3C30C7E62A89E412,
+    0x6590EB228FFFFFAD,
+    0xD9824148CFCFB18E,
+    0x13FB87791F7E5643,
+    0x2259781019F56587,
+    0x05E4347FD69DA9A9,
+    0xC149AFCA80118085,
+    0xB2C7DFD9A190A0B5,
+    0x1D86758E9A78E98E,
+    0xE05F91CBFC3F6720,
+    0xF29978C2C9D3AF59,
+    0xE7AC193883E470EC,
+    0xCDA7E9922AB91CCC,
+    0x32D1C6748C543C3C,
+    0xF801670EA1CCA280,
+    0x14D567EBB4188B77,
+    0xCBA0C0826565F4C1,
+    0x78E3B157D38E6082,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always


### PR DESCRIPTION
A fortress the player cannot walk around is a wasted lock — they play it
because it is in the way, and the lock it opens was never a decision. The
charter has called that the cardinal sin since the rebuild, but nothing
measured it on the world we ship, and `forts.rs` said the off-path preference
had to be argued from a census that did not exist yet.

Closes #163.

## Measure first

`WorldState::forced_positions` walls a position off with **every lock open**
and asks whether the goal is still reachable — the geometry question alone.
Keeping the fort's lock shut instead (the first version of the metric) called
61-93% of forts forced, because it also caught every goal gate: the player
must beat that fort, but they had to go *find* it, which is the good structure
rather than the sin.

Three census readouts hang off it: `forced%` and `onC1%` columns in the
shaping A/B, and a new `test_builder_forced_blanks_census` that measures the
pool rather than the draw.

The census settled two things:

1. **Uniform placement left 24% of forts forced and shaping repaired none of
   it** — it has no rung that can. Forcedness is a property of terrain plus
   the pipe web, fixed before any content lands: content only occupies node
   tiles and every node tile is walkable, so nothing placed later changes who
   is a cut vertex.
2. **`tight%` was 0 in 8000 out of 8000 world-builds.** The non-forced pool
   always covers the world's fort budget — even W1, worst at 46% forced blanks
   and the only world with no pipe budget to fix it, averages 5.9 safe blanks
   for 1.86 forts. No world needs a fallback rate.

## The rule

`Forts` drops cut-vertex blanks, asked once per phase. `try_fort_lock`
filters its relocation targets the same way (hoisted — that rung never touches
the pipe web). `try_pipe_move` rejects a rewiring that strands a fort: a pipe
*added* can only remove a cut vertex, but a mouth *taken away* can create one
under a fort that was safe when it was placed.

No rate and no fallback branch beyond a deadlock guard that logs when it
fires. `tight%` = 0 earned that simplicity.

## Result — 1000 seeds

`forced%` **22% -> 0.0%** in six worlds, **0.4%** in W4 and **0.2%** in W7.
The residue is the pipe-web redeal, which restores the placement snapshot and
re-runs `Connectivity` with the forts frozen, so a fresh web can force one.
Left unguarded at one fort in 250 rather than growing the redeal key.
`onC1%` fell 70% -> 64% without being targeted.

`test_route_census`, before -> after, both measured at 1000 seeds on this tree:

| | before | after |
|---|---|---|
| mean routes/world | 2.537 | **2.595** |
| linear% | 6.91 | **6.22** |
| C1 mean | 19.4 | 19.2 |
| below own dealt floor | 0.34% | 0.39% |
| goal-open | 3.0% | 2.7% |
| build time (shaped) | 52.1 ms/seed | 52.5 ms/seed |

The feared trade did not appear: C1 gives up 0.2 points and choice improves
rather than regressing (W1 linear 9% -> 4% is the biggest single move).
Per-world linear% is flat or better everywhere except W4 (12 -> 14) and W3
(5 -> 6). The extra BFS lands inside noise — the walker was never the
expensive part, route enumeration is.

Two columns moved that are **not** targets, recorded in the charter so a later
reader does not rediscover them as a surprise: W1 `zero-gate%` 3 -> 8 and W7
`goal-open%` 14 -> 19. Both are charter non-defects, both from the same cause
— forts off the trunk gate less of the map.

## The byte baseline

Recaptured, and it needs saying that **it was already stale at HEAD**: #205
(king quotes) rewrote quote text in every ROM without recapturing, so all 20
seeds had moved before this branch existed. Both causes are named in the
const's doc comment rather than letting the inherited drift ride along
silently. To pin this branch's half: neutralising all three guards reproduced
the HEAD hashes exactly on all 20 seeds, so `forced_positions` and the census
columns change no output and the difference is the guards alone.

## Verification

- `cargo clippy --all-targets` clean, `cargo fmt --check` clean
- full suite green (423 lib + integration, baseline back to passing)
- `CENSUS_SEEDS=500 all_world_targets_reachable` passes (237s)
- `CENSUS_SEEDS=1000 test_route_census` as tabled above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
