### PR TITLE
fix: the maze whistle was in a slot the player could not reach

### DIFF
--- a/docs/smb3_rom_reference.md
+++ b/docs/smb3_rom_reference.md
@@ -1770,6 +1770,31 @@ PRG031 via `$07F5`. The handler also stores the item to `$07F5` at $A5D8.
 `Inv_UseItem_Anchor` ($A682) sets `Map_Anchored`, plays the anchor sound, removes the
 item from inventory, and returns — it never enters the powerup animation path.
 
+### The Inventory Is a Compacted List (PRG026)
+
+`Inventory_Items` (`$7D80`, 28 slots, four rows of seven) is not an addressed
+array — it is a **packed list with no holes**, and the engine's routines both
+assume and maintain that:
+
+- **Use** — `Inv_UseItem_ShiftOver` memmoves the whole tail down over the used
+  slot (`LDA Inventory_Items+1,Y / STA Inventory_Items,Y`, loop at
+  `PRG026_A638`, file **0x34648**, running to index 27) and zeroes the last one.
+  It shifts the tail wholesale, so it does **not** close a pre-existing hole —
+  a gap just moves down with everything else.
+- **Panel input** — `PRG026_A4A1` (file **0x344B1**) reads slot 0 first and
+  `RTS`es when it is zero. Left/right *and* the A-press "use" path both sit
+  behind that check, so **an empty slot 0 makes the whole panel inert**: no
+  cursor, no item use, even when later slots hold items.
+- **Holes above slot 0 are survivable.** Moving the highlight onto an empty slot
+  re-enters the move in the same direction (`PRG026_A4EB`, file **0x344FB**), so
+  the cursor skips gaps. Only slot 0 is fatal.
+
+**Consequence for any patch that seeds the inventory**: write from slot 0 upward
+and leave no gap. Parking an item in a high slot at new-game time — a guaranteed
+whistle, say — makes it permanently unreachable unless something else fills
+every slot beneath it. The world maze hit exactly this: its whistle sat in slot
+3 above the (by default empty) starting-item slots 0-2 and could never be used.
+
 ### Inventory Item Draw (PRG026)
 
 `Inventory_DrawItemsOrCards` at CPU **$A366** (file **0x34376**) draws every non-empty
@@ -4634,8 +4659,8 @@ velocity — faster horizontal movement = higher jump. Fall velocity is clamped 
 
 | Address | Size | Description |
 |---------|------|-------------|
-| $7D80–$7D9B | 28 bytes | Mario's items (13 slots, Global Item IDs) |
-| $7DA3–$7DBE | 28 bytes | Luigi's items (13 slots) |
+| $7D80–$7D9B | 28 bytes | Mario's items — 28 slots, 4 rows of 7, Global Item IDs. Packed from slot 0 with no holes; see "The Inventory Is a Compacted List" |
+| $7DA3–$7DBE | 28 bytes | Luigi's items (same layout) |
 | $7D9C–$7D9E | 3 bytes | Mario's goal cards (0=none, 1=mushroom, 2=flower, 3=star) |
 | $7DBF–$7DC1 | 3 bytes | Luigi's goal cards |
 | $7DA2 | 1 byte | Mario's coins |

--- a/docs/world_maze_design.md
+++ b/docs/world_maze_design.md
@@ -1040,10 +1040,22 @@ requested pad role distribution.
 - **The player starts holding the whistle, and keeps it.** It is the mode's
   fast travel, so it is granted at the first frame rather than hidden: an
   earlier cut pinned one into a toad-house chest to guarantee it existed, which
