### PR TITLE
feature: the tracker's locks follow the 1:1 fortress rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ deploys.
   is in puts that fortress on the board, and if that world has no fortress that
   could open the lock and no room for one, it says so rather than accepting a
   map that cannot exist. Each world wears the king's HELP balloon until you
-  cross it off, which counts your wands for you. And when the board says something the game could not have built — more locks in a world than it has room for, a lock whose key is in a world with nothing that could open it — it says so, and keeps saying so until you fix it. It fills itself in as you explore and keeps what you typed
+  cross it off, which counts your wands for you. And when the board says something the game could not have built — more locks in a world than it has room for, a lock whose key is in a world with nothing that could open it — it says so, and keeps saying so until you fix it. Every fortress stands beside a lock, so filling in the fortresses fills in the locks: plain where that fortress opens it, tinted where its key is somewhere else. It fills itself in as you explore and keeps what you typed
   in your browser.
 
 - **Deja Vu counts fortresses.** A fourth pill on the Deja Vu row, toggling on

--- a/web/maze-tracker.html
+++ b/web/maze-tracker.html
@@ -608,16 +608,43 @@ function lockWorldOf(world, fort) {
 	}
 }
 
-// Every lock standing in `target`: the free-standing ones the player logged,
-// plus every fortress anywhere whose lock has been placed there.
+// Every lock standing in `target`.
+//
+// One per fortress in that world, always — `WorldState::fort_count` is "also
+// the number of lock sections", so a world's locks are its own fortresses'
+// locks whatever those fortresses open. The design only decides whether the
+// lock is plain (this world's fortress opens it) or tinted (its key is
+// somewhere else).
+//
+// Then the ones a fortress elsewhere opens here: a W8-design fortress reaching
+// into Dark Land, or a remote one the player has placed.
 function locksIn(target) {
 	const out = state.worlds[target].locks.map(lock => ({ kind: "free", lock, world: target }));
+	for (const fort of state.worlds[target].forts) {
+		out.push({ kind: "own", fort, world: target });
+	}
 	state.worlds.forEach((world, w) => {
+		if (w === target) return;
 		for (const fort of world.forts) {
 			if (lockWorldOf(w, fort) === target) out.push({ kind: "fort", fort, world: w });
 		}
 	});
 	return out;
+}
+
+// Whether a fortress's own-world lock is open.
+//
+// For a local fortress that is the same fact as "have I beaten it" — it opens
+// the lock standing beside it. For every other design it is a separate fact,
+// because the lock in its world is opened by some fortress elsewhere, and the
+// two are cleared at different times.
+function ownLockOpen(fort) {
+	return fort.hint === "here" ? !!fort.done : !!fort.ownLockOpen;
+}
+
+function setOwnLockOpen(fort, open) {
+	if (fort.hint === "here") fort.done = open;
+	else fort.ownLockOpen = open;
 }
 
 // --- Counting against the budgets -------------------------------------
@@ -663,6 +690,22 @@ function lockCapacity(w) {
 	return w === W8 ? 4 : FORTS_MAX;
 }
 
