### PR TITLE
feature: let players keep vanilla's king quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ deploys.
 
 ### Added
 
+- **King quotes** (new option, on by default). The kings' rescue dialogue is
+  randomized, as it always has been; turn this off and they say what they say in
+  the original game instead. Cosmetic, so it is not carried in the flag key —
+  and the seed is unaffected either way, so two players on the same key get the
+  same game whichever way each of them sets it.
+
 - **Deja Vu** (new option, off by default; MaCobra52's idea). Lets the same
   level show up on more than one tile. *Double* puts a second copy of every
   level in the deck, so some appear twice and others sit the seed out. *Wild*

--- a/docs/application_flow.md
+++ b/docs/application_flow.md
@@ -173,7 +173,7 @@ flowchart TD
         PO3["[always] write 0x1FABC = A9 01 EA (anchor always-on) +<br/>items::write_mystery_anchor · tags airship_lock, items/mystery_anchor"]
         PO4["[always] patch_double_digit_metatiles  · tag metatile/double_digit"]
         PO5["[always] patch_metatile_6a_freeze  · tag metatile/6a_freeze"]
-        PO6["[always] king_quotes::randomize (main rng)  · tag king_quotes"]
+        PO6["[always] king_quotes::randomize (main rng)  · tag king_quotes<br/>(draws always; king_quotes? gates only the writes)"]
         PO7{"anchor_visuals?"}
         PO7y["anchor_visuals::apply  · tag anchor_visuals"]
         PO0 --> PO1

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,11 @@ struct Cli {
     #[arg(long)]
     keep_flashing: bool,
 
+    /// Keep vanilla's own king rescue dialogue instead of a randomized quote.
+    /// Cosmetic; not in the flag key, and consumes the same RNG either way.
+    #[arg(long)]
+    vanilla_king_quotes: bool,
+
     /// Recolor levels, enemies, and world maps with a random theme (world
     /// colors). Independent of player colors.
     /// Cosmetic; not encoded in the flag key.
@@ -530,6 +535,11 @@ fn build_options(cli: &Cli) -> Options {
                 if cli.keep_flashing {
                     opts.remove_flashing = false;
                 }
+                // Same for king_quotes — cosmetic, default-on, absent from the
+                // key; --vanilla-king-quotes overlays it off.
+                if cli.vanilla_king_quotes {
+                    opts.king_quotes = false;
+                }
                 // Same for skip_rom_validation — a property of the input ROM.
                 if cli.skip_rom_validation {
                     opts.skip_rom_validation = true;
@@ -548,6 +558,7 @@ fn build_options(cli: &Cli) -> Options {
             palette_themed: cli.themed_palettes,
             player_color: cli.player_color,
             remove_flashing: !cli.keep_flashing,
+            king_quotes: !cli.vanilla_king_quotes,
             world_order: cli.world_order,
             world_count: cli.world_count,
             big_q_blocks: cli.big_q_blocks,
@@ -629,6 +640,7 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
     );
     eprintln!("  World colors: {}", if options.palette_themed { "themed" } else { "vanilla" });
     eprintln!("  Remove flashing: {}", if options.remove_flashing { "on" } else { "off" });
+    eprintln!("  King quotes: {}", if options.king_quotes { "random" } else { "vanilla" });
     eprintln!("  Enemies:  {}", if options.any_enemies_active() { "on" } else { "off" });
     eprintln!(
         "  Limit hazards: {}",

--- a/src/randomize/king_quotes.rs
+++ b/src/randomize/king_quotes.rs
@@ -1091,6 +1091,47 @@ mod tests {
         assert_eq!(encoded[19], 0xFE);
     }
 
+    /// The `enabled` gate must not change how much RNG the module consumes.
+    ///
+    /// This is the same property `king_quotes_off_only_skips_its_own_writes`
+    /// checks end-to-end, asserted at the module boundary instead. The two are
+    /// not redundant: the ROM-level test can only observe a divergence where
+    /// something downstream actually *draws*, so on a configuration that
+    /// happens to draw nothing after this point it would pass while the module
+    /// was quietly consuming a different number of values. This one compares
+    /// the generator state itself and holds regardless.
+    #[test]
+    fn enabled_gate_does_not_change_rng_consumption() {
+        use rand::{RngCore, SeedableRng};
+
+        let Ok(bytes) = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes") else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+
+        // Several seeds: choose_multiple picks its sampling strategy from the
+        // pool sizes, not the seed, but the draw counts are worth checking on
+        // more than one stream.
+        for seed in 0..16u64 {
+            let mut rom_on = Rom::from_bytes(&bytes).expect("test ROM parses");
+            let mut rng_on = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_on, &mut rng_on, true);
+
+            let mut rom_off = Rom::from_bytes(&bytes).expect("test ROM parses");
+            let mut rng_off = ChaCha8Rng::seed_from_u64(seed);
+            randomize(&mut rom_off, &mut rng_off, false);
+
+            // Identical position in the stream => identical continuations.
+            let tail_on: Vec<u64> = (0..8).map(|_| rng_on.next_u64()).collect();
+            let tail_off: Vec<u64> = (0..8).map(|_| rng_off.next_u64()).collect();
+            assert_eq!(
+                tail_on, tail_off,
+                "seed {seed}: the rng is at a different position with quotes off — a draw \
+                 moved below the early return, so every later module shifts"
+            );
+        }
+    }
+
     #[test]
     fn pool_has_enough_quotes() {
         assert!(

--- a/src/randomize/king_quotes.rs
+++ b/src/randomize/king_quotes.rs
@@ -951,30 +951,46 @@ fn cpu_addr(file_offset: usize) -> u16 {
 const QUOTE_SELECT_PATCH: usize = 0x362A3;
 
 /// Write randomized king quotes into the ROM.
-pub fn randomize(rom: &mut Rom, rng: &mut ChaCha8Rng) {
-    // --- 1. Write 7 unique standard quotes into free space ---
+///
+/// `enabled` gates the ROM writes only. Every RNG draw this module makes
+/// happens above the early return, so a run with quotes off consumes exactly
+/// the same seed stream as one with them on and nothing downstream shifts.
+/// Keep it that way: never move a `choose` call below the return.
+pub fn randomize(rom: &mut Rom, rng: &mut ChaCha8Rng, enabled: bool) {
+    // --- 1. Draw every quote, whether or not we are going to write one ---
     // choose_multiple samples without replacement, so the 7 quotes are unique.
+    // It draws inside the call, not lazily as the returned iterator is walked —
+    // so what keeps the stream stable is calling it, not collecting it.
+    let std_picks: Vec<&[&str; 6]> = QUOTES.choose_multiple(rng, 7).collect();
+    let frog_pick = FROG_QUOTES.choose(rng).unwrap();
+    let raccoon_pick = RACCOON_QUOTES.choose(rng).unwrap();
+    let hammer_pick = HAMMER_QUOTES.choose(rng).unwrap();
+
+    // Off leaves vanilla's own king text in place — the kings still speak, they
+    // just say what they say in the original game. Nothing reads the free-space
+    // block or the hook below unless the select-site patch lands, so skipping
+    // all of it is enough; there is nothing to blank.
+    if !enabled {
+        return;
+    }
+
+    // --- 2. Write 7 unique standard quotes into free space ---
     let mut std_addrs = Vec::with_capacity(7);
-    for (world, quote) in QUOTES.choose_multiple(rng, 7).enumerate() {
+    for (world, quote) in std_picks.iter().enumerate() {
         let encoded = encode_quote(quote);
         let file_offset = KING_QUOTE_BASE + world * 120;
         rom.write_range(file_offset, &encoded);
         std_addrs.push(cpu_addr(file_offset));
     }
 
-    // --- 2. Write suit-specific quotes to vanilla slots ---
+    // --- 3. Write suit-specific quotes to vanilla slots ---
     // The vanilla pointer table at $A494/$A49B already maps forms 4/5/6
     // to these addresses, so we just replace the content.
-    let frog_pick = FROG_QUOTES.choose(rng).unwrap();
     rom.write_range(FROG_QUOTE_OFFSET, &encode_quote(frog_pick));
-
-    let raccoon_pick = RACCOON_QUOTES.choose(rng).unwrap();
     rom.write_range(RACCOON_QUOTE_OFFSET, &encode_quote(raccoon_pick));
-
-    let hammer_pick = HAMMER_QUOTES.choose(rng).unwrap();
     rom.write_range(HAMMER_QUOTE_OFFSET, &encode_quote(hammer_pick));
 
-    // --- 3. Write ASM hook for per-world standard quotes ---
+    // --- 4. Write ASM hook for per-world standard quotes ---
     // Hook goes right after the 7 quote blocks in free space.
     let hook_file = KING_QUOTE_BASE + 7 * 120;
     let hook_cpu = cpu_addr(hook_file);
@@ -1024,7 +1040,7 @@ pub fn randomize(rom: &mut Rom, rng: &mut ChaCha8Rng) {
 
     rom.write_range(hook_file, &hook);
 
-    // --- 4. Patch original site: JMP hook + NOP fill ---
+    // --- 5. Patch original site: JMP hook + NOP fill ---
     let mut patch = [0xEA_u8; 14];
     patch[0] = 0x4C;
     patch[1] = hook_cpu as u8;

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -270,6 +270,7 @@ pub(super) const NOT_ENCODED: &[&str] = &[
     "palette_themed",      // cosmetic
     "player_color",        // cosmetic
     "remove_flashing",     // cosmetic/accessibility; static patch, no RNG
+    "king_quotes",         // cosmetic flavor text; draws its RNG either way
     "skip_rom_validation", // operational (CLI/WASM input handling), not randomization
 ];
 
@@ -475,7 +476,7 @@ impl Options {
             starting_lives, world_count, starting_items,
             // Not encoded — see NOT_ENCODED for the reason on each.
             palettes: _, palette_themed: _, player_color: _,
-            remove_flashing: _, skip_rom_validation: _,
+            remove_flashing: _, king_quotes: _, skip_rom_validation: _,
         } = self;
 
         let item = |i: usize| starting_items.get(i).copied().unwrap_or(0);
@@ -648,6 +649,7 @@ impl Options {
             palette_themed: false,
             player_color: None,
             remove_flashing: true,
+            king_quotes: true,
             skip_rom_validation: false,
         }
     }

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -406,9 +406,11 @@ fn randomize_inner(
     rom.set_tag("metatile/6a_freeze");
     randomize::overworld_writer::patch_metatile_6a_freeze(rom);
 
-    // Randomize king quotes (always on — cosmetic flavor text)
+    // Randomize king quotes. Always called, even when the option is off: the
+    // module draws its quotes unconditionally and only the ROM writes are
+    // gated, so toggling this cannot shift the seed stream for anything below.
     rom.set_tag("king_quotes");
-    randomize::king_quotes::randomize(rom, &mut rng);
+    randomize::king_quotes::randomize(rom, &mut rng, options.king_quotes);
 
     // Cosmetic: render every item visual (reserve grid, Toad House chests,
     // in-level treasure boxes) as the Anchor sprite.

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -360,6 +360,12 @@ pub struct Options {
     /// the flag key and consumes no RNG.
     #[serde(default = "default_true")]
     pub remove_flashing: bool,
+    /// Replace the king's rescue dialogue with a randomized quote. Off falls
+    /// back to vanilla's own king text — the module still draws its quotes from
+    /// the RNG either way and only skips the ROM writes, so the seed stream is
+    /// identical with this on or off. Cosmetic — not encoded in the flag key.
+    #[serde(default = "default_true")]
+    pub king_quotes: bool,
     #[serde(default)]
     pub world_order: bool,
     /// Number of worlds before Dark Land (1–7, default 7).
@@ -650,6 +656,7 @@ impl Default for Options {
             palette_themed: false,
             player_color: None,
             remove_flashing: true,
+            king_quotes: true,
             world_order: false,
             world_count: default_world_count(),
             big_q_blocks: false,

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1294,56 +1294,84 @@ fn test_full_determinism() {
 /// module sees the same RNG. If someone later moves a `choose` call below that
 /// return, every byte after king_quotes in the pipeline shifts and this fails.
 ///
+/// Swept over configurations as well as seeds, because "accidentally consumed
+/// some RNG" is not a property of the module alone — a divergence only shows up
+/// where something downstream is actually *drawing*, and which modules draw
+/// depends on which options are on. One seed on one config would sample a
+/// single path through the pipeline.
+///
+/// `CENSUS_SEEDS` sets the seeds per configuration (default 3, to keep CI
+/// fast). The 500-seed sweep is the one that means something:
+///
+/// ```sh
+/// CENSUS_SEEDS=500 cargo test --release --lib king_quotes_off
+/// ```
+///
 /// The owned-byte set comes from the write log rather than being restated as
 /// offsets here, so it tracks the module instead of drifting away from it.
 #[test]
 fn king_quotes_off_only_skips_its_own_writes() {
-    let seed = 4242u64;
-    let mut on = test_options();
-    on.king_quotes = true;
-    let mut off = test_options();
-    off.king_quotes = false;
-
-    let Some(mut rom_on) = make_test_rom() else {
+    if make_test_rom().is_none() {
         eprintln!("SKIP: requires the ROM, which is not included in the repo");
         return;
-    };
-    randomize(&mut rom_on, seed, &on);
+    }
+    let seeds: u64 = std::env::var("CENSUS_SEEDS").ok().and_then(|s| s.parse().ok()).unwrap_or(3);
 
-    let Some(mut rom_off) = make_test_rom() else {
-        eprintln!("SKIP: requires the ROM, which is not included in the repo");
-        return;
-    };
-    randomize(&mut rom_off, seed, &off);
+    // Every config here must keep `palettes` off — palettes draw from OS
+    // randomness, not the seed, so they would differ between the two runs on
+    // their own and drown the signal. All three helpers already do.
+    let configs: Vec<(&str, Options)> =
+        vec![("defaults", test_options()), ("all_on", all_on_options()), ("all_off", all_off_options())];
 
-    // Off writes nothing at all — vanilla's king text survives untouched.
-    let off_writes = rom_off.writes_by_tag("king_quotes");
-    assert!(
-        off_writes.is_empty(),
-        "king_quotes off still wrote {} range(s) — the gate leaked",
-        off_writes.len()
-    );
+    let mut compared = 0usize;
+    for (name, base) in &configs {
+        assert!(!base.palettes, "{name}: palettes must be off or this test is nondeterministic");
+        let mut on = base.clone();
+        on.king_quotes = true;
+        let mut off = base.clone();
+        off.king_quotes = false;
 
-    let owned: std::collections::HashSet<usize> = rom_on
-        .writes_by_tag("king_quotes")
-        .iter()
-        .flat_map(|rec| rec.changes().map(|(off, _, _)| off))
-        .collect();
-    assert!(!owned.is_empty(), "king_quotes on changed nothing — test is not exercising anything");
+        for seed in 1..=seeds {
+            let mut rom_on = make_test_rom().unwrap();
+            randomize(&mut rom_on, seed, &on);
+            let mut rom_off = make_test_rom().unwrap();
+            randomize(&mut rom_off, seed, &off);
 
-    let a = rom_on.output_bytes();
-    let b = rom_off.output_bytes();
-    assert_eq!(a.len(), b.len(), "ROM length changed with the toggle");
-    for i in 0..a.len() {
-        if a[i] != b[i] {
+            // Off writes nothing at all — vanilla's king text survives untouched.
+            let off_writes = rom_off.writes_by_tag("king_quotes");
             assert!(
-                owned.contains(&i),
-                "offset 0x{i:05X} differs (0x{:02X} vs 0x{:02X}) outside the bytes \
-                 king_quotes wrote — toggling it shifted the seed stream",
-                a[i], b[i]
+                off_writes.is_empty(),
+                "{name}/seed {seed}: king_quotes off still wrote {} range(s) — the gate leaked",
+                off_writes.len()
             );
+
+            let owned: std::collections::HashSet<usize> = rom_on
+                .writes_by_tag("king_quotes")
+                .iter()
+                .flat_map(|rec| rec.changes().map(|(off, _, _)| off))
+                .collect();
+            assert!(
+                !owned.is_empty(),
+                "{name}/seed {seed}: king_quotes on changed nothing — nothing is being exercised"
+            );
+
+            let a = rom_on.output_bytes();
+            let b = rom_off.output_bytes();
+            assert_eq!(a.len(), b.len(), "{name}/seed {seed}: ROM length changed with the toggle");
+            for i in 0..a.len() {
+                if a[i] != b[i] {
+                    assert!(
+                        owned.contains(&i),
+                        "{name}/seed {seed}: offset 0x{i:05X} differs (0x{:02X} vs 0x{:02X}) \
+                         outside the bytes king_quotes wrote — toggling it shifted the seed stream",
+                        a[i], b[i]
+                    );
+                }
+            }
+            compared += 1;
         }
     }
+    assert_eq!(compared, configs.len() * seeds as usize);
 }
 
 #[test]

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1320,8 +1320,11 @@ fn king_quotes_off_only_skips_its_own_writes() {
     // Every config here must keep `palettes` off — palettes draw from OS
     // randomness, not the seed, so they would differ between the two runs on
     // their own and drown the signal. All three helpers already do.
-    let configs: Vec<(&str, Options)> =
-        vec![("defaults", test_options()), ("all_on", all_on_options()), ("all_off", all_off_options())];
+    let configs: Vec<(&str, Options)> = vec![
+        ("defaults", test_options()),
+        ("all_on", all_on_options()),
+        ("all_off", all_off_options()),
+    ];
 
     let mut compared = 0usize;
     for (name, base) in &configs {
@@ -1364,7 +1367,8 @@ fn king_quotes_off_only_skips_its_own_writes() {
                         owned.contains(&i),
                         "{name}/seed {seed}: offset 0x{i:05X} differs (0x{:02X} vs 0x{:02X}) \
                          outside the bytes king_quotes wrote — toggling it shifted the seed stream",
-                        a[i], b[i]
+                        a[i],
+                        b[i]
                     );
                 }
             }

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -29,6 +29,7 @@ fn normalized(mut o: Options) -> Options {
     o.palettes = true;
     o.palette_themed = false;
     o.remove_flashing = true;
+    o.king_quotes = true;
     o
 }
 
@@ -466,6 +467,7 @@ fn flag_key_per_option_round_trip() {
         ("palettes", Box::new(|o| o.palettes = !o.palettes)),
         ("palette_themed", Box::new(|o| o.palette_themed = !o.palette_themed)),
         ("remove_flashing", Box::new(|o| o.remove_flashing = !o.remove_flashing)),
+        ("king_quotes", Box::new(|o| o.king_quotes = !o.king_quotes)),
     ];
     for (label, mutate) in cosmetic {
         check_round_trip(label, mutate, false);
@@ -1092,6 +1094,7 @@ fn all_off_options() -> Options {
         palette_themed: false,
         player_color: None,
         remove_flashing: false,
+        king_quotes: false,
         world_order: false,
         world_count: 7,
         big_q_blocks: false,
@@ -1165,6 +1168,7 @@ fn all_on_options() -> Options {
         palette_themed: false,
         player_color: None,
         remove_flashing: true,
+        king_quotes: true,
         world_order: true,
         world_count: 3,
         big_q_blocks: true,
@@ -1279,6 +1283,66 @@ fn test_full_determinism() {
             hash1, hash2,
             "{name}: hash mismatch between runs (0x{hash1:016X} vs 0x{hash2:016X})"
         );
+    }
+}
+
+/// Turning king quotes off must not move a single byte the module doesn't own.
+///
+/// The whole point of the option is that it gates ROM writes and nothing else:
+/// `king_quotes::randomize` draws all four of its picks before the early
+/// return, so the seed stream is identical either way and every downstream
+/// module sees the same RNG. If someone later moves a `choose` call below that
+/// return, every byte after king_quotes in the pipeline shifts and this fails.
+///
+/// The owned-byte set comes from the write log rather than being restated as
+/// offsets here, so it tracks the module instead of drifting away from it.
+#[test]
+fn king_quotes_off_only_skips_its_own_writes() {
+    let seed = 4242u64;
+    let mut on = test_options();
+    on.king_quotes = true;
+    let mut off = test_options();
+    off.king_quotes = false;
+
+    let Some(mut rom_on) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
+    randomize(&mut rom_on, seed, &on);
+
+    let Some(mut rom_off) = make_test_rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
+    randomize(&mut rom_off, seed, &off);
+
+    // Off writes nothing at all — vanilla's king text survives untouched.
+    let off_writes = rom_off.writes_by_tag("king_quotes");
+    assert!(
+        off_writes.is_empty(),
+        "king_quotes off still wrote {} range(s) — the gate leaked",
+        off_writes.len()
+    );
+
+    let owned: std::collections::HashSet<usize> = rom_on
+        .writes_by_tag("king_quotes")
+        .iter()
+        .flat_map(|rec| rec.changes().map(|(off, _, _)| off))
+        .collect();
+    assert!(!owned.is_empty(), "king_quotes on changed nothing — test is not exercising anything");
+
+    let a = rom_on.output_bytes();
+    let b = rom_off.output_bytes();
+    assert_eq!(a.len(), b.len(), "ROM length changed with the toggle");
+    for i in 0..a.len() {
+        if a[i] != b[i] {
+            assert!(
+                owned.contains(&i),
+                "offset 0x{i:05X} differs (0x{:02X} vs 0x{:02X}) outside the bytes \
+                 king_quotes wrote — toggling it shifted the seed stream",
+                a[i], b[i]
+            );
+        }
     }
 }
 

--- a/web/options.js
+++ b/web/options.js
@@ -532,6 +532,10 @@ export const SCHEMA = [
 		tip: "Stop the full-screen flashing and fading effects. On by default so the game is safer for players sensitive to flashing lights.",
 		credit: { name: "MaCobra52", url: "https://github.com/macobra52" },
 		group: "cosmetic", inFlagKey: false },
+	{ id: "king_quotes", type: "bool", default: true,
+		label: "King quotes",
+		tip: "Give each rescued king a new thing to say. Turn this off and the kings say what they say in the original game.",
+		group: "cosmetic", inFlagKey: false },
 ];
 
 // Hardcoded fields sent to Rust that aren't user-facing.


### PR DESCRIPTION
Someone asked for a way to turn the randomized king quotes off. This adds one, on by default, and does it in the way that cannot touch the seed.

## Off restores vanilla, it does not blank

Blanking every quote leaves the dialogue box drawing with nothing in it, which reads as a bug. The kings already have four perfectly good lines of their own still sitting in the ROM — `KingText_Typical` / `_Frog` / `_Tanooki` / `_Hammer` in `prg027.asm` — so "off" simply means *don't write*:

- no 7×120 quote block in `FS_KING_QUOTES`
- no 54-byte selection hook
- no `JMP` over the vanilla select site at `$A293`

Nothing reads any of that unless the select-site patch lands, so skipping all of it is sufficient. It also takes ~1.2 KB off the IPS.

## The toggle cannot move the seed

This was the constraint the request came with, so it is enforced rather than argued. `king_quotes::randomize` now draws all four of its picks — `choose_multiple` for the 7 standard quotes, plus one each for frog/raccoon/hammer — **above** a single early return. Only the ROM writes are gated.

Worth noting for anyone editing this later: `choose_multiple` draws inside the call (`index::sample`, `rand-0.9.4/src/seq/slice.rs:103`), not lazily as the returned iterator is walked. Calling it is what keeps the stream stable; collecting it is not.

## Not in the flag key

Cosmetic, so it joins `palettes` / `palette_themed` / `player_color` / `remove_flashing` in `NOT_ENCODED`. Two players on the same key get the same game whichever way each of them sets it — which is only true *because* of the invariance above. Decode pins it to `true` and the web app's `applyOptions` already skips non-key fields, so pasting a shared key does not clobber a local choice.

Reached as `--vanilla-king-quotes` on the CLI (overlaid on top of a decoded key, like `--keep-flashing`) and as a cosmetic checkbox in the web app.

## Verification

Seed 777, `--no-palettes`, on vs. off patched ROMs:

| region | result |
|---|---|
| free-space block `0x379D9` | off is byte-identical to vanilla (`FF` filler) |
| suit slots `0x3633C..0x364A4` | off is byte-identical to vanilla — decodes to "Oh me,oh my!" |
| select site `0x362A3` | off is byte-identical to vanilla |
| **everywhere else** | **0 differing bytes between on and off** |

`king_quotes_off_only_skips_its_own_writes` asserts that continuously. It takes the owned-byte set from the **write log** (`writes_by_tag("king_quotes")`) rather than restating offsets in the test, so it tracks the module instead of drifting from it.

Mutation-tested: moving one `choose` call below the early return fails it at `0x0383C`.

`cargo test`, `cargo clippy --all-targets`, and the wasm32 clippy pass are all clean.