### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,30 +9,7 @@ deploys.
 
 ## [Unreleased]
 
-### Changed
-
-- **Fortresses no longer sit where you cannot walk around them.** A fortress in
-  the middle of the only road is a wasted lock — you play it because it is in
-  the way, and the lock it opens was never a decision. Fortresses now take a
-  spot you could have walked past, so going to find one is a choice you make.
-  Measured across 1000 seeds, unavoidable fortresses went from 22% to under
-  0.5%, and worlds came out with slightly more routes rather than fewer.
-
-- **The level clock now counts real seconds.** Vanilla steps the timer every 41
-  frames, so a unit was 0.68 s and the clock ran about 47% fast — a "300" level
-  was really about 3:25, not five minutes. The divider is now 60 frames, giving
-  a measured 0.998 s per unit, on every seed.
-
-  The reason is less about the clock than about what it lets us build: a timer
-  that reads seconds is a unit other options can use. **Bro Battle Timer** below
-  says ten seconds and means ten seconds, and anything timed added later gets
-  that for free.
-
-  Worth being straight that the fast clock was a *choice*, not a bug — the
-  stored divider is 40, exactly 2/3 s at 60 Hz, and the PAL release uses the
-  same value, so it was never scaled to a refresh rate. Levels are therefore
-  more generous in real terms than Nintendo shipped, though running the clock
-  out was already a rare way to lose a seed.
+## [1.3.0] - 2026-09-05
 
 ### Added
 
@@ -51,10 +28,10 @@ deploys.
 
 - **Bro Battle Timer** (new option, off by default). Walking into a Hammer,
   Boomerang, Heavy or Fire Bro starts the clock at 10 instead of the arena's
-  usual 200 — and with the clock fix above, ten really is ten seconds. Miss it
-  and the fight takes the life instead. Only encounters entered through a bro
-  sprite are affected; every other level, including World 8's full-length
-  Hammer Bro entry, keeps its own time.
+  usual 200 — and with the clock fix in this release, ten really is ten
+  seconds. Miss it and the fight takes the life instead. Only encounters
+  entered through a bro sprite are affected; every other level, including
+  World 8's full-length Hammer Bro entry, keeps its own time.
 
 - **Limit Hazards** (new option: Off / Some / All, off by default). Stops enemy
   swaps from dropping a hazard into a level that wasn't built for one — nippers,
@@ -89,11 +66,6 @@ deploys.
   Measured over 300 seeds, 99% have room for both; in the rest 8F1 stays
   required.
 
-- **Beginner Friendly** preset now uses Limit Hazards (All) and Friendlier
-  Levels, and has its Ghosts class turned back on. The class was previously
-  disabled outright just to stop Boo → Hot Foot; blocking that directly brings
-  Boo ↔ Dry Bones variety back.
-
 - **Shuffle Big ? Rooms** (new option, off by default). Every level with a Big ?
   pipe draws from a pool of 19 rooms instead of always opening its own — the 11
   vanilla rooms plus 8 from "Unused Level 5", a complete set of eight bonus
@@ -104,6 +76,38 @@ deploys.
 
   Flag keys shared during the beta, when this ran unconditionally, now decode
   with it **off** — tick the box to get those seeds back.
