### PR TITLE
feature: publish the flag-key format version in versions.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,37 @@ jobs:
           ARR=$(ls versions-repo/v 2>/dev/null | sort -Vr | sed 's/.*/"&"/' | paste -sd, -)
           CUR=$(ls versions-repo/v 2>/dev/null | sort -V | tail -1)
           CUR=${CUR:-$VER}   # empty archive (first ever run): fall back to main's version
-          printf '{"current":"%s","versions":[%s]}\n' "$CUR" "$ARR" > _site/versions.json
+
+          # `flagKeyVersion` is the flag-key FORMAT version the app at the root
+          # reads. It is what lets the racetime seed bot
+          # (github.com/../smb3r-seedbot) reject a racer's stale key before it
+          # posts the seed link, instead of posting a link that every racer's
+          # browser then refuses — leaving each of them to generate from their
+          # own leftover settings. Pre-v29 keys carry no checksum, so the bot's
+          # structural checks cannot catch them; only a version comparison can.
+          # Absent or non-integer, the bot soft-fails to structural checks only,
+          # which is the behaviour this replaces.
+          #
+          # Read from main-src, NOT from the archive, and the difference from
+          # `CUR` above is deliberate. The two answer different questions:
+          # `current` names an archive entry the picker will link to, so it MUST
+          # come from the archive or it links a 404. `flagKeyVersion` describes
+          # the code that will actually accept or reject the key at `/`, and the
+          # root is staged from main-src (see "Stage main into _site/"), so
+          # main-src is the honest source. In the window where main is ahead of
+          # the archive these disagree, and each is still right about its own
+          # question.
+          FKV=$(sed -n 's/.*FLAG_KEY_VERSION: u8 = \([0-9]*\).*/\1/p' \
+                  main-src/src/randomizer/flag_key.rs | head -1)
+          if [ -z "$FKV" ]; then
+            echo "::error::Could not read FLAG_KEY_VERSION from src/randomizer/flag_key.rs."
+            echo "::error::If the constant was renamed or moved, update this step to match."
+            exit 1
+          fi
+          echo "Flag-key format version: $FKV"
+
+          printf '{"current":"%s","flagKeyVersion":%s,"versions":[%s]}\n' \
+            "$CUR" "$FKV" "$ARR" > _site/versions.json
           cat _site/versions.json
 
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ deploys.
 
 - **Three new king rescue quotes** join the pool the kings draw from.
 
+- The version manifest now publishes the **flag-key format version**, which lets
+  the racetime seed bot reject a stale key *before* it posts the seed link.
+  Previously it could only check a key's shape, and keys older than the current
+  format carry no checksum — so a leftover key from an older randomizer sailed
+  through, the bot posted the link, and every racer's browser then refused the
+  key and fell back to whatever settings they happened to have. Racers in the
+  same race could end up playing different rulesets with nothing on screen to
+  say so. The bot now answers with which version the key is from.
+
 ### Changed
 
 - **Fortresses no longer sit where you cannot walk around them.** A fortress in


### PR DESCRIPTION
Adds `flagKeyVersion` to `versions.json`. Refs #169.

This is the half of the racetime seed bot's flag-key validation that has never been able to run.

## Why

The bot (`smb3r-seedbot` PR #4, merged and deployed) already validates a racer's key before posting the seed link — but only **structurally**: charset, canonical length, and the CRC-8. The CRC only exists from format **v29 onward**. A key from an older randomizer carries no integrity data at all, so it passes every check the bot can make on its own.

So today: the bot accepts a stale key → posts the seed link → each racer's browser refuses the key → each of them silently generates from their own leftover `localStorage` settings. **Racers in the same race play different rulesets with nothing on screen to say so.** That is issue #158's scenario surviving in the one place #158's fix couldn't reach.

Only a version comparison catches it, and the version was never published — so `flag_key_version_for()` always soft-failed to `None`, and the bot's `older` / `newer` branches have been dead code since they were written.

## Verified end-to-end

Against the bot's real `flag_key.check`, rather than by reading both files:

| key | today (no field) | with `flagKeyVersion: 29` |
|---|---|---|
| live 1.3.0 key `SMB3R-3PHFKHRF000525AG00X0` | passes | passes |
| crafted pre-v29 key (version byte 26, no checksum) | **accepted** | rejected: `older` |

The rejection message a racer would get:

> flag key is from an older version of the randomizer (format 26, the app reads 29)

Also confirmed the emitted field parses as a JSON **integer**, not a string — the bot logs a warning and ignores a non-int.

## One design note worth reading

`flagKeyVersion` is read from **main-src**, not from the archive — deliberately different from `CUR` immediately above it. The two answer different questions:

- `current` names an archive entry the version picker will link to, so it **must** come from the archive or it links a 404. That's the 1.2.0 bug this workflow already carries a fix for.
- `flagKeyVersion` describes the code that will actually accept or reject the key at `/`, and the root is staged from `main-src` (see "Stage main into `_site/`"). So `main-src` is the honest source.

In the window where main is ahead of the archive they disagree, and each is still right about its own question. The reasoning is in the step's comment so the next reader doesn't "fix" the apparent inconsistency.

## Failure behaviour

The step **fails loudly** if `FLAG_KEY_VERSION` can't be parsed (renamed or moved). A silent fallback would degrade to exactly the dead-code state this PR removes — which is the failure mode that let this sit unnoticed for a month.

## Release note

This ships in **1.3.0**, since Saturday's release merges all of `beta/next`, so the changelog entry is filed under `[1.3.0]` rather than opening a new `[Unreleased]`.

`ci.yml` validated as parsing YAML. Note the `build`/`deploy` jobs gate on `push`, so this step won't execute on this PR — its first real run is the merge to `beta/next`, and `cat _site/versions.json` in the step log is where to confirm it.

## Follow-up, not in this PR

`/beta/versions.json` is still a genuine 404, so the bot has no `beta_manifest_url` — and beta is exactly where version skew happens. Publishing a beta manifest would need a matching seedbot config change, so it's a separate piece of work across two repos.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>