-  made the mode's core tool something to go and find. `items::with_starting_whistle`
-  puts it in an empty inventory slot, appends while there is room, and otherwise
-  displaces the LAST requested item — so a player who asked for three things
-  gets two of them plus the one the mode cannot work without.
+  made the mode's core tool something to go and find. `completion_bits`'
+  new-game init writes it into **inventory slot 0**, and `qol::starting_state`
+  is told to start the player's own items at slot 1, so three requested items
+  still fit and none of them is displaced.
+
+  Slot 0 is not arbitrary. The inventory is a **compacted list**, not an
+  addressed array: the engine gives every item the first free slot, and using
+  one memmoves the tail down over it. Its panel handler reads slot 0 first and
+  returns immediately when it is empty (`PRG026_A4A1`) — no cursor, no use — so
+  a hole at the bottom is a dead panel, not a blank square. Two earlier cuts
+  fell into this. Merging the whistle into the starting-items list ate one of
+  the three the UI offers; moving it clear of them, to slot 3, meant that with
+  the default of *no* starting items the whistle sat above three empty slots
+  and could never be reached at all. The rule the two writers now share: fill
+  from slot 0 up, never leave a gap, and the whistle takes the bottom because
+  it is the one item the player is guaranteed to be holding.
 - **The whistle is not consumed.** Vanilla's `Inv_UseItem_WarpWhistle` ends
   with `JSR Inv_UseItem_ShiftOver`, which deletes the item — correct for a
   one-shot warp, fatal for fast travel: one whistle would buy exactly one trip,

--- a/src/randomize/completion_bits.rs
+++ b/src/randomize/completion_bits.rs
@@ -895,16 +895,28 @@ const NEW_GAME_INIT_CPU: u16 = (0xC000 + FS_NEW_GAME_INIT - 0x32010) as u16;
 ///   rather than a list means the next allocation is covered by having been
 ///   declared there.
 ///
-/// * the warp whistle, into the **fourth** inventory slot. The mode's fast
+/// * the warp whistle, into the **first** inventory slot. The mode's fast
 ///   travel is useless if the player cannot reach it, so it is theirs from the
-///   first frame. It lands here rather than in the starting-items trampoline
-///   for two reasons. `write_starting_items` fills slots 0-2 and the UI offers
-///   exactly three, so a whistle competing for those slots silently ate the
-///   player's third choice; and that trampoline is full — 33 of 33 bytes, with
-///   `start_airship_swap` starting at the next byte and 128-byte DMC filler
-///   ahead of it that a sample's length register can legally run into. Slot 3
-///   is free: `Inventory_Items` is 28 slots (`$7D80..$7D9B`), so this displaces
-///   nothing and stops short of `Inventory_Cards`.
+///   first frame — and slot 0 is the only slot that makes "reach it" true.
+///   The inventory is a *compacted list*, not an addressed array: the engine
+///   hands every item to the first free slot, and using one memmoves the tail
+///   down over it. Its input handler (`PRG026_A4A1`) reads slot 0 first and
+///   returns immediately when it is empty — no cursor, no use — so a hole at
+///   slot 0 is not an empty square, it is a dead panel.
+///
+///   That is why the whistle cannot sit *above* the player's own items, which
+///   is where it used to sit (slot 3). With fewer than three starting items —
+///   the default is none — slot 0 was empty, and the whistle the mode depends
+///   on could never be reached. It takes slot 0 now and
+///   [`write_starting_items`](super::qol::write_starting_items) is told to
+///   begin at slot 1, so the four writes stay contiguous either way.
+///
+///   It lands here rather than in that trampoline because the trampoline is
+///   full — 33 of 33 bytes, with `start_airship_swap` starting at the next
+///   byte and 128-byte DMC filler ahead of it that a sample's length register
+///   can legally run into. Three items plus a whistle is four of the 28 slots
+///   in `Inventory_Items` (`$7D80..$7D9B`), so this displaces nothing and
+///   stops short of `Inventory_Cards`.
 ///
 /// The whistle write is last on purpose. `A` must stay zero across the three
 /// loops, and this is the one place it is free again.
