### PR TITLE
Mode-aware option flags, World Count 0, and tracker sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,21 @@ deploys.
 
 ### Changed
 
+- **World Count goes down to 0 — start the game in Dark Land.** It becomes the
+  whole game, and displays as World 1. There is no airship before Bowser's
+  castle at that count, so no wand exists in the run.
+
+- **The page says which settings your mode is actually using.** World Maze is
+  now the first section, because it is a mode rather than a flag: it decides
+  what several settings below it mean. Ones it takes over — World Order, Remove
+  Warp Whistles, No Game Over Penalty — show the value the mode will use, greyed
+  out and labelled "Forced on by World Maze", and go back to what you had when
+  you turn it off. Ones it has no use for, like World Count, grey out and say
+  "Standard only"; Wands To Enter and Hints say "Maze only" the rest of the
+  time. Before this, a greyed-out control still fed the generator — a maze could
+  take its world count from a row the page had greyed out — and greying a row
+  did not visibly grey anything.
+
 - **World Maze: the warp whistle goes in world order, and gets there faster.**
   Blowing it used to walk the worlds in an order that looked like nothing at
   all; now it steps World 1, 2, 3 and so on, skipping the ones you have not set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ deploys.
   could open the lock and no room for one, it says so rather than accepting a
   map that cannot exist. Each world wears the king's HELP balloon until you
   cross it off, which counts your wands for you. And when the board says something the game could not have built — more locks in a world than it has room for, a lock whose key is in a world with nothing that could open it — it says so, and keeps saying so until you fix it. Every fortress stands beside a lock, so filling in the fortresses fills in the locks: plain where that fortress opens it, tinted where its key is somewhere else. It fills itself in as you explore and keeps what you typed
-  in your browser.
+  in your browser. A size slider at the top scales the whole board, for sitting
+  it beside an emulator at whatever size the screen has room for.
 
 - **Deja Vu counts fortresses.** A fourth pill on the Deja Vu row, toggling on
   its own rather than as a fourth mode. Fortresses are then dealt the way levels

--- a/docs/application_flow.md
+++ b/docs/application_flow.md
@@ -91,7 +91,7 @@ changes every seed that uses `Maybe`.
 | 2.6 | `beta_tornado::randomize_beta9_tornado` · `beta_tornado` | [opt `include_beta_stages`] — after the enemy pass so the Tornado is final |
 | 2.7 | `bowser_castle::randomize` | [always] |
 | 2.8 | `podoboo_gauntlet::randomize` | [always] |
-| 2.9 | `world_order::randomize(world_count)` → `credits_progression` · `world_order` | [opt `world_order` **∨ `world_maze`**] — the maze reads this table as its airship spine, so it forces the pass on |
+| 2.9 | `world_order::randomize(world_count)` → `credits_progression` · `world_order` | [opt `world_order` **∨ `world_maze`**] — the maze reads this table as its airship spine, so it forces the pass on, and pins `world_count` to 7 (the web form greys that control out in maze mode). `world_count` 0 starts the game in Dark Land |
 | 2.10 | `enemies::randomize_big_q_blocks` · `enemies/big_q_blocks` | [opt `big_q_blocks`] |
 | 2.11 | `levels::randomize_airships` · `levels/airships` | [opt `shuffle_airships`] |
 | 2.12 | `antechambers::shuffle` · `levels/antechambers` | [tri `antechamber_shuffle`] — level data only, independent of the builder |

--- a/docs/world_maze_design.md
+++ b/docs/world_maze_design.md
@@ -89,6 +89,13 @@ table — it absorbed what an earlier `foreign_locks.rs` did; see
   (`GlobalState::in_maze`), exactly as a shorter game means fewer worlds in
   standard mode.
 
