### PR TITLE
fix: spread Hammer Bros in the march graph, not on the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ deploys.
 
 ## [Unreleased]
 
+### Fixed
+
+- Wandering Hammer Bros are spread further apart on the world map. They were
+  being placed as close as two tiles, which is exactly one of their marching
+  steps — a bro could land on top of another, and the game makes both of them
+  march again, so a crowded world could keep marching for a very long time
+  before handing you back your turn.
+
 ## [1.3.0] - 2026-09-05
 
 ### Added

--- a/src/randomize/overworld_build/capacity.rs
+++ b/src/randomize/overworld_build/capacity.rs
@@ -576,44 +576,12 @@ pub(super) fn distribute_hb_sprites<R: Rng>(
     counts
 }
 
-/// Pick `count` positions from `candidates`, preferring spread: greedily accept
-/// a shuffled candidate when it is not adjacent (Chebyshev distance >= 2) to an
-/// already-chosen one, then top up from the remainder if spacing left us short.
-pub(super) fn pick_spread_positions<R: Rng>(
-    candidates: &[(usize, usize)],
-    count: usize,
-    rng: &mut R,
-) -> Vec<(usize, usize)> {
-    let count = count.min(candidates.len());
-    let mut shuffled = candidates.to_vec();
-    shuffled.shuffle(rng);
-
-    let mut chosen: Vec<(usize, usize)> = Vec::with_capacity(count);
-    for &pos in &shuffled {
-        if chosen.len() == count {
-            break;
-        }
-        let far = chosen.iter().all(|&(r, c)| r.abs_diff(pos.0).max(c.abs_diff(pos.1)) >= 2);
-        if far {
-            chosen.push(pos);
-        }
-    }
-    // Spacing may have rejected too many; top up from the rest.
-    for &pos in &shuffled {
-        if chosen.len() == count {
-            break;
-        }
-        if !chosen.contains(&pos) {
-            chosen.push(pos);
-        }
-    }
-    chosen
-}
-
 /// Decide redistributed Hammer Bro sprite positions + rewards for every world.