+
+- **Three new king rescue quotes** join the pool the kings draw from.
+
+### Changed
+
+- **Fortresses no longer sit where you cannot walk around them.** A fortress in
+  the middle of the only road is a wasted lock — you play it because it is in
+  the way, and the lock it opens was never a decision. Fortresses now take a
+  spot you could have walked past, so going to find one is a choice you make.
+  Measured across 1000 seeds, unavoidable fortresses went from 22% to under
+  0.5%, and worlds came out with slightly more routes rather than fewer.
+
+- **The level clock now counts real seconds.** Vanilla steps the timer every 41
+  frames, so a unit was 0.68 s and the clock ran about 47% fast — a "300" level
+  was really about 3:25, not five minutes. The divider is now 60 frames, giving
+  a measured 0.998 s per unit, on every seed.
+
+  The reason is less about the clock than about what it lets us build: a timer
+  that reads seconds is a unit other options can use. **Bro Battle Timer**
+  says ten seconds and means ten seconds, and anything timed added later gets
+  that for free.
+
+  Worth being straight that the fast clock was a *choice*, not a bug — the
+  stored divider is 40, exactly 2/3 s at 60 Hz, and the PAL release uses the
+  same value, so it was never scaled to a refresh rate. Levels are therefore
+  more generous in real terms than Nintendo shipped, though running the clock
+  out was already a rare way to lose a seed.
+
+- **Beginner Friendly** preset now uses Limit Hazards (All) and Friendlier
+  Levels, and has its Ghosts class turned back on. The class was previously
+  disabled outright just to stop Boo → Hot Foot; blocking that directly brings
+  Boo ↔ Dry Bones variety back.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smb3-rs"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "base32",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smb3-rs"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2024"
 
 [lib]

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -220,26 +220,26 @@ fn sweep_is_deterministic() {
 /// `WorldState::forced_positions` and the census columns that read it change
 /// no output — and cause 1 is inherited, not created here.
 const BASELINE: [u64; SEEDS as usize] = [
-    0x29A3EEA5BF4AE51F,
-    0xDF1B453A02F3E8CE,
-    0x3C30C7E62A89E412,
-    0x6590EB228FFFFFAD,
-    0xD9824148CFCFB18E,
-    0x13FB87791F7E5643,
-    0x2259781019F56587,
-    0x05E4347FD69DA9A9,
-    0xC149AFCA80118085,
-    0xB2C7DFD9A190A0B5,
-    0x1D86758E9A78E98E,
-    0xE05F91CBFC3F6720,
-    0xF29978C2C9D3AF59,
-    0xE7AC193883E470EC,
-    0xCDA7E9922AB91CCC,
-    0x32D1C6748C543C3C,
-    0xF801670EA1CCA280,
-    0x14D567EBB4188B77,
-    0xCBA0C0826565F4C1,
-    0x78E3B157D38E6082,
+    0xFD3FFDA78CEBE40B,
+    0x537A3227F1E2FFB6,
+    0x9ED28342952A8D20,
+    0x3AE3AF6E96DDA7C9,
+    0x3712E83EFC34B620,
+    0x6CB36AAE8DCA2679,
+    0x5347FC554F8DBC63,
+    0x0F1BAD9250CC2665,
+    0xE9B53E297E11748D,
+    0x0D94E4766BD79E3D,
+    0xACD46A9D5F37C0C6,
+    0xCAABC56562F82B88,
+    0xF03CC97B45307A4D,
+    0xEB78E7B7E9A6996A,
+    0x1C67E99EE6BF458E,
+    0x655975B0A768C930,
+    0xC3D739C461564CFC,
+    0x6AA516C7728E6E4F,
+    0x02EF1B2DA0673419,
+    0x7D1F5E1B09905D72,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
@@ -290,6 +290,19 @@ const BASELINE: [u64; SEEDS as usize] = [
 /// bytes reverted to `$28` and re-hashed, and all 20 then reproduced the
 /// previous baseline exactly — so those two bytes are the entire diff. No map
 /// tile, pointer table or level byte moved.
+///
+/// Re-captured 2026-09-01 for the **1.3.0 version bump** and nothing else. The
+/// hash folds `CARGO_PKG_VERSION`, so 1.2.1 -> 1.3.0 rewrites every seed's
+/// title-screen verification icons and with them all 20 whole-ROM hashes. That
+/// is the version guard working as designed, not a randomization change.
+///
+/// Attribution is by byte diff, the same way as the entries above: seeds 1-3
+/// were generated with `--no-palettes --patched-rom` at 1.2.1 and again at
+/// 1.3.0, and every differing byte in all three lands inside
+/// `FS_SEED_HASH_DATA` (0x3E93D + 40) and nowhere else — 9 to 11 bytes per
+/// seed, all within the icon payload. No RNG draw moved, so no module
+/// downstream shifted; the flag-key stamp at 0x19DF0 is byte-identical, since
+/// the key does not carry the release version.
 
 #[test]
 fn output_matches_baseline() {


### PR DESCRIPTION
Prepares 1.3.0 on `beta/next`. The merge to `main` is planned for **Saturday 2026-09-05** and will be a separate PR headed by `release/1.3.0` — heading it with `beta/next` would let the repo's auto-delete-on-merge remove the integration branch and fail the Pages deploy.

## What's in it

Version bump, the changelog section, and the baseline recapture the bump forces. No randomization logic changes here.

**CHANGELOG** — `[Unreleased]` becomes `[1.3.0] - 2026-09-05`, reordered to Added/Changed/Fixed to match every other released section. Three edits beyond the move:

- The **Beginner Friendly preset** item was filed under Added, but it changes an existing preset — moved to Changed.
- Added a line for the **three new king rescue quotes** (#205), which had no entry.
- The level-clock and Bro Battle Timer items cross-referenced each other as "above" / "below". The reorder inverted that, so both now read direction-free.

**Baseline** — `overworld_baseline` moves on all 20 seeds because `compute_hash` folds `CARGO_PKG_VERSION`. That is the version guard working as designed, not a randomization change. Attribution was established twice and is recorded in the doc comment above `const BASELINE`:

- **Byte diff.** Seeds 1-3 generated with `--no-palettes --patched-rom` at 1.2.1 and again at 1.3.0. Every differing byte in all three lands inside `FS_SEED_HASH_DATA` (0x3E93D + 40) and nowhere else — 9 to 11 bytes per seed. The flag-key stamp at 0x19DF0 is byte-identical, since the key does not carry the release version. So no RNG draw moved and nothing downstream shifted.
- **Round trip.** Reverting `Cargo.toml` to 1.2.1 fails the new array; restoring 1.3.0 passes it. (`touch src/lib.rs` before each capture — cargo does not rebuild on a version-only `Cargo.toml` edit.)

## Verification at 1.3.0

| Check | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo clippy --lib --target wasm32-unknown-unknown -- -D warnings` | clean |
| `cargo test` | 437 passed, 0 failed |

This release carries the off-path fortress rework (#206), so both deep overworld censuses were run rather than relying on the shallow CI arms:

- `CENSUS_SEEDS=500 cargo test --release --lib all_world_targets_reachable` — ok, no stranded targets (242s)
- `CENSUS_SEEDS=1000 cargo test --release --lib test_route_census` — 2.595 routes/world, 6.22% linear, C1 19.2, 0.39% below dealt floor, 2.7% goal-open. Reproduces the post-#206 table in `docs/choice_first_charter.md` exactly.

## Notes for the merge to main

- **Flag key stays at v29.** All five new options spent reserve bits, so 1.2.x keys still decode — new options read as zero, which is Off for each of them.
- **#188 reaches `main` for the first time with this release**: the CI concurrency group is now scoped by branch, and `versions.json` takes `current` from the newest archived version rather than `Cargo.toml`. That is what makes the 1.2.0 archive bug non-repeatable, but it is unproven on a real release until this one.
- The `[1.3.0]` heading is dated 2026-09-05. Re-check it against the calendar before merging.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>