### PR TITLE
feature: Deja Vu — let one level appear on several tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ deploys.
 
 ### Added
 
+- **Deja Vu** (new option, off by default; MaCobra52's idea). Lets the same
+  level show up on more than one tile. *Double* puts a second copy of every
+  level in the deck, so some appear twice and others sit the seed out. *Wild*
+  deals with replacement — a level can turn up any number of times, or never.
+  Levels that hand out a one-off item (the chest levels and the World 8 hand
+  rooms) still appear exactly once in both modes.
+
 - **Bro Battle Timer** (new option, off by default). Walking into a Hammer,
   Boomerang, Heavy or Fire Bro starts the clock at 10 instead of the arena's
   usual 200 — and with the clock fix above, ten really is ten seconds. Miss it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use rom::Rom;
 
 pub use ips::apply_ips_patch;
 pub use randomizer::{
-    EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
+    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
     ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser,
     current_flag_key_version, flag_key_fields, flag_key_version_of, item_display_name, item_id,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use std::process;
 
 use smb3_rs::{
-    EnemyMode, FireFlowerMode, HazardLimit, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES,
-    Tri, WildChaser, item_display_name, item_id,
+    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, ITEMS, Options, PiranhaMode,
+    STARTING_LIVES_VALUES, Tri, WildChaser, item_display_name, item_id,
 };
 
 /// Human-readable label for a tri-state flag in the run summary.
@@ -75,6 +75,16 @@ fn parse_hazard_limit(s: &str) -> Result<HazardLimit, String> {
         "some" => Ok(HazardLimit::Sparse),
         "all" => Ok(HazardLimit::All),
         _ => Err("valid values: off, some, all".to_string()),
+    }
+}
+
+/// clap value parser for `--deja-vu` (off/double/wild).
+fn parse_deja_vu(s: &str) -> Result<DejaVuMode, String> {
+    match s {
+        "off" => Ok(DejaVuMode::Off),
+        "double" => Ok(DejaVuMode::Double),
+        "wild" => Ok(DejaVuMode::Wild),
+        _ => Err("valid values: off, double, wild".to_string()),
     }
 }
 
@@ -422,6 +432,14 @@ struct Cli {
     #[arg(long)]
     friendlier_levels: bool,
 
+    /// Deja Vu: let one level appear on more than one map tile — off, double,
+    /// or wild (default: off). `double` puts two copies of every level in the
+    /// deck; `wild` deals with replacement, so a level can appear any number of
+    /// times or not at all. Levels holding a one-off item are dealt once either
+    /// way. (MaCobra52's idea.)
+    #[arg(long, default_value = "off", value_parser = parse_deja_vu)]
+    deja_vu: DejaVuMode,
+
     /// Seed a level-wide chaser into a fraction of levels. A comma-separated
     /// set of `sun`, `lakitu`, `bass`; or `all`; or `off` (default). A level
     /// whose CHR can't fit an allowed chaser is skipped rather than given one
@@ -586,6 +604,7 @@ fn build_options(cli: &Cli) -> Options {
             hb_encounters: cli.hb_encounters,
             limit_hazards: cli.limit_hazards,
             friendlier_levels: cli.friendlier_levels,
+            deja_vu: cli.deja_vu,
             wild_injections: cli.wild_injections.0.clone(),
             starting_lives: cli.starting_lives,
             starting_items,
@@ -620,6 +639,14 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
         }
     );
     eprintln!("  Friendlier levels: {}", if options.friendlier_levels { "on" } else { "off" });
+    eprintln!(
+        "  Deja Vu: {}",
+        match options.deja_vu {
+            DejaVuMode::Off => "off",
+            DejaVuMode::Double => "double",
+            DejaVuMode::Wild => "wild",
+        }
+    );
     eprintln!("  World order: {}", if options.world_order { "on" } else { "off" });
     if options.world_order && options.world_count < 7 {
         eprintln!("  World count: {}", options.world_count);

--- a/src/randomize/overworld_writer/assign.rs
+++ b/src/randomize/overworld_writer/assign.rs
@@ -78,7 +78,7 @@ pub(super) fn assign_pool<R: Rng>(
     rng: &mut R,
     flags: WriteFlags,
 ) -> Vec<WorldAssignments> {
-    let WriteFlags { shuffle_hammer_bros, friendlier_levels, .. } = flags;
+    let WriteFlags { shuffle_hammer_bros, friendlier_levels, deja_vu, .. } = flags;
     let pickup = data.pickup;
     let catalog = data.catalog;
     // Partition pool by kind.
@@ -216,30 +216,77 @@ pub(super) fn assign_pool<R: Rng>(
             || rom_data::is_chest_level(ce.world_idx, ce.entry_idx)
     };
 
-    // Friendlier Levels: hold the harshest levels out of the deck, then refill
-    // it so the draw still reaches VANILLA_LEVEL_COUNT.
+    // --- Deck surgery -------------------------------------------------
     //
-    // Refilling is mandatory, not cosmetic: the builder places exactly
+    // Three steps, in this order: Friendlier Levels takes levels *out*, Deja Vu
+    // decides how many copies of what is left go *in*, and then the deck is
+    // topped back up if either left it short.
+    //
+    // The top-up is mandatory, not cosmetic: the builder places exactly
     // VANILLA_LEVEL_COUNT levels every seed and the draw below is a bare
-    // `pop_front().expect(...)`, so a short deck panics. Beta stages already
-    // leave the deck oversized (they are appended without raising the number
-    // drawn), so they absorb the removals first and only the shortfall becomes
-    // duplicates — which is why `short` is a saturating subtraction rather
-    // than the blocklist length.
+    // `pop_front().expect(...)`, so a short deck panics.
     //
     // A duplicate is just the same pool index dealt twice. The writer reads
     // the level entry through it, so both slots get the same level; nothing
     // needs a synthetic catalog entry.
+
+    // Friendlier Levels: hold the harshest levels out of the deck.
     if friendlier_levels {
         level_pool.retain(|&pi| {
             !rom_data::is_friendlier_blocked(&catalog.entries[pickup.pool[pi].catalog_idx].name)
         });
-        let sources: Vec<usize> =
-            level_pool.iter().copied().filter(|&pi| !holds_unique_item(pi)).collect();
-        let short = VANILLA_LEVEL_COUNT.saturating_sub(level_pool.len());
+    }
+
+    // Deja Vu: let levels repeat. Both modes redeal the deck to exactly
+    // VANILLA_LEVEL_COUNT cards, so the whole deck is dealt and the redeal is
+    // what the player sees rather than a shuffle-and-truncate after it.
+    //
+    // The deck is seeded with the levels holding a one-off inventory item, one
+    // copy each, and they are then held out of the redeal. That is the only way
+    // to keep both halves of their rule true at once: never dealt twice (the
+    // item would be handed out twice) and never dropped (it would be out of
+    // reach). Everything else is fair game.
+    //
+    // `sources` is never empty — the pool is dozens of levels and only a
+    // handful hold an item.
+    if deja_vu != DejaVuMode::Off {
+        let (mut deck, sources): (Vec<usize>, Vec<usize>) =
+            level_pool.iter().copied().partition(|&pi| holds_unique_item(pi));
+        let want = VANILLA_LEVEL_COUNT.saturating_sub(deck.len());
+        match deja_vu {
+            // Double: two copies of every level in the bag, dealt without
+            // replacement. A level lands on at most two tiles, and the levels
+            // the deal misses sit the seed out.
+            DejaVuMode::Double => {
+                let mut bag: Vec<usize> = sources.iter().chain(sources.iter()).copied().collect();
+                bag.as_mut_slice().shuffle(rng);
+                bag.truncate(want);
+                deck.extend(bag);
+            }
+            // Wild: drawn with replacement, so nothing caps how many tiles one
+            // level can take.
+            _ => {
+                for _ in 0..want {
+                    deck.push(*sources.choose(rng).expect("no repeatable levels in pool"));
+                }
+            }
+        }
+        level_pool = deck;
+    }
+
+    // Top the deck back up to the number of slots the builder placed. Only
+    // Friendlier Levels can leave it short, and only with Deja Vu off or beta
+    // stages off: beta stages already leave the deck oversized (they are
+    // appended without raising the number drawn) so they absorb the removals
+    // first, and either Deja Vu mode refills it well past the line. That is why
+    // `short` is a saturating subtraction rather than the blocklist length.
+    let short = VANILLA_LEVEL_COUNT.saturating_sub(level_pool.len());
+    if short > 0 {
         // Without replacement, so no level is dealt a third time. `sources` is
         // far larger than `short` for any sane blocklist; the deck-length
         // assertion in the tests is what holds that true.
+        let sources: Vec<usize> =
+            level_pool.iter().copied().filter(|&pi| !holds_unique_item(pi)).collect();
         level_pool.extend(sources.choose_multiple(rng, short).copied());
     }
 

--- a/src/randomize/overworld_writer/mod.rs
+++ b/src/randomize/overworld_writer/mod.rs
@@ -7,8 +7,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use rand::Rng;
 use rand::seq::{IndexedRandom, SliceRandom};
 
-use crate::PiranhaMode;
 use crate::rom::Rom;
+use crate::{DejaVuMode, PiranhaMode};
 
 use super::node_catalog::NodeKind;
 use super::overworld_build::{
@@ -134,6 +134,8 @@ pub(crate) fn write_overworld<R: Rng>(
 pub(crate) struct WriteFlags {
     pub shuffle_hammer_bros: bool,
     pub piranha: PiranhaMode,
+    /// Deja Vu: how many times one level may appear on the map.
+    pub deja_vu: DejaVuMode,
     /// Friendlier Levels: drop `FRIENDLIER_BLOCKED_LEVELS` from the level deck
     /// and refill it with duplicates of what remains.
     pub friendlier_levels: bool,

--- a/src/randomize/overworld_writer/tests.rs
+++ b/src/randomize/overworld_writer/tests.rs
@@ -248,6 +248,128 @@ fn test_friendlier_levels_blocks_and_refills() {
     }
 }
 
+/// Deja Vu deck surgery, both modes and both beta arms.
+///
+/// Three things the deck has to keep true no matter how it is redealt:
+///
+///  - The deal still fills every slot. The draw is a bare
+///    `pop_front().expect(...)` against a fixed `VANILLA_LEVEL_COUNT`, so a
+///    short deck panics rather than degrading.
+///  - A level holding a one-off inventory item is dealt exactly once — never
+///    twice (the item would be handed out twice) and never zero times (it
+///    would be unreachable).
+///  - The mode does what it says: `Double` caps a level at two tiles, `Wild`
+///    does not.
+///
+/// Both beta arms are checked because they change the deck length before Deja
+/// Vu ever sees it: with beta stages on it starts oversized.
+#[test]
+fn test_deja_vu_repeats_levels() {
+    let rom = match load_rom() {
+        Some(r) => r,
+        None => return,
+    };
+
+    for beta in [false, true] {
+        let catalog = node_catalog::NodeCatalog::build(&rom, beta);
+        let pickup = standard_pickup(&rom, &catalog);
+
+        for mode in [DejaVuMode::Double, DejaVuMode::Wild] {
+            // Wild only has to *allow* unbounded repeats, so the "it repeats at
+            // all" check is over the whole seed range rather than per seed.
+            let mut max_copies = 0usize;
+
+            for seed in 0u64..16 {
+                let mut rng = ChaCha8Rng::seed_from_u64(seed);
+                let build = overworld_build::build(
+                    &rom,
+                    &OverworldData { pickup: &pickup, catalog: &catalog },
+                    &mut rng,
+                    standard_build_flags(),
+                );
+                let assignments = assign_pool(
+                    &rom,
+                    &build,
+                    &OverworldData { pickup: &pickup, catalog: &catalog },
+                    &mut rng,
+                    WriteFlags { deja_vu: mode, ..Default::default() },
+                );
+
+                let placed: Vec<usize> =
+                    assignments.iter().flat_map(|wa| wa.level.iter().map(|a| a.pool_idx)).collect();
+
+                assert_eq!(
+                    placed.len(),
+                    overworld_build::VANILLA_LEVEL_COUNT,
+                    "beta={beta} {mode:?} seed {seed}: dealt {} levels",
+                    placed.len(),
+                );
+
+                let mut seen: HashMap<usize, usize> = HashMap::new();
+                for &pi in &placed {
+                    *seen.entry(pi).or_insert(0) += 1;
+                }
+
+                for (&pi, &n) in &seen {
+                    let ce = &catalog.entries[pickup.pool[pi].catalog_idx];
+                    let unique = rom_data::is_chest_level(ce.world_idx, ce.entry_idx)
+                        || rom_data::is_hand_level(ce.world_idx, ce.entry_idx);
+                    if unique {
+                        assert_eq!(
+                            n, 1,
+                            "beta={beta} {mode:?} seed {seed}: {} holds a one-off item and was dealt {n} times",
+                            ce.name,
+                        );
+                    }
+                    if mode == DejaVuMode::Double {
+                        assert!(
+                            n <= 2,
+                            "beta={beta} {mode:?} seed {seed}: {} dealt {n} times",
+                            ce.name,
+                        );
+                    }
+                    max_copies = max_copies.max(n);
+                }
+
+                // Every one-off item still reaches the map.
+                for &pi in &level_pool_unique_items(&catalog, &pickup) {
+                    assert!(
+                        seen.contains_key(&pi),
+                        "beta={beta} {mode:?} seed {seed}: {} holds a one-off item and was not dealt",
+                        catalog.entries[pickup.pool[pi].catalog_idx].name,
+                    );
+                }
+            }
+
+            assert!(
+                max_copies >= 2,
+                "beta={beta} {mode:?}: no level was ever repeated across 16 seeds",
+            );
+        }
+    }
+}
+
+/// The regular-level pool entries that hand out a one-off inventory item —
+/// the chest levels and the W8 hand rooms. (1-F is a chest level too but is a
+/// fortress, so it never sits in the level pool.)
+fn level_pool_unique_items(
+    catalog: &node_catalog::NodeCatalog,
+    pickup: &overworld_pickup::PickupResult,
+) -> Vec<usize> {
+    pickup
+        .pool
+        .iter()
+        .enumerate()
+        .filter(|(_, pe)| {
+            let ce = &catalog.entries[pe.catalog_idx];
+            matches!(ce.kind, NodeKind::Level)
+                && (rom_data::is_chest_level(ce.world_idx, ce.entry_idx)
+                    || rom_data::is_hand_level(ce.world_idx, ce.entry_idx))
+        })
+        .map(|(pi, _)| pi)
+        .collect()
+}
+
 /// Friendlier Levels' fortress half: 7F2 then 8F1 are parked on
 /// secret-exit-safe slots so their locks can stay shut, leaving them beatable
 /// but off the critical path.
@@ -1071,6 +1193,7 @@ fn test_march_veto_pipeline_writes_registry() {
             piranha: PiranhaMode::Wild,
             shuffle_hammer_bros: true,
             friendlier_levels: false,
+            deja_vu: DejaVuMode::Off,
         },
     );
 

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -408,9 +408,12 @@ mod payload {
         pub(super) friendlier_levels: bool,
         /// Bro encounters run on a 10-second clock.
         pub(super) bro_battle_timer: bool,
+        /// How many times one level may appear on the map. Zero is `Off`, so an
+        /// older key decodes to the once-each deal it was minted with.
+        pub(super) deja_vu: DejaVuMode,
 
         // --- Reserve ---
-        // 141 bits. Adding an option is: declare it immediately above this
+        // 139 bits. Adding an option is: declare it immediately above this
         // block, then take the same number of bits off `B19`. An older key
         // simply has those bits zero, which is "off" for a bool and the default
         // for every enum here, so it stays a correct key for the settings it
@@ -425,7 +428,7 @@ mod payload {
         #[skip]
         __: B128,
         #[skip]
-        __: B13,
+        __: B11,
     }
 }
 
@@ -467,7 +470,7 @@ impl Options {
             eights_are_wild, troll_pipes, antechamber_shuffle,
             ground, shell, flying, piranhas, ghosts, thwomps, rotodiscs,
             cannons, water, bros, hb_encounters, limit_hazards, friendlier_levels,
-            bro_battle_timer,
+            bro_battle_timer, deja_vu,
             fire_flower, piranha_shuffle, wild_injections,
             starting_lives, world_count, starting_items,
             // Not encoded — see NOT_ENCODED for the reason on each.
@@ -533,6 +536,7 @@ impl Options {
             .with_limit_hazards(*limit_hazards)
             .with_friendlier_levels(*friendlier_levels)
             .with_bro_battle_timer(*bro_battle_timer)
+            .with_deja_vu(*deja_vu)
             .with_fire_flower(*fire_flower)
             .with_piranha_shuffle(*piranha_shuffle)
             .with_wild_sun(has(WildChaser::Sun))
@@ -624,6 +628,7 @@ impl Options {
             hb_encounters: f.hb_encounters_or_err().unwrap_or_default(),
             limit_hazards: f.limit_hazards_or_err().unwrap_or_default(),
             friendlier_levels: f.friendlier_levels(),
+            deja_vu: f.deja_vu_or_err().unwrap_or_default(),
             fire_flower: f.fire_flower_or_err().unwrap_or_default(),
             piranha_shuffle: f.piranha_shuffle_or_err().unwrap_or_default(),
             wild_injections: chasers,

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -17,7 +17,7 @@ use options::*;
 // Public API re-exported by the crate root (see lib.rs).
 pub use flag_key::{current_flag_key_version, flag_key_fields, flag_key_version_of};
 pub use options::{
-    EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
+    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
     ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser,
     item_display_name, item_id,
 };
@@ -315,6 +315,7 @@ fn randomize_inner(
             shuffle_hammer_bros: options.shuffle_hammer_bros,
             piranha: options.piranha_shuffle,
             friendlier_levels: options.friendlier_levels,
+            deja_vu: options.deja_vu,
         },
     );
 

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -212,6 +212,44 @@ pub enum HazardLimit {
     All,
 }
 
+/// How many times a single level may appear on the finished map.
+///
+/// The writer deals levels out of a deck (see `assign_pool`), so this is deck
+/// surgery and nothing more: the map is already decided by the time it runs.
+///
+/// `Double` deals a second copy of every level, so any one of them can land on
+/// two tiles. `Wild` rebuilds the deck by drawing with replacement, so a level
+/// can land any number of times — or none at all.
+///
+/// Levels holding a one-off inventory item (the chest levels and the W8 hand
+/// rooms) are exempt in both modes: they are dealt exactly once, because a
+/// second copy would hand the same item out twice and no copy would put it out
+/// of reach.
+///
+/// (MaCobra52's idea.)
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    modular_bitfield::Specifier,
+)]
+#[bits = 2]
+#[serde(rename_all = "snake_case")]
+pub enum DejaVuMode {
+    /// Every level appears at most once — vanilla shuffle behavior.
+    #[default]
+    Off,
+    /// Two copies of each level in the deck; a level can appear twice.
+    Double,
+    /// Draw with replacement; a level can appear any number of times, or none.
+    Wild,
+}
+
 /// A level-wide chaser the wild-injection pass can seed into a level. The
 /// option is the *set* of these the player allowed — an empty set is off.
 ///
@@ -584,6 +622,9 @@ pub struct Options {
     /// that remain. See `FRIENDLIER_BLOCKED_LEVELS` for the list.
     #[serde(default)]
     pub friendlier_levels: bool,
+    /// How many times one level may appear on the map. See [`DejaVuMode`].
+    #[serde(default)]
+    pub deja_vu: DejaVuMode,
     /// Which level-wide chasers may be seeded into a fraction of real levels
     /// (CHR-compatible). Empty = off. See [`WildChaser`].
     #[serde(default)]
@@ -665,6 +706,7 @@ impl Default for Options {
             hb_encounters: EnemyMode::Off,
             limit_hazards: HazardLimit::Off,
             friendlier_levels: false,
+            deja_vu: DejaVuMode::Off,
             wild_injections: Vec::new(),
             starting_lives: default_starting_lives(),
             starting_items: Vec::new(),

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1084,6 +1084,7 @@ fn all_off_options() -> Options {
     Options {
         fire_flower: FireFlowerMode::Off,
         friendlier_levels: false,
+        deja_vu: DejaVuMode::Off,
         limit_hazards: HazardLimit::Off,
         piranha_shuffle: PiranhaMode::Off,
         powerups: false,
@@ -1157,6 +1158,7 @@ fn all_on_options() -> Options {
         fire_flower: FireFlowerMode::On,
         limit_hazards: HazardLimit::All,
         friendlier_levels: true,
+        deja_vu: DejaVuMode::Wild,
         piranha_shuffle: PiranhaMode::On,
         powerups: true,
         palettes: false,

--- a/web/options.js
+++ b/web/options.js
@@ -86,6 +86,14 @@ const OFF_ON_WILD = [
 	{ value: "wild", label: "Wild" },
 ];
 
+// Off / Double / Wild pill for Deja Vu. Values match the Rust `DejaVuMode`
+// enum's serde representation.
+const OFF_DOUBLE_WILD = [
+	{ value: "off", label: "Off" },
+	{ value: "double", label: "Double" },
+	{ value: "wild", label: "Wild" },
+];
+
 // Categories rendered as <fieldset> sections, in order.
 export const GROUPS = [
 	{ id: "map", label: "Map" },
@@ -352,6 +360,11 @@ export const SCHEMA = [
 	{ id: "friendlier_levels", type: "bool", default: false,
 		label: "Friendlier Levels",
 		tip: "Keeps the roughest levels out of the shuffle — 2-3, 5-3, 6-6, 7-5, 7-8 and 8-1. Their slots go to beta stages if you have those on, otherwise to a second visit to a level already in the seed. Two fortresses, 7F2 and 8F1, are usually made optional rather than removed: still there, still beatable, just not in your way.",
+		group: "map", inFlagKey: true },
+	{ id: "deja_vu", type: "tri", options: OFF_DOUBLE_WILD, default: "off",
+		label: "Deja Vu", flavor: "Haven't we been here?",
+		tip: "Let the same level show up on more than one tile. Double: every level gets a second copy in the deck, so some show up twice and others sit the seed out. Wild: no limit — a level can turn up over and over, or never. Levels that hand you an item still appear exactly once.",
+		credit: { name: "MaCobra52", url: "https://github.com/macobra52" },
 		group: "map", inFlagKey: true },
 	{ id: "limit_hazards", type: "tri", options: OFF_SOME_ALL, default: "off",
 		label: "Limit Hazards",


### PR DESCRIPTION
MaCobra52's idea: an **off / double / wild** option that lets the same level show up on more than one map tile.

## How it works

The writer already deals levels out of a deck of exactly `VANILLA_LEVEL_COUNT` cards — one per slot the builder placed. So the whole feature is deck surgery in one place (`assign_pool`). The map is decided before that runs, and nothing downstream can tell a repeat from a first appearance; Friendlier Levels has been dealing duplicates through the same path since it landed.

| Mode | Deck | Measured over 16 seeds |
|---|---|---|
| **Double** | Two copies of every level, dealt without replacement | ~48 distinct levels of 62, hard cap of 2 copies |
| **Wild** | Drawn with replacement — nothing caps repeats | ~41 distinct of 62, one level reached 5 copies |

Under Double the levels the deal misses simply sit the seed out; under Wild a level can turn up over and over, or never.

## One-off items are dealt exactly once

Levels handing out a one-off inventory item — the chest levels (3-7 Cloud, 5-1 Music Box, 8-Tank Star) and the W8 hand rooms — are seeded into the deck once and then held out of the redeal, in **both** modes.

- Never twice: the item would be handed out twice. That is the existing rule Friendlier Levels already keys off, via the shared `holds_unique_item` predicate.
- Never zero times: both modes *redeal* the deck rather than extending it, so without seeding these in up front they can be dropped. Not hypothetical — the first version extended the deck instead, and Double lost 3-7 on seed 0, putting the Cloud out of reach.

## Not a `Tri`

Off/Double/Wild is a graded three-state. `Tri` in this codebase means Off/On/**Maybe** (the seed secretly flips a coin from `MAYBE_SALT`), so this is a plain 2-bit mode enum next to `PiranhaMode` and `HazardLimit` — same cost, same web pill, and it stays out of the maybe-resolution order where the determinism contract lives.

## Composing with Friendlier Levels

Friendlier Levels' refill is now a shared top-up step that runs *after* Deja Vu instead of inside the friendlier block. Order is remove → redeal → top up, so the two features compose rather than stacking duplicates on duplicates (previously a friendlier duplicate would have been doubled again, giving four copies). With Deja Vu off no RNG is drawn and the top-up is a no-op, so the draw sequence is unchanged.

## Flag key

Appended field, reserve 141 → 139 bits, **no version bump** — an older key reads those bits as zero, which is `Off`. Keys already in circulation stay correct.

## Verification

- Full suite green: 424 tests, including `overworld_baseline::output_matches_baseline` — Deja Vu off draws no RNG, so output is byte-identical to before.
- New `test_deja_vu_repeats_levels`: both modes × both beta arms × 16 seeds. Asserts the deal still fills every slot, one-off-item levels appear exactly once, Double caps at two copies, and repeats actually happen.
- `cargo clippy --all-targets` and the wasm32 pass both clean; `cargo fmt --check` clean.
- CLI round-trip: `--deja-vu off|double|wild` gives three distinct ROMs from one seed, and the emitted flag key decodes back to the right mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)