+  **No shipped maze run has a short spine any more** (2026-09-11). World Count
+  greys out under the mode and the form sends its default, and `randomize_inner`
+  pins `world_count` to 7 so a CLI run and a pasted flag key agree with the page.
+  Everything below still holds and is still tested: the capability is intact, the
+  censuses exercise it, and re-exposing it is a UI decision — un-grey the control
+  and drop the pin — rather than a generator change.
+
   **They are not merely optional, and this section used to say they were.**
   `in_maze` scopes two things — which fortresses must be beatable, and what the
   spoiler log counts. It does *not* scope the lock list or the fill's pool of

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,8 +205,10 @@ struct Cli {
     #[arg(long)]
     world_order: bool,
 
-    /// Number of worlds before Dark Land (1-7, default 7; requires --world-order)
-    #[arg(long, default_value_t = 7, value_parser = clap::value_parser!(u8).range(1..=7))]
+    /// Number of worlds before Dark Land (0-7, default 7; 0 starts the game in
+    /// Dark Land itself. Requires --world-order; ignored under --world-maze,
+    /// which always uses all eight worlds)
+    #[arg(long, default_value_t = 7, value_parser = clap::value_parser!(u8).range(0..=7))]
     world_count: u8,
 
     /// World maze: the eight maps become one Metroidvania, linked by telepads,
@@ -712,8 +714,14 @@ fn print_summary(options: &Options, seed: u64, output_path: &std::path::Path) {
     if options.world_maze {
         eprintln!("  World maze: on ({} wand(s) to open the castle)", options.maze_wands);
     }
-    if options.world_order && options.world_count < 7 {
-        eprintln!("  World count: {}", options.world_count);
+    // Silent under --world-maze: the mode pins the spine to all eight worlds, so
+    // printing the player's value would report a setting the run ignores.
+    if options.world_order && !options.world_maze && options.world_count < 7 {
+        if options.world_count == 0 {
+            eprintln!("  World count: 0 (the game starts in Dark Land)");
+        } else {
+            eprintln!("  World count: {}", options.world_count);
+        }
     }
     eprintln!("  Big ? Blocks: {}", if options.big_q_blocks { "on" } else { "off" });
     eprintln!(

--- a/src/randomize/maze/mod.rs
+++ b/src/randomize/maze/mod.rs
@@ -90,12 +90,19 @@ pub(crate) struct MazeLock {
 /// is the whole reason the mode forces that option on; this constant exists so
 /// a census can pin the spine and vary one thing at a time.
 ///
-/// A spine need not name all eight worlds. `world_order` with `world_count < 7`
-/// returns a shorter order, and the worlds it leaves out are still built, still
-/// full of content, and still on the map — they simply have no airship edge
-/// into them, so **the only way in is a telepad**. That is not a degradation of
-/// the mode, it is the mode: a world you can only reach by pad is the closest
-/// thing the terrain allows to the charter's pad-only island.
+/// The generator does not require a spine that names all eight worlds. A
+/// shorter one leaves worlds still built, still full of content, still on the
+/// map, and with no airship edge into them, so **the only way in is a telepad**
+/// — which is not a degradation of the mode but the mode itself: a world you can
+/// only reach by pad is the closest thing the terrain allows to the charter's
+/// pad-only island.
+///
+/// **No shipped run produces one today.** `world_count` used to reach this
+/// (`world_order` returns a shorter order below 7), but the mode now pins it to
+/// 7 in `randomizer::randomize_inner`, and the web form greys that control out
+/// under the mode. The capability is kept here, and censuses still exercise
+/// short spines, so re-exposing it is a UI decision rather than a generator
+/// change.
 #[cfg(test)]
 pub(crate) const IDENTITY_SPINE: [usize; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
 

--- a/src/randomize/world_order.rs
+++ b/src/randomize/world_order.rs
@@ -88,6 +88,16 @@ const VANILLA_SITES: [(usize, &[u8], &str); 2] = [
 /// (first entry is the starting world, last is always 7/Dark Land). With
 /// `world_count` < 7 this is shorter than 8 (unvisited worlds are omitted).
 /// Callers such as [`super::credits`] use it to align the ending montage.
+///
+/// **`world_count` 0 is the degenerate end of that range, not a special case.**
+/// The prefix is simply empty, so the progression is `[7]` alone: the player
+/// starts *in* Dark Land and it displays as "WORLD 1". Nothing below branches on
+/// it, but two consequences are worth naming. No airship stands before Bowser's
+/// castle, so no wand exists in the game at all — which is why the world maze
+/// pins this to 7 rather than exposing it (see `randomizer::randomize_inner`).
+/// And the seven unvisited worlds keep display tile `$00`, exactly as any
+/// `world_count` < 7 already leaves them; it is invisible because they cannot be
+/// reached.
 pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, world_count: u8) -> Vec<u8> {
     for (offset, want, what) in VANILLA_SITES {
         assert_eq!(
@@ -100,7 +110,7 @@ pub fn randomize<R: Rng>(rom: &mut Rom, rng: &mut R, world_count: u8) -> Vec<u8>
         );
     }
 
-    let world_count = world_count.clamp(1, 7) as usize;
+    let world_count = world_count.min(7) as usize;
 
     // Build shuffled world order: shuffle worlds 0-6, take first world_count, append world 7
     let mut pool: Vec<u8> = (0..7).collect();
@@ -398,5 +408,29 @@ mod tests {
         // Display table: Dark Land should show as "WORLD 4" ($F4)
         let display = rom.read_range(DISPLAY_TABLE_OFFSET, 8);
         assert_eq!(display[7], 0xF4, "Dark Land should display as World 4 with world_count=3");
+    }
+
+    /// `world_count` 0: the whole game is Dark Land, entered from the title
+    /// screen. The old `clamp(1, 7)` silently turned this into a one-world
+    /// prefix plus Dark Land, so the option would have looked like it worked
+    /// while giving two worlds.
+    #[test]
+    fn test_world_count_0_starts_in_dark_land() {
+        let mut rom = make_test_rom();
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let order = randomize(&mut rom, &mut rng, 0);
+
+        assert_eq!(order, vec![7], "world_count=0 is Dark Land alone");
+        assert_eq!(rom.read_byte(WORLD_INIT_OPERAND), 7, "the game must start in Dark Land");
+
+        // Nothing leads into Dark Land, and Dark Land leads to itself — so the
+        // airship transition can never walk out of the one world that exists.
+        let table = rom.read_range(FS_WORLD_ORDER + 12, 8);
+        assert_eq!(table, vec![0, 0, 0, 0, 0, 0, 0, 7]);
+
+        // And it is "WORLD 1", not "WORLD 8": the display table is keyed by
+        // position in the progression, and Dark Land is now position 0.
+        let display = rom.read_range(DISPLAY_TABLE_OFFSET, 8);
+        assert_eq!(display[7], 0xF1, "Dark Land should display as World 1 with world_count=0");
     }
 }

--- a/src/randomizer/flag_key.rs
+++ b/src/randomizer/flag_key.rs
@@ -386,7 +386,17 @@ mod payload {
         // --- Numbers ---
         /// Index into [`STARTING_LIVES_VALUES`].
         pub(super) starting_lives: B2,
-        /// 1–7; 0 is a dead pattern that decodes to the default of 7.
+        /// 0–7, every pattern a real value.
+        ///
+        /// **0 used to be dead and decode to the default of 7.** It became the
+        /// "start in Dark Land" count, which is the one kind of change the
+        /// reserve-bit scheme does not cover for free — but it needs no version
+        /// bump either, because no key in circulation carries it: the encoder
+        /// clamped to 1–7 from the day the field existed. The only skew is a
+        /// *newer* key read by an older build, which decodes 0 to 7 and plays
+        /// seven worlds. An appended "start in Dark Land" bool would have had
+        /// the identical failure there (an older build reads the bit as zero),
+        /// so it would have bought nothing for an extra bit.
         pub(super) world_count: B3,
         /// Item IDs directly (0 = empty slot), including the `ITEM_RANDOM*`
         /// sentinels — 5 bits covers all of them, where the old layout needed a
@@ -570,7 +580,13 @@ impl Options {
             .with_wild_lakitu(has(WildChaser::Lakitu))
             .with_wild_bass(has(WildChaser::Bass))
             .with_starting_lives(lives_to_idx(*starting_lives))
-            .with_world_count((*world_count).clamp(1, 7))
+            // Verbatim, including 0, and NOT normalized to 7 when the maze is
+            // on. The maze does pin the spine to all eight worlds, but it pins
+            // it in `randomize_inner` — the writer is what ignores this field,
+            // the same split `deja_vu_forts` uses, and normalizing here would
+            // move the key string of every maze key already minted with a
+            // shorter spine.
+            .with_world_count((*world_count).min(7))
             .with_world_maze(*world_maze)
             // Zero unless the maze is on. The field is meaningless with it
             // off, and encoding its default anyway would have moved the
@@ -668,9 +684,6 @@ impl Options {
             piranha_shuffle: f.piranha_shuffle_or_err().unwrap_or_default(),
             wild_injections: chasers,
             starting_lives: idx_to_lives(f.starting_lives()),
-            // 0 is unreachable from the encoder (it clamps to 1–7) but reachable
-            // from a corrupt or newer key; take the default rather than a world
-            // count the builder can't satisfy.
             world_maze: f.world_maze(),
             // 0 is a REAL value with the maze on — a pure maze, no gate on the
             // castle — so it is taken at face value there. With the maze off
@@ -681,10 +694,11 @@ impl Options {
             } else {
                 HintMode::default()
             },
-            world_count: match f.world_count() {
-                0 => default_world_count(),
-                n => n,
-            },
+            // Every pattern is a value now, 0 included — it is "start in Dark
+            // Land", not "unset". A key minted before that meaning existed
+            // cannot carry 0 (the encoder clamped to 1–7), so nothing older is
+            // being reinterpreted; see the field's own comment.
+            world_count: f.world_count(),
             starting_items: items,
             // Not encoded: fixed to the values a shared key should never
             // override. The web app skips these fields when applying a decoded

--- a/src/randomizer/mod.rs
+++ b/src/randomizer/mod.rs
@@ -190,9 +190,22 @@ fn randomize_inner(
     // chains the wand counter through the routine it installs, so it cannot run
     // without it. Forced here rather than only in the CLI, because a flag key
     // can name `world_maze` with `world_order` off.
+    //
+    // **The maze pins the spine to all eight worlds.** `world_count` means two
+    // different things in the two modes — worlds before Dark Land in standard,
+    // spine length in the maze — and the web form now greys the control out
+    // under the mode and sends its default instead. Pinning it here is what
+    // makes that true of a CLI run and a pasted flag key as well, rather than
+    // leaving the page describing one game and the ROM playing another. The key
+    // still carries whatever the player chose; see `flag_key`.
+    //
+    // Free of the seed: `world_order::randomize` shuffles all seven worlds and
+    // then takes a prefix, so the count selects from the deal without changing a
+    // single RNG draw.
+    let world_count = if options.world_maze { 7 } else { options.world_count };
     let credits_progression = if options.world_order || options.world_maze {
         rom.set_tag("world_order");
-        Some(randomize::world_order::randomize(rom, &mut rng, options.world_count))
+        Some(randomize::world_order::randomize(rom, &mut rng, world_count))
     } else {
         None
     };

--- a/src/randomizer/options.rs
+++ b/src/randomizer/options.rs
@@ -448,7 +448,17 @@ pub struct Options {
     pub king_quotes: bool,
     #[serde(default)]
     pub world_order: bool,
-    /// Number of worlds before Dark Land (1–7, default 7).
+    /// Number of worlds before Dark Land (0–7, default 7). Only read when
+    /// [`Options::world_order`] is on, since its table is the mechanism.
+    ///
+    /// **0 starts the game in Dark Land**, which is then the whole game and
+    /// displays as "WORLD 1". No airship stands before Bowser's castle at that
+    /// count, so no wand exists in the run.
+    ///
+    /// **Ignored when [`Options::world_maze`] is on**, which pins the spine to
+    /// all eight worlds: the web form greys the control out under the mode, and
+    /// `randomize_inner` makes that true of every other entry point. The flag
+    /// key still carries the player's value verbatim.
     #[serde(default = "default_world_count")]
     pub world_count: u8,
     /// **World maze.** The eight world maps stop being a sequence and become

--- a/src/randomizer/tests.rs
+++ b/src/randomizer/tests.rs
@@ -626,7 +626,9 @@ fn flag_key_per_option_round_trip() {
         assert_eq!(recovered.starting_lives, lives, "starting_lives={lives}: round-trip mismatch");
         assert_eq!(recovered, expected, "starting_lives={lives}: full struct mismatch");
     }
-    for wc in 1u8..=7 {
+    // 0 included: it is "start in Dark Land", not a dead pattern, since the
+    // world-count control gained that rung.
+    for wc in 0u8..=7 {
         let opts = Options { world_count: wc, ..Default::default() };
         let expected = normalized(opts.clone());
         let recovered = Options::from_flag_key(&opts.to_flag_key()).unwrap();
@@ -914,7 +916,17 @@ fn flag_key_short_key_zero_fills() {
     assert!(decoded.powerups, "an early option must survive a short key");
     assert_eq!(decoded.ground, EnemyMode::Shuffle);
     // starting_lives/world_count/items live in the truncated tail.
-    assert_eq!(decoded.world_count, default_world_count());
+    assert_eq!(decoded.starting_lives, STARTING_LIVES_VALUES[0]);
+    assert_eq!(decoded.starting_items, Vec::<u8>::new());
+
+    // **`world_count` is the one field with no "absent" pattern left**: since
+    // 0 became "start in Dark Land", a key that stops short of it reads as that
+    // rather than as the default of seven worlds. Nothing in circulation can
+    // land there — a real key truncated in transit fails the checksum, and this
+    // one only decodes because `forge_key` recomputes it — but the day another
+    // field needs a "this key predates me" pattern, this is the one that cannot
+    // supply one.
+    assert_eq!(decoded.world_count, 0);
 }
 
 /// The checksum's reason for existing, measured.

--- a/tests/web_schema_parity.rs
+++ b/tests/web_schema_parity.rs
@@ -389,3 +389,56 @@ fn preset_overrides_name_live_flag_key_fields() {
 
     assert!(bad.is_empty(), "presets reference ids they cannot apply: {bad:?}");
 }
+
+/// The mode keys (`mode`, `forcedInMaze`) hold the page's story about which
+/// options apply in which mode, and their failure modes are silent in a browser:
+/// a mode spelled wrong makes an option inert in *both* modes, since neither
+/// matches; an entry marked both mode-specific and forced has its value written
+/// by the mode and then thrown away by `getOptions`. Nothing throws, so nothing
+/// but a check like this one would report either.
+///
+/// Deliberately not a list of which options are mode-specific — that is the
+/// schema's to say. This only asserts the markings are coherent with each other.
+#[test]
+fn mode_markings_are_coherent() {
+    let src = options_js();
+    let entries: Vec<(String, &str)> = entries(array_block(&src, "SCHEMA"))
+        .into_iter()
+        .map(|e| (entry_id(e).to_string(), e))
+        .collect();
+
+    let mode_of = |body: &str| -> Option<String> {
+        let at = body.find("mode: \"")? + "mode: \"".len();
+        let rest = &body[at..];
+        Some(rest[..rest.find('"').expect("mode value is not terminated")].to_string())
+    };
+    let mut modes = 0;
+    let mut forced_count = 0;
+    for (id, body) in entries.iter() {
+        let mode = mode_of(body);
+        let forced = body.contains("forcedInMaze:");
+        if forced {
+            forced_count += 1;
+        }
+
+        let Some(m) = &mode else { continue };
+        modes += 1;
+        assert!(
+            m == "maze" || m == "standard",
+            "SCHEMA entry `{id}` has mode `{m}`, which is neither mode",
+        );
+        assert!(
+            !forced,
+            "SCHEMA entry `{id}` is both mode-specific and forced — the mode would \
+             write its value and `getOptions` would then throw it away",
+        );
+        assert!(
+            body.contains("inFlagKey: true"),
+            "SCHEMA entry `{id}` is mode-specific but not in the flag key, so \
+             nothing it does can differ between modes in the first place",
+        );
+    }
+
+    assert!(modes > 0, "no mode-specific entries parsed from {OPTIONS_JS} — parser drift");
+    assert!(forced_count > 0, "no forced entries parsed from {OPTIONS_JS} — parser drift");
+}

--- a/web/maze-tracker.html
+++ b/web/maze-tracker.html
@@ -21,7 +21,16 @@
    Sized to be used one-handed with a controller in the other: every control is
    a real tap target and every chip is readable from arm's length, because this
    gets glanced at mid-level rather than studied. */
-.tracker { max-width: 1400px; }
+/* The size slider zooms the whole board, the way browser zoom would — so the
+   cards, their text and the chips all grow together.
+
+   It has to sit on this element rather than on the grid inside it. `zoom` scales
+   an element's *contents* while its own box still fills the space it was given,
+   so zooming a grid whose columns are `1fr` changes nothing at all: each column
+   is a third of the same width, measured in a coordinate space that shrank by
+   exactly the factor it is then drawn at. Zooming the container instead means
+   `max-width` is what gets scaled, which is a real size change. */
+.tracker { max-width: 1400px; zoom: var(--tracker-scale, 1); }
 .tracker .note { font-size: 0.82rem; color: #7a7a96; }
 
 .tracker-nav {
@@ -34,7 +43,25 @@
 }
 .tracker-nav a { color: #5c94fc; text-decoration: none; font-size: 0.95rem; }
 .tracker-nav a:hover { text-decoration: underline; }
-.tracker-nav .tools { display: flex; gap: 0.5rem; }
+.tracker-nav .tools { display: flex; gap: 0.5rem; align-items: center; }
+
+/* Board size. A tracker is something you sit and stare at next to an emulator,
+   so how much of the screen it wants is the player's call, not the layout's. */
+.tracker-nav .scale {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #9a9ab0;
+    font-size: 0.85rem;
+}
+.tracker-nav .scale input { width: 8rem; accent-color: #5c94fc; cursor: pointer; }
+/* Fixed width on the readout: it changes as you drag, and without one the
+   slider shuffles sideways under the cursor every time a digit is added. */
+.tracker-nav .scale #scale-value {
+    width: 4ch;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
 .tracker-nav button {
     background: #1c1c38;
     color: #9a9ab0;
@@ -153,10 +180,16 @@
 .pad-links path.same-world { stroke-dasharray: 5 5; opacity: 0.55; }
 .pad-links circle { fill: #a05cff; opacity: 0.55; }
 
-/* --- World cards --- */
+/* --- World cards ---
+   Three fixed columns, so the eight cards always land 1-2-3 / 4-5-6 / 7 + Dark
+   Land. `auto-fill` decided the count from the viewport instead, which moved
+   Dark Land around as the window changed and stranded it on a row of its own at
+   most widths. Fixed columns also keep the arrangement steady under the size
+   slider, which with `auto-fill` would have bought extra columns instead of
+   bigger cards. */
 .worlds {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1rem;
 }
 
@@ -169,9 +202,24 @@
     flex-direction: column;
     gap: 0.7rem;
 }
-/* Dark Land holds four fortresses and is where the run ends, so it gets the
-   whole row rather than being squeezed into a column with the rest. */
-.wcard.dark-land { grid-column: 1 / -1; }
+/* Dark Land holds four fortresses, so it wants more width than one column —
+   but it is still the eighth world, and putting it on its own row read as a
+   separate thing rather than the end of the run. Two columns beside World 7
+   fills the last row exactly. */
+.wcard.dark-land { grid-column: span 2; }
+
+/* Narrower windows. These come after the rule above on purpose: a media query
+   adds no specificity, so an override written before it would simply lose. */
+@media (max-width: 1100px) {
+    .worlds { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    /* Two columns already leave one free cell beside World 7, so Dark Land
+       takes it as an ordinary card rather than spanning onto a row of its own. */
+    .wcard.dark-land { grid-column: auto; }
+}
+
+@media (max-width: 760px) {
+    .worlds { grid-template-columns: minmax(0, 1fr); }
+}
 .wcard.droppable { outline: 3px dashed #f0c040; outline-offset: 3px; }
 .wcard.dragover { background: #1e1e3e; }
 
@@ -400,6 +448,11 @@
     <div class="tracker-nav">
         <a href="index.html">&larr; Back to the randomizer</a>
         <div class="tools">
+            <label class="scale" for="scale">
+                Size
+                <input id="scale" type="range" min="60" max="150" step="5" value="100">
+                <span id="scale-value">100%</span>
+            </label>
             <button id="reset-btn" type="button">Reset</button>
         </div>
     </div>
@@ -570,6 +623,30 @@ function stampIds() {
 
 function save() {
 	try { localStorage.setItem(STORE_KEY, JSON.stringify(state)); } catch { /* private mode */ }
+}
+
+// Board size, stored apart from the board. It is a view preference rather than
+// anything the player found, so Reset must not take it away and a shape check
+// on the tracker's own entry must never be able to throw it out.
+const SCALE_KEY = "smb3r-maze-tracker-scale";
+
+function loadScale() {
+	try {
+		const raw = Number(localStorage.getItem(SCALE_KEY));
+		// Clamped, not trusted: a hand-edited entry that scaled the grid to
+		// nothing would leave a page with no visible way back.
+		return Number.isFinite(raw) && raw >= 60 && raw <= 150 ? raw : 100;
+	} catch { return 100; }
+}
+
+function applyScale(percent) {
+	document.documentElement.style.setProperty("--tracker-scale", String(percent / 100));
+	if (scaleValueEl) scaleValueEl.textContent = `${percent}%`;
+	try { localStorage.setItem(SCALE_KEY, String(percent)); } catch { /* private mode */ }
+	// The cards just changed size, so the curves between them are measuring a
+	// layout that no longer exists. The ResizeObserver catches this too; calling
+	// it here makes the redraw immediate rather than a frame behind the drag.
+	drawPadLinks();
 }
 
 function load() {
@@ -862,6 +939,8 @@ const aimingText = document.getElementById("aiming-text");
 const countsEl = document.getElementById("counts");
 const linksEl = document.getElementById("pad-links");
 const problemsEl = document.getElementById("problems");
+const scaleEl = document.getElementById("scale");
+const scaleValueEl = document.getElementById("scale-value");
 
 function el(tag, attrs = {}, ...children) {
 	const node = document.createElement(tag);
@@ -928,11 +1007,22 @@ function drawPadLinks() {
 	const base = worldsEl.getBoundingClientRect();
 	if (!base.width) return;
 
+	// The size slider zooms the whole tracker, this overlay included. A zoomed
+	// element measures *out* in screen pixels and draws *in* its own unscaled
+	// ones — `getBoundingClientRect` reports the scaled box while `offsetWidth`
+	// reports the layout box — so every distance taken from a rect has to come
+	// back down by the same factor or the curves drift off their chips by
+	// exactly the amount the board was scaled by.
+	const zoom = worldsEl.offsetWidth ? base.width / worldsEl.offsetWidth : 1;
+
 	const centreOf = padId => {
 		const node = worldsEl.querySelector(`[data-pad="${padId}"]`);
 		if (!node) return null;
 		const r = node.getBoundingClientRect();
-		return { x: r.left - base.left + r.width / 2, y: r.top - base.top + r.height / 2 };
+		return {
+			x: (r.left - base.left + r.width / 2) / zoom,
+			y: (r.top - base.top + r.height / 2) / zoom,
+		};
 	};
 
 	const drawn = new Set();
@@ -1387,6 +1477,16 @@ document.getElementById("reset-btn").addEventListener("click", () => {
 	aiming = null;
 	render();
 });
+
+if (scaleEl) {
+	// Applied, not just shown: the stored size has to reach the CSS variable on
+	// load, or the slider comes back where the player left it while the board
+	// renders at 100%.
+	const percent = loadScale();
+	scaleEl.value = String(percent);
+	applyScale(percent);
+	scaleEl.addEventListener("input", () => applyScale(Number(scaleEl.value)));
+}
 
 // The curves are measured from the laid-out grid, so anything that reflows it
 // has to redraw them. Guarded because none of this exists headlessly.

--- a/web/options.js
+++ b/web/options.js
@@ -6,6 +6,7 @@
 //   - Live flag-key updates (universal change listener)
 //   - Sub-option visibility (enabledWhen — a value, or a list meaning "any of")
 //   - Pills that ride on another entry's group (pillOf)
+//   - Mode-specific applicability (mode / forcedInMaze — see below)
 //
 // Adding a new option = one schema entry. The renderer, serializer,
 // applier, and listener pick it up automatically. A load-time parity
@@ -102,14 +103,19 @@ const OFF_DOUBLE_WILD = [
 ];
 
 // Categories rendered as <fieldset> sections, in order.
+//
+// **World Maze comes first because it is a mode, not a flag.** It decides what
+// several of the sections below even mean — a row further down can be greyed,
+// badged or replaced outright by it — and a switch that reaches that far has to
+// be read before the options it governs, not found underneath them.
 export const GROUPS = [
-	{ id: "map", label: "Map" },
 	{ id: "maze", label: "World Maze",
-		note: "Only affects World Maze. With the mode off these are ignored, and they leave your flag key alone.",
+		note: "The mode switch, and the settings only it uses. Options elsewhere that the maze takes over or has no use for say so in their own row.",
 		// Relative on purpose: the /beta/ deploy is a copy of this whole folder,
 		// so the beta page links to the beta tracker and the root page to the
 		// root one, with no build-time knowledge of which it is.
 		link: { href: "maze-tracker.html", label: "Open the World Maze tracker →" } },
+	{ id: "map", label: "Map" },
 	{ id: "enemies", label: "Enemies" },
 	{ id: "bosses", label: "Bosses" },
 	{ id: "items", label: "Items & Pickups" },
@@ -310,13 +316,19 @@ export const SCHEMA = [
 	{ id: "world_order", type: "bool", default: false,
 		label: "World Order",
 		tip: "Shuffle the order you progress through Worlds 1-8",
-		group: "map", inFlagKey: true },
+		group: "map", inFlagKey: true,
+		// The maze reads this table as its airship spine, so it cannot run
+		// without it — see `randomizer::randomize_inner`.
+		forcedInMaze: true },
+	// Standard-only: the maze uses all eight worlds, so it pins this to 7 (see
+	// `randomizer::randomize_inner`) and the row greys out under the mode.
 	{ id: "world_count", type: "tri", numeric: true,
-		options: [1,2,3,4,5,6,7].map(n => ({ value: n, label: String(n) })),
+		options: [0,1,2,3,4,5,6,7].map(n => ({ value: n, label: String(n) })),
 		default: 7,
 		label: "World Count",
-		tip: "Number of worlds before Dark Land (fewer = shorter game)",
+		tip: "Number of worlds before Dark Land (fewer = shorter game). 0 starts you in Dark Land — it becomes the whole game, and there is no airship before Bowser's castle.",
 		group: "map", inFlagKey: true,
+		mode: "standard",
 		enabledWhen: { world_order: true } },
 
 	// --- World Maze ---
@@ -324,7 +336,7 @@ export const SCHEMA = [
 	// what the group note says.
 	{ id: "world_maze", type: "bool", default: false,
 		label: "World Maze",
-		tip: "The eight maps become one big maze. Warp pads link them, a fortress can open a lock in another world, and your progress in a world is still there when you come back. Turns World Order on.",
+		tip: "The eight maps become one big maze. Warp pads link them, a fortress can open a lock in another world, and your progress in a world is still there when you come back. Turns World Order on, and uses all eight worlds.",
 		group: "maze", inFlagKey: true },
 	{ id: "maze_wands", type: "tri", numeric: true,
 		options: [0,1,2,3,4,5,6,7].map(n => ({ value: n, label: String(n) })),
@@ -332,12 +344,12 @@ export const SCHEMA = [
 		label: "Wands To Enter",
 		tip: "Wands needed before Bowser's castle will open. Fewer is a shorter game; 0 lets you walk straight in if you find a way there.",
 		group: "maze", inFlagKey: true,
-		enabledWhen: { world_maze: true } },
+		mode: "maze" },
 	{ id: "hints", type: "tri", options: OFF_SOME_FULL, default: "some",
 		label: "Hints",
 		tip: "How much the map gives away about which fortress opens which lock. Some marks a fortress with the design for where its lock is, and tints a lock whose key is in another world. Full also stamps that lock with the world number to go to.",
 		group: "maze", inFlagKey: true,
-		enabledWhen: { world_maze: true } },
+		mode: "maze" },
 
 	// --- Enemies ---
 	{ id: "ground", type: "tri", options: TRI, default: "shuffle",
@@ -497,7 +509,12 @@ export const SCHEMA = [
 		label: "Remove Warp Whistles",
 		tip: "Remove warp whistles so all worlds must be played",
 		icon: WHISTLE,
-		group: "items", inFlagKey: true },
+		group: "items", inFlagKey: true,
+		// A vanilla whistle warps to a world number, which the maze has no use
+		// for — it would be an item that takes a slot and does nothing. The
+		// maze's own whistle is a different thing entirely, and it is not from
+		// the item pool this removes from.
+		forcedInMaze: true },
 	{ id: "hammer_breaks_locks", type: "tri", options: ON_OFF_MAYBE, default: "off",
 		label: "Hammer Breaks Locks",
 		tip: "Hammer item also breaks fortress locks on the overworld map. Maybe: the seed secretly decides on or off, so you won't know until you play.",
@@ -529,7 +546,10 @@ export const SCHEMA = [
 		label: "No Game Over Penalty",
 		tip: "Game Over no longer wipes your inventory, map progress, or cards — continue picks up where you left off.",
 		credit: { name: "MaCobra52", url: "https://github.com/macobra52" },
-		group: "player", inFlagKey: true },
+		group: "player", inFlagKey: true,
+		// Without it a Game Over wipes map completions, and in a mode built on
+		// "a world you can come back to" that is the whole point undone.
+		forcedInMaze: true },
 	{ id: "faster_frog", type: "bool", default: false,
 		label: "Faster Frog",
 		tip: "Speeds up swimming and running while wearing the Frog Suit.",
@@ -717,6 +737,7 @@ export const PRESETS = [
 // fields untouched (same fields applyOptions skips). Mirrors applyOptions so
 // callers update the flag key + summary the same way afterward.
 export function applyPreset(overrides) {
+	clearForcedMemo();
 	for (const entry of SCHEMA) {
 		if (!entry.inFlagKey) continue;
 		const v = overrides && entry.id in overrides ? overrides[entry.id] : entry.default;
@@ -739,6 +760,139 @@ export function assertPresetParity() {
 		}
 	}
 	if (bad.length) console.error("Preset references unknown flag-key fields", bad);
+}
+
+// --- Modes ---
+//
+// One option is not a flag but a *mode switch*: World Maze does not add a
+// feature the other options describe, it changes which of them describe
+// anything at all. Three shapes fall out of that, and each is a schema key
+// rather than a special case in the renderer:
+//
+//   mode: "maze" | "standard"  This option only means something in that mode.
+//                              Outside it the row is greyed, badged, and — the
+//                              part that matters — REPLACED BY ITS DEFAULT in
+//                              `getOptions`, so it cannot reach the generator.
+//   forcedInMaze: <value>      The maze decides this one. The row shows the
+//                              value the ROM will use, greyed and badged, and
+//                              the player's own setting comes back when they
+//                              leave the mode.
+//
+// Every mode-specific option stays in the section it belongs to and keeps its
+// own row. Hiding one, or swapping two onto a shared row, was tried and dropped:
+// a control that vanishes teaches a player nothing about why, where a greyed row
+// with "Maze only" on it says the rule out loud in the place they are looking.
+//
+// **Greying alone was never enough.** `readValue` ignores `disabled`, so a
+// greyed control still fed `getOptions`, the flag key and the generator: that is
+// how a maze seed could take its spine length from a World Count pill the page
+// had greyed out. Anything inert here is neutralized in the value, and the
+// greying is only how that is explained to the player.
+//
+// The Rust side neutralizes the same fields independently (`hints` outside the
+// maze, `world_count` inside it, `maze_wands` in the key). That is deliberate
+// duplication: the CLI and a pasted flag key never run this file.
+const MODE_SWITCH = "world_maze";
+
+function currentMode() {
+	const entry = SCHEMA.find(s => s.id === MODE_SWITCH);
+	return entry && readValue(entry) ? "maze" : "standard";
+}
+
+// True when the option describes nothing in the mode the form is currently in.
+function isInert(entry, mode) {
+	return !!entry.mode && entry.mode !== mode;
+}
+
+function modeBadgeText(entry) {
+	if (entry.forcedInMaze !== undefined) {
+		return `Forced ${entry.forcedInMaze ? "on" : "off"} by World Maze`;
+	}
+	return entry.mode === "maze" ? "Maze only" : "Standard only";
+}
+
+// What the player had before the maze pinned a forced option, so turning the
+// mode off gives it back. Kept out of the settings blob: `saveSettings` stores
+// what the inputs currently show, which while the maze is on is the forced
+// value — restoring a page in maze mode would otherwise eat the memo.
+const FORCED_MEMO_KEY = "smb3r-forced-memo";
+
+function loadForcedMemo() {
+	try {
+		return JSON.parse(localStorage.getItem(FORCED_MEMO_KEY) ?? "{}");
+	} catch (_) {
+		return {};
+	}
+}
+
+function saveForcedMemo(memo) {
+	try {
+		localStorage.setItem(FORCED_MEMO_KEY, JSON.stringify(memo));
+	} catch (_) {}
+}
+
+// Forget the pre-maze values. Any wholesale rewrite of the form — a preset, a
+// pasted flag key — states every flag-key field outright, so the memo describes
+// a form that no longer exists: without this, leaving maze mode afterwards would
+// restore settings from before the rewrite, silently overwriting three of the
+// values it had just delivered.
+function clearForcedMemo() {
+	try {
+		localStorage.removeItem(FORCED_MEMO_KEY);
+	} catch (_) {}
+}
+
+// Values first, before anything reads them: the maze pins World Order on, and
+// World Count's `enabledWhen` rides on that.
+function applyForcedValues() {
+	const forced = currentMode() === "maze";
+	const memo = loadForcedMemo();
+	let dirty = false;
+	for (const entry of SCHEMA) {
+		if (entry.forcedInMaze === undefined) continue;
+		if (forced) {
+			if (!(entry.id in memo)) {
+				memo[entry.id] = readValue(entry);
+				dirty = true;
+			}
+			writeValue(entry, entry.forcedInMaze);
+		} else if (entry.id in memo) {
+			writeValue(entry, memo[entry.id]);
+			delete memo[entry.id];
+			dirty = true;
+		}
+	}
+	if (dirty) saveForcedMemo(memo);
+}
+
+function setBadge(entry, text) {
+	const badge = document.getElementById(`badge-${entry.id}`);
+	if (!badge) return;
+	badge.textContent = text ?? "";
+	badge.hidden = !text;
+}
+
+// Fold the current mode into the form: grey and badge what the mode makes
+// inert, and show forced options at the value the ROM will actually use.
+export function applyModeStates() {
+	const mode = currentMode();
+	for (const entry of SCHEMA) {
+		if (entry.forcedInMaze !== undefined) {
+			const forced = mode === "maze";
+			applyEntryEnabled(entry, !forced);
+			setBadge(entry, forced ? modeBadgeText(entry) : null);
+			continue;
+		}
+		if (!entry.mode) continue;
+		const inert = isInert(entry, mode);
+		// Inert always greys. Re-enabling belongs to `applyEnabledWhen` when the
+		// entry has a host to answer to (World Count still rides on World Order),
+		// and to us when it does not; without that second half an option greyed
+		// in one mode would stay greyed after switching into the one it belongs
+		// to.
+		if (inert || !entry.enabledWhen) applyEntryEnabled(entry, !inert);
+		setBadge(entry, inert ? modeBadgeText(entry) : null);
+	}
 }
 
 // --- DOM helpers ---
@@ -1132,10 +1286,27 @@ const RENDERERS = {
 	nescolor: renderNesColor,
 };
 
+// A mode-specific option carries a badge in its own row — "Maze only",
+// "Forced on by World Maze" — so the rule is legible where the control is,
+// rather than only in a note at the top of a section. It renders empty and
+// hidden; `applyModeStates` fills it in for whichever mode the form is in.
+function modeBadge(entry) {
+	if (entry.forcedInMaze === undefined && !entry.mode) return null;
+	return el("span", { class: "opt-badge", id: `badge-${entry.id}`, hidden: true });
+}
+
 function renderEntry(entry) {
 	const r = RENDERERS[entry.type];
 	if (!r) throw new Error(`Unknown schema type: ${entry.type}`);
 	const node = r(entry);
+	const badge = modeBadge(entry);
+	if (badge) {
+		// Before the pills, so it reads as part of the label rather than as
+		// another choice on the right-hand side.
+		const group = node.querySelector?.(".pill-group");
+		if (group) node.insertBefore(badge, group);
+		else node.appendChild?.(badge);
+	}
 	const block = tipBlock(entry);
 	if (!block) return node;
 	const frag = document.createDocumentFragment();
@@ -1273,8 +1444,13 @@ export function writeValue(entry, value) {
 
 export function getOptions() {
 	const out = { ...CONSTANT_FIELDS };
+	const mode = currentMode();
 	for (const entry of SCHEMA) {
-		out[entry.id] = readValue(entry);
+		// An option the current mode makes inert sends its default, not what its
+		// greyed-out control still shows. This is the load-bearing half of
+		// `mode`: disabling an input does not stop `readValue` reading it, so
+		// without this a stale World Count would still set a maze's spine.
+		out[entry.id] = isInert(entry, mode) ? entry.default : readValue(entry);
 	}
 	return out;
 }
@@ -1283,7 +1459,11 @@ export function getOptions() {
 // the schema default. Used by the changes-summary UI in the control panel.
 export function getChangedFields() {
 	const changed = [];
+	const mode = currentMode();
 	for (const entry of SCHEMA) {
+		// Inert in this mode: it changes nothing about the seed, so listing it
+		// as a change would be a lie of the same kind the badges exist to stop.
+		if (isInert(entry, mode)) continue;
 		const current = readValue(entry);
 		if (!valuesEqual(current, entry.default)) {
 			changed.push({ entry, current });
@@ -1338,6 +1518,7 @@ export function getOptionsJson() {
 // fields (palettes, palette_themed, remove_flashing, skip_rom_validation) so applying a
 // shared key doesn't clobber the user's local cosmetic / ROM choices.
 export function applyOptions(opts) {
+	clearForcedMemo();
 	for (const entry of SCHEMA) {
 		if (!entry.inFlagKey) continue;
 		writeValue(entry, opts[entry.id]);
@@ -1345,6 +1526,7 @@ export function applyOptions(opts) {
 }
 
 export function applyEnabledWhen() {
+	applyForcedValues();
 	for (const entry of SCHEMA) {
 		if (!entry.enabledWhen) continue;
 		const enabled = Object.entries(entry.enabledWhen).every(
@@ -1362,6 +1544,10 @@ export function applyEnabledWhen() {
 		if (!enabled && entry.pillOf) writeValue(entry, false);
 		applyEntryEnabled(entry, enabled);
 	}
+	// Last, so the mode wins: it forces values that `enabledWhen` reads (the
+	// maze pins World Order on, which is what un-greys the row beside it), and
+	// an option the mode has made inert must stay greyed whatever its host says.
+	applyModeStates();
 }
 
 function applyEntryEnabled(entry, enabled) {
@@ -1376,8 +1562,16 @@ function applyEntryEnabled(entry, enabled) {
 			elNode.nextElementSibling?.classList.toggle("pill-disabled", !enabled);
 			continue;
 		}
-		// Walk up to the wrapping label/div so the visual styling matches today
-		const wrap = elNode.closest("label, .radio-group-vertical, .pill-group");
+		// Walk up to the row that wraps the whole option — its label, or the
+		// vertical group for the types that have no single label.
+		//
+		// `.pill-group` used to be in this list, and since `closest` matches the
+		// NEAREST ancestor rather than the first selector listed, a pill entry
+		// always landed the class on the group div — which no rule styles. So
+		// "greyed out" greyed nothing out for every pill option on the page; the
+		// pills just quietly stopped responding. The class belongs on the row,
+		// where `.select-label.disabled` dims it and the badge explains it.
+		const wrap = elNode.closest("label, .radio-group-vertical");
 		if (wrap) wrap.classList.toggle("disabled", !enabled);
 	}
 }

--- a/web/style.css
+++ b/web/style.css
@@ -554,6 +554,37 @@ input[type="radio"] {
     margin-left: 0.25rem;
 }
 
+/* Mode badge: "Maze only", "Forced on by World Maze". Sits in the row it talks
+   about rather than in a note at the top of the section, because the thing a
+   player needs to know is why *this* control is not theirs to set. Amber, not
+   the flavor pill's green — it is a warning about the control, not a joke about
+   the option. `margin-left: auto` pushes it to the pill group's left edge, so a
+   column of badges lines up down the form. */
+.opt-badge {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #0c0c1e;
+    background: #e8a33d;
+    margin-left: auto;
+    margin-right: 0.5rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    white-space: nowrap;
+}
+
+/* A row the mode (or its host option) has made inert. Until this rule, greying
+   a row only stopped its pills responding to clicks — nothing on screen said
+   why, which reads as a broken page rather than a rule. The pills themselves
+   keep their colors so a forced value is still legible at a glance. */
+.select-label.disabled {
+    opacity: 0.5;
+}
+
+.select-label.disabled .pill-group label {
+    cursor: default;
+}
+
 .option-flavor {
     font-size: 0.65rem;
     color: #0c0c1e;


### PR DESCRIPTION
## Why

World Maze is a mode rather than a flag — it decides what several options below it mean — and the page had no way to say so. What it did instead was worse than silence: **a greyed-out control still fed the generator**, because `readValue` ignores `disabled`. That is how a maze seed could take its spine length from a World Count row the page had greyed out.

Greying was not even visible. `applyEntryEnabled` walked up with `closest("label, .radio-group-vertical, .pill-group")`, and `closest` matches the *nearest* ancestor rather than the first selector listed — so every pill option on the page landed the class on the pill-group div, which no CSS rule styles. The pills just quietly stopped responding.

## The whole mode-specific surface

Found by grepping every `world_maze` read in `src/`:

| Option | Relationship |
|---|---|
| `world_order`, `remove_whistles`, `no_game_over_penalty` | forced on by the maze, player's setting ignored |
| `maze_wands`, `hints` | maze-only, inert outside it |
| `world_count` | means a different thing per mode — and the row that was silently feeding the generator |
| `starting_items` | not overridden, but the maze owns inventory slot 0 for its whistle. Left unbadged; a line in its tip may be all it needs |

## What the page does now

Two schema keys carry the rule, so a new mode-specific option is one entry rather than a renderer change:

- `mode: "maze" | "standard"` — inert outside that mode: greyed, badged, and **replaced by its default in `getOptions`**
- `forcedInMaze: <value>` — the mode decides it; the row shows the value the ROM will use, and the player's own setting comes back when they leave the mode

World Maze moves to the top of the form, since a switch that reaches that far has to be read before the options it governs.

A swap — one row that became Wands To Enter in maze mode — was built first and then dropped: a control that vanishes teaches a player nothing about why, where a greyed row saying "Maze only" states the rule in the place they are looking.

## World Count 0

Starts the game in Dark Land, which is then the whole game and displays as "WORLD 1". No airship stands before Bowser's castle at that count, so no wand exists in the run.

In the flag key, 0 was a dead pattern decoding to the default of 7. It is a real value now and needs **no version bump**: no key in circulation can carry it, since the encoder clamped to 1–7 from the day the field existed. An appended `start_in_dark_land` bool would have had the identical new-key-read-by-older-build failure for an extra bit.

The maze pins `world_count` to 7 in `randomize_inner`, so a CLI run and a pasted key agree with the page. The key still carries the player's value verbatim (the `deja_vu_forts` split), so no maze key string moves.

## Tracker

Dark Land is now a two-column card beside World 7 — the grid was `auto-fill`, so the column count followed the window and Dark Land almost always sat alone on a row of its own — plus a size slider, 60–150%, stored apart from the tracker state so Reset cannot clear it.

`zoom` on the grid did nothing at all, which is worth recording: it scales an element's *contents* while its own box still fills the space it was given, so a grid with `1fr` columns cancels it exactly. Measured 433px / 436px at 100% / 70% before the fix. On the container, where `max-width` is what gets scaled, it is a real size change (433 → 303). That puts the pad-link overlay inside the zoomed element, and a zoomed element measures out in screen pixels while drawing in its own unscaled ones, so `drawPadLinks` divides by `base.width / worldsEl.offsetWidth` — without it the curves drift off their chips by exactly the scale factor.

## Verification

- `cargo fmt --check`, clippy native + wasm32, full `cargo test` — all green.
- `mode_markings_are_coherent` added to `tests/web_schema_parity.rs`, mutation-tested against a bad partner id and a wrong group.
- **A headless DOM harness over `options.js`** (CI runs no JavaScript): 30 assertions across both modes, the force/restore memo, and a flag key pasted while in maze mode. That last one found a bug reading could not — a preset or pasted key rewrites every field, and the restore memo then clobbered three of the values it had just delivered. Fixed with `clearForcedMemo()`.
- **Headless Chromium over CDP** for the tracker at 100%, 70% and 140%: three columns, Dark Land on World 7's row, curve starting 0px from its pad chip at every scale.
- End-to-end on the real ROM: `--world-count 0` writes `A9 07` at `0x30CC1` (the game starts in Dark Land), and `--world-maze --world-count 3` still assigns all eight display positions `$F1`–`$F8`.

Neither harness is committed — both live in the session scratchpad. The JS one is genuine coverage CI cannot otherwise get, but landing it means putting Node in the workflow; happy to do that as a follow-up if it is wanted.

**Not playtested** — this is page and plumbing work, but World Count 0 in particular is a real ROM change that wants eyes on an emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wLx2t4mCA5koCY5CnaQHb
