### PR TITLE
feature: Hints — off, some or full, and an alternate-colour remote lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ deploys.
   World 8 — the ones that open the way to Bowser. Worth knowing before you
   decide a fortress isn't worth the detour.
 
+- **World Maze: Hints, a setting.** Off, Some or Full, defaulting to Some. Off
+  says nothing and goes back to giving fortresses their design at random. Some
+  marks each fortress with the design for where its lock is, and tints a lock
+  whose key is in another world. Full also stamps that lock with the number of
+  the world to go to. Only affects World Maze, and with the mode off it leaves
+  your flag key alone.
+
 - **World Maze: a lock now tells you which world its key is in.** A lock opened
   from another world wears that world's number; a lock with no number is opened
   by a fortress in the world you're standing in. So a locked path is no longer a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,10 @@ use rom::Rom;
 
 pub use ips::apply_ips_patch;
 pub use randomizer::{
-    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
-    ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser,
-    current_flag_key_version, flag_key_fields, flag_key_version_of, item_display_name, item_id,
+    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, HintMode, ITEM_RANDOM,
+    ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode,
+    STARTING_LIVES_VALUES, Tri, WildChaser, current_flag_key_version, flag_key_fields,
+    flag_key_version_of, item_display_name, item_id,
 };
 
 /// Validate a ROM blob without doing any randomization. Returns Ok if the bytes

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::process;
 
 use smb3_rs::{
-    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, ITEMS, Options, PiranhaMode,
+    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, HintMode, ITEMS, Options, PiranhaMode,
     STARTING_LIVES_VALUES, Tri, WildChaser, item_display_name, item_id,
 };
 
@@ -85,6 +85,16 @@ fn parse_deja_vu(s: &str) -> Result<DejaVuMode, String> {
         "double" => Ok(DejaVuMode::Double),
         "wild" => Ok(DejaVuMode::Wild),
         _ => Err("valid values: off, double, wild".to_string()),
+    }
+}
+
+/// clap value parser for `--hints` (off/some/full).
+fn parse_hints(s: &str) -> Result<HintMode, String> {
+    match s {
+        "off" => Ok(HintMode::Off),
+        "some" => Ok(HintMode::Partial),
+        "full" => Ok(HintMode::Full),
+        _ => Err("valid values: off, some, full".to_string()),
     }
 }
 