@@ -936,16 +948,16 @@ const NEW_GAME_INIT: [u8; 38] = [
     0x10, 0xFA,                                     // 30: BPL -6 -> live_loop
 
     0xA9, super::items::WARP_WHISTLE,               // 32: LDA #$0C
-    0x8D, INVENTORY_SLOT_4 as u8,
-          (INVENTORY_SLOT_4 >> 8) as u8,            // 34: STA Inventory_Items+3
+    0x8D, INVENTORY_WHISTLE_SLOT as u8,
+          (INVENTORY_WHISTLE_SLOT >> 8) as u8,      // 34: STA Inventory_Items
     0x60,                                           // 37: RTS
 ];
 
-/// `Inventory_Items + 3` — the fourth of Mario's 28 item slots (`$7D80..$7D9B`,
-/// four rows of seven; `Inventory_Cards` follows at `$7D9C`). The starting-items
-/// trampoline writes slots 0-2 and the UI offers exactly three, so this one is
-/// the first the player can never have asked for.
-const INVENTORY_SLOT_4: u16 = 0x7D83;
+/// `Inventory_Items` — the first of Mario's 28 item slots (`$7D80..$7D9B`, four
+/// rows of seven; `Inventory_Cards` follows at `$7D9C`). The panel is dead
+/// while this slot is empty, so the maze's whistle owns it and the
+/// starting-items trampoline begins at slot 1. See [`NEW_GAME_INIT`].
+const INVENTORY_WHISTLE_SLOT: u16 = 0x7D80;
 
 /// The `Map_Completions` wipe in `PRG030_84A0`: CPU `$84CD`, ten bytes, three
 /// whole instructions, nothing branching into the middle.
@@ -1968,9 +1980,12 @@ mod tests {
             mem.set_byte(LIVE_WORLD, 0xAA);
             mem.set_byte(DEBUG_FLAG, 0xAA);
             // One byte past each region, so an off-by-one in either loop's
-            // index is a failure rather than an invisible extra zero.
+            // index is a failure rather than an invisible extra zero. The live
+            // loop's fence is `$7D81`, not `$7D80` — the whistle store lands on
+            // `$7D80` after the loop and would paper over an overrun there.
             mem.set_byte(PACKED + PACKED_LEN as u16, 0xAA);
             mem.set_byte(0x7D80, 0xAA);
+            mem.set_byte(0x7D81, 0xAA);
             for i in 0..maze_state::MAZE_STATE_LEN {
                 mem.set_byte(maze_state::MAZE_STATE_START + i as u16, 0xAA);
             }
@@ -2024,7 +2039,20 @@ mod tests {
                 0xAA,
                 "the maze loop ran past the run maze_state declares",
             );
-            assert_eq!(cpu.memory.get_byte(0x7D80), 0xAA, "the live loop ran past $7D7F");
+            assert_eq!(cpu.memory.get_byte(0x7D81), 0xAA, "the live loop ran past $7D80");
+            // ...and because that fence sits one byte further out than it used
+            // to, pin the loop's own bound as well.
+            assert_eq!(NEW_GAME_INIT[25], 0x7F, "the live loop no longer stops at $7D7F");
+
+            // The whistle itself, in the one slot that makes it reachable: the
+            // inventory panel returns without opening for use while slot 0 is
+            // empty, so anywhere above a hole and the mode's fast travel is
+            // unusable for the whole run.
+            assert_eq!(
+                cpu.memory.get_byte(0x7D80),
+                crate::randomize::items::WARP_WHISTLE,
+                "the maze whistle must land in inventory slot 0",
+            );
         }
     }
 

