### PR TITLE
A maze that cannot be finished is dealt again, not shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@ deploys.
 
 ### Fixed
 
+- **World Maze: a seed that could not be finished can no longer be handed out.**
+  Nothing was known to produce one, but nothing checked either — the game worked
+  out whether a maze was winnable and then threw the answer away. It now deals
+  again for a finishable maze rather than merely a long one, and says so loudly
+  instead of staying quiet if it ever runs out of ways to make one.
+
 - **World Maze: the same airship could be beaten for a second wand.** Nothing
   marks an airship as beaten, so a world you walk back into still has one — and
   each clear counted, which meant seven trips through one airship could open a

--- a/docs/world_maze_design.md
+++ b/docs/world_maze_design.md
@@ -83,11 +83,34 @@ table — it absorbed what an earlier `foreign_locks.rs` did; see
   to need no new definition. `world_order::randomize` with `world_count < 7`
   returns a shorter order; the worlds it leaves out are still built, still on
   the ROM and still full of content, but no airship leads into them. In maze
-  mode that makes them **optional bonus content reachable only by telepad** —
-  which is as close as the terrain gets to the pad-only island the charter
-  wanted, and it costs nothing to support. Solvability is scoped to the worlds
-  the spine names (`GlobalState::in_maze`), exactly as a shorter game means
-  fewer worlds in standard mode. `a_short_spine_still_finishes` pins it.
+  mode that makes them **reachable only by telepad** — which is as close as the
+  terrain gets to the pad-only island the charter wanted, and it costs nothing
+  to support. Solvability is scoped to the worlds the spine names
+  (`GlobalState::in_maze`), exactly as a shorter game means fewer worlds in
+  standard mode.
+
+  **They are not merely optional, and this section used to say they were.**
+  `in_maze` scopes two things — which fortresses must be beatable, and what the
+  spoiler log counts. It does *not* scope the lock list or the fill's pool of
+  candidate keys, both of which span all eight worlds. So the fill can hand a
+  lock on the spine a fortress in a world the spine never names, and that world
+  becomes **required**, reachable only through a pad. That is arguably the best
+  version of the mode rather than a bug — it is the shape the charter wanted —
+  but "optional bonus content" is the wrong thing to tell a player deciding
+  whether a world is worth the detour.
+
+  It is safe because the fill only ever takes a key from a fortress already
+  reachable from the global start at the moment it places the gate, and the
+  fixpoint walks all eight grids. What is *not* covered is the other direction:
+  a fortress stranded in an off-spine world is invisible to `solvable`, so
+  nothing distinguishes "bonus content nobody can reach" from "bonus content
+  nobody needs". Deliberate for short spines; still worth knowing.
+
+  **Pinned by `a_short_spine_is_still_winnable`** (a cheap property test at
+  three spine lengths x two K values) and `maze_spine_length_census` (the whole
+  7x8 grid). This paragraph previously cited `a_short_spine_still_finishes`,
+  which never existed — so until 2026-09-10 **no test covered a spine shorter
+  than eight at all**, and every maze test used the full `IDENTITY_SPINE`.
 - **`maze_wands` (K) is a player-facing option**; the two generator biases are
   not. See "Knobs".
 