@@ -457,6 +467,14 @@ struct Cli {
     #[arg(long, default_value = "off", value_parser = parse_deja_vu)]
     deja_vu: DejaVuMode,
 
+    /// World maze: how much the map tells you about which fortress opens which
+    /// lock — off, some, or full (default: some). `some` gives each fortress a
+    /// design saying whether its lock is local, elsewhere, or in World 8, and
+    /// tints a lock whose key is in another world; `full` also numbers that lock
+    /// with the world to go to. Ignored outside `--world-maze`.
+    #[arg(long, default_value = "some", value_parser = parse_hints)]
+    hints: HintMode,
+
     /// Deja Vu counts fortresses too, in whatever mode `--deja-vu` is set to,
     /// so a fortress can take two map tiles or none. Ignored with `--deja-vu
     /// off`. 1-F is always dealt exactly once: it holds the warp whistle, and
@@ -641,6 +659,7 @@ fn build_options(cli: &Cli) -> Options {
             friendlier_levels: cli.friendlier_levels,
             deja_vu: cli.deja_vu,
             deja_vu_forts: cli.deja_vu_forts,
+            hints: cli.hints,
             wild_injections: cli.wild_injections.0.clone(),
             starting_lives: cli.starting_lives,
             starting_items,

--- a/src/randomize/lock_keys.rs
+++ b/src/randomize/lock_keys.rs
@@ -309,6 +309,37 @@ const HINT_REVEALS: [(u8, u8); 4] = [
 /// the wrong color.
 const WATER_ORIENTATION: usize = 3;
 
+/// **`HintMode::Partial`'s vocabulary: the same padlock in the other colour.**
+///
+/// One per orientation, in [`HINT_REVEALS`] order. A remote lock wears the
+/// alternate colour and a local lock does not — that is the whole message, and
+/// it costs no glyph.
+///
+/// The colour *is* the palette page: `$54`/`$56` are page 1 and `$E4` is page 3,
+/// identical CHR. So an alt lock has to live in page 3, and on a ground path it
+/// reveals a page-1 tile. The effect writes no attribute byte, so the revealed
+/// path draws in the lock's colours until the next map reload — accepted
+/// deliberately, the same trade the numbered bridge gaps take.
+///
+/// `$FC`-`$FE` are the last three usable page-3 indices (`$FF` is a background
+/// tile), so this fills the page.
+const ALT_REMOTE_TILES: [u8; 4] = [0xFC, 0xFD, 0xE4, 0xFE];
+
+/// **The local sky lock has to move, or every sky lock would lie.**
+///
+/// Sky's plain lock is `$E4`, which is *already* page 3 — the alt colour. Left
+/// alone, a local sky lock would wear the mark that means "elsewhere". So in
+/// this mode local sky takes a page-1 tile revealing `$DA`, `$E4` becomes
+/// remote-sky, and the rule "alternate colour means the key is elsewhere" holds
+/// everywhere instead of almost everywhere.
+///
+/// Sky locks are rare — far rarer than the other three — which is an argument
+/// for not noticing this, not for letting it lie.
+const ALT_LOCAL_SKY: u8 = 0x7B;
+
+/// Index of the sky orientation in [`HINT_REVEALS`] / [`ALT_REMOTE_TILES`].
+const SKY_ORIENTATION: usize = 2;
+
 /// The level panels' lower-right quadrants for worlds 1-8: the digit glyphs.
 ///
 /// **The whole art budget of this feature.** A variant is the tile it stands in
@@ -348,6 +379,14 @@ pub(crate) fn obstacle_vocabulary() -> Vec<(u8, u8)> {
             out.push((tile, HINT_REVEALS[o].1));
         }
     }
+    // `HintMode::Partial`'s set. `$E4` is already a base row, so only the three
+    // new remote tiles and the relocated local sky lock are added.
+    for (o, &tile) in ALT_REMOTE_TILES.iter().enumerate() {
+        if tile != HINT_REVEALS[o].0 {
+            out.push((tile, HINT_REVEALS[o].1));
+        }
+    }
+    out.push((ALT_LOCAL_SKY, HINT_REVEALS[SKY_ORIENTATION].1));
     out
 }
 
@@ -847,9 +886,39 @@ pub(crate) fn tiles_on_map(rom: &Rom) -> [bool; 256] {
 /// The animation index is the hammer's, and the vertical set is the odd one out
 /// — the same `1, 0, 0` the plain locks use, for the same reason.
 pub(crate) fn numbered_lock(tile: u8) -> Option<(u8, u8)> {
-    HINT_TILES.iter().position(|set| set.contains(&tile)).map(|orientation| {
+    hint_orientation(tile).map(|orientation| {
         (HINT_REVEALS[orientation].1, u8::from(orientation == VERTICAL_ORIENTATION))
     })
+}
+
+/// Which orientation a hint lock belongs to, across **every** family this module
+/// can stamp: the numbered set, the alternate-colour set, and the relocated
+/// local sky lock.
+///
+/// **One lookup on purpose.** The hammer builds its breakable table from this,
+/// and a family missing here is a family the hammer silently refuses to break —
+/// which is exactly the bug the numbered set shipped with once already. Adding a
+/// family means adding it here, not at the call sites.
+///
+/// **`$E4` is not a hint tile, even though it is in [`ALT_REMOTE_TILES`].** Sky's
+/// remote tile is its plain tile — the alternate colour was already the sky
+/// lock's colour — so a cell wearing `$E4` may be a remote sky lock or an
+/// ordinary one, and nothing about the byte says which. Claiming it here made
+/// every plain sky lock count as a hint and put `the_obstacle_table_never_overflows`
+/// one over. Callers that need `$E4` have it from `rom_data::LOCK_TILES`.
+fn hint_orientation(tile: u8) -> Option<usize> {
+    // A tile that is some orientation's *plain* lock belongs to vanilla's
+    // vocabulary, not this module's, whichever list it also appears in.
+    if HINT_REVEALS.iter().any(|&(plain, _)| plain == tile) {
+        return None;
+    }
+    if let Some(o) = HINT_TILES.iter().position(|set| set.contains(&tile)) {
+        return Some(o);
+    }
+    if let Some(o) = ALT_REMOTE_TILES.iter().position(|&t| t == tile) {
+        return Some(o);
+    }
+    (tile == ALT_LOCAL_SKY).then_some(SKY_ORIENTATION)
 }
 
 /// Is this numbered lock a water gap rather than a path lock?
@@ -859,7 +928,7 @@ pub(crate) fn numbered_lock(tile: u8) -> Option<(u8, u8)> {
 /// locks", and giving a bridge gap a digit must not quietly move it from one
 /// switch to the other.
 pub(crate) fn numbered_lock_is_water(tile: u8) -> bool {
-    HINT_TILES[WATER_ORIENTATION].contains(&tile)
+    hint_orientation(tile) == Some(WATER_ORIENTATION)
 }
 
 /// The index of the vertical set in [`HINT_TILES`] / [`HINT_REVEALS`].
@@ -919,7 +988,10 @@ pub(crate) fn removable_rows(rom: &Rom) -> Vec<(u8, u8)> {
 /// The digit is the *fortress's* world, because that is the question the player
 /// is asking: not where am I, but where do I have to go. A local lock keeps the
 /// plain tile, and the absence of a digit is itself the answer.
-fn stamp_numbered_locks(rom: &mut Rom, entries: &[LockEntry]) {
+fn stamp_hint_locks(rom: &mut Rom, entries: &[LockEntry], hints: crate::HintMode) {
+    if !hints.hints_at_all() {
+        return;
+    }
     for e in entries.iter().filter(|e| e.is_away()) {
         let off = rom_data::map_tile_offset(e.target_world, e.target_pos.0, e.target_pos.1);
         let plain = rom.read_byte(off);
@@ -934,12 +1006,68 @@ fn stamp_numbered_locks(rom: &mut Rom, entries: &[LockEntry]) {
             );
             continue;
         };
-        // Keyed by the number shown, not the internal index, so a tile means the
-        // same thing in every seed: `$6B` is always "horizontal, world 1".
-        let shown = displayed_world(rom, e.key_world);
-        let tile = HINT_TILES[orientation][shown - 1];
-        rom.write_byte(off, tile);
-        write_hint_metatile(rom, tile, plain, shown - 1);
+        if hints.numbers_locks() {
+            // Keyed by the number shown, not the internal index, so a tile means
+            // the same thing in every seed: `$6B` is always "horizontal, world 1".
+            let shown = displayed_world(rom, e.key_world);
+            let tile = HINT_TILES[orientation][shown - 1];
+            rom.write_byte(off, tile);
+            write_hint_metatile(rom, tile, plain, shown - 1);
+        } else {
+            let tile = ALT_REMOTE_TILES[orientation];
+            rom.write_byte(off, tile);
+            write_plain_metatile(rom, tile, plain);
+        }
+    }
+
+    if !hints.numbers_locks() {
+        let remote: std::collections::HashSet<(usize, (usize, usize))> = entries
+            .iter()
+            .filter(|e| e.is_away())
+            .map(|e| (e.target_world, e.target_pos))
+            .collect();
+        move_local_sky_locks(rom, &remote);
+    }
+}
+
+/// Give every *local* sky lock the page-1 tile, so the alternate colour keeps
+/// meaning "elsewhere" on a sky path too.
+///
+/// **`remote` is not an optimisation, it is the whole correctness of this.** Sky
+/// is the one orientation whose remote tile is the plain tile — `$E4` is already
+/// the alternate colour, so stamping a remote sky lock leaves the byte alone.
+/// A sweep that looked only at the tile would therefore find every sky lock
+/// still wearing `$E4`, remote ones included, and move them all to the local
+/// tile. Measured before this argument existed: 10 seeds in 30 had a sky lock,
+/// and *every one* came back local.
+fn move_local_sky_locks(
+    rom: &mut Rom,
+    remote: &std::collections::HashSet<(usize, (usize, usize))>,
+) {
+    let plain_sky = HINT_REVEALS[SKY_ORIENTATION].0;
+    for world in 0..8 {
+        let info = &rom_data::MAP_TILE_GRIDS[world];
+        for screen in 0..info.screens {
+            for row in 0..9 {
+                for col in 0..16 {
+                    let pos = (row, screen * 16 + col);
+                    let off = rom_data::map_tile_offset(world, pos.0, pos.1);
+                    if rom.read_byte(off) == plain_sky && !remote.contains(&(world, pos)) {
+                        rom.write_byte(off, ALT_LOCAL_SKY);
+                        write_plain_metatile(rom, ALT_LOCAL_SKY, plain_sky);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Copy a tile's whole 2x2 art onto another index, changing nothing but which
+/// palette page it lands in.
+fn write_plain_metatile(rom: &mut Rom, tile: u8, plain: u8) {
+    for plane in 0..4 {
+        let pattern = rom.read_byte(PRG012_FILE_BASE + plane * 256 + plain as usize);
+        rom.write_byte(PRG012_FILE_BASE + plane * 256 + tile as usize, pattern);
     }
 }
 
@@ -1097,13 +1225,13 @@ fn assert_one_key_per_lock(entries: &[LockEntry]) {
 /// If [`assert_one_key_per_lock`] is violated, or if more than [`MAX_ENTRIES`]
 /// are handed over. Truncating would leave a lock no fortress opens, which is an
 /// unwinnable seed; a build-time failure is the better end of that trade.
-pub fn apply(rom: &mut Rom, entries: &[LockEntry]) {
+pub fn apply(rom: &mut Rom, entries: &[LockEntry], hints: crate::HintMode) {
     assert_one_key_per_lock(entries);
 
     // Order matters and is one-way. The numbered tiles are stamped onto the map
     // first, because `removable_rows` reads the map to decide what the table
     // needs; the table is written next, because `mirror_bytes` reads the table.
-    stamp_numbered_locks(rom, entries);
+    stamp_hint_locks(rom, entries, hints);
     relocate_removable_tables(rom, &removable_rows(rom));
 
     let mirror = mirror_bytes(rom);
@@ -1290,13 +1418,26 @@ mod asm_checks {
         // are the rows nobody wrote out by hand.
         let vocabulary = obstacle_vocabulary();
         for &(obstacle, revealed) in &vocabulary[8..] {
-            // **The water-gap variants are a deliberate exception**, and the
-            // only one. Page 2 has no index to spare, so they sit in page 3 and
-            // reveal a page-2 bridge: the lock draws in the wrong palette, and
-            // so does the bridge until the next map reload. See
-            // [`WATER_ORIENTATION`] for why that trade was taken.
+            // **Two deliberate exceptions, and both are the same trade.** The
+            // water-gap variants sit in page 3 because page 2 has no index to
+            // spare; the alternate-colour set sits in page 3 because being in
+            // another page *is* what the colour is. Both reveal a tile from the
+            // page their path lives in, so the revealed tile draws in the lock's
+            // colours until the next map reload. See [`WATER_ORIENTATION`] and
+            // [`ALT_REMOTE_TILES`].
             if HINT_TILES[WATER_ORIENTATION].contains(&obstacle) {
                 assert_eq!(revealed, rom_data::BRIDGE_TILE, "a water variant reveals a bridge");
+                continue;
+            }
+            if ALT_REMOTE_TILES.contains(&obstacle) || obstacle == ALT_LOCAL_SKY {
+                let orientation = HINT_REVEALS
+                    .iter()
+                    .position(|&(_, path)| path == revealed)
+                    .expect("an alt lock reveals one of the four path tiles");
+                assert_eq!(
+                    revealed, HINT_REVEALS[orientation].1,
+                    "{obstacle:#04X} reveals the wrong path for its orientation"
+                );
                 continue;
             }
             assert_eq!(
@@ -1348,6 +1489,9 @@ mod asm_checks {
         for seed in 0..seeds() {
             let options = crate::Options {
                 world_maze: true,
+                // Explicit: `Partial` is the default now, and neither of these
+                // measures anything with the numbered tiles switched off.
+                hints: crate::HintMode::Full,
                 palettes: false,
                 palette_themed: false,
                 ..Default::default()
@@ -1424,6 +1568,9 @@ mod asm_checks {
         for seed in 0..seeds() {
             let options = crate::Options {
                 world_maze: true,
+                // Explicit: `Partial` is the default now, and neither of these
+                // measures anything with the numbered tiles switched off.
+                hints: crate::HintMode::Full,
                 palettes: false,
                 palette_themed: false,
                 ..Default::default()
@@ -1467,6 +1614,79 @@ mod asm_checks {
             );
         }
         eprintln!("worst row count {worst}/{REMOVABLE_COUNT}");
+    }
+
+    /// **Every away lock wears the alternate colour, sky included.**
+    ///
+    /// Sky is the orientation that gets this wrong quietly. Its remote tile *is*
+    /// its plain tile — `$E4` is already the alternate colour — so stamping a
+    /// remote sky lock changes no byte, and a local-sky sweep that keyed on the
+    /// tile alone swept the remote ones up with the local ones. Measured before
+    /// the skip set existed: 10 seeds in 30 had a sky lock and every one came
+    /// back local, which no other assertion in this file would have noticed.
+    ///
+    /// Counting is enough to catch it: a remote lock moved onto the local tile
+    /// stops being counted, so the totals stop matching.
+    #[test]
+    fn every_away_lock_wears_the_alternate_colour() {
+        let Ok(bytes) = std::fs::read(ROM_PATH) else {
+            eprintln!("SKIP: requires the ROM");
+            return;
+        };
+        let mut sky_local = 0usize;
+        let mut sky_remote = 0usize;
+        for seed in 0..seeds() {
+            let options = crate::Options {
+                world_maze: true,
+                hints: crate::HintMode::Partial,
+                palettes: false,
+                palette_themed: false,
+                ..Default::default()
+            };
+            let Ok((rom, _)) =
+                crate::randomize_rom_with_overworld_capture(&bytes, seed, &options, None)
+            else {
+                continue;
+            };
+
+            let away = decode_entries(&rom).iter().filter(|e| e.away).count();
+            let mut marked = 0usize;
+            for world in 0..8 {
+                let info = &rom_data::MAP_TILE_GRIDS[world];
+                for screen in 0..info.screens {
+                    for row in 0..9 {
+                        for col in 0..16 {
+                            let off = rom_data::map_tile_offset(world, row, screen * 16 + col);
+                            let tile = rom.read_byte(off);
+                            if ALT_REMOTE_TILES.contains(&tile) {
+                                marked += 1;
+                                if tile == ALT_REMOTE_TILES[SKY_ORIENTATION] {
+                                    sky_remote += 1;
+                                }
+                            }
+                            if tile == ALT_LOCAL_SKY {
+                                sky_local += 1;
+                            }
+                            // No numbered tile may exist in this mode.
+                            assert!(
+                                !HINT_TILES.iter().any(|set| set.contains(&tile)),
+                                "seed {seed}: Partial mode stamped the numbered tile {tile:#04X}"
+                            );
+                        }
+                    }
+                }
+            }
+            assert_eq!(
+                marked, away,
+                "seed {seed}: {away} away locks but {marked} wearing the alternate colour"
+            );
+        }
+        // Both sides of the sky split have to occur, or the skip set is untested.
+        assert!(
+            sky_local > 0 && sky_remote > 0,
+            "sampled seeds produced {sky_local} local and {sky_remote} remote sky locks; \
+             raise CENSUS_SEEDS until both appear or this proves nothing"
+        );
     }
 
     /// The helper decodes, fits its allocation, and its self-reference resolves.
@@ -1616,7 +1836,7 @@ mod asm_checks {
         );
 
         let mut patched = rom.clone();
-        apply(&mut patched, &[]);
+        apply(&mut patched, &[], crate::HintMode::Full);
         assert_eq!(patched.read_range(MAP_OP8_VECTOR, 2), FORTRESS_FX_CPU.to_le_bytes());
     }
 
@@ -1724,7 +1944,7 @@ mod asm_checks {
         }
 
         let mut patched = rom.clone();
-        apply(&mut patched, &[]);
+        apply(&mut patched, &[], crate::HintMode::Full);
         assert_eq!(patched.read_range(FS_LOCK_MIRROR, MIRROR_LEN), mirror);
     }
 
@@ -1748,7 +1968,7 @@ mod asm_checks {
             );
         }
         let mut patched = rom.clone();
-        apply(&mut patched, &[]);
+        apply(&mut patched, &[], crate::HintMode::Full);
         for &off in &rom_data::BOOMBOOM_Y_OFFSETS {
             assert_eq!(patched.read_byte(off), rom.read_byte(off), "{off:#07X} was written");
         }
@@ -1893,7 +2113,7 @@ mod asm_checks {
     fn one_lock(rom: &Rom, e: LockEntry) -> (Rom, Option<[u8; 2]>) {
         let base = with_locks(rom, &[e]);
         let mut patched = base.clone();
-        apply(&mut patched, &[e]);
+        apply(&mut patched, &[e], crate::HintMode::Full);
         let payload = e.is_away().then(|| {
             let map = CompletionMap::from_rom(&base);
             away_target(&map, e.target_world, e.target_pos).expect("the cell owns a bit")
@@ -2237,7 +2457,7 @@ mod asm_checks {
 
         let base = with_locks(&rom, &entries);
         let mut patched = base.clone();
-        apply(&mut patched, &entries);
+        apply(&mut patched, &entries, crate::HintMode::Full);
         assert_eq!(decode_entries(&patched).len(), MAX_ENTRIES, "the table must be full");
         let map = CompletionMap::from_rom(&base);
 

--- a/src/randomize/qol/hammer_breaks.rs
+++ b/src/randomize/qol/hammer_breaks.rs
@@ -57,6 +57,14 @@ fn push_numbered(
             continue;
         }
         if let Some((revealed, anim)) = lock_keys::numbered_lock(tile) {
+            // Belt and braces: `numbered_lock` already declines vanilla's own
+            // lock tiles, so this cannot fire today. It stays because being
+            // wrong costs a duplicate row, and removing it costs finding out the
+            // hard way that some future family overlaps vanilla's again.
+            debug_assert!(
+                !rom_data::LOCK_TILES.contains(&tile) && tile != rom_data::WATER_GAP_TILE,
+                "{tile:#04X} is both a vanilla lock and a hint tile"
+            );
             breakable.push(tile);
             replace.push(revealed);
             tilefix.push(anim);
@@ -255,9 +263,10 @@ mod tests {
             return;
         };
 
-        let build = |locks: crate::Tri, bridges: crate::Tri| {
+        let build = |locks: crate::Tri, bridges: crate::Tri, hints: crate::HintMode| {
             let options = crate::Options {
                 world_maze: true,
+                hints,
                 hammer_breaks_locks: locks,
                 hammer_breaks_bridges: bridges,
                 palettes: false,
@@ -273,36 +282,43 @@ mod tests {
             rom.read_range(FS_HAMMER_TABLES, n).to_vec()
         };
 
-        let rom = build(crate::Tri::On, crate::Tri::Off);
-        let present = lock_keys::tiles_on_map(&rom);
-        let numbered: Vec<u8> = (0..=255u8)
-            .filter(|&t| present[t as usize] && lock_keys::numbered_lock(t).is_some())
-            .collect();
-        assert!(!numbered.is_empty(), "seed 5 has no numbered locks, so this proves nothing");
-        assert!(
-            numbered.iter().any(|&t| lock_keys::numbered_lock_is_water(t)),
-            "seed 5 has no numbered water gap, so the split below proves nothing"
-        );
-
-        // Locks on, bridges off: the path locks break, the water gaps do not.
-        // Giving a bridge gap a digit must not move it onto the other switch.
-        let table = breakable(&rom);
-        for &tile in &numbered {
-            let water = lock_keys::numbered_lock_is_water(tile);
-            assert_eq!(
-                table.contains(&tile),
-                !water,
-                "numbered {} {tile:#04X}: breakable={}, expected {}",
-                if water { "water gap" } else { "lock" },
-                table.contains(&tile),
-                !water
+        // Both hint modes, because they stamp different tile families and the
+        // hammer has to know both. It knew only one of them once already.
+        for hints in [crate::HintMode::Full, crate::HintMode::Partial] {
+            let rom = build(crate::Tri::On, crate::Tri::Off, hints);
+            let present = lock_keys::tiles_on_map(&rom);
+            let numbered: Vec<u8> = (0..=255u8)
+                .filter(|&t| present[t as usize] && lock_keys::numbered_lock(t).is_some())
+                .collect();
+            assert!(
+                !numbered.is_empty(),
+                "{hints:?}: seed 5 has no hint locks, so this proves nothing"
             );
-        }
+            assert!(
+                numbered.iter().any(|&t| lock_keys::numbered_lock_is_water(t)),
+                "{hints:?}: seed 5 has no hint water gap, so the split below proves nothing"
+            );
 
-        // Both on: everything numbered breaks.
-        let table = breakable(&build(crate::Tri::On, crate::Tri::On));
-        for &tile in &numbered {
-            assert!(table.contains(&tile), "{tile:#04X} unbreakable with both switches on");
+            // Locks on, bridges off: the path locks break, the water gaps do not.
+            // Giving a bridge gap a digit must not move it onto the other switch.
+            let table = breakable(&rom);
+            for &tile in &numbered {
+                let water = lock_keys::numbered_lock_is_water(tile);
+                assert_eq!(
+                    table.contains(&tile),
+                    !water,
+                    "numbered {} {tile:#04X}: breakable={}, expected {}",
+                    if water { "water gap" } else { "lock" },
+                    table.contains(&tile),
+                    !water
+                );
+            }
+
+            // Both on: everything numbered breaks.
+            let table = breakable(&build(crate::Tri::On, crate::Tri::On, hints));
+            for &tile in &numbered {
+                assert!(table.contains(&tile), "{tile:#04X} unbreakable with both switches on");
+            }
         }
     }
 

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -44,7 +44,7 @@ pub(super) const MAYBE_SALT: u64 = 0x4D41_5942_455F_5631; // "MAYBE_V1"
 
 /// Bytes of payload the format can address, past the two-byte envelope.
 ///
-/// 97 bits are spent today, leaving 143 in reserve — years of headroom at the
+/// 99 bits are spent today, leaving 141 in reserve — years of headroom at the
 /// rate this project has actually added options (the layout was bumped six
 /// times in the 38 days to 2026-08-06). It is deliberately generous rather than
 /// "one more byte than we need": running out of reserve is the one thing that
@@ -427,10 +427,19 @@ mod payload {
         /// `world_maze` is on**, so a key from a seed that never touches the
         /// mode is byte-for-byte what it was before this field existed. Zero is
         /// a real value with the maze on (a pure maze, no gate).
+        /// How much the maze's map says about which fortress opens which lock.
+        /// **Only written when `world_maze` is on**, like `maze_wands` above, so
+        /// a key from a seed that never touches the mode is byte-for-byte what
+        /// it was before this field existed.
+        ///
+        /// `Full` is the zero discriminant on purpose — see [`HintMode`]. A key
+        /// minted before this option decodes to the hints it was minted with
+        /// rather than to silence.
+        pub(super) hints: HintMode,
         pub(super) maze_wands: B3,
 
         // --- Reserve ---
-        // 134 bits. Adding an option is: declare it immediately above this
+        // 132 bits. Adding an option is: declare it immediately above this
         // block, then take the same number of bits off `B19`. An older key
         // simply has those bits zero, which is "off" for a bool and the default
         // for every enum here, so it stays a correct key for the settings it
@@ -445,7 +454,7 @@ mod payload {
         #[skip]
         __: B128,
         #[skip]
-        __: B6,
+        __: B4,
     }
 }
 
@@ -489,7 +498,7 @@ impl Options {
             cannons, water, bros, hb_encounters, limit_hazards, friendlier_levels,
             bro_battle_timer, deja_vu, deja_vu_forts,
             fire_flower, piranha_shuffle, wild_injections,
-            starting_lives, world_count, world_maze, maze_wands, starting_items,
+            starting_lives, world_count, world_maze, maze_wands, hints, starting_items,
             // Not encoded — see NOT_ENCODED for the reason on each.
             palettes: _, palette_themed: _, player_color: _,
             remove_flashing: _, king_quotes: _, skip_rom_validation: _,
@@ -568,6 +577,7 @@ impl Options {
             // default key string for every seed that never touches the mode —
             // which is a flag-key compatibility event bought for nothing.
             .with_maze_wands(if *world_maze { (*maze_wands).min(7) } else { 0 })
+            .with_hints(if *world_maze { *hints } else { HintMode::default() })
             .with_starting_item_0(sanitize_item(item(0)))
             .with_starting_item_1(sanitize_item(item(1)))
             .with_starting_item_2(sanitize_item(item(2)))
@@ -666,6 +676,11 @@ impl Options {
             // castle — so it is taken at face value there. With the maze off
             // the field was never encoded, so the default is the honest read.
             maze_wands: if f.world_maze() { f.maze_wands() } else { default_maze_wands() },
+            hints: if f.world_maze() {
+                f.hints_or_err().unwrap_or_default()
+            } else {
+                HintMode::default()
+            },
             world_count: match f.world_count() {
                 0 => default_world_count(),
                 n => n,

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -17,9 +17,9 @@ use options::*;
 // Public API re-exported by the crate root (see lib.rs).
 pub use flag_key::{current_flag_key_version, flag_key_fields, flag_key_version_of};
 pub use options::{
-    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, ITEM_RANDOM, ITEM_RANDOM_NO_WHISTLE,
-    ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode, STARTING_LIVES_VALUES, Tri, WildChaser,
-    item_display_name, item_id,
+    DejaVuMode, EnemyMode, FireFlowerMode, HazardLimit, HintMode, ITEM_RANDOM,
+    ITEM_RANDOM_NO_WHISTLE, ITEM_RANDOM_SUIT_ONLY, ITEMS, Options, PiranhaMode,
+    STARTING_LIVES_VALUES, Tri, WildChaser, item_display_name, item_id,
 };
 
 #[cfg(test)]
@@ -420,7 +420,9 @@ fn randomize_inner(
         randomize::maze::writer::stamp_pad_tiles(rom, &state);
         // And the same question from the fortress's end: which of the three
         // fortress tiles it wears says where the lock it opens is.
-        randomize::maze::writer::stamp_fort_tiles(rom, &state);
+        if options.hints.hints_at_all() {
+            randomize::maze::writer::stamp_fort_tiles(rom, &state);
+        }
         rom.set_tag("wand_gate");
         randomize::wand_gate::apply(rom, wands);
         // Last of the grid writers, and the first thing that reads them: this
@@ -450,7 +452,7 @@ fn randomize_inner(
     // the table is a permutation, which is what catches the wrong order.
     rom.set_tag("lock_keys");
     let lock_entries = maze_lock_keys.unwrap_or_else(|| lock_pairing.lock_entries(&build));
-    randomize::lock_keys::apply(rom, &lock_entries);
+    randomize::lock_keys::apply(rom, &lock_entries, options.hints);
 
     // Big [?] bonus-room shuffle: every level with a Big [?] pipe draws from a
     // pool of 19 rooms (11 vanilla + 8 in the otherwise-dead "Unused Level 5").

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -256,6 +256,80 @@ pub enum DejaVuMode {
     Wild,
 }
 
+/// How much the world maze's map tells you about which fortress opens which
+/// lock. Inert outside the maze, where every lock is local and every fortress
+/// opens something in the world you are standing in.
+///
+/// # The three rungs
+///
+/// * **Off** — nothing is said. Fortresses wear one of their three designs at
+///   random, as they did before any of this, and locks are the plain tiles.
+/// * **Partial** (`some`) — a fortress's design says whether the lock it opens is in this
+///   world, another one, or World 8; and a lock in the alternate colour is one
+///   whose key is somewhere else. Two independent readings of the same fact,
+///   from either end.
+/// * **Full** — as Partial, and the lock carries the *number* of the world its
+///   fortress is in.
+///
+/// # Why the order is not the ladder
+///
+/// Declaration order is the flag-key wire format, and the key's whole
+/// compatibility story is that an unset field decodes as zero *and zero is the
+/// default* — see the `flag_key` module header. So `Partial` is declared first.
+/// [`HintMode::rung`] is the ladder; nothing should read the declaration order
+/// as one.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    modular_bitfield::Specifier,
+)]
+#[bits = 2]
+#[serde(rename_all = "snake_case")]
+pub enum HintMode {
+    /// Fortress designs, and a lock's colour says whether its key is local.
+    /// The default: it answers the question a player actually has without
+    /// handing them the whole map.
+    ///
+    /// Named `Partial` rather than `Some` so it never reads as `Option::Some`
+    /// at a match site — the same trick [`HazardLimit::Sparse`] plays. The
+    /// serde/CLI/web value stays "some".
+    #[default]
+    #[serde(rename = "some")]
+    Partial,
+    /// As Partial, and the lock carries the number of the world to go to.
+    Full,
+    /// No hints at all; fortress designs go back to being random.
+    Off,
+}
+
+impl HintMode {
+    /// Position on the ladder — 0 Off, 1 Some, 2 Full — so callers can ask
+    /// "at least Some" without caring that the encoding is in the other order.
+    pub fn rung(self) -> u8 {
+        match self {
+            HintMode::Off => 0,
+            HintMode::Partial => 1,
+            HintMode::Full => 2,
+        }
+    }
+
+    /// Does the map say anything at all about which fortress opens which lock?
+    pub fn hints_at_all(self) -> bool {
+        self.rung() >= HintMode::Partial.rung()
+    }
+
+    /// Do locks carry the world number, rather than only a colour?
+    pub fn numbers_locks(self) -> bool {
+        self == HintMode::Full
+    }
+}
+
 /// A level-wide chaser the wild-injection pass can seed into a level. The
 /// option is the *set* of these the player allowed — an empty set is off.
 ///
@@ -660,6 +734,10 @@ pub struct Options {
     /// How many times one level may appear on the map. See [`DejaVuMode`].
     #[serde(default)]
     pub deja_vu: DejaVuMode,
+    /// How much the world maze's map says about which fortress opens which
+    /// lock. See [`HintMode`]. Inert outside the maze.
+    #[serde(default)]
+    pub hints: HintMode,
     /// Deja Vu counts fortresses too. A modifier on [`Options::deja_vu`]
     /// rather than an option of its own: it is ignored when that is off, and
     /// takes its mode from it when it is on.
@@ -759,6 +837,7 @@ impl Default for Options {
             friendlier_levels: false,
             deja_vu: DejaVuMode::Off,
             deja_vu_forts: false,
+            hints: HintMode::Partial,
             wild_injections: Vec::new(),
             starting_lives: default_starting_lives(),
             starting_items: Vec::new(),

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1098,6 +1098,11 @@ fn fnv1a(data: &[u8]) -> u64 {
 fn all_off_options() -> Options {
     Options {
         fire_flower: FireFlowerMode::Off,
+        // Not "off": with the maze off this option is inert, and the key
+        // normalizes it to the default the way it does maze_wands. Claiming
+        // Off here would fail the round trip against a decoder that
+        // deliberately returns the default.
+        hints: crate::HintMode::default(),
         friendlier_levels: false,
         deja_vu: DejaVuMode::Off,
         deja_vu_forts: false,
@@ -1175,6 +1180,7 @@ fn all_off_options() -> Options {
 fn all_on_options() -> Options {
     Options {
         fire_flower: FireFlowerMode::On,
+        hints: crate::HintMode::default(),
         limit_hazards: HazardLimit::All,
         friendlier_levels: true,
         deja_vu: DejaVuMode::Wild,

--- a/web/options.js
+++ b/web/options.js
@@ -78,6 +78,12 @@ const OFF_SOME_ALL = [
 	{ value: "all", label: "All" },
 ];
 
+const OFF_SOME_FULL = [
+	{ value: "off", label: "Off" },
+	{ value: "some", label: "Some" },
+	{ value: "full", label: "Full" },
+];
+
 // Off / On / Wild pill for Random Fire Flower. "Wild" widens the pool to also
 // include the Small/Big downgrade outcomes. Values match the Rust
 // `FireFlowerMode` enum's serde representation.
@@ -98,6 +104,8 @@ const OFF_DOUBLE_WILD = [
 // Categories rendered as <fieldset> sections, in order.
 export const GROUPS = [
 	{ id: "map", label: "Map" },
+	{ id: "maze", label: "World Maze",
+		note: "Only affects World Maze. With the mode off these are ignored, and they leave your flag key alone." },
 	{ id: "enemies", label: "Enemies" },
 	{ id: "bosses", label: "Bosses" },
 	{ id: "items", label: "Items & Pickups" },
@@ -306,16 +314,25 @@ export const SCHEMA = [
 		tip: "Number of worlds before Dark Land (fewer = shorter game)",
 		group: "map", inFlagKey: true,
 		enabledWhen: { world_order: true } },
+
+	// --- World Maze ---
+	// The mode switch first; everything under it is inert without it, which is
+	// what the group note says.
 	{ id: "world_maze", type: "bool", default: false,
 		label: "World Maze",
 		tip: "The eight maps become one big maze. Warp pads link them, a fortress can open a lock in another world, and your progress in a world is still there when you come back. Turns World Order on.",
-		group: "map", inFlagKey: true },
+		group: "maze", inFlagKey: true },
 	{ id: "maze_wands", type: "tri", numeric: true,
 		options: [0,1,2,3,4,5,6,7].map(n => ({ value: n, label: String(n) })),
 		default: 3,
 		label: "Wands To Enter",
 		tip: "Wands needed before Bowser's castle will open. Fewer is a shorter game; 0 lets you walk straight in if you find a way there.",
-		group: "map", inFlagKey: true,
+		group: "maze", inFlagKey: true,
+		enabledWhen: { world_maze: true } },
+	{ id: "hints", type: "tri", options: OFF_SOME_FULL, default: "some",
+		label: "Hints",
+		tip: "How much the map gives away about which fortress opens which lock. Some marks a fortress with the design for where its lock is, and tints a lock whose key is in another world. Full also stamps that lock with the world number to go to.",
+		group: "maze", inFlagKey: true,
 		enabledWhen: { world_maze: true } },
 
 	// --- Enemies ---


### PR DESCRIPTION
The maze's two map hints become one setting, **defaulting to Some**.

| | |
|---|---|
| **Off** | Nothing is said. Fortresses go back to wearing a design at random. |
| **Some** | A fortress's design says where its lock is; a lock in the alternate colour is one whose key is in another world. |
| **Full** | As Some, and the lock carries the number of the world to go to. |

Only affects World Maze, and with the mode off it leaves your flag key alone —
the encoder normalizes it the way it does `maze_wands`, so picking a hint level
on a standard seed does not change the string. The web page gets a **World Maze**
section with the mode switch at the top and the two maze-only settings under it.

## Off needs no new code

The random fortress-tile assignment never went away — `overworld_writer/grid.rs`
still does it, and `stamp_fort_tiles` was simply overwriting it afterwards. Not
calling that gives the random spread back. Seed 5: **7/2/5** local/away/W8 with
hints off, against the logical **2/8/4** with them on.

## The new rung, and what it forced

A remote lock wears the alternate colour; a local one does not. Three new page-3
tiles (`$FC`/`$FD`/`$FE`) plus `$E4`, which was already that colour.

**The sky lock had to move, or it would lie.** `$E4` is *already* page 3, so a
local sky lock would wear the mark meaning "elsewhere". In Some, local sky takes
a page-1 tile revealing `$DA` and `$E4` becomes remote-sky, so "alternate colour
means the key is elsewhere" holds everywhere instead of almost everywhere.

**Full cannot also be alt-coloured.** 8 digits x 4 orientations is 32 tiles and
page 3 has 20, so Full trades the colour cue for the precise answer.

**The revealed path draws in the lock's colours until the next map reload**, on
every remote lock, because the effect writes no attribute byte. Accepted
deliberately — the same trade the numbered bridge gaps already take.

## Two bugs found while building it, both silent

- **The local-sky sweep keyed on the tile alone.** Sky's remote tile *is* its
  plain tile, so stamping a remote sky lock changes no byte and the sweep moved
  the remote ones to the local tile with the local ones. Measured: **10 seeds in
  30 had a sky lock and every one came back local.**
  `every_away_lock_wears_the_alternate_colour` now counts both sides and fails
  unless both occur.
- **The hammer knew only the numbered family**, so in Some it would have refused
  every alt-colour lock — the identical regression the numbered set shipped with
  earlier. There is now one `hint_orientation` lookup covering every family, and
  the hammer test runs both modes.

`$E4` is deliberately *not* a hint tile despite being in the alt set: it is
vanilla's sky lock, and claiming it counted every plain sky lock as a hint.

## Encoding

`Partial` is the zero discriminant, because the flag key's compatibility story is
"an unset field decodes as zero **and zero is the default**" — the `flag_key`
module header says so, and breaking it would falsify a documented property.
2 bits of 141 reserve.

## Verification

587 tests, both clippy passes (including the wasm32 one CI runs separately),
`fmt --check`. All three modes diffed on a real ROM: Off leaves 8 table rows and
no hint tile, Some stamps 15 alt-colour locks, Full stamps the same 15 numbered.

## Not playtested

The alternate colour is the entire signal in Some mode and I have only ever seen
it as a palette index. Whether it reads as "different lock" on a TV is the first
thing worth checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJ6sXwR1jy6X8SRPDPVm65
