### PR TITLE
A fortress shows where the lock it opens is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ deploys.
 
 ### Changed
 
+- **World Maze: a fortress now shows where its lock is.** The three fortress
+  designs used to be picked at random for variety; now the one a fortress wears
+  tells you whether the lock it opens is in this world, in another one, or in
+  World 8 — the ones that open the way to Bowser. Worth knowing before you
+  decide a fortress isn't worth the detour.
+
 - **World Maze: locks now tell you whether their key is nearby.** A marker sits
   on any lock the world's own fortresses can open; a lock without one is opened
   from somewhere else. That's the difference between searching a world you can

--- a/src/randomize/maze/tests.rs
+++ b/src/randomize/maze/tests.rs
@@ -2214,3 +2214,133 @@ fn w8_bridge_keys() {
     }
     println!("constructive fill stalled on {ctor_stalled}/{seeds} seeds (both policies counted)");
 }
+
+/// **What a three-way fortress tile would actually say.**
+///
+/// The proposal: a fortress's own tile tells you where the lock it opens is —
+/// `$67` in this world, `$EB` in another, `$6A` in World 8 (the ones that open
+/// the way to the castle). Own-world wins, then W8, then elsewhere.
+///
+/// All three already exist and `overworld_writer::grid` picks among them at
+/// random, so the encoding is free; the question is whether the three buckets
+/// are populated enough to mean anything.
+///
+/// ```sh
+/// CENSUS_SEEDS=60 cargo test --release --lib fort_tile_encoding_census \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn fort_tile_encoding_census() {
+    use super::super::rom_data::W8_IDX;
+
+    let Some(raw) = load_rom() else { return };
+    let seeds = census_seeds(60);
+    let k = super::DEFAULT_WANDS_REQUIRED;
+
+    let (mut home, mut w8, mut away, mut none) = (0usize, 0usize, 0usize, 0usize);
+    let mut per_world = [[0usize; 3]; 8];
+
+    for seed in 0..seeds {
+        let (_, state, _) = generated(&raw, seed, &Knobs::default(), k);
+        for world in &state.worlds {
+            for slot in world.slots.iter().filter(|s| s.kind == SlotKind::Fortress) {
+                let me = super::FortRef { world: world.world_idx, section: slot.section };
+                let Some(lock) = state.locks.iter().find(|l| l.fort == Some(me)) else {
+                    none += 1;
+                    continue;
+                };
+                let bucket = if lock.world == world.world_idx {
+                    0 // $67 — the lock is here
+                } else if lock.world == W8_IDX {
+                    2 // $6A — it opens the way to the castle
+                } else {
+                    1 // $EB — somewhere else
+                };
+                per_world[world.world_idx][bucket] += 1;
+                match bucket {
+                    0 => home += 1,
+                    1 => away += 1,
+                    _ => w8 += 1,
+                }
+            }
+        }
+    }
+    let total = home + away + w8;
+    println!("\n=== fortress tile encoding, {seeds} seeds ===");
+    println!("{total} fortresses with a lock ({none} with none)");
+    let pct = |n: usize| 100.0 * n as f64 / total.max(1) as f64;
+    println!("  $67 lock is in this world : {home:>4}  ({:.0}%)", pct(home));
+    println!("  $EB lock is elsewhere     : {away:>4}  ({:.0}%)", pct(away));
+    println!("  $6A lock is in World 8    : {w8:>4}  ({:.0}%)", pct(w8));
+    println!("\n{:<6}{:>8}{:>8}{:>8}", "world", "$67", "$EB", "$6A");
+    for (wi, counts) in per_world.iter().enumerate() {
+        println!(
+            "W{:<5}{:>8.2}{:>8.2}{:>8.2}",
+            wi + 1,
+            counts[0] as f64 / seeds as f64,
+            counts[1] as f64 / seeds as f64,
+            counts[2] as f64 / seeds as f64,
+        );
+    }
+}
+
+/// **A fortress's tile says where its lock is, and never lies.**
+///
+/// `$67` the lock is in this world, `$EB` it is in another, `$6A` it is in
+/// World 8. Own world wins over World 8, so a World 8 fortress opening a World
+/// 8 lock reads `$67`.
+///
+/// The tile was cosmetic before — `overworld_writer::grid` picks among the
+/// three at random — so nothing else pins it, and a stray writer could put a
+/// fortress tile back without anyone noticing. This reads the bytes that reach
+/// the grid rather than the decision that produced them.
+#[test]
+fn a_fortress_tile_says_where_its_lock_is() {
+    use super::super::rom_data::{self, W8_IDX};
+
+    let Some(raw) = load_rom() else { return };
+    let mut checked = 0usize;
+    let mut seen = [0usize; 3];
+    for seed in 0..census_seeds(8) {
+        let (rom, state, _) =
+            generated(&raw, seed, &Knobs::default(), super::DEFAULT_WANDS_REQUIRED);
+        let mut rom = rom;
+        super::writer::stamp_fort_tiles(&mut rom, &state);
+
+        for lock in &state.locks {
+            let Some(fort) = lock.fort else { continue };
+            let Some(pos) = state.worlds[fort.world]
+                .slots
+                .iter()
+                .find(|s| s.section == fort.section && s.kind == SlotKind::Fortress)
+                .map(|s| s.pos)
+            else {
+                continue;
+            };
+            let (want, why, bucket) = if lock.world == fort.world {
+                (0x67u8, "its lock is in this world", 0)
+            } else if lock.world == W8_IDX {
+                (0x6A, "its lock is in World 8", 2)
+            } else {
+                (0xEB, "its lock is in another world", 1)
+            };
+            let got = rom.read_byte(rom_data::map_tile_offset(fort.world, pos.0, pos.1));
+            assert_eq!(
+                got,
+                want,
+                "seed {seed}: the fortress at W{} {pos:?} wears {got:#04X} but {why}, which is \
+                 {want:#04X} — the tile is a claim now, not decoration",
+                fort.world + 1,
+            );
+            seen[bucket] += 1;
+            checked += 1;
+        }
+    }
+    assert!(checked > 0, "no fortresses checked; the test is vacuous");
+    // All three states must actually occur, or two of them are untested.
+    for (bucket, name) in [(0, "$67 local"), (1, "$EB elsewhere"), (2, "$6A World 8")] {
+        assert!(seen[bucket] > 0, "no fortress exercised {name}; that state is unchecked");
+    }
+    println!("{checked} fortresses: {} local, {} elsewhere, {} World 8", seen[0], seen[1], seen[2]);
+}