--- a/src/randomize/maze/metrics.rs
+++ b/src/randomize/maze/metrics.rs
@@ -168,8 +168,23 @@ pub(crate) fn completion_cost(state: &GlobalState) -> CompletionCost {
 /// instrument, not something to call in a build — unlike its neighbour
 /// [`completion_cost`], which `maze::CONTENT_FLOOR` promoted to the shipping
 /// path.
+///
+/// **Returns `None` when the maze was not winnable to begin with, and that
+/// guard is not paranoia — it is a bug this instrument actually caused.** The
+/// question asked per level is "block it; is the game still solvable?" On a
+/// maze that was never solvable the answer is "no" for every level, so the
+/// count comes back as *every level in the game* and reads as a map of pure
+/// corridors. Two seeds reported 62 of 62 that way and the figure reached a
+/// census table before anyone noticed the mazes behind it had unreachable
+/// castles and nine unbeatable fortresses between them.
+///
+/// A lying instrument is worst exactly when something upstream is already
+/// broken, which is when you are reading it most carefully.
 #[cfg(test)]
-pub(crate) fn required_levels(state: &GlobalState) -> usize {
+pub(crate) fn required_levels(state: &GlobalState) -> Option<usize> {
+    if !state.spheres().solvable {
+        return None;
+    }
     let levels: Vec<MazePos> = state
         .worlds
         .iter()
@@ -188,5 +203,5 @@ pub(crate) fn required_levels(state: &GlobalState) -> usize {
             count += 1;
         }
     }
-    count
+    Some(count)
 }

--- a/src/randomize/maze/mod.rs
+++ b/src/randomize/maze/mod.rs
@@ -679,9 +679,10 @@ pub(crate) struct Spheres {
 impl Spheres {
     /// The per-sphere spoiler log, the mode's primary debugging instrument.
     ///
-    /// Test-only: the censuses and every failing assertion print it, and
-    /// nothing in a shipped run has anywhere to put it.
-    #[cfg(test)]
+    /// Not gated, because [`generate`]'s unwinnable-maze `debug_assert!` prints
+    /// it and a `debug_assert!` type-checks its arguments in every profile. In
+    /// release the call sits inside `if false` and the whole thing — this
+    /// function included — is eliminated, so the binary does not carry it.
     pub(crate) fn spoiler(&self) -> String {
         let mut out = String::new();
         for (i, s) in self.spheres.iter().enumerate() {
@@ -745,13 +746,33 @@ pub(crate) struct GenReport {
 /// It exists because the content floor deals more than once and has to choose
 /// between attempts. Nothing outside `generate` sees one.
 struct Deal {
+    /// **The primary sort key, ahead of [`Deal::content`].** A maze nobody can
+    /// finish is worse than a short one, so a solvable deal beats an unsolvable
+    /// one however long the unsolvable one measures.
+    ///
+    /// Deliberately [`Spheres::solvable`] and not `completion_cost().reached`,
+    /// which is the weaker question. `reached` asks only whether the castle can
+    /// be entered; `solvable` also demands every fortress be beatable, because
+    /// content sealed out of the game is a bug in its own right. A deal can
+    /// satisfy the first and fail the second.
+    solvable: bool,
     /// Levels and fortresses a play-through beats, or 0 when the castle was
     /// never reached. See [`metrics::completion_cost`].
     content: usize,
     state: GlobalState,
+    /// The fixpoint this deal was judged on, kept so the winner does not have
+    /// to be re-measured after the loop.
+    spheres: Spheres,
     fill: fill::FillReport,
     pads: Vec<graph::PlacedPad>,
     unsafe_worlds: Vec<usize>,
+}
+
+impl Deal {
+    /// What the loop maximises: solvable first, then long.
+    fn rank(&self) -> (bool, usize) {
+        (self.solvable, self.content)
+    }
 }
 
 /// Build a maze from eight finished worlds.
@@ -822,7 +843,8 @@ pub(crate) fn generate<R: Rng>(
             unsafe_worlds.retain(|&wi| !state.start_region_escapable(wi));
         }
 
-        Deal { content: 0, state, fill, pads, unsafe_worlds }
+        let spheres = state.spheres();
+        Deal { solvable: spheres.solvable, content: 0, state, spheres, fill, pads, unsafe_worlds }
     };
 
     // **The content floor.** Deal until the maze is long enough, keeping the
@@ -844,22 +866,22 @@ pub(crate) fn generate<R: Rng>(
     while deals < MAX_DEALS {
         deals += 1;
         let mut dealt = deal(rng);
-        // A deal that never reaches the castle scores zero, so it can only win
-        // if every deal did — and the solvability guard below then catches it.
         let cost = metrics::completion_cost(&dealt.state);
         dealt.content = if cost.reached { cost.content } else { 0 };
-        let floor_met = dealt.content >= CONTENT_FLOOR;
-        if best.as_ref().is_none_or(|seen| dealt.content > seen.content) {
+        // Accept only a deal that is BOTH finishable and long enough. Ranking
+        // solvability above length is what makes an unsolvable deal impossible
+        // to keep while any solvable one has been seen — the fallback below is
+        // then a genuine last resort rather than the only guard.
+        let accept = dealt.solvable && dealt.content >= CONTENT_FLOOR;
+        if best.as_ref().is_none_or(|seen| dealt.rank() > seen.rank()) {
             best = Some(dealt);
         }
-        if floor_met {
+        if accept {
             break;
         }
     }
-    let Deal { content, mut state, fill, pads, mut unsafe_worlds } =
+    let Deal { content, mut state, mut spheres, fill, pads, mut unsafe_worlds, .. } =
         best.expect("MAX_DEALS is non-zero, so at least one deal was kept");
-
-    let mut spheres = state.spheres();
 
     // Defence in depth, and the one guard this mode cannot do without.
     //
@@ -875,7 +897,8 @@ pub(crate) fn generate<R: Rng>(
     //
     // It outranks the content floor: a long maze nobody can finish is worse
     // than a short one, so this runs after the loop and overrides whatever it
-    // kept.
+    // kept. The deal loop ranks the same way, so reaching here means EVERY deal
+    // was unsolvable, not merely the last one.
     if !spheres.solvable {
         state = GlobalState::from_build(result, spine, wands_required);
         spheres = state.spheres();
@@ -888,6 +911,28 @@ pub(crate) fn generate<R: Rng>(
         unsafe_worlds =
             (0..state.worlds.len()).filter(|&wi| !state.start_region_escapable(wi)).collect();
     }
+
+    // **And the fallback itself is checked, which it never used to be.**
+    //
+    // It resets to the per-world builder's own local locks with no pads, a
+    // shape `the_spine_alone_completes_the_maze` guarantees is solvable — but
+    // that guarantee rests on each world being completable, which is the
+    // builder's invariant and not this module's. If a world ships
+    // uncompletable, the fallback inherits the problem and there is nothing
+    // left below it to fall back to.
+    //
+    // Recomputing without looking was the real gap: an unwinnable maze then
+    // shipped in silence, and the only way to find out is to play to the wall.
+    // A `debug_assert` is the right weight for it — the censuses run thousands
+    // of seeds per arm, so this fires in testing long before it could reach a
+    // player, and it costs a shipped run nothing.
+    debug_assert!(
+        spheres.solvable,
+        "the maze is unwinnable and the spine-alone fallback did not save it — \
+         a world is uncompletable, which is the builder's invariant, not this \
+         module's\n{}",
+        spheres.spoiler()
+    );
 
     // Last, and after the fallback above, so it judges the assignment that
     // actually ships. Consumes no RNG.

--- a/src/randomize/maze/tests.rs
+++ b/src/randomize/maze/tests.rs
@@ -983,17 +983,30 @@ fn maze_game_length_census() {
     let mut played = Vec::new();
     let mut required = Vec::new();
     let mut total_levels = Vec::new();
+    let mut unwinnable = 0usize;
     let mut detours = Vec::new();
 
     for seed in 0..seeds {
         // At the SHIPPING wand requirement, not K=0. K=0 is a legal setting but
         // it is the one where a pad chain can finish a seed in a single level,
         // so measuring the game's length there answers a question nobody asked.
-        let (_, state, _) = generated(&raw, seed, &knobs, super::DEFAULT_WANDS_REQUIRED);
+        let (_, state, report) = generated(&raw, seed, &knobs, super::DEFAULT_WANDS_REQUIRED);
         let cost = super::metrics::completion_cost(&state);
+        // **A maze nobody can finish is not a game, and averaging it in makes
+        // the table lie.** It used to record `content` for a run that never
+        // reached the castle and take `required_levels` at its word on the
+        // same seed, where the honest answer is "every level" — which is how a
+        // required-count of 62 of 62 got into this census. Count them and say
+        // so instead.
+        let Some(req) = super::metrics::required_levels(&state) else {
+            unwinnable += 1;
+            continue;
+        };
+        assert!(cost.reached, "solvable but the castle was never reached, seed {seed}");
+        assert!(report.spheres.solvable);
         played.push(cost.content);
         detours.push(cost.detours);
-        required.push(super::metrics::required_levels(&state));
+        required.push(req);
         total_levels.push(
             state
                 .worlds
@@ -1015,6 +1028,7 @@ fn maze_game_length_census() {
         "\n=== how long is a maze game, {seeds} seeds, K={} ===",
         super::DEFAULT_WANDS_REQUIRED
     );
+    eprintln!("  UNWINNABLE, excluded      {unwinnable}  (must be 0)");
     eprintln!("  levels in the game        {:.0}", mean(&total_levels));
     eprintln!(
         "  BEATEN on a completion    mean {:.1}  min {pl}  median {pm}  max {ph}",
@@ -2475,6 +2489,15 @@ fn a_shipped_maze_clears_the_content_floor() {
             // lost — the sealable repair can open a lock after the loop.
             let cost = super::metrics::completion_cost(&state);
             assert!(cost.reached, "seed {seed} K={k}: castle unreachable");
+            // The strong property, and the one the deal loop's `(solvable,
+            // content)` ranking exists to guarantee: not merely that the castle
+            // can be entered, but that no fortress is sealed out of the game.
+            // `reached` alone would pass a maze that strands content.
+            assert!(
+                report.spheres.solvable,
+                "seed {seed} K={k}: reachable but not solvable\n{}",
+                report.spheres.spoiler()
+            );
             if report.deals < super::MAX_DEALS {
                 assert_eq!(
                     cost.content, report.content,
@@ -2543,4 +2566,110 @@ fn maze_content_floor_census() {
         );
     }
     eprintln!("  under = mazes shipped below the floor because the deal budget ran out");
+}
+
+// ---------------------------------------------------------------------------
+// Short spines
+// ---------------------------------------------------------------------------
+
+/// Build the spine `world_order` would hand the maze for a given `world_count`.
+///
+/// Mirrors `world_order::randomize`: shuffle worlds 0-6, take `world_count` of
+/// them, append World 8. So the spine is 2 to 8 worlds long, its last entry is
+/// always the castle, and the worlds it leaves out are in the game but off the
+/// required path.
+fn spine_for(world_count: usize, rng: &mut ChaCha8Rng) -> Vec<usize> {
+    let mut pool: Vec<usize> = (0..7).collect();
+    pool.shuffle(rng);
+    let mut spine: Vec<usize> = pool[..world_count.clamp(1, 7)].to_vec();
+    spine.push(7);
+    spine
+}
+
+/// **A maze on a short spine is still finishable.**
+///
+/// `world_count` is a player-facing setting and it makes the spine shorter than
+/// eight — a two-world maze is a legal configuration. Every other test in this
+/// file uses [`IDENTITY_SPINE`], so until this existed **no test covered a
+/// spine shorter than 8 at all**, and the shorter ones are exactly where the
+/// mode has least to work with: fewer worlds means fewer fortresses, so fewer
+/// keys, and `K` is clamped to the airships the spine offers.
+///
+/// Deliberately asserts the strong property. `Spheres::solvable` demands the
+/// castle be reachable *and* every fortress on the spine be beatable, which is
+/// what `completion_cost().reached` alone would miss.
+#[test]
+fn a_short_spine_is_still_winnable() {
+    let Some(raw) = load_rom() else { return };
+    let knobs = Knobs::default();
+    for seed in 0..census_seeds(4) {
+        let (_, result) = census_build(&raw, seed);
+        // 1 and 6 are the interesting ends: the smallest maze the mode can
+        // make, and one world short of the full spine.
+        for world_count in [1usize, 3, 6] {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0xABCD);
+            let spine = spine_for(world_count, &mut rng);
+            for k in [0u8, super::DEFAULT_WANDS_REQUIRED] {
+                let wands = k.min(spine.len().saturating_sub(1) as u8);
+                let mut grng = ChaCha8Rng::seed_from_u64(seed ^ 0x5EED_1234);
+                let (state, report) =
+                    super::generate(&result, &spine, wands, &knobs, SEALABLE_NEEDED, &mut grng);
+                assert!(
+                    report.spheres.solvable,
+                    "seed {seed}, spine {spine:?}, K={wands}: unwinnable\n{}",
+                    report.spheres.spoiler()
+                );
+                assert!(
+                    super::metrics::completion_cost(&state).reached,
+                    "seed {seed}, spine {spine:?}, K={wands}: castle never reached"
+                );
+            }
+        }
+    }
+}
+
+/// The whole spine-length x K grid, for when the cheap test above is not
+/// enough — a stranding bug on a rare short spine passes at 4 seeds.
+///
+/// ```sh
+/// CENSUS_SEEDS=60 cargo test --release --lib maze_spine_length_census \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn maze_spine_length_census() {
+    let Some(raw) = load_rom() else { return };
+    let seeds = census_seeds(30);
+    let knobs = Knobs::default();
+
+    eprintln!("\n=== unwinnable mazes by spine length and K, {seeds} seeds each ===");
+    eprintln!("  {:>5} {:>6}  K=0   1   2   3   4   5   6   7", "count", "spine");
+    let mut worst = 0usize;
+    for world_count in 1..=7usize {
+        let mut row = Vec::new();
+        for k in 0..=7u8 {
+            let mut bad = 0usize;
+            for seed in 0..seeds {
+                let (_, result) = census_build(&raw, seed);
+                let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0xABCD);
+                let spine = spine_for(world_count, &mut rng);
+                let wands = k.min(spine.len().saturating_sub(1) as u8);
+                let mut grng = ChaCha8Rng::seed_from_u64(seed ^ 0x5EED_1234);
+                let (state, report) =
+                    super::generate(&result, &spine, wands, &knobs, SEALABLE_NEEDED, &mut grng);
+                if !report.spheres.solvable || !super::metrics::completion_cost(&state).reached {
+                    bad += 1;
+                }
+            }
+            worst = worst.max(bad);
+            row.push(bad);
+        }
+        eprintln!(
+            "  {world_count:>5} {:>6}  {}",
+            world_count + 1,
+            row.iter().map(|n| format!("{n:>3}")).collect::<Vec<_>>().join(" ")
+        );
+    }
+    eprintln!("  cells are seeds where the castle is unreachable or a spine fortress unbeatable");
+    assert_eq!(worst, 0, "a spine length shipped an unwinnable maze");
 }


### PR DESCRIPTION
`maze::generate` worked out whether a maze was winnable and the caller threw the answer away:

```rust
let (state, _report) = randomize::maze::generate(...)
```

Nothing acted on it, nothing logged it, nothing failed. An unwinnable seed would have shipped in silence, and the only way to find out is to play to the wall — the one failure a maze has no recovery from, and the one with no guard.

No shipping configuration is known to produce one (0 in 11,360 mazes across every K and spine length), but the guarantee rested on luck rather than on code.

## The deal loop ranks on `(solvable, content)`

It used to score an unreachable deal as `content = 0`, which only deprioritised it *against other deals* — if every deal came back bad, one still shipped.

It also measured the weaker property. `completion_cost().reached` asks only whether the castle can be entered; `Spheres::solvable` also demands every fortress be beatable, because content sealed out of the game is a bug in its own right. **A deal can satisfy the first and fail the second**, win on length, and strand content.

## The fallback is checked too, which it never was

The spine-alone fallback resets to the builder's local locks and recomputes the fixpoint **without ever looking at the result**. Its guarantee rests on `the_spine_alone_completes_the_maze`, which rests on each world being completable — the builder's invariant, not this module's. If a world ships uncompletable, the fallback inherits the problem and there is nothing below it.

A `debug_assert` is the right weight: the censuses run thousands of seeds per arm, so it fires in testing long before it could reach a player, and it costs a shipped run nothing. `Spheres::spoiler` loses its `cfg(test)` as a consequence — a `debug_assert` type-checks its arguments in every profile, and in release the call sits inside `if false` and is eliminated.

## Short spines had no test at all

`world_count` is player-facing and ships spines of **2 to 8 worlds**. Every maze test used the full eight-world `IDENTITY_SPINE`. The design doc claimed `a_short_spine_still_finishes` pinned it — **a test that does not exist**.

- `a_short_spine_is_still_winnable` — three spine lengths x two K values, cheap enough for the default suite.
- `maze_spine_length_census` — the whole 7x8 grid. **0 of 3,360 unwinnable.**

Mutation-tested: demanding more wands than the spine offers makes it fail as it should (`seed 0, spine [4, 7], K=8: unwinnable`).

## Two instruments stopped lying

- **`required_levels` returns `None`** on an unsolvable maze instead of counting every level mandatory. This is the bug that put "62 of 62 required" into a census table — on two seeds whose castles were unreachable, with nine unbeatable fortresses between them. Asking "block this level, is it still solvable?" of a maze that was never solvable answers "no" for every level.
- **The length census excludes and reports** seeds that never reach the castle rather than averaging them in.

A lying instrument is worst exactly when something upstream is already broken, which is when you are reading it most carefully.

## Doc correction

`in_maze` scopes which fortresses must be beatable and what the spoiler counts — **not** the lock list or the fill's pool of candidate keys, both of which span all eight worlds. So the fill can hand a lock on the spine a fortress in a world the spine never names, making that world **required**, reachable only through a pad. The doc called those worlds "optional bonus content reachable only by telepad", which is the wrong thing to tell a player deciding whether a world is worth the detour.

## Testing

fmt, both clippy passes, 600 tests green. `maze_spine_length_census` at 40 seeds per cell: all zero.

## Not in this PR

The `randomize_inner`-level rebuild I floated. On reflection it is the wrong shape: replaying it means redoing `build` plus `hands_levels` plus `troll_pipes` and their ROM writes, for a case that has never occurred, when the actual root cause — an uncompletable world — already has its own redeal inside `run_shaped_with_web_retries`. The `debug_assert` puts the failure where it would be found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wLx2t4mCA5koCY5CnaQHb