--- a/src/randomize/qol/starting_state.rs
+++ b/src/randomize/qol/starting_state.rs
@@ -21,14 +21,23 @@ pub fn set_starting_lives(rom: &mut Rom, lives: u8) {
 /// Replaces the 8-byte lives init at 0x308E0 with `JSR $E250`
 /// (FS_STARTING_ITEMS) into a routine that sets lives, does the intro skip,
 /// queues the seeded menu music, AND writes up to 3 items to inventory
-/// ($7D80+).
+/// (`Inventory_Items`, `$7D80+`).
+///
+/// `first_slot` is where those items start. It is 0 normally and **1 in the
+/// world maze**, which claims slot 0 for its permanent whistle in
+/// [`completion_bits`](crate::randomize::completion_bits)' new-game init.
+/// The inventory is a compacted list — the engine's own panel refuses to open
+/// for use at all when slot 0 is empty, and using an item memmoves the tail
+/// down over it — so the two writers must be contiguous from slot 0, never
+/// leave a hole, and the whistle is the one that has to be at the bottom
+/// because it is the one the player may hold alone.
 ///
 /// Must run AFTER title_screen: both patch the lives-init region, and this
 /// JSR overwrites title_screen's intro-skip hook at 0x308E2. The trampoline
 /// replays the identical intro-skip + menu-music bytes (shared
 /// `title_screen::intro_skip_music_bytes`), so behavior is preserved;
 /// title_screen's FS_INTRO_SKIP routine is left in ROM unreferenced.
-pub fn write_starting_items(rom: &mut Rom, seed: u64, lives: u8, items: &[u8]) {
+pub fn write_starting_items(rom: &mut Rom, seed: u64, lives: u8, items: &[u8], first_slot: u8) {
     let lives = lives.clamp(1, 99);
     let cpu = crate::randomize::rom_data::prg031_file_to_cpu(FS_STARTING_ITEMS); // $E250
     // Build trampoline: lives init + intro skip + menu music + item writes + RTS
@@ -41,10 +50,11 @@ pub fn write_starting_items(rom: &mut Rom, seed: u64, lives: u8, items: &[u8]) {
     ]);
     buf.extend_from_slice(&crate::randomize::title_screen::intro_skip_music_bytes(seed));
     for (i, &item) in items.iter().take(3).enumerate() {
+        let slot = first_slot + i as u8;
         #[rustfmt::skip]
         buf.extend_from_slice(&[
             0xA9, item,                      // LDA #item
-            0x8D, (0x80 + i as u8), 0x7D,    // STA $7D80+i
+            0x8D, (0x80 + slot), 0x7D,       // STA $7D80+slot
         ]);
     }
     buf.push(0x60); // RTS

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -720,12 +720,22 @@ fn randomize_inner(
     // identical intro-skip + menu-music bytes (shared
     // `title_screen::intro_skip_music_bytes`), so behavior is unchanged;
     // title_screen's FS_INTRO_SKIP routine is left in ROM unreferenced.
-    // Gated on the RESOLVED list, not the requested one: maze mode adds a
-    // whistle to an otherwise-empty inventory, and gating on the request would
-    // have dropped it silently.
+    //
+    // The maze owns inventory slot 0 — its permanent whistle goes there in
+    // `completion_bits`' new-game init — so the player's own items start at
+    // slot 1 there. The inventory is a compacted list and the engine's panel
+    // is dead while slot 0 is empty, so the two writers have to be contiguous
+    // from the bottom; see `write_starting_items`.
     if !resolved_items.is_empty() {
         rom.set_tag("qol/starting_items");
-        randomize::qol::write_starting_items(rom, seed, options.starting_lives, &resolved_items);
+        let first_slot = u8::from(options.world_maze);
+        randomize::qol::write_starting_items(
+            rom,
+            seed,
+            options.starting_lives,
+            &resolved_items,
+            first_slot,
+        );
     }
 
     // MaCobra patches — always-on bugfixes and fairness tweaks.

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -1643,19 +1643,26 @@ fn a_maze_rom_puts_a_pad_tile_under_every_arrival_key() {
     }
 }
 
-/// **The maze player starts holding a whistle, it survives being blown, and it
-/// does not cost them a starting item.**
+/// **The maze player starts holding a whistle, it survives being blown, it does
+/// not cost them a starting item, and they can actually get at it.**
 ///
-/// Three halves of one promise, in three modules, so this is the only place
+/// Four clauses of one promise, in three modules, so this is the only place
 /// that can check the promise itself: `completion_bits` puts the whistle in
-/// inventory slot 3 at the new-game signal, `world_travel` stops the engine
-/// consuming it, and `qol::starting_state` still owns slots 0-2.
+/// inventory **slot 0** at the new-game signal, `world_travel` stops the engine
+/// consuming it, and `qol::starting_state` takes slots 1-3 instead of 0-2 so
+/// the player's own three still fit.
 ///
-/// The third clause is the regression. The whistle used to be merged into the
-/// player's starting-items list, and since the CLI and the web UI both offer
-/// exactly three, a player who asked for three got two of them plus a whistle
-/// — the mode quietly ate a choice. Slot 3 is a slot the UI cannot request,
-/// so the two no longer compete.
+/// Two regressions live here. The whistle used to be merged into the player's
+/// starting-items list, and since the CLI and the web UI both offer exactly
+/// three, a player who asked for three got two of them plus a whistle — the
+/// mode quietly ate a choice. The fix put it in slot 3, above the player's
+/// slots 0-2, which was the second bug: the inventory is a *compacted list*,
+/// and the engine's panel returns immediately when slot 0 is empty
+/// (`PRG026_A4A1` — no cursor, no use). With fewer than three starting items,
+/// and the default is none, slot 0 was empty and the whistle the whole mode
+/// leans on was unreachable for the entire run. So the whistle takes the
+/// bottom slot — it is the one item the player is guaranteed to hold — and
+/// everything else stacks on top of it with no hole.
 ///
 /// Read out of the finished ROM rather than from the options, because the two
 /// writes are emitted by different patches into different banks.
@@ -1684,17 +1691,20 @@ fn a_maze_player_starts_with_a_permanent_whistle() {
 
         let new_game = rom.read_range(FS_NEW_GAME_INIT, 40);
         assert!(
-            writes_slot(new_game, WHISTLE, 3),
-            "[{label}] the new-game init puts no whistle in inventory slot 3"
+            writes_slot(new_game, WHISTLE, 0),
+            "[{label}] the new-game init puts no whistle in inventory slot 0 — \
+             anywhere above an empty slot 0 and the panel will not open for use"
         );
 
-        // The player's own choices keep slots 0-2, and the whistle stays out of
-        // the trampoline entirely — that is the bug this guards.
+        // The player's own choices stack on top of it, contiguously, and the
+        // whistle stays out of the trampoline entirely — the two bugs this
+        // guards.
         let tramp = rom.read_range(FS_STARTING_ITEMS, 40);
-        for (slot, &item) in requested.iter().enumerate() {
+        for (i, &item) in requested.iter().enumerate() {
+            let slot = i as u8 + 1;
             assert!(
-                writes_slot(tramp, item, slot as u8),
-                "[{label}] requested item {item:#04X} lost its slot {slot} to the whistle"
+                writes_slot(tramp, item, slot),
+                "[{label}] requested item {item:#04X} is not in slot {slot}"
             );
         }
         assert!(
@@ -1712,18 +1722,28 @@ fn a_maze_player_starts_with_a_permanent_whistle() {
     }
 
     // Without the maze, none of it applies — otherwise this test would pass
-    // for a reason that has nothing to do with the mode.
+    // for a reason that has nothing to do with the mode. And the slot shift is
+    // part of "none of it": nothing writes slot 0 outside the maze, so the
+    // player's items must start there or the panel is dead for them too.
     let mut plain = rom.clone();
     randomize(
         &mut plain,
         12345,
-        &Options { world_maze: false, starting_items: vec![], ..audit_options() },
+        &Options { world_maze: false, starting_items: vec![0x01, 0x02, 0x03], ..audit_options() },
     );
     assert_ne!(
         plain.read_range(crate::randomize::world_travel::WHISTLE_CONSUME_OFFSET, 3),
         [0xEA, 0xEA, 0xEA],
         "the whistle-keeping patch leaked into a non-maze seed"
     );
+    let plain_tramp = plain.read_range(FS_STARTING_ITEMS, 40);
+    for (slot, item) in [0x01u8, 0x02, 0x03].into_iter().enumerate() {
+        assert!(
+            writes_slot(plain_tramp, item, slot as u8),
+            "without the maze, item {item:#04X} is not in slot {slot} — a hole at \
+             slot 0 leaves the inventory panel dead"
+        );
+    }
 }
 
 /// **The web build's entry path carries the maze.**

--- a/src/testrom.rs
+++ b/src/testrom.rs
@@ -1122,7 +1122,17 @@ pub fn build(vanilla: &[u8], spec: &TestRomSpec) -> Result<TestRom, String> {
         let items: Vec<u8> = spec.starting_items.iter().copied().take(3).collect();
         // Seed only drives the intro-skip menu music; any fixed value is fine
         // for a test ROM and keeps output reproducible.
-        crate::randomize::qol::write_starting_items(&mut rom, 0, spec.starting_lives, &items);
+        // Slot 0 unless the base is a maze seed, which has already put its
+        // permanent whistle there — see `write_starting_items`.
+        let maze_base =
+            matches!(&spec.base, Base::Randomized { options, .. } if options.world_maze);
+        crate::randomize::qol::write_starting_items(
+            &mut rom,
+            0,
+            spec.starting_lives,
+            &items,
+            u8::from(maze_base),
+        );
         report.push(format!(
             "inventory: {} ({} lives)",
             items.iter().map(|&id| crate::item_display_name(id)).collect::<Vec<_>>().join(", "),


### PR DESCRIPTION
## The bug

The world maze grants a permanent warp whistle at new-game time — its fast travel, and by design its escape hatch. It went into **inventory slot 3**, deliberately clear of the three slots `write_starting_items` owns, so it could not eat one of the three items the UI offers.

But starting items default to *none*. So the default maze game opened with the whistle sitting above **three empty slots**, and that is fatal:

- `PRG026_A4A1` (file `0x344B1`) reads `Inventory_Items` slot 0 first and `RTS`es when it is zero. The left/right cursor **and** the A-press "use" path both sit behind that check — an empty slot 0 makes the whole panel inert, whatever is above it.
- `Inv_UseItem_ShiftOver` (loop at `0x34648`) memmoves the tail down wholesale, so it never *closes* a hole; a gap just travels with everything else.

The inventory is a compacted list, not an addressed array. Nothing in "put it in a free slot" hints at that, which is how it got past review.

## The fix

The whistle takes **slot 0** — it is the one item a maze player is guaranteed to be holding, so it is the one that belongs at the bottom. `qol::write_starting_items` gains a `first_slot`: **1 in the maze**, so the player's own three stack contiguously at 1–3, **0 everywhere else**, where the emitted bytes are unchanged.

Shifting the items to 1–3 unconditionally would not have worked — a non-maze seed then has the same empty slot 0 and the same dead panel.

## Also

- `docs/smb3_rom_reference.md` gains a "The Inventory Is a Compacted List" section; every offset in it was checked against the ROM.
- `docs/world_maze_design.md`'s whistle bullet described `items::with_starting_whistle`, which has not existed for two cuts. Rewritten to what is actually there, with why slot 0 is not arbitrary.

## Tests

- The maze whistle test asserts slot 0 and items at 1–3, and gained a non-maze arm asserting items still start at slot 0 — a hole there is dead for them too.
- The `completion_bits` CPU test used `$7D80` as the live loop's overrun fence. The whistle store now lands there *after* the loop and would paper over a one-byte overrun, so the fence moved to `$7D81` and the loop's bound is pinned as a constant as well.

`cargo fmt --check`, `cargo clippy --all-targets` and the wasm32 clippy pass are clean; 587 lib tests pass. Verified in an emulator by @michio.

## Heads up: a red check that is not this PR

`tests/overworld_baseline.rs::output_matches_baseline` fails for all 20 seeds — and it **already failed on a clean `beta/next` at 79310b2** (verified by stashing). #221 changed overworld output without regenerating the baseline. Unrelated to this change and left alone here; it needs its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJ6sXwR1jy6X8SRPDPVm65