+// How many fortresses open a lock in this world.
+//
+// This, not the number of chips on the card, is what the capacity is about. A
+// world's own fortresses each stand beside a lock whatever they open, so the
+// chips are always at least the fort count; what cannot exceed it is the number
+// of KEYS pointing here. For Dark Land that sum is exactly the one to watch —
+// the plain fortresses standing there plus every special fortress out in the
+// other worlds.
+function keysInto(target) {
+	let n = state.worlds[target].locks.length;
+	state.worlds.forEach((world, w) => {
+		for (const fort of world.forts) if (lockWorldOf(w, fort) === target) n++;
+	});
+	return n;
+}
+
 function worldName(w) {
 	if (w === W8) return DARK_LAND.name;
 	const t = TERRAINS.find(t => t.id === state.worlds[w].terrain);
@@ -675,14 +718,14 @@ function worldName(w) {
 function problems() {
 	const out = [];
 	for (let w = 0; w < 8; w++) {
-		const have = locksIn(w).length;
+		const have = keysInto(w);
 		const max = lockCapacity(w);
 		if (have <= max) continue;
 		out.push(w === W8
-			? `${have} locks in ${DARK_LAND.name}, which only ever has ${max}. `
-				+ "Count the special fortresses in the other worlds plus the plain ones here — "
-				+ "together they cannot come to more than four."
-			: `${have} locks in ${worldName(w)}, which can hold at most ${max}.`);
+			? `${have} fortresses open a lock in ${DARK_LAND.name}, which only ever has ${max}. `
+				+ "That sum is the special fortresses out in the other worlds plus the plain "
+				+ "ones standing here — together they cannot come to more than four."
+			: `${have} fortresses open a lock in ${worldName(w)}, which only has ${max}.`);
 	}
 	return out;
 }
@@ -938,7 +981,7 @@ function renderCounts() {
 	const rows = [
 		["Wands", countWands(), WANDS_TOTAL],
 		["Fortresses", countForts(), FORTS_TOTAL],
-		["Locks found", countLockChips(), LOCKS_TOTAL],
+		["Keys placed", countLockChips(), LOCKS_TOTAL],
 		["Pad tiles", countPadTiles(), PAD_TILES_MAX],
 		["Pairs linked", countPadPairs(), PAD_TILES_MAX / 2],
 	];
@@ -976,10 +1019,10 @@ function renderWorld(w) {
 	card.appendChild(renderRow("Locks", renderLocks(w),
 		() => { world.locks.push({ id: id(), keyWorld: null, done: false }); render(); },
 		countLockChips() >= LOCKS_TOTAL));
-	if (locksIn(w).length > lockCapacity(w)) {
+	if (keysInto(w) > lockCapacity(w)) {
 		card.classList.add("overfull");
 		card.appendChild(el("p", { class: "card-warn" },
-			`${locksIn(w).length} locks here — at most ${lockCapacity(w)} can be.`));
+			`${keysInto(w)} keys point here — this world only has ${lockCapacity(w)} locks.`));
 	}
 	card.appendChild(renderRow("Pads", renderPads(w),
 		() => { world.pads.push({ id: id(), dest: null, partner: null }); render(); },
@@ -1151,6 +1194,7 @@ function lockToken(w, fort) {
 function renderLocks(w) {
 	return locksIn(w).map(entry => {
 		if (entry.kind === "free") return renderFreeLock(w, entry.lock);
+		if (entry.kind === "own") return renderOwnLock(entry.fort);
 		const { fort, world } = entry;
 		const away = world !== w;
 		const chip = el("span", {
@@ -1188,6 +1232,26 @@ function renderLocks(w) {
 		}
 		return chip;
 	});
+}
+
+// The lock that stands beside a fortress, in its own world. Plain when that
+// fortress opens it, tinted when its key is somewhere else — which is what the
+// lock tile itself says on Some hints and above.
+function renderOwnLock(fort) {
+	const local = fort.hint === "here";
+	const open = ownLockOpen(fort);
+	const chip = el("span", {
+		class: "chip lock" + (local ? "" : " away") + (open ? " done" : ""),
+	});
+	chip.appendChild(el("button", {
+		class: "body",
+		type: "button",
+		title: open ? "Mark shut again" : "Mark open",
+		onclick: ev => { ev.stopPropagation(); setOwnLockOpen(fort, !open); render(); },
+	}, open ? "🔓" : "🔒"));
+	chip.appendChild(el("span", { class: "src" },
+		local ? "here" : (fort.hint === "unknown" ? "key: ?" : "key: elsewhere")));
+	return chip;
 }
 
 function renderFreeLock(w, lock) {


### PR DESCRIPTION
Follow-up to #228. Reworks how the tracker derives locks, after the model turned out to be wrong.

## The rule

A world is 1:1 fortresses to locks — `WorldState::fort_count` is *"also the number of lock sections"* — so a world's locks are its own fortresses' locks, regardless of which fortress opens each one. The tracker drew them the other way round: a lock appeared only where a fortress's design pointed, so a remote fortress produced no lock at all.

Now every fortress puts a lock in its own world, and the design only decides the kind:

| Fort design | Lock in its own world | Plus |
|---|---|---|
| Local | plain — this fortress opens it | — |
| Remote | tinted — key is elsewhere | the lock it opens, wherever you place it |
| W8 | tinted — key is elsewhere | a lock in Dark Land |

A W8 fortress is a tinted lock at home like any other remote one; what is extra about it is that we also know there is a lock in Dark Land it opens. Dark Land comes prefilled with four locks as a result, from its four fortresses, with no special case to do it.

## Two things that follow

**A remote fortress's own lock cannot share its "beaten" flag.** The lock standing beside it is opened by somebody else, so beating that fortress does not open it — the two are cleared at different times and are now separate state. For a local fortress they stay one fact, because there they are one fact.

**The capacity check counts keys, not chips.** Under this model a card always shows at least its fort count in lock chips, so the old "chips > capacity" test would fire on every W8-design fortress. What genuinely cannot exceed the count is how many fortresses *open* a lock there. For Dark Land that sum is the one originally asked for: the plain fortresses standing there plus every special fortress out in the other worlds, four maximum.

## Testing

127 assertions against a stubbed DOM. Four existing ones asserted the old model and were rewritten rather than deleted; the rest of the change is covered by new ones, including that the two "open" flags stay separate for a remote fortress and stay joined for a local one.

No Rust changed.

**Still not rendered in a browser by me.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oqTyX4NrLBsJWXXYqdufN