--- a/src/randomize/maze/writer.rs
+++ b/src/randomize/maze/writer.rs
@@ -25,6 +25,16 @@ use super::GlobalState;
 /// entered by nothing, and present in every world already.
 const MAPOBJ_HINT: u8 = 0x01;
 
+/// Fortress wearing the alternate colour: the lock it opens is in another
+/// world. `Map_Removable_Tiles` turns it into rubble `$E3`, same as the
+/// default's `$60`.
+const TILE_FORT_AWAY_LOCK: u8 = 0xEB;
+
+/// Fortress whose lock is in World 8 — the ones that open the way to the
+/// castle. In neither tile registry, so it comes back wearing the completion
+/// marker rather than rubble; it still claims a completion bit.
+const TILE_FORT_W8_LOCK: u8 = 0x6A;
+
 /// Every pad, as the spec `world_persist::apply` takes.
 ///
 /// Arrival ids are assigned by position in this list, which is what makes the
@@ -98,6 +108,61 @@ pub(crate) fn open_uninstalled_locks(rom: &mut Rom, state: &GlobalState) {
             rom_data::map_tile_offset(lock.world, lock.pos.0, lock.pos.1),
             lock.replace_tile,
         );
+    }
+}
+
+/// Say on each fortress where the lock it opens is.
+///
+/// The lock hint answers "is this lock's key nearby"; this answers the same
+/// question from the other end, at the moment the player is deciding whether a
+/// fortress is worth the detour. Three states, and the ROM already has three
+/// fortress tiles:
+///
+/// | tile | means | on beat |
+/// |---|---|---|
+/// | `$67` | the lock is in this world | rubble `$60` |
+/// | `$EB` | the lock is in another world | rubble `$E3` |
+/// | `$6A` | the lock is in **World 8** | the M/L completion marker |
+///
+/// Own world wins, then World 8, then elsewhere — so a World 8 fortress opening
+/// a World 8 lock reads `$67`, not `$6A`. Measured over 60 seeds the split is
+/// 24% / 59% / 17%, with every world seeing a mix.
+///
+/// **This costs nothing.** All three tiles exist, all three are already stamped
+/// — `overworld_writer::grid` picks among them at random for cosmetic variety —
+/// so the only change is that the choice now means something. No new tile, no
+/// `Map_Removable_Tiles` entry, no CHR, no 6502.
+///
+/// `$6A` is the odd one and it is deliberate: it is in neither
+/// `Map_Removable_Tiles` nor `Map_Completable_Tiles`, so it never becomes
+/// rubble and comes back wearing the completion marker instead. It still claims
+/// a completion bit — `overworld_build::is_completion_unsafe` names it, and the
+/// threshold check would catch it regardless — so the packed store allocates it
+/// one and the beat persists. Different look, same bookkeeping, which is what
+/// makes it usable as a third state at all.
+///
+/// Runs after `write_overworld`, which stamped the random pick, and before
+/// `world_persist` derives its stencil. The stencil is unaffected either way:
+/// all three tiles claim a bit.
+pub(crate) fn stamp_fort_tiles(rom: &mut Rom, state: &GlobalState) {
+    for lock in &state.locks {
+        let Some(fort) = lock.fort else { continue };
+        let Some(pos) = state.worlds[fort.world]
+            .slots
+            .iter()
+            .find(|s| s.section == fort.section && s.kind == SlotKind::Fortress)
+            .map(|s| s.pos)
+        else {
+            continue; // `lock_keys` is the one that panics on this
+        };
+        let tile = if lock.world == fort.world {
+            rom_data::TILE_FORTRESS
+        } else if lock.world == rom_data::W8_IDX {
+            TILE_FORT_W8_LOCK
+        } else {
+            TILE_FORT_AWAY_LOCK
+        };
+        rom.write_byte(rom_data::map_tile_offset(fort.world, pos.0, pos.1), tile);
     }
 }
 

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -422,6 +422,9 @@ fn randomize_inner(
         // outside the grid-writer ordering above — but it must follow
         // `write_overworld`, which is what fills the slots it counts as spare.
         randomize::maze::writer::stamp_lock_hints(rom, &state);
+        // And the same question from the fortress's end: which of the three
+        // fortress tiles it wears says where the lock it opens is.
+        randomize::maze::writer::stamp_fort_tiles(rom, &state);
         rom.set_tag("wand_gate");
         randomize::wand_gate::apply(rom, wands);
         // Last of the grid writers, and the first thing that reads them: this


### PR DESCRIPTION
The lock hint that shipped in #215 answers "is this lock's key nearby". This
answers the same question from the other end — at the fortress, where the player
is deciding whether it is worth the detour at all.

| tile | means | on beat |
|---|---|---|
| `$67` | the lock is in this world | rubble `$60` |
| `$EB` | the lock is in another world | rubble `$E3` |
| `$6A` | the lock is in **World 8** | the M/L completion marker |

Own world wins over World 8, so a World 8 fortress opening a World 8 lock reads
`$67`. Measured over 60 seeds: **24% / 59% / 17%**, with every world seeing a
mix.

## It costs nothing

All three fortress tiles are already stamped — `overworld_writer::grid` picks
among them at random for cosmetic variety — so the only change is that the
choice now carries information. No new tile, no `Map_Removable_Tiles` entry, no
CHR, no 6502.

That matters because a *new* fortress tile would have been expensive: the table
holds eight entries, sits adjacent to `Map_RemoveTo_Tiles` so it cannot grow in
place, and its loop bound is a baked `LDX #$07` — plus our own PRG011 mirror.

## Why `$6A` behaves differently, and why that is fine

It is in neither `Map_Removable_Tiles` nor `Map_Completable_Tiles`, so it never
becomes rubble and comes back wearing the completion marker instead — which is
exactly what it does in play today. It still claims a completion bit
(`is_completion_unsafe` names it explicitly, and the threshold check would catch
it anyway), so the packed store allocates one and the beat persists. Different
look, same bookkeeping.

## Checks

`a_fortress_tile_says_where_its_lock_is` reads the bytes that reach the grid
rather than the decision behind them, and refuses to pass unless all three
states actually occurred — two would otherwise go unchecked.

577 tests, both clippy passes clean, `cargo fmt --check` clean. Maze-only:
standard-mode seeds 1 / 4242 / 12345 are byte-identical.

## Worth watching in play

This and the lock hint encode the same relationship from opposite ends. That may
be exactly right — you read the fortress when choosing, the lock when blocked —
or one of them may turn out to be noise. Neither has been playtested.