-/// Selects from each world's final `HammerBro` slot tiles (light anti-clump)
-/// and pairs each with a reward picked up from the vanilla encounters. Stores
-/// the result in `worlds[wi].hb_sprites`; the writer stamps the ROM tables.
+/// Selects from each world's final `HammerBro` slot tiles, spread apart in the
+/// march graph so the sprites do not keep landing on each other (see
+/// [`super::march`]), and pairs each with a reward picked up from the vanilla
+/// encounters. Stores the result in `worlds[wi].hb_sprites`; the writer stamps
+/// the ROM tables.
 pub(super) fn assign_hb_sprites<R: Rng>(
     rom: &Rom,
     pickup: &PickupResult,
@@ -624,6 +592,9 @@ pub(super) fn assign_hb_sprites<R: Rng>(
     // (where the ROM can store a sprite), and the HammerBro tiles to spawn on.
     let mut caps = [0usize; 8];
     let mut hb_tiles: Vec<Vec<(usize, usize)>> = Vec::with_capacity(8);
+    // Positions the writer will stamp as nodes — impassable to a marching
+    // sprite even though they are still blank path tiles on the build grid.
+    let mut blocked: Vec<HashSet<Pos>> = Vec::with_capacity(8);
     for wi in 0..8 {
         let tiles: Vec<(usize, usize)> = worlds[wi]
             .slots
@@ -637,6 +608,14 @@ pub(super) fn assign_hb_sprites<R: Rng>(
         let world_max = if wi == 7 { W8_HB_CAP } else { MAX_HB_PER_WORLD };
         caps[wi] = world_max.min(map_slots).min(tiles.len());
         hb_tiles.push(tiles);
+        blocked.push(
+            worlds[wi]
+                .slots
+                .iter()
+                .filter(|s| s.kind != SlotKind::HammerBro)
+                .map(|s| s.pos)
+                .collect(),
+        );
     }
 
     // Place the vanilla number of encounters, clamped to total capacity.
@@ -649,7 +628,13 @@ pub(super) fn assign_hb_sprites<R: Rng>(
     let mut reward_iter = rewards.into_iter();
 
     for wi in 0..8 {
-        let positions = pick_spread_positions(&hb_tiles[wi], counts[wi], rng);
+        let positions = super::march::pick_spread_positions(
+            &hb_tiles[wi],
+            counts[wi],
+            &worlds[wi].grid,
+            &blocked[wi],
+            rng,
+        );
         worlds[wi].hb_sprites = positions
             .into_iter()
             .map(|grid_pos| HbSprite { grid_pos, reward: reward_iter.next().unwrap_or(0) })

--- a/src/randomize/overworld_build/march.rs
+++ b/src/randomize/overworld_build/march.rs
@@ -1,0 +1,205 @@
+//! The Hammer-Bro march graph — where a wandering map sprite can actually go.
+//!
+//! Wandering sprites do not walk the player's map graph. Their movement is
+//! `Map_Object_March` (PRG011), and three ROM facts shape it:
+//!
+//! - **A march is exactly two tiles.** `Map_March_InitValues` seeds the
+//!   counter with `$20` = 32, `Map_Object_Travel_X/Y` moves one unit per
+//!   tick, and a map tile is 16 pixels. Every leg is 2 tiles in one of the
+//!   four directions — never one, never a diagonal.
+//! - **The tile travelled over must be a path tile of the matching
+//!   orientation.** `Map_MarchValidateTravel` checks the adjacent tile
+//!   against `Map_Object_Valid_Left/Right` (horizontal) or
+//!   `Map_Object_Valid_Down/Up` (vertical). A level number, a fortress, a
+//!   toad house or a lock all stop a bro dead — the graph is the *path
+//!   network*, not the walkable map.
+//! - **Landing on another sprite costs a whole extra march.** When a bro's
+//!   counter reaches zero it scans the other map-object slots for one at
+//!   rest on the identical tile; on a match `PRG011_AF85` sets *both*
+//!   counters back to `$20`. `MO_HammerBroMarch` (PRG010) will not end the
+//!   map turn until every counter is zero, so each collision buys another 32
+//!   frames for two sprites, with no cap. Bros placed close together collide
+//!   repeatedly and the march phase visibly drags.
+//!
+//! That last fact is why placement measures distance *here* rather than on
+//! the grid. Chebyshev distance answers the wrong question twice over: two
+//! tiles six columns apart down one corridor are three legs apart, while two
+//! tiles six columns apart in different corridors may be unable to reach each
+//! other at all — and a pair that cannot meet can never collide.
+//!
+//! # Deliberate over-approximation
+//!
+//! The graph models the *travel* check and skips two later ones: the
+//! forbidden-landing table (`Map_Object_Forbid_LandingTiles` +
+//! `Map_MarchXtraForbidTiles`) and the enterable-landing extension that
+//! doubles the counter to `$40` so a bro hops over a node. Both only ever
+//! *remove* resting places, so ignoring them can only make the graph more
+//! connected than the engine's — which makes distances shorter and separation
+//! stricter. The error is on the safe side, and the check that matters for
+//! corridor separation (the mid tile) is exact.
+//!
+//! Locks are treated as open for the same reason: a lock the player has not
+//! opened yet will open later, and two bros separated only by a closed lock
+//! would drift together the moment it does.
+
+use super::*;
+
+/// Tiles a marching sprite may travel over moving left or right. Mirror of
+/// `Map_Object_Valid_Left` / `Map_Object_Valid_Right` in PRG010 (the two are
+/// byte-identical; Nintendo duplicated them to leave room for one-way paths).
+const MARCH_VALID_HORIZONTAL: [u8; 9] = [
+    0x45, // horizontal path
+    0xB2, // horizontal drawbridge
+    0xB3, // bridge
+    0xAC, // horizontal path over water
+    0xB7, // ... land on left end
+    0xB8, // ... land on right end
+    0xDA, // sky horizontal path
+    0xB9, // ... land on both ends
+    0xE6, // W8 hand trap
+];
+
+/// Tiles a marching sprite may travel over moving up or down. Mirror of
+/// `Map_Object_Valid_Down` / `Map_Object_Valid_Up`, minus the two repeats of
+/// `0x46` the ROM uses to pad all four tables to the same length.
+const MARCH_VALID_VERTICAL: [u8; 7] = [
+    0x46, // vertical path
+    0xB1, // vertical drawbridge
+    0xAA, // vertical path over water, land upper
+    0xAB, // ... land lower
+    0xB0, // vertical path over water
+    0xDB, // sky vertical path
+    0xBA, // ... land on both ends
+];
+
+/// Tiles per march leg — `$20` counter ticks at 1 unit each, over a 16-pixel
+/// tile. See the module docs.
+const MARCH_LEG: usize = 2;
+
+/// Minimum separation between two Hammer Bro sprites, in march legs.
+///
+/// A leg is 2 tiles, so 1 means "can land on the other bro in a single
+/// march" — which is what the old Chebyshev `>= 2` rule permitted, i.e. the
+/// collision distance itself. 3 legs (6 tiles of travel) is satisfiable in
+/// 99.6% of multi-bro worlds; 4 legs drops to 94.2% and 5 to 84.2%, measured
+/// over 200 seeds. [`pick_spread_positions`] relaxes one rung at a time
+/// rather than failing, so the floor costs no placements.
+pub(super) const MIN_HB_SEPARATION_LEGS: u32 = 3;
+
+/// Can a sprite travel over the tile at `pos`? `blocked` holds the positions
+/// the writer will stamp as nodes (levels, fortresses, pipes, toad houses,
+/// spades) — those are still blank path tiles on the build grid, so the tile
+/// byte alone would wrongly say yes.
+fn traversable(grid: &Grid, blocked: &HashSet<Pos>, pos: Pos, vertical: bool) -> bool {
+    if blocked.contains(&pos) {
+        return false;
+    }
+    let tile = grid.get(pos.0, pos.1);
+    if vertical {
+        MARCH_VALID_VERTICAL.contains(&tile)
+    } else {
+        MARCH_VALID_HORIZONTAL.contains(&tile)
+    }
+}
+
+/// Every tile a sprite starting at `start` can reach, and in how many march
+/// legs. A tile absent from the map is unreachable — two sprites in that
+/// relationship can never collide, however close they look on the grid.
+pub(super) fn march_distances(
+    grid: &Grid,
+    blocked: &HashSet<Pos>,
+    start: Pos,
+) -> HashMap<Pos, u32> {
+    let mut dist: HashMap<Pos, u32> = HashMap::new();
+    dist.insert(start, 0);
+    let mut queue = std::collections::VecDeque::new();
+    queue.push_back(start);
+
+    while let Some(pos) = queue.pop_front() {
+        let legs = dist[&pos] + 1;
+        let (r, c) = pos;
+        // (mid, landing, vertical) for each of the four directions, skipping
+        // any that would step off the grid.
+        let mut steps: Vec<(Pos, Pos, bool)> = Vec::with_capacity(4);
+        if c + MARCH_LEG < grid.cols {
+            steps.push(((r, c + 1), (r, c + MARCH_LEG), false));
+        }
+        if c >= MARCH_LEG {
+            steps.push(((r, c - 1), (r, c - MARCH_LEG), false));
+        }
+        if r + MARCH_LEG < grid.rows() {
+            steps.push(((r + 1, c), (r + MARCH_LEG, c), true));
+        }
+        if r >= MARCH_LEG {
+            steps.push(((r - 1, c), (r - MARCH_LEG, c), true));
+        }
+        for (mid, land, vertical) in steps {
+            if !traversable(grid, blocked, mid, vertical) {
+                continue;
+            }
+            if dist.contains_key(&land) {
+                continue;
+            }
+            dist.insert(land, legs);
+            queue.push_back(land);
+        }
+    }
+    dist
+}
+
+/// Pick `count` positions from `candidates`, spread out in the march graph:
+/// greedily accept a shuffled candidate that is at least
+/// [`MIN_HB_SEPARATION_LEGS`] legs from every position already chosen — or
+/// unreachable from all of them, which is better still.
+///
+/// Best-effort by design. A cramped world may not hold `count` sprites at the
+/// full separation, so the floor is relaxed one leg at a time and, failing
+/// that, the remainder is topped up from the leftovers. Placing every
+/// encounter matters more than placing them well; the relaxation only bites
+/// where the map leaves no choice.
+pub(super) fn pick_spread_positions<R: Rng>(
+    candidates: &[Pos],
+    count: usize,
+    grid: &Grid,
+    blocked: &HashSet<Pos>,
+    rng: &mut R,
+) -> Vec<Pos> {
+    let count = count.min(candidates.len());
+    let mut shuffled = candidates.to_vec();
+    shuffled.shuffle(rng);
+
+    let mut chosen: Vec<Pos> = Vec::with_capacity(count);
+    // One reachability map per chosen position, computed on acceptance — at
+    // most `count` BFS passes per world.
+    let mut reach: Vec<HashMap<Pos, u32>> = Vec::with_capacity(count);
+
+    for floor in (1..=MIN_HB_SEPARATION_LEGS).rev() {
+        if chosen.len() == count {
+            break;
+        }
+        for &pos in &shuffled {
+            if chosen.len() == count {
+                break;
+            }
+            if chosen.contains(&pos) {
+                continue;
+            }
+            // `is_none_or`: absent from a reachability map means that sprite
+            // can never reach this tile, which trivially clears the floor.
+            if reach.iter().all(|d| d.get(&pos).is_none_or(|&legs| legs >= floor)) {
+                reach.push(march_distances(grid, blocked, pos));
+                chosen.push(pos);
+            }
+        }
+    }
+    // Spacing may still have rejected too many; top up from the rest.
+    for &pos in &shuffled {
+        if chosen.len() == count {
+            break;
+        }
+        if !chosen.contains(&pos) {
+            chosen.push(pos);
+        }
+    }
+    chosen
+}

--- a/src/randomize/overworld_build/mod.rs
+++ b/src/randomize/overworld_build/mod.rs
@@ -112,6 +112,7 @@ mod hammer_bros;
 mod islands;
 mod levels;
 mod locks;
+mod march;
 mod metrics;
 mod progression;
 mod route_choice;

--- a/src/randomize/overworld_build/tests.rs
+++ b/src/randomize/overworld_build/tests.rs
@@ -495,6 +495,32 @@ fn hammer_bro_redistribution_invariants() {
                 w.world_idx + 1,
                 eligible.saturating_sub(n)
             );
+            // Sprites are spread in the MARCH graph, not on the grid: a
+            // march is exactly 2 tiles, so a pair inside
+            // MIN_HB_SEPARATION_LEGS can land on each other and re-march,
+            // which is what makes a crowded world march for a very long time
+            // (see `march.rs`). Placement relaxes the floor rather than
+            // failing, so this is best-effort in principle — but 200 seeds
+            // produced zero violations, so a hard assert is the useful shape.
+            let blocked: HashSet<(usize, usize)> =
+                w.slots.iter().filter(|s| s.kind != SlotKind::HammerBro).map(|s| s.pos).collect();
+            for (i, a) in w.hb_sprites.iter().enumerate() {
+                let dist = super::march::march_distances(&w.grid, &blocked, a.grid_pos);
+                for b in &w.hb_sprites[i + 1..] {
+                    // Absent = the two can never reach each other, the best
+                    // outcome available.
+                    if let Some(&legs) = dist.get(&b.grid_pos) {
+                        assert!(
+                            legs >= super::march::MIN_HB_SEPARATION_LEGS,
+                            "seed {seed} W{}: HB sprites {:?} and {:?} are {legs} march legs apart",
+                            w.world_idx + 1,
+                            a.grid_pos,
+                            b.grid_pos
+                        );
+                    }
+                }
+            }
+
             // Every sprite sits on one of this world's HammerBro slot tiles.
             let hb_tiles: HashSet<(usize, usize)> =
                 w.slots.iter().filter(|s| s.kind == SlotKind::HammerBro).map(|s| s.pos).collect();

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -220,26 +220,26 @@ fn sweep_is_deterministic() {
 /// `WorldState::forced_positions` and the census columns that read it change
 /// no output — and cause 1 is inherited, not created here.
 const BASELINE: [u64; SEEDS as usize] = [
-    0xFD3FFDA78CEBE40B,
-    0x537A3227F1E2FFB6,
-    0x9ED28342952A8D20,
+    0xB7012FBBE009DEDA,
+    0xB54D37E4FFD3D8AE,
+    0xBFD83B867F89617B,
     0x3AE3AF6E96DDA7C9,
-    0x3712E83EFC34B620,
-    0x6CB36AAE8DCA2679,
+    0xC0EF7CADDA97AB67,
+    0xEF9795996185C2C1,
     0x5347FC554F8DBC63,
-    0x0F1BAD9250CC2665,
-    0xE9B53E297E11748D,
-    0x0D94E4766BD79E3D,
+    0x62C90BD528DB1917,
+    0x63BFCF0020458635,
+    0xA307E02E087DCDA7,
     0xACD46A9D5F37C0C6,
-    0xCAABC56562F82B88,
+    0xE3F830196B0275BB,
     0xF03CC97B45307A4D,
-    0xEB78E7B7E9A6996A,
-    0x1C67E99EE6BF458E,
-    0x655975B0A768C930,
-    0xC3D739C461564CFC,
+    0x573DF773A5F9A5AB,
+    0x2C97E3BD489CE05A,
+    0xDA579C998ACBF1FF,
+    0x7623A27865A3EF1D,
     0x6AA516C7728E6E4F,
-    0x02EF1B2DA0673419,
-    0x7D1F5E1B09905D72,
+    0x4885DC78F066CFE2,
+    0xCAA51780A10B76A5,
 ];
 ///
 /// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
@@ -303,6 +303,23 @@ const BASELINE: [u64; SEEDS as usize] = [
 /// seed, all within the icon payload. No RNG draw moved, so no module
 /// downstream shifted; the flag-key stamp at 0x19DF0 is byte-identical, since
 /// the key does not carry the release version.
+///
+/// Re-captured 2026-09-01 for the Hammer-Bro march spacing. Wandering sprites
+/// were spread by Chebyshev distance with a floor of 2 — which is exactly one
+/// march leg, so a bro could land on another and force both to march again.
+/// Spacing now runs on the march graph (`overworld_build::march`) with a floor
+/// of 3 legs, so the chosen tiles moved.
+///
+/// Attribution is by byte diff, the same way as the entries above: seeds 1-3
+/// were generated with `--no-palettes --patched-rom` before and after. Every
+/// one of the 71 / 27 / 66 changed bytes lands in one of two regions and
+/// nowhere else — the per-world map-object sub-tables reached through
+/// `MAP_OBJ_*_MASTER` (6 / 3 / 5 bytes, the sprite coordinates themselves) and
+/// the world pointer tables inside `WORLDS[..].rowtype_offset` (65 / 24 / 61
+/// bytes, because `assign` splits HammerBro slots into sprite slots and filler
+/// slots and feeds the two different pools). No map tile grid byte, no
+/// map-object reward byte, no level byte and no flag-key byte moved, and the
+/// RNG draw count is unchanged, so nothing downstream shifted.
 
 #[test]
 fn output_matches_baseline() {


### PR DESCRIPTION
## The bug

Wandering Hammer Bro sprites could be placed **two tiles apart** — which is exactly one march leg. `Map_March_InitValues` seeds the counter with `$20` = 32, `Map_Object_Travel_X/Y` moves one unit per tick, and a map tile is 16 pixels, so every march is 2 tiles.

That means a bro could land on another in a single march. `PRG011_AF85` answers a landing-on-another-sprite by setting **both** counters back to `$20`:

```asm
PRG011_AF85:
	LDA #$20
	STA Map_March_Count,X	; the bro that landed
	CPY #$01
	BEQ PRG011_AF93
	LDA #$20
	STA Map_March_Count,Y	; and the one it landed on
```

And `MO_HammerBroMarch` (PRG010) will not end the map turn until every counter reads zero — it loops all 14 slots and bails the moment one is non-zero. So each collision buys another 32 frames for two sprites, with no cap, and re-collisions compound. A crowded world marches for a long time before handing the turn back.

## The fix

`pick_spread_positions` used Chebyshev distance with a floor of 2 — the collision distance itself. Chebyshev is the wrong ruler twice over:

- it permitted the one-leg collision distance, and
- bros travel only over path tiles of the matching orientation (`Map_Object_Valid_Left/Right` for horizontal, `Map_Object_Valid_Down/Up` for vertical). Two tiles six columns apart down one corridor are three legs apart; two in different corridors may not be able to reach each other **at all** — and a pair that cannot meet can never collide.

New `overworld_build::march` builds that graph (2-tile legs over direction-valid path tiles, with the positions the writer will stamp as nodes treated as walls) and placement requires 3 legs of separation, relaxing a rung at a time rather than failing.

The graph deliberately over-approximates: it models the travel check and skips the forbidden-landing table and the enterable-landing extension, both of which only ever *remove* resting places. The error is on the safe side — a more connected graph means shorter distances and stricter separation. Locks are treated as open for the same reason.

## Measured

200 seeds, 1001 multi-bro worlds, 1799 sprite pairs:

| | before | after |
|---|---|---|
| pairs at the one-leg collision distance | 252 | **0** |
| multi-bro worlds with a same-lattice pair | 94.8% | — |
| pairs under 3 march legs | — | **0** |
| pairs mutually unreachable (can never collide) | — | **497 / 1799** |

Feasibility of the floor, best greedy over all start tiles: 3 legs 99.6% of worlds, 4 legs 94.2%, 5 legs 84.2%. At 3 it costs no placements.

I also chased a parity angle first — a march always moves ±2 tiles, so `(row%2, col%2)` is invariant and bros in different classes can never share a tile. It doesn't work: 1208 of 1600 worlds have only one parity class among their HB tiles, because the map lattice is itself parity-aligned. Noted here so nobody re-derives it.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo clippy --target wasm32-unknown-unknown --lib` — all clean
- Full suite green
- `CENSUS_SEEDS=500 all_world_targets_reachable` — passes (no stranding)
- `CENSUS_SEEDS=1000 test_route_census` — mean 2.595 routes/world, 6.22% linear, matching `docs/choice_first_charter.md` exactly. Placement runs after shaping and draws the same RNG, so nothing downstream moved.
- Baseline recaptured. Seeds 1-3 diffed before/after with `--no-palettes --patched-rom`: every one of the 71 / 27 / 66 changed bytes lands in the per-world map-object sub-tables (the sprite coordinates) or the world pointer tables (`assign` splits HammerBro slots into sprite vs filler and feeds them different pools). No map tile grid byte, no reward byte, no level byte, no flag-key byte. Attribution written into `tests/overworld_baseline.rs`.

Caveat worth stating: bros random-walk all world, so placement delays convergence rather than preventing it. The 497 unreachable pairs are the only hard guarantee here. Bounding it outright would take a ROM patch to the re-march at `PRG011_AF85`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)