### PR TITLE
test: the overworld baseline hashes the overworld, not the whole ROM

### DIFF
--- a/docs/overworld_baseline_log.md
+++ b/docs/overworld_baseline_log.md
@@ -1,0 +1,313 @@
+# Overworld baseline — recapture log
+
+`tests/overworld_baseline.rs` holds one committed constant: a hash of the bytes
+that describe the overworld, for the first 20 seeds. Every regeneration of that
+constant gets an entry here, dated, saying **what moved and how that was
+established**. No entry, no recapture.
+
+The rule the entries exist to enforce: **regenerate only for a change intended
+to alter output, and say so explicitly in the commit — never to make a red test
+green.** An unattributed recapture is indistinguishable from papering over a
+bug, which is the whole reason the guard exists.
+
+Whole-ROM byte identity is a separate instrument with no committed baseline at
+all — see `tests/rom_identity.rs`.
+
+## Why the log starts over on 2026-09-08
+
+Until that date the baseline hashed the **entire ROM**, so it moved for any byte
+anywhere: version bumps, king quotes, a title routine changing address, an
+always-on splice that touched no gameplay. Twenty recaptures in five weeks, each
+one paid for with a paragraph of manual attribution proving the difference
+landed somewhere harmless — and twice it silently went stale instead, which is
+worse than having no guard at all (see the 2026-08-31 entry, which had to
+untangle its own change from PR #205's inherited drift).
+
+The hash now covers the overworld alone — terrain, where each tile leads, the
+sprites on it, pipe destinations, lock keys — so it moves for a real topology
+change or an RNG-stream shift, and for very little else.
+
+**The entries below the divider are the whole-ROM era.** They are kept because
+they are the record of what actually changed in the ROM over those five weeks,
+and several of them are the only written account of a change's attribution. The
+hashes they describe are gone; the reasoning is not.
+
+## Entries
+
+### 2026-09-08 — the fingerprint replaces the whole-ROM hash
+
+First capture of the narrowed fingerprint, and it inherits real drift rather
+than merely changing units. Both facts are separated here on purpose, because a
+new instrument's first reading is the easiest place in the world to hide a bug.
+
+**The instrument.** `overworld_fingerprint` is differential-tested rather than
+argued for (`rom_data::fingerprint::tests`): flipping a byte in the
+title-screen seed icons, the flag-key stamp, or the enemy data must leave it
+unchanged — all three are places that forced a whole-ROM recapture at least once
+in the log below — and flipping a byte in each of the six regions it claims
+(map tiles, pointer tables, map-object ids, map-object rewards, pipe
+destinations, lock entries) must move it.
+
+**The drift, measured not assumed.** The last valid whole-ROM capture was at
+`9694907` (2026-09-01, the Hammer-Bro march spacing). Seeds 1-20 were generated
+from a clean checkout of that commit and from `beta/next` at `aaee028`, both
+with `--no-palettes --patched-rom`, and both sets were fingerprinted with the
+new code. **All 20 seeds differ in the overworld**, not merely in the ROM. So
+the staleness was not the old instrument crying wolf — the maps really did move
+and nothing recorded it. The world-maze merge (#215-#217) and the numbered-lock
+and fortress-deck work (#218-#221) landed in between; between them they re-deal
+the fortress deck, add lock tiles, and replace vanilla's fortress-FX slot tables
+with the position-keyed lock table the fingerprint now reads.
+
+Attribution stops at "the overworld genuinely changed, across that range of
+merges". Splitting it further would mean bisecting sixty commits to apportion a
+change nobody disputes was intended, and the log's purpose is to stop an
+*unexplained* recapture, not to re-derive a month of intended work.
+
+**Not from the maze-whistle fix in this same branch.** That change only writes
+inventory slots, and only differently when `world_maze` is on, which the sweep's
+default options leave off. It moves no byte here.
+
+---
+
+# Historical: the whole-ROM baseline (2026-08-03 – 2026-09-01)
+
+Transcribed verbatim from the doc comment on the old `BASELINE` constant. The
+entries were written in two blocks either side of the array and are not in
+chronological order — that disorder is itself part of why this moved out of the
+source file.
+
+
+Captured 2026-08-03 before the `rom_data::tiles` migration; re-captured
+2026-08-05 for the always-on stomp-fairness patch, which writes 31 bytes
+into every ROM (`stomp_fairness::apply`). These hashes cover the whole
+output, so all 20 seeds moved. Overworld topology is untouched by that
+change — the ROM bytes differ, the maps do not.
+
+Re-captured again 2026-08-05 for the Wild Injections sun/lakitu pool
+(`FLAG_KEY_VERSION` 27 → 28). The version byte is stamped into every ROM,
+so all 20 seeds moved for that reason alone: pinning the constant back to
+27 reproduced the previous hashes exactly, which is the check that this
+regeneration hides no real change. Default options leave the injection
+mode Off, so no gameplay byte differs.
+
+Re-captured again 2026-08-09 for the wider title-hash icon set: ICON_TILES
+grew from 15 to 20 rows and the palette digit was dropped, so the 40-byte
+sprite table at `FS_SEED_HASH_DATA` differs for every seed and all 20 moved.
+Verified the same way as the v29 recapture — seeds 1-3 generated before and
+after with `--no-palettes` (the player wardrobe is not seed-deterministic)
+and diffed byte by byte. Every difference lands inside FS_SEED_HASH_DATA; no
+overworld, level or enemy byte moved.
+
+Re-captured again 2026-08-06 for the v29 flag-key re-layout (issue #158).
+Same story, verified the same way but end-to-end rather than by pinning a
+constant, since the whole format changed: seeds 1-3 were generated before
+and after and diffed byte by byte. Every difference lands in one of the two
+places that carry the flag bytes on purpose — the stamp block at 0x19DF0 and
+the title-screen verification icons at `FS_SEED_HASH_DATA` (0x3E93D), whose
+hash folds `to_flag_bytes()`. No overworld, level, or enemy byte moved.
+Re-captured 2026-08-10 for the title-screen B-to-mute toggle, which writes
+25 bytes into every ROM (`title_screen::mute_routine` plus its hook), so all
+20 seeds moved. Verified the same way as the recaptures above: seeds 1-3
+generated before and after with `--no-palettes --patched-rom` and diffed byte
+by byte. Exactly 24 bytes differ per seed, in two places — the `JSR` operand
+at the hook site 0x30C94 and the 22-byte routine at 0x33529, which was $FF
+filler. No overworld, level or enemy byte moved.
+
+Re-captured 2026-08-11 for the dealt C1 floor (`capacity::deal_c1_floors`).
+This one DOES change overworld topology, on purpose: each world is dealt a
+floor of 11 / 14 / 17 instead of a flat 14, so shaping resolves differently.
+It also draws twice from the shared RNG (the pair count, then a shuffle),
+which shifts every downstream stream position — so all 20 seeds move for
+two reasons at once and a byte-level diff could not attribute them.
+Verified by pinning instead, the way the v28 recapture was: making
+`deal_c1_floors` return `[C1_FLOOR; 8]` with no draw reproduced the
+PREVIOUS hashes exactly, which shows the difference is the deal alone and
+that threading the floor through the shaping sites changed no decision.
+(The `C1_FLOOR_FLAT` env arm cannot do this job — it is `cfg(test)`, and
+this file links the library as an outside consumer.)
+Re-captured 2026-08-17 for the treasure-box room rules. Two changes, both
+deliberate, and every seed moves because both shift the shared RNG stream:
+
+1. A `$81` in a `Level_Event = 7` room that is not a real bro battle is
+   rewritten by `ObjInit_HammerBro` into an unkillable object, so it is now
+   excluded from every such room (`rewrites_hammer_bro`).
+2. Those rooms are cleared to be left, so they take the bro-fight pool:
+   the 8-Tank treasure room joins the Coin Ship as a `HammerBro` segment,
+   and Dry Bones moved from `STOMPABLE_ENEMIES` to `HB_NEEDS_SHELL_ENEMIES`
+   (it is stompable but revives, so only a kicked shell clears it).
+
+Attributed rather than assumed. Against the previous build at default flags
+(`hb_encounters` Off): **no** enemy ID in any treasure-box room differs, and
+`0x0DA3A` (the 8-Tank slot) now holds vanilla `$82` in every seed checked.
+That is the whole story — with `hb_encounters` Off, `hb_modes` is all-Off, so
+routing that room through the HB path means its single entry no longer draws
+at all where the old `ForceTankBro` row drew once. One fewer draw, and every
+downstream consumer (chest items, later segments, the overworld) shifts. The
+pool changes themselves only bite with `hb_encounters` on, which this sweep
+does not exercise — `treasure_box_rooms_never_get_a_hammer_bro` and the
+shell-pairing invariant in `enemies::tests` cover that instead.
+
+Re-captured 2026-08-20 for the W8 bridges-out deal
+(`overworld_build::locks::deal_bridge_spans`). Every seed moves, and for
+the usual two reasons at once: `capacity::roll_bridges_out` draws once
+from the shared RNG before the worlds are built, shifting every downstream
+stream position, and the deal itself changes W8's lock placement on
+purpose. Attribution is by census rather than by byte, since a lock moving
+re-prices the world: `w8_bridges_out_census` shows the count going from
+11.5/62.3/18.0/8.2/0% to 3.0/46.1/40.2/10.8/~0.02% across 0-4 spans out,
+the same-span rate from 78% to 33%, and `test_route_census` at 1000 seeds
+shows W8 mean routes 2.27 -> 2.25 (linear 4% -> 5%), overall 2.548 -> 2.537
+(linear 6.60% -> 6.91%), nothing below its dealt floor either way.
+
+Re-captured 2026-08-24 for the `SPOILED_SEGMENT_RANGES` off-by-one
+(issue #181). The middle row ended one byte past the next real stream's
+page byte, so after autoscroll removal the enemy-data walker resumed
+mid-entry and stayed out of phase for 18 slots. Attribution is by
+pinning, as with the v28 and C1-floor recaptures: restoring the range to
+`0x0D037..0x0D042` reproduces the hashes above exactly, so this one byte
+is the whole difference. What it changes: the walker now sees the two
+segments it was reading through, whose 17 entries were pinned to vanilla
+in every seed before. They are unrelated levels that merely sit next to
+each other in the block — `0x0D041` is 4-1's underwater sub-area and
+`0x0D049` is 5-4. Only four of the 17 can move: the two Big Berthas at
+`0x0D042`/`0x0D045` (water) and the two para-troopas at
+`0x0D068`/`0x0D074` (flying). The other 13 are `$90`-`$93`, the tilting
+and twirling platforms, which belong to no class pool and so never draw
+at any flag setting. Those four extra draws shift the shared RNG stream,
+which is why all 20 seeds move and the overworld moves with them.
+Nothing was being written to a wrong byte before the fix — the 18
+out-of-phase slots held X, Y and page bytes, all `$01..$19` and in no
+class pool, so 500 seeds at all-Wild never wrote one. It was latent, and
+`every_enemy_entry_point_is_a_walker_segment_start` keeps it that way.
+
+Re-captured 2026-08-26 for the Super Princess Peach title-screen fix. The
+B-to-mute routine moved from 0x33529 to 0x33FF0 — same 22 bytes, different
+home, because Peach's title logo claims 0x33530..0x336A7 and the randomizer
+writes last. Every seed moves because the ROM bytes moved. Attribution is by
+byte diff, as with the recaptures above: seeds 1-3 generated before and
+after with `--no-palettes --patched-rom` differ in exactly 46 bytes, in
+three runs — the 2-byte `JSR` operand at 0x30C94, the 22 bytes at 0x33529
+returning to `$FF` filler, and the byte-identical routine reappearing at
+0x33FF0. The routine's seeded music byte is unchanged per seed, so no RNG
+draw shifted; no overworld, level or enemy byte moved.
+
+Re-captured 2026-08-26 for the 1.2.1 bump. A version bump alone moves every
+seed: `compute_hash` folds `CARGO_PKG_VERSION`, which is the whole point of
+the version-guard. Attribution is by round trip *and* by byte. Round trip:
+1.2.0 on this same tree reproduces the previous array exactly and 1.2.1
+reproduces this one, so the version string is the only cause. Byte: seeds
+1-3 generated at each version with `--no-palettes --patched-rom` differ in
+2-3 bytes, every one of them inside `FS_SEED_HASH_DATA` (0x3E93D+40) -- the
+title-screen verification icons, which is exactly what is supposed to move.
+
+One trap worth naming: `cargo` did NOT rebuild on a version-only edit to
+`Cargo.toml` here, so the first recapture attempt printed a stale binary's
+hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
+trusting any number this test prints after a bump.
+
+Re-captured 2026-08-30 for the pipe screen-squish fix: the always-on
+MaCobra bundle gained a 9-byte splice at 0x10476 (PRG008 $A466) that exempts
+pipe travel from the left-edge crush death. It consumes no RNG, so nothing
+downstream shifted — verified rather than argued: for all 20 of these seeds
+the pre- and post-fix ROMs were diffed byte for byte (`--no-palettes
+--patched-rom`) and the diff is exactly 0x10476..0x1047F on every one of
+them, with no second span. No map tile, pointer table or level byte moved.
+
+Re-captured 2026-08-31 for the off-path fort rule (`Forts` may no longer
+take a blank the player cannot walk around; `try_fort_lock` and
+`try_pipe_move` hold the same line). Overworld topology changes on
+purpose. TWO causes are folded into this recapture and both are named
+here on purpose:
+
+1. The baseline was ALREADY stale at HEAD — PR #205 (three new king rescue
+   quotes) rewrites quote text in every ROM and did not recapture, so all
+   20 seeds had already moved before this change was written.
+2. This change itself, which moves fortresses and therefore locks, C1, and
+   the shaping decisions downstream of them.
+
+Verified by pinning, the way the v28 and dealt-C1-floor recaptures were:
+neutralising all three guards (an empty forced set in `Forts` and in
+`try_fort_lock`, `any_fort_forced` returning false) reproduced the HEAD
+hashes EXACTLY, all 20 seeds. So cause 2 is the guards alone — the new
+`WorldState::forced_positions` and the census columns that read it change
+no output — and cause 1 is inherited, not created here.
+
+Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
+on. Every seed moves, for two reasons that are both intended:
+
+1. `qol::big_q`'s lookup routine grew from 106 to 207 bytes (slot seeding
+   plus four new 13-entry payload tables), and the Big [?] exit path's
+   `JMP PRG026_AA8A` at 0x34A84 now jumps into it.
+2. `big_q_rooms::shuffle` draws twice from the shared RNG and rewrites the
+   per-row area/arrival tables, and 7-F1's drawn block is forced to Tanooki.
+
+**Overworld topology is untouched**, which is the thing worth checking here.
+The pass runs after `write_overworld`, so it cannot move a map tile — and
+that was verified rather than argued: the 8 map grids were hashed for all 20
+seeds with the `shuffle` call live and with it stubbed to return an empty
+vec, and the two sets are identical. The ROM bytes differ, the maps do not.
+
+Amended the same week: Unused Level 5's screens 6 and 7 got new arrival
+coordinates after playtesting showed the originals killed the player. Four
+table bytes, so every seed that draws one of those rooms moves. No RNG draw
+changed — the pool is the same size — so this is a pure byte difference.
+
+Re-captured 2026-08-29 again, for `shuffle_big_q_rooms`. The room shuffle is
+now an option and **off by default**, so the pass no longer draws its two
+values from the shared RNG on a default build, which shifts every module
+downstream of it (`credits`, `items`, `king_quotes`, `koopalings`).
+
+The on-path was checked against the build this option was carved out of: for
+seeds 1-12, `--shuffle-big-q-rooms` reproduces `beta/next` byte for byte
+apart from `[stamp]` (0x19DF0..0x19E09) and `[title_screen]` (0x3E924..),
+both of which are derived from the flag key — and the key necessarily grew
+one bit. The randomization itself is untouched.
+
+Re-captured 2026-08-29 for the 7-F1 return fix: the entry and exit halves of
+the `qol::big_q` routine now share one `bq_lookup` subroutine, which moved
+every label and table after offset $09 and shrank it from 207 to 199 bytes.
+Again a pure byte difference, and again verified rather than argued — for
+each of these 20 seeds the pre- and post-fix ROMs were diffed byte for byte,
+and the only bytes that changed outside `FS_BIG_Q_LOOKUP`'s own 224-byte
+allocation were the exit hook's operand at 0x34A85. No map tile, pointer
+table or level byte moved.
+
+Re-captured 2026-08-30 for `qol::level_clock`: the level clock's frame
+divider is now 60 rather than vanilla's 41, so a unit is a real second. It
+is two immediate operands (0x34FC6, 0x3C517) and is applied to every seed,
+so every hash moved. Verified rather than argued, the same way as the
+entries above: for each of these 20 seeds the generated ROM had those two
+bytes reverted to `$28` and re-hashed, and all 20 then reproduced the
+previous baseline exactly — so those two bytes are the entire diff. No map
+tile, pointer table or level byte moved.
+
+Re-captured 2026-09-01 for the **1.3.0 version bump** and nothing else. The
+hash folds `CARGO_PKG_VERSION`, so 1.2.1 -> 1.3.0 rewrites every seed's
+title-screen verification icons and with them all 20 whole-ROM hashes. That
+is the version guard working as designed, not a randomization change.
+
+Attribution is by byte diff, the same way as the entries above: seeds 1-3
+were generated with `--no-palettes --patched-rom` at 1.2.1 and again at
+1.3.0, and every differing byte in all three lands inside
+`FS_SEED_HASH_DATA` (0x3E93D + 40) and nowhere else — 9 to 11 bytes per
+seed, all within the icon payload. No RNG draw moved, so no module
+downstream shifted; the flag-key stamp at 0x19DF0 is byte-identical, since
+the key does not carry the release version.
+
+Re-captured 2026-09-01 for the Hammer-Bro march spacing. Wandering sprites
+were spread by Chebyshev distance with a floor of 2 — which is exactly one
+march leg, so a bro could land on another and force both to march again.
+Spacing now runs on the march graph (`overworld_build::march`) with a floor
+of 3 legs, so the chosen tiles moved.
+
+Attribution is by byte diff, the same way as the entries above: seeds 1-3
+were generated with `--no-palettes --patched-rom` before and after. Every
+one of the 71 / 27 / 66 changed bytes lands in one of two regions and
+nowhere else — the per-world map-object sub-tables reached through
+`MAP_OBJ_*_MASTER` (6 / 3 / 5 bytes, the sprite coordinates themselves) and
+the world pointer tables inside `WORLDS[..].rowtype_offset` (65 / 24 / 61
+bytes, because `assign` splits HammerBro slots into sprite slots and filler
+slots and feeds the two different pools). No map tile grid byte, no
+map-object reward byte, no level byte and no flag-key byte moved, and the
+RNG draw count is unchanged, so nothing downstream shifted.

--- a/docs/write_log_design.md
+++ b/docs/write_log_design.md
@@ -274,10 +274,14 @@ That is weak evidence, though: the audit only sees the 36 free-space regions,
 which is a small share of what a run writes. It lowers the urgency; it does not
 clear the structural problem.
 
-**Verification:** `tests/overworld_baseline.rs` covers it. Tagging is metadata
-and must not move a single ROM byte, so all 20 seeds must stay byte-identical.
-Note that harness excludes palettes (not seed-stable) and only exercises default
-options, so pair it with the existing pinned-table tests for flag-gated passes.
+**Verification:** `tests/rom_identity.rs` covers it — `capture` on the base
+commit, `compare` after. Tagging is metadata and must not move a single ROM
+byte, so all 20 seeds must stay byte-identical, which is exactly the question
+that harness answers. (`tests/overworld_baseline.rs` is the wrong instrument
+here: it hashes the overworld alone, so it would stay green for a tagging
+change that moved bytes elsewhere.) Note the sweep excludes palettes (not
+seed-stable) and only exercises default options, so pair it with the existing
+pinned-table tests for flag-gated passes.
 
 ---
 

--- a/src/randomize/lock_keys.rs
+++ b/src/randomize/lock_keys.rs
@@ -147,7 +147,11 @@ const COUNT_OPERAND: usize = 36;
 const BOUNDARY_OPERAND: usize = 71;
 
 /// Bytes reserved for the entry table. Four per entry.
-const ENTRIES_RESERVED: usize = 112;
+///
+/// `pub(crate)` so the overworld fingerprint can hash the whole reservation
+/// without re-deriving its size — the tail past the live entries is `$FF`
+/// filler, which is stable and so hashes fine.
+pub(crate) const ENTRIES_RESERVED: usize = 112;
 
 /// How many locks a build can key. Today's ceiling is the 17-card fortress deck
 /// — and every fortress keys exactly one lock, so 17 is also the floor. The

--- a/src/randomize/rom_data/access.rs
+++ b/src/randomize/rom_data/access.rs
@@ -346,7 +346,7 @@ fn read_sprite_positions(
 ) -> Vec<(usize, usize)> {
     let mut positions = Vec::new();
 
-    for slot in 0..9 {
+    for slot in 0..MAP_OBJ_SLOTS {
         let id_off = map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot);
         if !pred(rom.read_byte(id_off)) {
             continue;
@@ -398,7 +398,7 @@ pub(crate) const MAP_OBJ_REWARDS: usize = 0x16190;
 
 /// File offset of the reward byte for map-object `slot` in `world_idx`.
 pub(crate) fn map_obj_reward_offset(world_idx: usize, slot: usize) -> usize {
-    MAP_OBJ_REWARDS + world_idx * 9 + slot
+    MAP_OBJ_REWARDS + world_idx * MAP_OBJ_SLOTS + slot
 }
 
 /// First map-object slot usable for sprite placement in a world. Slot 0
@@ -415,7 +415,7 @@ pub(crate) fn first_usable_map_obj_slot(world_idx: usize) -> usize {
 /// (`0x03-0x06`, which redistribution clears) — so the result is identical
 /// before and after [`clear_hb_sprites`].
 pub(crate) fn eligible_hb_map_slots(rom: &Rom, world_idx: usize) -> Vec<usize> {
-    (first_usable_map_obj_slot(world_idx)..9)
+    (first_usable_map_obj_slot(world_idx)..MAP_OBJ_SLOTS)
         .filter(|&slot| {
             let id = rom.read_byte(map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot));
             id == 0x00 || is_hb_sprite_id(id)
@@ -429,7 +429,7 @@ pub(crate) fn eligible_hb_map_slots(rom: &Rom, world_idx: usize) -> Vec<usize> {
 pub(crate) fn collect_hb_sprite_rewards(rom: &Rom) -> Vec<u8> {
     let mut rewards = Vec::new();
     for world_idx in 0..8 {
-        for slot in 0..9 {
+        for slot in 0..MAP_OBJ_SLOTS {
             let id = rom.read_byte(map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot));
             if is_hb_sprite_id(id) {
                 rewards.push(rom.read_byte(map_obj_reward_offset(world_idx, slot)));
@@ -443,7 +443,7 @@ pub(crate) fn collect_hb_sprite_rewards(rom: &Rom) -> Vec<u8> {
 /// slot's id, position, and reward byte are zeroed so the tile is freed and the
 /// sprite no longer spawns. Used before writing redistributed Hammer Bros.
 pub(crate) fn clear_hb_sprites(rom: &mut Rom, world_idx: usize) {
-    for slot in 0..9 {
+    for slot in 0..MAP_OBJ_SLOTS {
         let id_off = map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot);
         if is_hb_sprite_id(rom.read_byte(id_off)) {
             clear_map_sprite(rom, world_idx, slot);
@@ -456,7 +456,7 @@ pub(crate) fn clear_hb_sprites(rom: &mut Rom, world_idx: usize) {
 /// writer (which fills eligible slots from the bottom) and the reserved
 /// dynamic-spawn buffer.
 pub(crate) fn last_empty_map_obj_slot(rom: &Rom, world_idx: usize) -> Option<usize> {
-    (first_usable_map_obj_slot(world_idx)..9).rev().find(|&slot| {
+    (first_usable_map_obj_slot(world_idx)..MAP_OBJ_SLOTS).rev().find(|&slot| {
         rom.read_byte(map_obj_slot_offset(rom, MAP_OBJ_IDS_MASTER, world_idx, slot)) == 0x00
     })
 }

--- a/src/randomize/rom_data/fingerprint.rs
+++ b/src/randomize/rom_data/fingerprint.rs
@@ -1,0 +1,174 @@
+//! A stable hash of the bytes that describe the overworld.
+//!
+//! [`tests/overworld_baseline.rs`] compares this against a committed constant,
+//! so that a change to the map a player walks is caught the moment it happens
+//! rather than a fortnight later.
+//!
+//! **Why not hash the whole ROM.** That is what the baseline used to do, and it
+//! moved on a version bump, on three new king quotes, on a 22-byte title
+//! routine changing address, on any always-on splice — none of which is an
+//! overworld change. Twenty recaptures in a month, each one paid for with a
+//! paragraph of manual attribution proving the diff landed somewhere harmless.
+//! A guard that is usually red is a guard nobody reads, and it went stale twice
+//! for exactly that reason (see `docs/overworld_baseline_log.md`).
+//!
+//! Whole-ROM identity is still worth having, but as an on-demand check with no
+//! committed constant to rot — that is `tests/rom_identity.rs`.
+//!
+//! **What is in.** Only data the engine reads to draw and walk a map: terrain,
+//! where each tile leads, the sprites standing on it, where pipes come out, and
+//! which fortress opens which lock. Every region is named by a `rom_data`
+//! constant, never by an offset spelled out here — `tools/offset_dups.py`
+//! exists to keep it that way.
+//!
+//! **What moves it, and should.** A real topology change. And an RNG-stream
+//! shift from a new draw anywhere upstream, because that genuinely re-deals
+//! every seed's map — the difference is that saying so takes a line, not a
+//! paragraph.
+//!
+//! **What is out.** 6502 code, including the routines that *act on* these
+//! tables. A patch that rewrites the lock-breaking routine byte for byte
+//! changes no map, and the shape of that routine is the `asm::check` tests'
+//! business, not this one's.
+
+use super::*;
+use crate::rom::Rom;
+
+/// FNV-1a. Rolled by hand rather than using `DefaultHasher`, whose output is
+/// explicitly not guaranteed stable across Rust releases — a baseline that
+/// changes when the toolchain updates is worse than none.
+struct Fnv(u64);
+
+impl Fnv {
+    fn new() -> Self {
+        Fnv(0xcbf2_9ce4_8422_2325)
+    }
+
+    fn eat(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.0 ^= b as u64;
+            self.0 = self.0.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+
+    fn eat_byte(&mut self, b: u8) {
+        self.eat(&[b]);
+    }
+}
+
+/// Hash the overworld-describing bytes of a finished ROM.
+///
+/// Stable across toolchains and across every part of the ROM that is not the
+/// overworld. See the module docs for what that covers and why.
+pub fn overworld_fingerprint(rom: &Rom) -> u64 {
+    let mut h = Fnv::new();
+
+    // 1. Terrain. Grids are screen-major, `ROWS * 16` bytes per screen, so the
+    //    whole block is exactly the tiles and nothing else.
+    for info in &MAP_TILE_GRIDS {
+        h.eat(rom.read_range(info.file_offset, info.screens * ROWS * 16));
+    }
+
+    // 2. Where each tile leads: the five parallel per-entry arrays (row/type,
+    //    screen-column, and the object and layout pointer halves).
+    for world in &WORLDS {
+        h.eat(rom.read_range(world.rowtype_offset, world.entry_count * 5));
+    }
+
+    // 3. The sprites standing on the map. The master words first — a repointed
+    //    sub-table is a change even if the bytes it now names happen to match —
+    //    then every slot's position and type, then its reward.
+    for master in [MAP_OBJ_YS_MASTER, MAP_OBJ_XHIS_MASTER, MAP_OBJ_XLOS_MASTER, MAP_OBJ_IDS_MASTER]
+    {
+        h.eat(rom.read_range(master, WORLDS.len() * 2));
+        for world_idx in 0..WORLDS.len() {
+            for slot in 0..MAP_OBJ_SLOTS {
+                h.eat_byte(rom.read_byte(map_obj_slot_offset(rom, master, world_idx, slot)));
+            }
+        }
+    }
+    h.eat(rom.read_range(MAP_OBJ_REWARDS, WORLDS.len() * MAP_OBJ_SLOTS));
+
+    // 4. Where a pipe puts the player down.
+    for base in [PIPE_MAP_XHI, PIPE_MAP_X, PIPE_MAP_Y, PIPE_MAP_SCRL_XHI] {
+        h.eat(rom.read_range(base, PIPE_DEST_LEN));
+    }
+
+    // 5. Which fortress opens which lock — position-keyed, so it describes the
+    //    map rather than the routine that reads it.
+    h.eat(rom.read_range(FS_LOCK_ENTRIES, crate::randomize::lock_keys::ENTRIES_RESERVED));
+
+    h.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vanilla() -> Option<Rom> {
+        let bytes = std::fs::read("roms/Super Mario Bros. 3 (USA) (Rev 1).nes").ok()?;
+        Some(Rom::from_bytes(&bytes).unwrap())
+    }
+
+    /// A differential test, not a golden one: flip one byte and say whether the
+    /// fingerprint was supposed to notice. This is the whole claim the harness
+    /// rests on, and the old whole-ROM hash could not have passed the first
+    /// half of it.
+    #[test]
+    fn it_watches_the_overworld_and_nothing_else() {
+        let Some(rom) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+        let base = overworld_fingerprint(&rom);
+
+        // Bytes it must ignore. Each is a place a real change has forced a
+        // whole-ROM recapture at least once — see
+        // `docs/overworld_baseline_log.md`.
+        for (off, what) in [
+            (FS_SEED_HASH_DATA, "the title-screen seed icons"),
+            (FS_SEED_STAMP, "the flag-key stamp"),
+            (ENEMY_DATA_START, "an enemy entry"),
+        ] {
+            let mut m = rom.clone();
+            m.write_byte(off, rom.read_byte(off) ^ 0xFF);
+            assert_eq!(
+                overworld_fingerprint(&m),
+                base,
+                "the fingerprint moved for {what} ({off:#07X}), which is not the overworld"
+            );
+        }
+
+        // Bytes it must notice, one per region it claims to cover.
+        let map_obj_id = map_obj_slot_offset(&rom, MAP_OBJ_IDS_MASTER, 0, 2);
+        for (off, what) in [
+            (MAP_TILE_GRIDS[0].file_offset, "a W1 map tile"),
+            (WORLDS[0].rowtype_offset, "a W1 pointer table entry"),
+            (map_obj_id, "a map-object sprite id"),
+            (map_obj_reward_offset(0, 2), "a map-object reward"),
+            (PIPE_MAP_Y, "a pipe destination"),
+            (FS_LOCK_ENTRIES, "a lock's key"),
+        ] {
+            let mut m = rom.clone();
+            m.write_byte(off, rom.read_byte(off) ^ 0xFF);
+            assert_ne!(
+                overworld_fingerprint(&m),
+                base,
+                "the fingerprint ignored {what} ({off:#07X}), which is the overworld"
+            );
+        }
+    }
+
+    /// Reading the fingerprint must not change the ROM — it is run on output
+    /// the tests then go on to compare by other means.
+    #[test]
+    fn it_is_a_pure_read() {
+        let Some(rom) = vanilla() else {
+            eprintln!("SKIP: requires the ROM, which is not included in the repo");
+            return;
+        };
+        let before = rom.clone();
+        overworld_fingerprint(&rom);
+        assert_eq!(rom.data, before.data, "the fingerprint wrote to the ROM");
+    }
+}

--- a/src/randomize/rom_data/mod.rs
+++ b/src/randomize/rom_data/mod.rs
@@ -18,6 +18,7 @@ mod access;
 #[cfg(test)]
 pub(crate) mod asm;
 mod engine;
+mod fingerprint;
 mod free_space;
 mod grid;
 mod tables;
@@ -32,6 +33,11 @@ pub(crate) use tiles::*;
 
 // Part of the lib's public API (consumed by the chr_stats integration test).
 pub use access::{ENEMY_DATA_END, ENEMY_DATA_START};
+
+// Part of the lib's public API: `tests/overworld_baseline.rs` links the library
+// as an outside consumer, so the regions it hashes have to be reachable from
+// here rather than copied into the test as offsets.
+pub use fingerprint::overworld_fingerprint;
 
 // Part of the lib's public API: the CLI's `--write-log` dump audits free space
 // against the run it just produced.

--- a/src/randomize/rom_data/tables.rs
+++ b/src/randomize/rom_data/tables.rs
@@ -405,6 +405,11 @@ pub(crate) const ROWS: usize = 9;
 pub(crate) const PRG012_FILE_BASE: usize = 0x18010;
 
 // Pipe destination tables (PRG002)
+
+/// Entries in each pipe destination table. The four tables are contiguous and
+/// this is also their stride, which is the check if one of them ever moves.
+pub(crate) const PIPE_DEST_LEN: usize = 24;
+
 pub(crate) const PIPE_MAP_XHI: usize = 0x046AA;
 
 pub(crate) const PIPE_MAP_X: usize = 0x046C2;
@@ -787,6 +792,11 @@ pub(crate) const HB_NEEDS_SHELL_ENEMIES: &[u8] = &[
 pub(crate) const HB_EXCLUDE_ENTRIES: &[(u16, u8)] = &[
     (0xC640, 3), // W3[41] — tileset 3 is wrong for lay 0xB3E7
 ];
+
+/// Map-object sprite slots per world. Slot 0 always holds a fixed non-HB
+/// marker and slot 1 is the airship's in W1-W7; see
+/// [`first_usable_map_obj_slot`](super::first_usable_map_obj_slot).
+pub(crate) const MAP_OBJ_SLOTS: usize = 9;
 
 /// Master pointer table for Map_List_Object_Ys (8 words, one per world).
 pub(crate) const MAP_OBJ_YS_MASTER: usize = 0x16020;

--- a/tests/overworld_baseline.rs
+++ b/tests/overworld_baseline.rs
@@ -1,47 +1,47 @@
-//! Byte-identity baseline for overworld output.
+//! Baseline for overworld output.
 //!
-//! Guards refactors that are supposed to change nothing — the tile-predicate
-//! consolidation in `rom_data::tiles` being the motivating case. Each migration
-//! of a call site onto a shared predicate must leave these hashes untouched; a
-//! changed hash means the substituted predicate covers a different set than the
-//! inlined list it replaced, which is exactly the kind of silent behaviour
-//! change a "pure refactor" is not allowed to make.
+//! A committed hash, per seed, of the bytes that describe the map a player
+//! walks — terrain, where each tile leads, the sprites standing on it, where
+//! pipes come out, and which fortress opens which lock. See
+//! [`overworld_fingerprint`] for exactly what is covered and why.
 //!
-//! Palette randomization is excluded: it is not seed-stable (two runs of the
-//! same seed differ in a handful of NES palette bytes), so it would make this
-//! harness flap for reasons unrelated to what it is guarding. Topology is
-//! unaffected.
+//! It moves for a real topology change, and for an RNG-stream shift from a new
+//! draw anywhere upstream — because that genuinely re-deals every seed's map.
+//! It does not move for a version bump, a new king quote, a relocated title
+//! routine, or an always-on splice, all of which used to force a recapture back
+//! when this hashed the whole ROM.
 //!
-//! Skipped when the ROM is absent, like the other ROM-dependent tests — the
-//! ROM is gitignored and CI has no copy.
+//! **Whole-ROM byte identity is a different question and lives in
+//! `tests/rom_identity.rs`** — capture on one tree, compare on another, no
+//! committed constant to go stale. Reach for that one when the claim is "this
+//! refactor changes nothing at all."
+//!
+//! Palette randomization is outside the fingerprint's regions, so the
+//! not-seed-stable palette bytes cannot make this flap. The sweep still runs
+//! with palettes off, so the two harnesses generate the same ROMs.
+//!
+//! Skipped when the ROM is absent, like the other ROM-dependent tests — the ROM
+//! is gitignored and CI has no copy.
 
+use smb3_rs::randomize::rom_data::overworld_fingerprint;
+use smb3_rs::rom::Rom;
 use smb3_rs::{Options, generate_patched_rom};
 
 const ROM_PATH: &str = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes";
 const SEEDS: u64 = 20;
 
-/// FNV-1a. Rolled by hand rather than using `DefaultHasher`, whose output is
-/// explicitly not guaranteed stable across Rust releases — a baseline that
-/// changes when the toolchain updates is worse than none.
-fn fnv1a(bytes: &[u8]) -> u64 {
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for &b in bytes {
-        h ^= b as u64;
-        h = h.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    h
-}
-
 fn options() -> Options {
     Options { palettes: false, palette_themed: false, ..Options::default() }
 }
 
-fn hashes(rom: &[u8]) -> Vec<u64> {
+fn fingerprints(rom: &[u8]) -> Vec<u64> {
     (1..=SEEDS)
         .map(|seed| {
             let out = generate_patched_rom(rom, seed, &options(), None)
                 .unwrap_or_else(|e| panic!("seed {seed} failed to generate: {e}"));
-            fnv1a(&out)
+            let parsed = Rom::from_bytes_lax(&out, true)
+                .unwrap_or_else(|e| panic!("seed {seed} produced an unreadable ROM: {e}"));
+            overworld_fingerprint(&parsed)
         })
         .collect()
 }
@@ -55,271 +55,26 @@ fn sweep_is_deterministic() {
         return;
     };
     assert_eq!(
-        hashes(&rom),
-        hashes(&rom),
-        "same seeds produced different output within one run — the baseline \
+        fingerprints(&rom),
+        fingerprints(&rom),
+        "same seeds produced different overworlds within one run — the baseline \
          cannot guard anything until this is stable"
     );
 }
 
-/// Regenerate ONLY for a change intended to alter output, and say so
-/// explicitly in the commit — never to make a red test green.
+/// Regenerate ONLY for a change intended to alter the overworld, and add a
+/// dated entry to `docs/overworld_baseline_log.md` in the same commit saying
+/// what moved and how you established it — never to make a red test green.
 ///
-/// Captured 2026-08-03 before the `rom_data::tiles` migration; re-captured
-/// 2026-08-05 for the always-on stomp-fairness patch, which writes 31 bytes
-/// into every ROM (`stomp_fairness::apply`). These hashes cover the whole
-/// output, so all 20 seeds moved. Overworld topology is untouched by that
-/// change — the ROM bytes differ, the maps do not.
-///
-/// Re-captured again 2026-08-05 for the Wild Injections sun/lakitu pool
-/// (`FLAG_KEY_VERSION` 27 → 28). The version byte is stamped into every ROM,
-/// so all 20 seeds moved for that reason alone: pinning the constant back to
-/// 27 reproduced the previous hashes exactly, which is the check that this
-/// regeneration hides no real change. Default options leave the injection
-/// mode Off, so no gameplay byte differs.
-///
-/// Re-captured again 2026-08-09 for the wider title-hash icon set: ICON_TILES
-/// grew from 15 to 20 rows and the palette digit was dropped, so the 40-byte
-/// sprite table at `FS_SEED_HASH_DATA` differs for every seed and all 20 moved.
-/// Verified the same way as the v29 recapture — seeds 1-3 generated before and
-/// after with `--no-palettes` (the player wardrobe is not seed-deterministic)
-/// and diffed byte by byte. Every difference lands inside FS_SEED_HASH_DATA; no
-/// overworld, level or enemy byte moved.
-///
-/// Re-captured again 2026-08-06 for the v29 flag-key re-layout (issue #158).
-/// Same story, verified the same way but end-to-end rather than by pinning a
-/// constant, since the whole format changed: seeds 1-3 were generated before
-/// and after and diffed byte by byte. Every difference lands in one of the two
-/// places that carry the flag bytes on purpose — the stamp block at 0x19DF0 and
-/// the title-screen verification icons at `FS_SEED_HASH_DATA` (0x3E93D), whose
-/// hash folds `to_flag_bytes()`. No overworld, level, or enemy byte moved.
-/// Re-captured 2026-08-10 for the title-screen B-to-mute toggle, which writes
-/// 25 bytes into every ROM (`title_screen::mute_routine` plus its hook), so all
-/// 20 seeds moved. Verified the same way as the recaptures above: seeds 1-3
-/// generated before and after with `--no-palettes --patched-rom` and diffed byte
-/// by byte. Exactly 24 bytes differ per seed, in two places — the `JSR` operand
-/// at the hook site 0x30C94 and the 22-byte routine at 0x33529, which was $FF
-/// filler. No overworld, level or enemy byte moved.
-///
-/// Re-captured 2026-08-11 for the dealt C1 floor (`capacity::deal_c1_floors`).
-/// This one DOES change overworld topology, on purpose: each world is dealt a
-/// floor of 11 / 14 / 17 instead of a flat 14, so shaping resolves differently.
-/// It also draws twice from the shared RNG (the pair count, then a shuffle),
-/// which shifts every downstream stream position — so all 20 seeds move for
-/// two reasons at once and a byte-level diff could not attribute them.
-/// Verified by pinning instead, the way the v28 recapture was: making
-/// `deal_c1_floors` return `[C1_FLOOR; 8]` with no draw reproduced the
-/// PREVIOUS hashes exactly, which shows the difference is the deal alone and
-/// that threading the floor through the shaping sites changed no decision.
-/// (The `C1_FLOOR_FLAT` env arm cannot do this job — it is `cfg(test)`, and
-/// this file links the library as an outside consumer.)
-/// Re-captured 2026-08-17 for the treasure-box room rules. Two changes, both
-/// deliberate, and every seed moves because both shift the shared RNG stream:
-///
-/// 1. A `$81` in a `Level_Event = 7` room that is not a real bro battle is
-///    rewritten by `ObjInit_HammerBro` into an unkillable object, so it is now
-///    excluded from every such room (`rewrites_hammer_bro`).
-/// 2. Those rooms are cleared to be left, so they take the bro-fight pool:
-///    the 8-Tank treasure room joins the Coin Ship as a `HammerBro` segment,
-///    and Dry Bones moved from `STOMPABLE_ENEMIES` to `HB_NEEDS_SHELL_ENEMIES`
-///    (it is stompable but revives, so only a kicked shell clears it).
-///
-/// Attributed rather than assumed. Against the previous build at default flags
-/// (`hb_encounters` Off): **no** enemy ID in any treasure-box room differs, and
-/// `0x0DA3A` (the 8-Tank slot) now holds vanilla `$82` in every seed checked.
-/// That is the whole story — with `hb_encounters` Off, `hb_modes` is all-Off, so
-/// routing that room through the HB path means its single entry no longer draws
-/// at all where the old `ForceTankBro` row drew once. One fewer draw, and every
-/// downstream consumer (chest items, later segments, the overworld) shifts. The
-/// pool changes themselves only bite with `hb_encounters` on, which this sweep
-/// does not exercise — `treasure_box_rooms_never_get_a_hammer_bro` and the
-/// shell-pairing invariant in `enemies::tests` cover that instead.
-///
-/// Re-captured 2026-08-20 for the W8 bridges-out deal
-/// (`overworld_build::locks::deal_bridge_spans`). Every seed moves, and for
-/// the usual two reasons at once: `capacity::roll_bridges_out` draws once
-/// from the shared RNG before the worlds are built, shifting every downstream
-/// stream position, and the deal itself changes W8's lock placement on
-/// purpose. Attribution is by census rather than by byte, since a lock moving
-/// re-prices the world: `w8_bridges_out_census` shows the count going from
-/// 11.5/62.3/18.0/8.2/0% to 3.0/46.1/40.2/10.8/~0.02% across 0-4 spans out,
-/// the same-span rate from 78% to 33%, and `test_route_census` at 1000 seeds
-/// shows W8 mean routes 2.27 -> 2.25 (linear 4% -> 5%), overall 2.548 -> 2.537
-/// (linear 6.60% -> 6.91%), nothing below its dealt floor either way.
-///
-/// Re-captured 2026-08-24 for the `SPOILED_SEGMENT_RANGES` off-by-one
-/// (issue #181). The middle row ended one byte past the next real stream's
-/// page byte, so after autoscroll removal the enemy-data walker resumed
-/// mid-entry and stayed out of phase for 18 slots. Attribution is by
-/// pinning, as with the v28 and C1-floor recaptures: restoring the range to
-/// `0x0D037..0x0D042` reproduces the hashes above exactly, so this one byte
-/// is the whole difference. What it changes: the walker now sees the two
-/// segments it was reading through, whose 17 entries were pinned to vanilla
-/// in every seed before. They are unrelated levels that merely sit next to
-/// each other in the block — `0x0D041` is 4-1's underwater sub-area and
-/// `0x0D049` is 5-4. Only four of the 17 can move: the two Big Berthas at
-/// `0x0D042`/`0x0D045` (water) and the two para-troopas at
-/// `0x0D068`/`0x0D074` (flying). The other 13 are `$90`-`$93`, the tilting
-/// and twirling platforms, which belong to no class pool and so never draw
-/// at any flag setting. Those four extra draws shift the shared RNG stream,
-/// which is why all 20 seeds move and the overworld moves with them.
-/// Nothing was being written to a wrong byte before the fix — the 18
-/// out-of-phase slots held X, Y and page bytes, all `$01..$19` and in no
-/// class pool, so 500 seeds at all-Wild never wrote one. It was latent, and
-/// `every_enemy_entry_point_is_a_walker_segment_start` keeps it that way.
-///
-/// Re-captured 2026-08-26 for the Super Princess Peach title-screen fix. The
-/// B-to-mute routine moved from 0x33529 to 0x33FF0 — same 22 bytes, different
-/// home, because Peach's title logo claims 0x33530..0x336A7 and the randomizer
-/// writes last. Every seed moves because the ROM bytes moved. Attribution is by
-/// byte diff, as with the recaptures above: seeds 1-3 generated before and
-/// after with `--no-palettes --patched-rom` differ in exactly 46 bytes, in
-/// three runs — the 2-byte `JSR` operand at 0x30C94, the 22 bytes at 0x33529
-/// returning to `$FF` filler, and the byte-identical routine reappearing at
-/// 0x33FF0. The routine's seeded music byte is unchanged per seed, so no RNG
-/// draw shifted; no overworld, level or enemy byte moved.
-///
-/// Re-captured 2026-08-26 for the 1.2.1 bump. A version bump alone moves every
-/// seed: `compute_hash` folds `CARGO_PKG_VERSION`, which is the whole point of
-/// the version-guard. Attribution is by round trip *and* by byte. Round trip:
-/// 1.2.0 on this same tree reproduces the previous array exactly and 1.2.1
-/// reproduces this one, so the version string is the only cause. Byte: seeds
-/// 1-3 generated at each version with `--no-palettes --patched-rom` differ in
-/// 2-3 bytes, every one of them inside `FS_SEED_HASH_DATA` (0x3E93D+40) -- the
-/// title-screen verification icons, which is exactly what is supposed to move.
-///
-/// One trap worth naming: `cargo` did NOT rebuild on a version-only edit to
-/// `Cargo.toml` here, so the first recapture attempt printed a stale binary's
-/// hashes. Force it (`touch src/lib.rs`, or `cargo clean -p smb3-rs`) before
-/// trusting any number this test prints after a bump.
-///
-/// Re-captured 2026-08-30 for the pipe screen-squish fix: the always-on
-/// MaCobra bundle gained a 9-byte splice at 0x10476 (PRG008 $A466) that exempts
-/// pipe travel from the left-edge crush death. It consumes no RNG, so nothing
-/// downstream shifted — verified rather than argued: for all 20 of these seeds
-/// the pre- and post-fix ROMs were diffed byte for byte (`--no-palettes
-/// --patched-rom`) and the diff is exactly 0x10476..0x1047F on every one of
-/// them, with no second span. No map tile, pointer table or level byte moved.
-///
-/// Re-captured 2026-08-31 for the off-path fort rule (`Forts` may no longer
-/// take a blank the player cannot walk around; `try_fort_lock` and
-/// `try_pipe_move` hold the same line). Overworld topology changes on
-/// purpose. TWO causes are folded into this recapture and both are named
-/// here on purpose:
-///
-/// 1. The baseline was ALREADY stale at HEAD — PR #205 (three new king rescue
-///    quotes) rewrites quote text in every ROM and did not recapture, so all
-///    20 seeds had already moved before this change was written.
-/// 2. This change itself, which moves fortresses and therefore locks, C1, and
-///    the shaping decisions downstream of them.
-///
-/// Verified by pinning, the way the v28 and dealt-C1-floor recaptures were:
-/// neutralising all three guards (an empty forced set in `Forts` and in
-/// `try_fort_lock`, `any_fort_forced` returning false) reproduced the HEAD
-/// hashes EXACTLY, all 20 seeds. So cause 2 is the guards alone — the new
-/// `WorldState::forced_positions` and the census columns that read it change
-/// no output — and cause 1 is inherited, not created here.
+/// Captured 2026-09-08, the first capture of the narrowed fingerprint.
+#[rustfmt::skip]
 const BASELINE: [u64; SEEDS as usize] = [
-    0xF17348EF0F2985C4,
-    0x621B8CB191263D06,
-    0x3BC07223110FE783,
-    0x22A6675215EBB035,
-    0x3DDF3EE3E904481D,
-    0x03862663D70C5745,
-    0x0E218D655154A03A,
-    0x2BDEA6043EEBB68D,
-    0x265B62CA0F64A752,
-    0xB53B04E61C42ED3F,
-    0xB620B46CDCEAF254,
-    0x42C8186A666CCDB0,
-    0xB7D9B39039E6D3B1,
-    0x1A1E3F733F719BC9,
-    0xD7BD60F947AAE514,
-    0x5DD7D64B3C5D7414,
-    0x1D055DB28774D936,
-    0x457C53E6D3E815A4,
-    0x7B786C0C3C0C731F,
-    0x1BDE02C1D3F3DD8B,
+    0xE280A526F23F2EF9, 0x5CFC4B6F55B505F9, 0x74A9232189958648, 0x9DDC56D6747419A1,
+    0x26B2B38284964235, 0xD38E6CD89C356D98, 0xFE93B76C550E591E, 0xE97FD6ED6D7C69FD,
+    0xED37AD9D1FAE43C2, 0x5165C56AD24CBDCE, 0x45E8CED514A354B4, 0xE9EB79071ACDCF32,
+    0xA060A28A69E722FC, 0x8778B2AB1C9A6E28, 0x3B9EBD48A49F2B64, 0x409474608E3E6886,
+    0x367675006DF2EE38, 0x989585727F05EF5A, 0x6958892EFCE3D548, 0xC7833220D6666BA5,
 ];
-///
-/// Re-captured 2026-08-27 for the Big [?] bonus-room shuffle, which is always
-/// on. Every seed moves, for two reasons that are both intended:
-///
-/// 1. `qol::big_q`'s lookup routine grew from 106 to 207 bytes (slot seeding
-///    plus four new 13-entry payload tables), and the Big [?] exit path's
-///    `JMP PRG026_AA8A` at 0x34A84 now jumps into it.
-/// 2. `big_q_rooms::shuffle` draws twice from the shared RNG and rewrites the
-///    per-row area/arrival tables, and 7-F1's drawn block is forced to Tanooki.
-///
-/// **Overworld topology is untouched**, which is the thing worth checking here.
-/// The pass runs after `write_overworld`, so it cannot move a map tile — and
-/// that was verified rather than argued: the 8 map grids were hashed for all 20
-/// seeds with the `shuffle` call live and with it stubbed to return an empty
-/// vec, and the two sets are identical. The ROM bytes differ, the maps do not.
-///
-/// Amended the same week: Unused Level 5's screens 6 and 7 got new arrival
-/// coordinates after playtesting showed the originals killed the player. Four
-/// table bytes, so every seed that draws one of those rooms moves. No RNG draw
-/// changed — the pool is the same size — so this is a pure byte difference.
-///
-/// Re-captured 2026-08-29 again, for `shuffle_big_q_rooms`. The room shuffle is
-/// now an option and **off by default**, so the pass no longer draws its two
-/// values from the shared RNG on a default build, which shifts every module
-/// downstream of it (`credits`, `items`, `king_quotes`, `koopalings`).
-///
-/// The on-path was checked against the build this option was carved out of: for
-/// seeds 1-12, `--shuffle-big-q-rooms` reproduces `beta/next` byte for byte
-/// apart from `[stamp]` (0x19DF0..0x19E09) and `[title_screen]` (0x3E924..),
-/// both of which are derived from the flag key — and the key necessarily grew
-/// one bit. The randomization itself is untouched.
-///
-/// Re-captured 2026-08-29 for the 7-F1 return fix: the entry and exit halves of
-/// the `qol::big_q` routine now share one `bq_lookup` subroutine, which moved
-/// every label and table after offset $09 and shrank it from 207 to 199 bytes.
-/// Again a pure byte difference, and again verified rather than argued — for
-/// each of these 20 seeds the pre- and post-fix ROMs were diffed byte for byte,
-/// and the only bytes that changed outside `FS_BIG_Q_LOOKUP`'s own 224-byte
-/// allocation were the exit hook's operand at 0x34A85. No map tile, pointer
-/// table or level byte moved.
-///
-/// Re-captured 2026-08-30 for `qol::level_clock`: the level clock's frame
-/// divider is now 60 rather than vanilla's 41, so a unit is a real second. It
-/// is two immediate operands (0x34FC6, 0x3C517) and is applied to every seed,
-/// so every hash moved. Verified rather than argued, the same way as the
-/// entries above: for each of these 20 seeds the generated ROM had those two
-/// bytes reverted to `$28` and re-hashed, and all 20 then reproduced the
-/// previous baseline exactly — so those two bytes are the entire diff. No map
-/// tile, pointer table or level byte moved.
-///
-/// Re-captured 2026-09-01 for the **1.3.0 version bump** and nothing else. The
-/// hash folds `CARGO_PKG_VERSION`, so 1.2.1 -> 1.3.0 rewrites every seed's
-/// title-screen verification icons and with them all 20 whole-ROM hashes. That
-/// is the version guard working as designed, not a randomization change.
-///
-/// Attribution is by byte diff, the same way as the entries above: seeds 1-3
-/// were generated with `--no-palettes --patched-rom` at 1.2.1 and again at
-/// 1.3.0, and every differing byte in all three lands inside
-/// `FS_SEED_HASH_DATA` (0x3E93D + 40) and nowhere else — 9 to 11 bytes per
-/// seed, all within the icon payload. No RNG draw moved, so no module
-/// downstream shifted; the flag-key stamp at 0x19DF0 is byte-identical, since
-/// the key does not carry the release version.
-///
-/// Re-captured 2026-09-01 for the Hammer-Bro march spacing. Wandering sprites
-/// were spread by Chebyshev distance with a floor of 2 — which is exactly one
-/// march leg, so a bro could land on another and force both to march again.
-/// Spacing now runs on the march graph (`overworld_build::march`) with a floor
-/// of 3 legs, so the chosen tiles moved.
-///
-/// Attribution is by byte diff, the same way as the entries above: seeds 1-3
-/// were generated with `--no-palettes --patched-rom` before and after. Every
-/// one of the 71 / 27 / 66 changed bytes lands in one of two regions and
-/// nowhere else — the per-world map-object sub-tables reached through
-/// `MAP_OBJ_*_MASTER` (6 / 3 / 5 bytes, the sprite coordinates themselves) and
-/// the world pointer tables inside `WORLDS[..].rowtype_offset` (65 / 24 / 61
-/// bytes, because `assign` splits HammerBro slots into sprite slots and filler
-/// slots and feeds the two different pools). No map tile grid byte, no
-/// map-object reward byte, no level byte and no flag-key byte moved, and the
-/// RNG draw count is unchanged, so nothing downstream shifted.
 
 #[test]
 fn output_matches_baseline() {
@@ -329,15 +84,17 @@ fn output_matches_baseline() {
     };
     if BASELINE.iter().all(|h| *h == 0) {
         panic!(
-            "BASELINE is unpopulated — run `cargo test print_baseline -- --ignored --nocapture`"
+            "BASELINE is unpopulated — run `cargo test --test overworld_baseline \
+             -- --ignored print_baseline --nocapture`"
         );
     }
-    let got = hashes(&rom);
+    let got = fingerprints(&rom);
     let mismatched: Vec<usize> = (0..SEEDS as usize).filter(|i| got[*i] != BASELINE[*i]).collect();
     assert!(
         mismatched.is_empty(),
-        "output changed for seed(s) {:?} — if this was intentional, regenerate \
-         the baseline in the same commit and explain why",
+        "the overworld changed for seed(s) {:?} — if that was intentional, \
+         regenerate the baseline in the same commit and add a dated entry to \
+         docs/overworld_baseline_log.md saying what moved",
         mismatched.iter().map(|i| i + 1).collect::<Vec<_>>()
     );
 }
@@ -352,7 +109,7 @@ fn print_baseline() {
         return;
     };
     println!("const BASELINE: [u64; SEEDS as usize] = [");
-    for chunk in hashes(&rom).chunks(4) {
+    for chunk in fingerprints(&rom).chunks(4) {
         let line: Vec<String> = chunk.iter().map(|h| format!("0x{h:016X}")).collect();
         println!("    {},", line.join(", "));
     }

--- a/tests/rom_identity.rs
+++ b/tests/rom_identity.rs
@@ -1,0 +1,154 @@
+//! Whole-ROM byte identity, on demand.
+//!
+//! The question this answers is **"I changed no behaviour — prove it."** A pure
+//! refactor, a module split, a helper extracted: the generated ROM must come
+//! out byte for byte identical for every seed, and if it does not, the
+//! substituted code covers a different set than what it replaced.
+//!
+//! # Using it
+//!
+//! ```sh
+//! git stash                                              # or check out the base commit
+//! cargo test --test rom_identity -- --ignored capture
+//! git stash pop                                          # ...now make the change
+//! cargo test --test rom_identity -- --ignored compare
+//! ```
+//!
+//! `capture` writes to `target/rom_identity_capture.txt`, which is gitignored
+//! by virtue of living in `target/`. (`cargo clean` takes it with everything
+//! else — recapture if that happens.)
+//!
+//! # Why there is no committed baseline here
+//!
+//! There used to be, and it was the wrong shape for this job. A whole-ROM hash
+//! moves for *any* byte anywhere: a version bump, a new king quote, a title
+//! routine changing address, an always-on splice that touches no gameplay. As a
+//! suite gate that meant a recapture — and a paragraph proving the diff was
+//! harmless — roughly every week, and twice the baseline silently went stale
+//! instead, which is strictly worse than not having one.
+//!
+//! A refactor check does not need a *stored* answer, only two trees. Capturing
+//! on demand is both less maintenance and more capable: it compares against
+//! whatever commit you point it at, not only the last one somebody blessed.
+//!
+//! What the suite still gates on is `tests/overworld_baseline.rs`, which hashes
+//! the overworld alone and so stays green through ordinary feature work.
+//!
+//! Skipped when the ROM is absent, like the other ROM-dependent tests — the ROM
+//! is gitignored and CI has no copy.
+
+use smb3_rs::{Options, generate_patched_rom};
+use std::path::Path;
+
+const ROM_PATH: &str = "roms/Super Mario Bros. 3 (USA) (Rev 1).nes";
+const CAPTURE_PATH: &str = "target/rom_identity_capture.txt";
+const SEEDS: u64 = 20;
+
+/// FNV-1a. Rolled by hand rather than using `DefaultHasher`, whose output is
+/// explicitly not guaranteed stable across Rust releases.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Palette randomization is excluded: it is not seed-stable (two runs of the
+/// same seed differ in a handful of NES palette bytes), so it would make this
+/// harness flap for reasons unrelated to what it is guarding.
+fn options() -> Options {
+    Options { palettes: false, palette_themed: false, ..Options::default() }
+}
+
+fn rom() -> Option<Vec<u8>> {
+    std::fs::read(ROM_PATH).ok()
+}
+
+fn hashes(rom: &[u8]) -> Vec<u64> {
+    (1..=SEEDS)
+        .map(|seed| {
+            let out = generate_patched_rom(rom, seed, &options(), None)
+                .unwrap_or_else(|e| panic!("seed {seed} failed to generate: {e}"));
+            fnv1a(&out)
+        })
+        .collect()
+}
+
+/// The harness is only worth anything if it is stable in the first place.
+/// Runs the sweep twice in one process and requires agreement. Not ignored:
+/// it costs one extra sweep and it is the reason a `compare` failure can be
+/// believed.
+#[test]
+fn sweep_is_deterministic() {
+    let Some(rom) = rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
+    assert_eq!(
+        hashes(&rom),
+        hashes(&rom),
+        "same seeds produced different output within one run — no identity \
+         check can mean anything until this is stable"
+    );
+}
+
+/// Record this tree's output. Run on the base commit, before the change.
+#[test]
+#[ignore]
+fn capture() {
+    let Some(rom) = rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
+    let body: String =
+        hashes(&rom).iter().map(|h| format!("{h:016X}\n")).collect::<Vec<_>>().concat();
+    std::fs::write(CAPTURE_PATH, &body).unwrap_or_else(|e| panic!("{CAPTURE_PATH}: {e}"));
+    eprintln!("captured {SEEDS} seeds to {CAPTURE_PATH}");
+}
+
+/// Compare this tree against the capture. Run after the change.
+///
+/// Fails loudly rather than skipping when there is no capture: "no baseline
+/// recorded" reported as a pass is how a refactor guard gets trusted for
+/// nothing.
+#[test]
+#[ignore]
+fn compare() {
+    let Some(rom) = rom() else {
+        eprintln!("SKIP: requires the ROM, which is not included in the repo");
+        return;
+    };
+    assert!(
+        Path::new(CAPTURE_PATH).exists(),
+        "no capture at {CAPTURE_PATH} — run `cargo test --test rom_identity -- \
+         --ignored capture` on the tree you mean to compare against first"
+    );
+    let text = std::fs::read_to_string(CAPTURE_PATH).unwrap();
+    let before: Vec<u64> = text
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| u64::from_str_radix(l.trim(), 16).expect("capture file is corrupt"))
+        .collect();
+    assert_eq!(
+        before.len(),
+        SEEDS as usize,
+        "capture holds {} seeds, this tree sweeps {SEEDS} — recapture",
+        before.len()
+    );
+
+    let after = hashes(&rom);
+    let moved: Vec<u64> =
+        (0..SEEDS as usize).filter(|i| after[*i] != before[*i]).map(|i| i as u64 + 1).collect();
+    assert!(
+        moved.is_empty(),
+        "{} of {SEEDS} seeds changed: {moved:?}\n\
+         The ROM is not byte-identical, so this was not a pure refactor. Either \
+         the change has an effect that was not intended, or it was never meant \
+         to be identity-preserving — in which case attribute the difference and \
+         say so, do not recapture to make this quiet.",
+        moved.len()
+    );
+    eprintln!("all {SEEDS} seeds byte-identical");
+}


### PR DESCRIPTION
## The problem

`tests/overworld_baseline.rs` said it guarded *"refactors that are supposed to change nothing."* It hashed the **entire ROM**, so it moved for any byte anywhere — a version bump, three new king quotes, a title routine changing address, an always-on splice that touched no gameplay.

That doc comment recorded **20 recaptures in five weeks**, each one paid for with a paragraph of manual attribution proving the diff landed somewhere harmless. And twice it silently went stale instead — the 2026-08-31 entry had to untangle its own change from PR #205's inherited drift, and it was stale again on arrival here. A guard that is usually red is a guard nobody reads.

## Two jobs, two instruments

**`overworld_fingerprint`** (new, `rom_data::fingerprint`) hashes the bytes that describe the map a player walks: terrain, where each tile leads, the sprites on it, pipe destinations, and which fortress opens which lock. `tests/overworld_baseline.rs` commits to that instead, so it stays green through ordinary feature work and moves for a real topology change or an RNG-stream shift.

Every region is named by a `rom_data` constant rather than an offset copied into the test — `tools/offset_dups.py` exists to keep it that way. The claim is **differential-tested, not asserted**: flipping a byte in the title-screen icons, the flag-key stamp, or the enemy data must leave it unchanged (all three forced a whole-ROM recapture at least once), and flipping one in each of the six regions it covers must move it.

**`tests/rom_identity.rs`** (new) keeps whole-ROM byte identity, with **no committed baseline at all**:

```sh
git stash                                              # or check out the base commit
cargo test --test rom_identity -- --ignored capture
git stash pop                                          # ...now make the change
cargo test --test rom_identity -- --ignored compare
```

A refactor check doesn't need a *stored* answer, only two trees. Capture-on-demand is both less maintenance — zero recaptures, ever, nothing to go stale — and more capable, since it compares against whatever commit you point it at rather than the last one somebody blessed. Both failure paths are mutation-tested, including the missing-capture case, so "nothing recorded" can never read as a pass.

## The log

The recapture ledger moves to `docs/overworld_baseline_log.md`, old entries kept verbatim — the hashes they describe are gone, the attribution reasoning is not. Going forward: no dated entry, no recapture.

`docs/write_log_design.md` pointed at the baseline for a byte-identity claim; it now points at `rom_identity`, which is the harness that actually answers it.

## The first capture inherits real drift — measured, not assumed

The last valid whole-ROM capture was `9694907` (2026-09-01). Seeds 1–20 were generated from a clean checkout of that commit and from `beta/next`, both `--no-palettes --patched-rom`, and both sets fingerprinted with the new code: **all 20 differ in the overworld**, not merely in the ROM. So the staleness wasn't the old instrument crying wolf — the maps really did move across the world-maze (#215–#217) and numbered-lock / fortress-deck (#218–#221) merges, and nothing recorded it.

Attribution stops at "the overworld genuinely changed across that range of merges". Bisecting sixty commits to apportion a change nobody disputes was intended is not what the log is for.

Not from #222's maze-whistle fix, which is on this same branch's base: that only writes inventory slots, and only differently when `world_maze` is on, which the sweep's default options leave off.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets`, wasm32 clippy — all clean. Full suite green, `output_matches_baseline` included, for the first time since the maze merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJ6sXwR1jy6X8SRPDPVm65