### PR TITLE
A fortress can stand in a different world from its lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ deploys.
   is in puts that fortress on the board, and if that world has no fortress that
   could open the lock and no room for one, it says so rather than accepting a
   map that cannot exist. Each world wears the king's HELP balloon until you
-  cross it off, which counts your wands for you. And when the board says something the game could not have built — more locks in a world than it has room for, a lock whose key is in a world with nothing that could open it — it says so, and keeps saying so until you fix it. Every fortress stands beside a lock, so filling in the fortresses fills in the locks: plain where that fortress opens it, tinted where its key is somewhere else. It fills itself in as you explore and keeps what you typed
+  cross it off, which counts your wands for you. And when the board says something the game could not have built — more locks in a world than it has room for, a lock whose key is in a world with nothing that could open it — it says so, and keeps saying so until you fix it. Filling in a fortress fills in the lock it opens, wherever that lock is: plain where it stands in the same world, tinted where its key is a world away. It fills itself in as you explore and keeps what you typed
   in your browser. A size slider at the top scales the whole board, for sitting
   it beside an emulator at whatever size the screen has room for.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ deploys.
 
 ### Changed
 
+- **World Maze: a world no longer has as many fortresses as it has locks.** One
+  or two fortresses a seed change places with a level in another world, so a
+  world can hold three locks and one fortress, or locks with no fortress of its
+  own at all. Counting the locks in front of you stops telling you how many
+  fortresses are behind you. Nothing about the run gets harder or longer — the
+  same fortresses open the same locks at the same points — you just walk
+  somewhere else to find the key. Dark Land is left alone: its locks are the
+  bridge to the castle, and moving a fortress there would change the endgame
+  rather than the map.
+
 - **World Count goes down to 0 — start the game in Dark Land.** It becomes the
   whole game, and displays as World 1. There is no airship before Bowser's
   castle at that count, so no wand exists in the run.

--- a/docs/world_maze_design.md
+++ b/docs/world_maze_design.md
@@ -226,6 +226,18 @@ fixpoint check per step, not a rebuild. The pass never moves content between
 worlds — levels stay in their own world, forts stay where placed — so the level
 deck model is untouched.
 
+> **Superseded in part, 2026-09-11.** A third pass, `maze::relocate`, does move
+> content between worlds: one or two fortresses a seed change places with a
+> level slot in another world. The level deck model is still untouched — the
+> exchange is 1:1, so no world's slot count moves and both decks are dealt
+> globally anyway. It runs between the pads and the fill, and it is exact rather
+> than checked: both ends of an exchange sit in the same sphere, which makes the
+> fixpoint provably identical afterwards. See that module's header for the
+> induction, and for the two relaxations (earlier sphere, later sphere) it
+> declines. **World 8 is held out**: its locks are the dealt bridge spans to
+> the castle and the wand gate stands on the same approach, so a fortress moved
+> on or off that corridor changes the endgame rather than how the map reads.)
+
 **Standard mode is not touched in v1.** There is no clean seam to extract from
 `locks.rs`, and sharing the code would move the overworld baseline and put the
 change on the hook for the deep censuses (500-seed reachability, 1000-seed
@@ -447,7 +459,12 @@ knob has to be earned:
   exist: every fortress must have exactly one lock (a lock breaking is the only
   feedback that says which fort did it, and a world's lock count is how the
   player deduces its fort count), so the assignment is a bijection and the count
-  is not a free parameter.
+  is not a free parameter. The bijection still holds and the knob
+  still cannot exist, but **the deduction is gone as of `maze::relocate`**: a
+  fortress can now stand in a different world from its lock, so a world's lock
+  count says nothing about its fortress count. What replaced the deduction is
+  the hint tiles — `LockHint` on the fortress, and the key's world number on
+  the lock at `HintMode::Full`.
 - **Key depth within a sphere** — the charter's proposed secondary dial. It is
   subsumed by `fort_distance_bias`: spine distance already orders keys from
   "same room" to "three worlds back", and a second dial over the same axis would

--- a/src/randomize/maze/mod.rs
+++ b/src/randomize/maze/mod.rs
@@ -51,6 +51,7 @@ pub(crate) mod graph;
 /// redeals the short ones, so this runs on the shipping path. The rest of the
 /// module is still census-only.
 pub(crate) mod metrics;
+pub(crate) mod relocate;
 pub(crate) mod roles;
 #[cfg(test)]
 mod tests;
@@ -745,6 +746,9 @@ pub(crate) struct GenReport {
     /// What the kept deal priced at, in levels and fortresses beaten. Below
     /// [`CONTENT_FLOOR`] only when [`MAX_DEALS`] ran out.
     pub content: usize,
+    /// Fortresses moved into another world — see [`relocate`]. Empty when the
+    /// spine-alone fallback fired.
+    pub relocated: relocate::RelocateReport,
 }
 
 /// One deal of the maze layer: everything [`generate`] draws in a single
@@ -773,6 +777,7 @@ struct Deal {
     fill: fill::FillReport,
     pads: Vec<graph::PlacedPad>,
     unsafe_worlds: Vec<usize>,
+    relocated: relocate::RelocateReport,
 }
 
 impl Deal {
@@ -818,6 +823,13 @@ pub(crate) fn generate<R: Rng>(
         let pads = graph::plan_pads(&state, knobs, rng);
         state.add_pads(pads.iter().map(|p| p.edge).collect());
 
+        // **Before the fill, after the pads.** The sphere index it reads has to
+        // include the pads, and the fill has to see the fortresses where they
+        // finally sit — it draws every key from the fortresses reachable at
+        // that moment, so a fortress that moves afterwards invalidates the
+        // reasoning that makes the fill safe by construction.
+        let relocated = relocate::relocate_forts(&mut state, rng);
+
         let fill = fill::assign_keys(&mut state, spine, knobs, rng);
 
         // A world whose start region has no walk-out still gets offered a pad,
@@ -851,7 +863,16 @@ pub(crate) fn generate<R: Rng>(
         }
 
         let spheres = state.spheres();
-        Deal { solvable: spheres.solvable, content: 0, state, spheres, fill, pads, unsafe_worlds }
+        Deal {
+            solvable: spheres.solvable,
+            content: 0,
+            state,
+            spheres,
+            fill,
+            pads,
+            unsafe_worlds,
+            relocated,
+        }
     };
 
     // **The content floor.** Deal until the maze is long enough, keeping the
@@ -887,8 +908,9 @@ pub(crate) fn generate<R: Rng>(
             break;
         }
     }
-    let Deal { content, mut state, mut spheres, fill, pads, mut unsafe_worlds, .. } =
-        best.expect("MAX_DEALS is non-zero, so at least one deal was kept");
+    let Deal {
+        content, mut state, mut spheres, fill, pads, mut unsafe_worlds, mut relocated, ..
+    } = best.expect("MAX_DEALS is non-zero, so at least one deal was kept");
 
     // Defence in depth, and the one guard this mode cannot do without.
     //
@@ -917,6 +939,10 @@ pub(crate) fn generate<R: Rng>(
         // escapable), which is exactly why it must not lie if it ever fires.
         unsafe_worlds =
             (0..state.worlds.len()).filter(|&wi| !state.start_region_escapable(wi)).collect();
+        // The fallback rebuilds from the BuildResult, so the relocations are
+        // gone with everything else. Report none rather than the ones that
+        // were dealt and then discarded.
+        relocated = relocate::RelocateReport::default();
     }
 
     // **And the fallback itself is checked, which it never used to be.**
@@ -955,7 +981,7 @@ pub(crate) fn generate<R: Rng>(
         spheres = state.spheres();
     }
 
-    (state, GenReport { spheres, fill, pads, unsafe_worlds, sealable, deals, content })
+    (state, GenReport { spheres, fill, pads, unsafe_worlds, sealable, deals, content, relocated })
 }
 
 /// Fold the maze's decisions back into the build, for the writer to write.
@@ -994,6 +1020,21 @@ pub(crate) fn stamp_into(build: &mut BuildResult, state: &GlobalState) {
     }
 
     for (world, built) in build.worlds.iter_mut().enumerate() {
+        // **Slots, first, because everything below reads them.** `relocate`
+        // exchanges a fortress with a level in another world, so a slot can
+        // have changed world, position and fortress id since the build handed
+        // it over. `section_count` is the writer's loop bound over fortress
+        // ids, and a world that lost one leaves a hole in the numbering, so it
+        // is the highest id in use rather than the count of them.
+        built.slots = state.worlds[world].slots.clone();
+        built.section_count = built
+            .slots
+            .iter()
+            .filter(|s| s.kind == SlotKind::Fortress)
+            .map(|s| s.section + 1)
+            .max()
+            .unwrap_or(0);
+
         for ((pad_world, (row, col)), _) in state.pad_edges() {
             if pad_world == world {
                 built.grid.set(row, col, rom_data::TILE_TELEPAD);
@@ -1048,5 +1089,12 @@ pub(crate) fn stamp_into(build: &mut BuildResult, state: &GlobalState) {
                 LockHint::Elsewhere
             };
         }
+    }
+
+    // Fortress counts moved with the slots. Only the censuses read this, but a
+    // stale count is a lie the next reader would have to catch by hand.
+    for wi in 0..build.worlds.len() {
+        build.fort_counts[wi] =
+            build.worlds[wi].slots.iter().filter(|s| s.kind == SlotKind::Fortress).count();
     }
 }

--- a/src/randomize/maze/relocate.rs
+++ b/src/randomize/maze/relocate.rs
@@ -1,0 +1,281 @@
+//! Move a fortress into another world, and a level back the other way.
+//!
+//! ## What it is for
+//!
+//! The per-world builder places **one lock per fortress, in that fortress's own
+//! world** (`overworld_build::locks`), so every world shows the player exactly
+//! as many fortresses as it shows locks. The key-assignment fill already breaks
+//! the *dependency* — 76% of locks end up opened by a fortress somewhere else —
+//! but it never moves a node, so the **counts** still match and the map still
+//! reads as eight self-contained worlds with the keys shuffled between them.
+//!
+//! This pass breaks the counts. It exchanges a fortress slot with a level slot
+//! in another world, which leaves a world holding more locks than fortresses
+//! and another holding more fortresses than locks. The fort/lock bijection is
+//! untouched — every fortress still opens exactly one lock — so what is lost is
+//! only the *deduction* "count the locks and you know the fort count", and the
+//! hint tiles already say what that deduction used to (`LockHint` on the
+//! fortress, the world number on the lock at `HintMode::Full`).
+//!
+//! It is a **perception** change and is deliberately small: one or two
+//! exchanges a seed, which is enough to stop the 1:1 reading without turning
+//! the fortress distribution into noise.
+//!
+//! ## Why the same-sphere rule makes this exact
+//!
+//! The move preserves the fixpoint **by construction**, the same discipline the
+//! constructive fill uses — there is no accept test and no retry, because there
+//! is nothing that can fail.
+//!
+//! [`GlobalState::spheres`] is a fixpoint over *positions*: round 0's reach
+//! depends on terrain and every lock shut, so it cannot depend on what occupies
+//! a slot. Say fortress `F` sits at `a` and a level sits at `b`, and both are
+//! first reached in round `s`. Exchange them, **carrying `F`'s identity to
+//! `b`** — its `FortRef` moves, so the lock it opens follows it. Then by
+//! induction on the round:
+//!
+//! * reach in round 0 is unchanged (it reads terrain, not slots);
+//! * if reach is unchanged through round `r`, the set of fortresses beaten in
+//!   round `r` is unchanged too — `F` was beaten at `s` before and is beaten at
+//!   `s` now, because `b` is reached at `s`, and no other fortress moved;
+//! * so the same locks open, so reach in round `r + 1` is unchanged.
+//!
+//! Every sphere, the spoiler log, `solvable`, and which locks are sealable come
+//! out identical. What *does* change is where the player has to walk to collect
+//! a key, which is the point.
+//!
+//! Two relaxations follow from the same monotonicity and are **not** taken
+//! here, recorded so the next reader does not have to re-derive them:
+//!
+//! * **Into an earlier sphere** is also free — the key arrives sooner and
+//!   reachability only grows — but it collapses spheres and makes the maze
+//!   shallower, which is the wrong direction.
+//! * **Into a later sphere** is where actual maze depth would come from, and it
+//!   is the only one that needs an accept test (one `spheres().solvable` per
+//!   proposal, cheap beside the fill's ~136). It is a different feature with a
+//!   different argument to make; this one is about what the map says.
+//!
+//! ## Where it runs
+//!
+//! Inside `generate`'s deal closure, **after the pads and before the fill**.
+//! Pads change reachability, so the sphere index has to be read with them in
+//! place; and the fill has to see the final fortress positions, since it draws
+//! each key from the fortresses reachable at that moment. Running here also
+//! keeps the fill's own fallback honest — it reverts to the builder's local
+//! pairing, and the re-keying below keeps that pairing solvable.
+
+use std::collections::HashMap;
+
+use rand::Rng;
+use rand::seq::IndexedRandom;
+
+use super::super::overworld_build::SlotKind;
+use super::super::rom_data::W8_IDX;
+use super::walk::MazePos;
+use super::{FortRef, GlobalState};
+
+/// What one exchange moved, for the census and the spoiler log.
+// Reason: production needs only that the exchange happened; all three fields
+// are the census's and the invariant test's readout of WHICH fortress went
+// where, and those are their only readers.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Relocation {
+    /// Where the fortress was, and which world it left.
+    pub from: MazePos,
+    /// Where it went, and the world that gained it.
+    pub to: MazePos,
+    /// The sphere both ends sit in — equal by construction.
+    pub sphere: usize,
+}
+
+/// What the pass did.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RelocateReport {
+    /// Exchanges rolled for this seed: [`MIN_SWAPS`]..=[`MAX_SWAPS`].
+    pub wanted: usize,
+    pub moves: Vec<Relocation>,
+    /// Eligible (fortress, level) pairs before the first exchange — the supply.
+    /// Zero means the pass could do nothing, which a census should notice
+    /// rather than read as "it chose not to".
+    // Reason: a census output, and the census is its only reader.
+    #[allow(dead_code)]
+    pub pairs: usize,
+}
+
+impl RelocateReport {
+    pub(crate) fn done(&self) -> usize {
+        self.moves.len()
+    }
+}
+
+/// Fewest exchanges a seed makes.
+pub(crate) const MIN_SWAPS: usize = 1;
+
+/// Most exchanges a seed makes.
+///
+/// Small on purpose. Each exchange decouples the lock and fortress counts of
+/// **two** worlds, so two already touches half the map; past that the fortress
+/// distribution stops looking like a map someone laid out and starts looking
+/// like a shuffle, which is the thing `overworld_build` spends its whole
+/// shaping loop avoiding.
+pub(crate) const MAX_SWAPS: usize = 2;
+
+/// The next free fortress id in a world.
+///
+/// Ids only have to be unique within their world — they pair a fortress with
+/// its lock and carry no ordering (`overworld_build::forts`) — so counting up
+/// from the highest in use is enough. It leaves holes in the numbering when a
+/// world loses a fortress, which the writer handles: `assign_pool` walks
+/// `0..section_count` and *looks up* the slot rather than assuming one exists.
+fn next_fort_id(state: &GlobalState, world: usize) -> usize {
+    state.worlds[world]
+        .slots
+        .iter()
+        .filter(|s| s.kind == SlotKind::Fortress)
+        .map(|s| s.section + 1)
+        .max()
+        .unwrap_or(0)
+}
+
+/// Exchange one fortress with one level, carrying the fortress's identity.
+///
+/// The two slot records swap worlds *and* positions, so every flag a level slot
+/// carries (`is_troll_pipe`, `is_hand_trap`) travels with the level rather than
+/// being applied to whatever lands on its old cell.
+fn exchange(state: &mut GlobalState, fort: MazePos, level: MazePos) {
+    let (fw, fpos) = fort;
+    let (lw, lpos) = level;
+    debug_assert_ne!(fw, lw, "an exchange inside one world moves no fortress between worlds");
+
+    let fi = state.worlds[fw]
+        .slots
+        .iter()
+        .position(|s| s.kind == SlotKind::Fortress && s.pos == fpos)
+        .expect("the fortress came from this world's slot list");
+    let mut fort_slot = state.worlds[fw].slots.remove(fi);
+
+    let li = state.worlds[lw]
+        .slots
+        .iter()
+        .position(|s| s.kind == SlotKind::Level && s.pos == lpos)
+        .expect("the level came from this world's slot list");
+    let mut level_slot = state.worlds[lw].slots.remove(li);
+
+    // Re-key BEFORE the fortress takes its new id, so `was` still names it.
+    let was = FortRef { world: fw, section: fort_slot.section };
+    let now = FortRef { world: lw, section: next_fort_id(state, lw) };
+    for lock in state.locks.iter_mut() {
+        if lock.fort == Some(was) {
+            lock.fort = Some(now);
+        }
+    }
+
+    fort_slot.pos = lpos;
+    fort_slot.section = now.section;
+    level_slot.pos = fpos;
+    // A level slot's `section` is always 0 and means nothing (every phase but
+    // `forts` writes it that way), so nothing has to be renumbered here.
+    state.worlds[lw].slots.push(fort_slot);
+    state.worlds[fw].slots.push(level_slot);
+}
+
+/// Move one or two fortresses into other worlds, keeping the fixpoint exact.
+///
+/// Consumes RNG, so it belongs inside the deal — a redeal gets a different
+/// distribution along with a different maze.
+pub(crate) fn relocate_forts<R: Rng>(state: &mut GlobalState, rng: &mut R) -> RelocateReport {
+    // The sphere index is invariant under every exchange this pass makes (see
+    // the module docs), so it is read once and reused rather than recomputed
+    // between exchanges.
+    let spheres = state.spheres();
+    let sphere_of: HashMap<MazePos, usize> = spheres
+        .spheres
+        .iter()
+        .enumerate()
+        .flat_map(|(i, s)| s.reached.iter().map(move |&p| (p, i)))
+        .collect();
+
+    // Two worlds are excluded on both sides.
+    //
+    // **Off-spine worlds**, because their content is bonus — `spheres` does not
+    // count their fortresses against solvability — so moving a required
+    // fortress into one would make it unrequired, and pulling one out would
+    // hand the maze a fortress it never had to beat.
+    //
+    // **World 8**, because this is a perception change and W8 is the one world
+    // where it would not be one. Its four locks include the dealt bridge spans
+    // to the castle (`capacity::BRIDGES_OUT_WEIGHTS` tunes how many are out,
+    // and each one drags another fortress onto the mandatory path), and the
+    // wand gate stands on the same approach. Moving a fortress off that
+    // corridor, or onto it, changes the endgame rather than how the map reads.
+    // W8 keeping 4 and 4 on every seed is a tell the mode accepts.
+    let sited = |state: &GlobalState, kind: SlotKind| -> Vec<(MazePos, usize)> {
+        state
+            .worlds
+            .iter()
+            .filter(|w| state.in_maze[w.world_idx] && w.world_idx != W8_IDX)
+            .flat_map(|w| {
+                w.slots.iter().filter(|s| s.kind == kind).map(move |s| (w.world_idx, s.pos))
+            })
+            .filter_map(|p| sphere_of.get(&p).map(|&s| (p, s)))
+            .collect()
+    };
+
+    let mut forts = sited(state, SlotKind::Fortress);
+    let mut levels = sited(state, SlotKind::Level);
+
+    let pairs =
+        |forts: &[(MazePos, usize)], levels: &[(MazePos, usize)]| -> Vec<(MazePos, MazePos)> {
+            forts
+                .iter()
+                .flat_map(|&((fw, fpos), fs)| {
+                    levels
+                        .iter()
+                        .filter(move |&&((lw, _), ls)| lw != fw && ls == fs)
+                        .map(move |&(lpos, _)| ((fw, fpos), lpos))
+                })
+                .collect()
+        };
+
+    let mut candidates = pairs(&forts, &levels);
+    let mut report = RelocateReport {
+        wanted: rng.random_range(MIN_SWAPS..=MAX_SWAPS),
+        pairs: candidates.len(),
+        moves: Vec::new(),
+    };
+
+    while report.done() < report.wanted {
+        let Some(&(fort, level)) = candidates.choose(rng) else {
+            break;
+        };
+        let sphere = sphere_of[&fort];
+        exchange(state, fort, level);
+        // Both cells are spent: the fortress is where the level was and vice
+        // versa, so leaving either in the pools would let the second exchange
+        // undo the first.
+        forts.retain(|&(p, _)| p != fort);
+        levels.retain(|&(p, _)| p != level);
+        report.moves.push(Relocation { from: fort, to: level, sphere });
+        candidates = pairs(&forts, &levels);
+    }
+
+    report
+}
+
+/// Every fortress id in a world, sorted.
+///
+/// Ids have to stay unique within a world — the writer looks a fortress up by
+/// `(world, id)` — and a relocation is the only thing that ever mints a new one,
+/// so the test that checks it lives beside the code that could break it.
+#[cfg(test)]
+pub(crate) fn fort_ids(state: &GlobalState, world: usize) -> Vec<usize> {
+    let mut ids: Vec<usize> = state.worlds[world]
+        .slots
+        .iter()
+        .filter(|s| s.kind == SlotKind::Fortress)
+        .map(|s| s.section)
+        .collect();
+    ids.sort_unstable();
+    ids
+}

--- a/src/randomize/maze/tests.rs
+++ b/src/randomize/maze/tests.rs
@@ -17,7 +17,7 @@ use super::graph::{Knobs, PAD_BUDGET};
 use super::{GenReport, GlobalState, IDENTITY_SPINE, MazeEdge};
 
 use crate::randomize::map_walker::walk_reachable;
-use crate::randomize::maze::walk::{MazeWorld, walk_maze};
+use crate::randomize::maze::walk::{MazePos, MazeWorld, walk_maze};
 use crate::randomize::node_catalog::NodeCatalog;
 /// Every census and property test asks for the same secret-exit slot count the
 /// pipeline does — the writer needs one, so the maze must leave one.
@@ -2395,12 +2395,13 @@ fn a_fortress_tile_says_where_its_lock_is() {
 
     let Some(raw) = load_rom() else { return };
     let mut checked = 0usize;
+    let mut relocated_checked = 0usize;
     let mut seen = [0usize; 3];
 
     for seed in 0..census_seeds(8) {
         let (_, mut build) = census_build(&raw, seed);
         let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x5EED_1234);
-        let (state, _) = super::generate(
+        let (state, report) = super::generate(
             &build,
             &IDENTITY_SPINE,
             super::DEFAULT_WANDS_REQUIRED,
@@ -2409,6 +2410,35 @@ fn a_fortress_tile_says_where_its_lock_is() {
             &mut rng,
         );
         super::stamp_into(&mut build, &state);
+
+        // **A relocated fortress is the case this test exists for.** Its hint is
+        // computed from the world it is in, and relocation is the only thing
+        // that changes that world after the builder has spoken — so if the hint
+        // were read before the move, or from the old world, this is where it
+        // would show. Assert the moved ones are actually in the sample below
+        // rather than trusting that they turned up.
+        for m in &report.relocated.moves {
+            let (nw, npos) = m.to;
+            assert!(
+                build.worlds[nw]
+                    .slots
+                    .iter()
+                    .any(|s| s.kind == SlotKind::Fortress && s.pos == npos),
+                "seed {seed}: the fortress relocated to W{} {npos:?} is not there after \
+                 stamp_into — the move never reached the build",
+                nw + 1
+            );
+            assert!(
+                !build.worlds[m.from.0]
+                    .slots
+                    .iter()
+                    .any(|s| s.kind == SlotKind::Fortress && s.pos == m.from.1),
+                "seed {seed}: a fortress is still at its old cell W{} {:?}",
+                m.from.0 + 1,
+                m.from.1
+            );
+            relocated_checked += 1;
+        }
 
         for (wi, built) in build.worlds.iter().enumerate() {
             for slot in built.slots.iter().filter(|s| s.kind == SlotKind::Fortress) {
@@ -2447,6 +2477,11 @@ fn a_fortress_tile_says_where_its_lock_is() {
         }
     }
     assert!(checked > 0, "no fortresses checked; the test is vacuous");
+    assert!(
+        relocated_checked > 0,
+        "no relocated fortress was checked — this test no longer covers the case where a \
+         fortress changed worlds after the builder set its hint"
+    );
     for (bucket, name) in [(0, "local"), (1, "elsewhere"), (2, "World 8")] {
         assert!(seen[bucket] > 0, "no fortress exercised {name}; that state is unchecked");
     }
@@ -2672,4 +2707,261 @@ fn maze_spine_length_census() {
     }
     eprintln!("  cells are seeds where the castle is unreachable or a spine fortress unbeatable");
     assert_eq!(worst, 0, "a spine length shipped an unwinnable maze");
+}
+
+// ---------------------------------------------------------------------------
+// Fortress relocation
+// ---------------------------------------------------------------------------
+
+/// The fixpoint as a relocation must leave it: per round, the cells first
+/// reached and the locks that open.
+type SphereShape = (bool, Option<usize>, Vec<(Vec<MazePos>, Vec<usize>)>);
+
+/// The fixpoint, read so that a moved fortress cannot hide inside it.
+///
+/// Neither `FortRef` identities nor the cells fortresses are beaten on survive a
+/// relocation — those are the move itself, and comparing them reports a
+/// difference on every seed the pass touches. What has to be identical is the
+/// causal chain: **which cells become reachable in which round, and which locks
+/// open in which round**. Lock indices are stable (no lock moves), so they say
+/// it exactly.
+fn sphere_shape(state: &GlobalState) -> SphereShape {
+    let s = state.spheres();
+    let rounds = s
+        .spheres
+        .iter()
+        .map(|round| {
+            let mut reached = round.reached.clone();
+            reached.sort_unstable();
+            let mut opened = round.opened.clone();
+            opened.sort_unstable();
+            (reached, opened)
+        })
+        .collect();
+    (s.solvable, s.goal_sphere, rounds)
+}
+
+/// The first place two fixpoint shapes disagree, in one line.
+///
+/// A whole-shape `assert_eq!` prints two thousand-cell dumps and hides the one
+/// cell that moved, which is the only thing worth knowing.
+fn first_difference(a: &SphereShape, b: &SphereShape) -> Option<String> {
+    if a.0 != b.0 {
+        return Some(format!("solvable {} -> {}", a.0, b.0));
+    }
+    if a.1 != b.1 {
+        return Some(format!("goal sphere {:?} -> {:?}", a.1, b.1));
+    }
+    if a.2.len() != b.2.len() {
+        return Some(format!("{} spheres -> {}", a.2.len(), b.2.len()));
+    }
+    fn gone<T: PartialEq + Copy + std::fmt::Debug>(x: &[T], y: &[T]) -> Vec<T> {
+        x.iter().filter(|p| !y.contains(p)).copied().collect()
+    }
+    for (i, (ra, rb)) in a.2.iter().zip(b.2.iter()).enumerate() {
+        let (lost, gained) = (gone(&ra.0, &rb.0), gone(&rb.0, &ra.0));
+        if !lost.is_empty() || !gained.is_empty() {
+            return Some(format!("sphere {i} reached: lost {lost:?}, gained {gained:?}"));
+        }
+        let (lost, gained) = (gone(&ra.1, &rb.1), gone(&rb.1, &ra.1));
+        if !lost.is_empty() || !gained.is_empty() {
+            return Some(format!("sphere {i} locks opened: lost {lost:?}, gained {gained:?}"));
+        }
+    }
+    None
+}
+
+/// **A same-sphere exchange cannot move the fixpoint**, and this is what says
+/// so rather than the argument in `relocate`'s module docs.
+///
+/// The pass has no accept test — it is safe by construction — so if the
+/// construction is wrong there is nothing downstream to catch it except a
+/// player walking into a gate whose key moved somewhere unreachable. That makes
+/// this the load-bearing test for the feature: every round of the fixpoint, the
+/// cells reached and the cells a fortress falls on, before and after.
+#[test]
+fn relocation_leaves_the_fixpoint_identical() {
+    let Some(raw) = load_rom() else { return };
+    let mut moves = 0usize;
+    let mut seeds_that_moved = 0usize;
+    let seeds = census_seeds(12);
+    for seed in 0..seeds {
+        let (_, result) = census_build(&raw, seed);
+        let mut state = GlobalState::from_build(&result, &IDENTITY_SPINE, 0);
+
+        // Pads first, exactly as `generate` orders it — a pad changes what is
+        // reachable, so a sphere index read without them is not the one the
+        // shipped maze has.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x5EED_1234);
+        let pads = super::graph::plan_pads(&state, &Knobs::default(), &mut rng);
+        state.add_pads(pads.iter().map(|p| p.edge).collect());
+
+        let before = sphere_shape(&state);
+        let report = super::relocate::relocate_forts(&mut state, &mut rng);
+        let after = sphere_shape(&state);
+
+        if let Some(why) = first_difference(&before, &after) {
+            panic!(
+                "seed {seed}: {} relocation(s) moved the fixpoint — the same-sphere \
+                 construction is wrong\n  {why}\n  moves: {:?}\n{}",
+                report.done(),
+                report.moves,
+                state.spheres().spoiler()
+            );
+        }
+        for m in &report.moves {
+            assert_ne!(m.from.0, m.to.0, "seed {seed}: a relocation stayed inside one world");
+            // W8 is held out on both sides — its locks are the castle approach,
+            // where a moved fortress changes the endgame rather than how the
+            // map reads. See the exclusion note in `relocate::relocate_forts`.
+            assert!(
+                m.from.0 != crate::randomize::rom_data::W8_IDX
+                    && m.to.0 != crate::randomize::rom_data::W8_IDX,
+                "seed {seed}: a relocation touched World 8 ({m:?})"
+            );
+        }
+        // Fortress ids stay unique within a world; the writer looks a fortress
+        // up by (world, id) and a collision would silently drop one.
+        for wi in 0..8 {
+            let ids = super::relocate::fort_ids(&state, wi);
+            let mut uniq = ids.clone();
+            uniq.dedup();
+            assert_eq!(ids, uniq, "seed {seed} W{}: duplicate fortress id in {ids:?}", wi + 1);
+        }
+
+        moves += report.done();
+        seeds_that_moved += usize::from(report.done() > 0);
+    }
+    eprintln!(
+        "  relocation: {moves} fortresses moved over {seeds} seeds, \
+         {seeds_that_moved} seeds touched"
+    );
+    assert!(
+        seeds_that_moved > 0,
+        "no seed relocated anything — the pass is inert and the test above proves nothing"
+    );
+}
+
+/// **What the player sees**: how often a world's lock count stops matching its
+/// fortress count, which is the entire point of the pass.
+///
+/// Reported rather than asserted at a number. The one assertion is that the
+/// mechanism fires at all — a supply that dries up would make this a no-op
+/// feature that still looks present in the code.
+#[test]
+fn relocation_decouples_lock_and_fort_counts() {
+    let Some(raw) = load_rom() else { return };
+    let seeds = census_seeds(12);
+    let mut supply = Vec::new();
+    let mut spheres: Vec<usize> = Vec::new();
+    let mut mismatched = 0usize;
+    let mut worlds = 0usize;
+    let mut fortless = 0usize;
+    let mut lockless = 0usize;
+    let mut empty = 0usize;
+    let mut max_forts = 0usize;
+    let mut max_locks = 0usize;
+    let mut roaming_seen: Vec<usize> = Vec::new();
+    for seed in 0..seeds {
+        let (_, result) = census_build(&raw, seed);
+        let mut build = result.clone();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x5EED_1234);
+        let (state, report) = super::generate(
+            &result,
+            &IDENTITY_SPINE,
+            super::DEFAULT_WANDS_REQUIRED,
+            &Knobs::default(),
+            SEALABLE_NEEDED,
+            &mut rng,
+        );
+        supply.push(report.relocated.pairs);
+        spheres.extend(report.relocated.moves.iter().map(|m| m.sphere));
+        super::stamp_into(&mut build, &state);
+
+        // After `stamp_into`, because that is the shape the writer sees. It
+        // panics on a lock naming a fortress that is not on the map, which is
+        // exactly the failure a mis-keyed relocation would produce.
+        //
+        // **And the entries are checked, not merely produced.** `key_world` is
+        // what colours the lock tile (`away = lock.fort.world != wi`) and what
+        // the world number on a `HintMode::Full` lock reads, so a key pointing
+        // at the fortress's OLD world would mislabel the lock rather than
+        // crash. Assert every key lands on a cell a fortress actually occupies.
+        for e in crate::randomize::overworld_writer::lock_entries(&build) {
+            assert!(
+                build.worlds[e.key_world]
+                    .slots
+                    .iter()
+                    .any(|s| s.kind == SlotKind::Fortress && s.pos == e.key_pos),
+                "seed {seed}: the lock at W{} {:?} names a key at W{} {:?}, where no \
+                 fortress stands",
+                e.target_world + 1,
+                e.target_pos,
+                e.key_world + 1,
+                e.key_pos
+            );
+        }
+
+        let mut roaming = 0usize;
+        for (wi, built) in build.worlds.iter().enumerate() {
+            let forts = built.slots.iter().filter(|s| s.kind == SlotKind::Fortress).count();
+            worlds += 1;
+            mismatched += usize::from(forts != built.locks.len());
+            fortless += usize::from(forts == 0 && !built.locks.is_empty());
+            if wi != crate::randomize::rom_data::W8_IDX {
+                max_forts = max_forts.max(forts);
+                roaming += forts;
+            } else {
+                assert_eq!(forts, 4, "seed {seed}: W8 must keep its four fortresses");
+            }
+            max_locks = max_locks.max(built.locks.len());
+            lockless += usize::from(forts > 0 && built.locks.is_empty());
+            empty += usize::from(forts == 0 && built.locks.is_empty());
+            assert!(
+                built.section_count
+                    > built
+                        .slots
+                        .iter()
+                        .filter(|s| s.kind == SlotKind::Fortress)
+                        .map(|s| s.section)
+                        .max()
+                        .unwrap_or(0)
+                    || forts == 0,
+                "seed {seed} W{}: section_count {} does not cover the fortress ids",
+                wi + 1,
+                built.section_count
+            );
+        }
+        roaming_seen.push(roaming);
+    }
+    let mean = |v: &[usize]| v.iter().sum::<usize>() as f64 / v.len() as f64;
+    eprintln!(
+        "  eligible (fort, level) pairs per seed: mean {:.1}, min {}",
+        mean(&supply),
+        supply.iter().min().copied().unwrap_or(0)
+    );
+    eprintln!(
+        "  worlds whose lock count != fort count: {mismatched}/{worlds} = {:.1}%",
+        100.0 * mismatched as f64 / worlds as f64
+    );
+    eprintln!("  worlds with locks but NO fortress: {fortless}/{worlds}");
+    eprintln!("  worlds with a fortress but NO lock: {lockless}/{worlds}");
+    eprintln!("  worlds with neither: {empty}/{worlds}");
+    let mut hist = [0usize; 8];
+    for s in &spheres {
+        hist[(*s).min(7)] += 1;
+    }
+    eprintln!("  relocations by sphere (0..=7+): {hist:?}");
+    eprintln!("  most fortresses in one W1-W7 world: {max_forts}  (the tracker's per-world cap)");
+    eprintln!("  most locks in one world: {max_locks}");
+    eprintln!(
+        "  fortresses across W1-W7: min {}, max {}  (W8 keeps 4, asserted above)",
+        roaming_seen.iter().min().copied().unwrap_or(0),
+        roaming_seen.iter().max().copied().unwrap_or(0)
+    );
+    assert!(
+        mismatched > 0,
+        "no world came out with a lock count that differs from its fortress count — \
+         the pass did nothing a player could see"
+    );
 }

--- a/web/maze-tracker.html
+++ b/web/maze-tracker.html
@@ -537,9 +537,10 @@ body {
                 wears the world number to go to.</dd>
             <dt><span class="chip lock unattributed"><span class="body">Lock</span></span></dt>
             <dd>Dashed: a lock you have seen but cannot yet pin on a fortress. Say
-                which world its key is in and it joins up with one. Every world has
-                as many locks as it has fortresses, so a lock you cannot account for
-                means there is a fortress here you have not found.</dd>
+                which world its key is in and it joins up with one. There are seventeen
+                locks and seventeen fortresses, one each, so a lock you cannot
+                account for means there is a fortress somewhere you have not
+                found — not necessarily in this world.</dd>
             <dt><span class="help" style="display:inline-block">HELP</span></dt>
             <dd>A world calls for help until you clear its castle and take its wand.
                 Click the balloon to cross it off. Dark Land has none — that is where
@@ -599,10 +600,18 @@ const W8_FORTS = ["Battleship", "Air Force", "Super Tank", "Fortress"];
 //   pad tiles overall — a pair is two tiles, so eight pairs.
 const PADS_MAX = 3;         // per world
 const PAD_TILES_MAX = 16;   // whole game; 8 pairs
-const FORTS_MAX = 3;        // per world, worlds 1-7
-const FORTS_ROAMING = 13;   // whole game, worlds 1-7
+// **Fortresses and locks are counted separately, and that is not redundant.**
+// The builder deals one lock per fortress in the same world, but `maze::relocate`
+// then moves up to two fortresses into other worlds — never a lock — so a world
+// can hold five fortresses and one lock, or none and three. Dark Land is held
+// out of that move, so its four stay four. Measured over 400 seeds: at most 5
+// fortresses in a W1-W7 world, at most 3 locks, and the W1-W7 fortress total is
+// 13 on every seed.
+const FORTS_MAX = 5;        // per world, worlds 1-7: 3 dealt + up to 2 moved in
+const LOCKS_MAX = 3;        // per world, worlds 1-7 — locks never move
+const FORTS_ROAMING = 13;   // whole game, worlds 1-7 — conserved by the move
 const FORTS_TOTAL = 17;     // those 13 plus Dark Land's 4
-const LOCKS_TOTAL = FORTS_TOTAL; // one lock per fortress
+const LOCKS_TOTAL = FORTS_TOTAL; // the fort/lock bijection survives relocation
 const WANDS_TOTAL = 7;      // one per world 1-7, held once its castle falls
 const W8 = 7;               // index of the Dark Land slot
 
@@ -621,7 +630,11 @@ function blankState() {
 			pads: [],
 		});
 	}
-	// Worlds 1-7 always hold at least one fortress; Dark Land holds its four.
+	// A starting guess, not a guarantee. The builder deals every world 1-7 at
+	// least one fortress, but `maze::relocate` can carry that one out again, so
+	// a world really can hold none (measured ~3.5% of worlds). The seeded chip
+	// says nothing until the player gives it a hint — an "unknown" fortress
+	// draws no lock anywhere — so a wrong guess costs one deletion.
 	for (let w = 0; w < 7; w++) worlds[w].forts.push(newFort());
 	worlds[W8].forts = W8_FORTS.map(label => newFort(label));
 	return { nextId: 1, worlds };
@@ -730,21 +743,23 @@ function lockWorldOf(world, fort) {
 
 // Every lock standing in `target`.
 //
-// One per fortress in that world, always — `WorldState::fort_count` is "also
-// the number of lock sections", so a world's locks are its own fortresses'
-// locks whatever those fortresses open. The design only decides whether the
-// lock is plain (this world's fortress opens it) or tinted (its key is
-// somewhere else).
+// **One per fortress whose KEY points here — not one per fortress standing
+// here.** Those were the same number until fortresses started changing worlds
+// (`maze::relocate`), because the builder dealt each world a lock per fortress
+// and nothing moved afterwards. Now a fortress can be carried into a world
+// without a lock coming with it, so the fortresses on a card no longer tell you
+// how many locks the card holds.
 //
-// Then the ones a fortress elsewhere opens here: a W8-design fortress reaching
-// into Dark Land, or a remote one the player has placed.
+// What survives is the bijection: every lock is opened by exactly one fortress.
+// So a lock stands here for each fortress ANYWHERE whose lock is here, plus the
+// free ones the player has walked up to but not yet pinned on a fortress.
+//
+// A fortress that has not said where its lock is draws nothing yet. It has one
+// out there somewhere, and putting it in that fortress's own world is exactly
+// the inference that stopped being true.
 function locksIn(target) {
 	const out = state.worlds[target].locks.map(lock => ({ kind: "free", lock, world: target }));
-	for (const fort of state.worlds[target].forts) {
-		out.push({ kind: "own", fort, world: target });
-	}
 	state.worlds.forEach((world, w) => {
-		if (w === target) return;
 		for (const fort of world.forts) {
 			if (lockWorldOf(w, fort) === target) out.push({ kind: "fort", fort, world: w });
 		}
@@ -752,20 +767,11 @@ function locksIn(target) {
 	return out;
 }
 
-// Whether a fortress's own-world lock is open.
-//
-// For a local fortress that is the same fact as "have I beaten it" — it opens
-// the lock standing beside it. For every other design it is a separate fact,
-// because the lock in its world is opened by some fortress elsewhere, and the
-// two are cleared at different times.
-function ownLockOpen(fort) {
-	return fort.hint === "here" ? !!fort.done : !!fort.ownLockOpen;
-}
-
-function setOwnLockOpen(fort, open) {
-	if (fort.hint === "here") fort.done = open;
-	else fort.ownLockOpen = open;
-}
+// `ownLockOpen`/`setOwnLockOpen` lived here. They tracked the lock standing in a
+// remote fortress's OWN world — the one some other fortress opens — which the
+// tracker no longer draws, because there is no longer any reason to believe it
+// exists. Every lock chip is now the lock its fortress opens, so `fort.done`
+// says whether it is open and the second flag has nothing left to mean.
 
 // --- Counting against the budgets -------------------------------------
 
@@ -790,40 +796,35 @@ function countPadPairs() {
 // Lock chips standing anywhere: the free ones the player logged, plus every
 // fortress whose lock has a home. A fortress still showing "?" has a lock out
 // there somewhere, but nothing to draw yet.
+//
+// Defined through [`locksIn`] rather than re-counting, because three places once
+// had their own idea of how many locks a world holds and they have to agree.
 function countLockChips() {
-	let n = 0;
-	state.worlds.forEach((world, w) => {
-		n += world.locks.length;
-		for (const fort of world.forts) if (lockWorldOf(w, fort) !== null) n++;
-	});
-	return n;
+	return state.worlds.reduce((n, _world, w) => n + locksIn(w).length, 0);
 }
 
-// A world holds exactly one lock per fortress — `WorldState::fort_count` is
-// "also the number of lock sections" — so a world can never hold more locks
-// than it can hold fortresses: three for worlds 1-7, four for Dark Land.
+// How many locks a world can hold: three for worlds 1-7, four for Dark Land.
+//
+// **Not `FORTS_MAX`, though it used to be.** The builder deals a world one lock
+// per fortress, and that ceiling is what survives — locks never move. What moves
+// is fortresses, so the two numbers came apart and a world can now hold more
+// fortresses than it has locks.
 //
 // Counted against the *ceiling* rather than against the fortresses the player
 // has actually logged. Finding a lock before its fortress is the normal way
 // round, and warning about that would cry wolf all run.
 function lockCapacity(w) {
-	return w === W8 ? 4 : FORTS_MAX;
+	return w === W8 ? 4 : LOCKS_MAX;
 }
 
 // How many fortresses open a lock in this world.
 //
-// This, not the number of chips on the card, is what the capacity is about. A
-// world's own fortresses each stand beside a lock whatever they open, so the
-// chips are always at least the fort count; what cannot exceed it is the number
-// of KEYS pointing here. For Dark Land that sum is exactly the one to watch —
-// the plain fortresses standing there plus every special fortress out in the
-// other worlds.
+// Now exactly the chips on the card — since a lock is drawn here only when some
+// fortress's key points here, the two questions have the same answer and one
+// definition. For Dark Land this is the sum to watch: the plain fortresses
+// standing there plus every special fortress out in the other worlds.
 function keysInto(target) {
-	let n = state.worlds[target].locks.length;
-	state.worlds.forEach((world, w) => {
-		for (const fort of world.forts) if (lockWorldOf(w, fort) === target) n++;
-	});
-	return n;
+	return locksIn(target).length;
 }
 
 function worldName(w) {
@@ -1335,7 +1336,6 @@ function lockToken(w, fort) {
 function renderLocks(w) {
 	return locksIn(w).map(entry => {
 		if (entry.kind === "free") return renderFreeLock(w, entry.lock);
-		if (entry.kind === "own") return renderOwnLock(entry.fort);
 		const { fort, world } = entry;
 		const away = world !== w;
 		const chip = el("span", {
@@ -1373,26 +1373,6 @@ function renderLocks(w) {
 		}
 		return chip;
 	});
-}
-
-// The lock that stands beside a fortress, in its own world. Plain when that
-// fortress opens it, tinted when its key is somewhere else — which is what the
-// lock tile itself says on Some hints and above.
-function renderOwnLock(fort) {
-	const local = fort.hint === "here";
-	const open = ownLockOpen(fort);
-	const chip = el("span", {
-		class: "chip lock" + (local ? "" : " away") + (open ? " done" : ""),
-	});
-	chip.appendChild(el("button", {
-		class: "body",
-		type: "button",
-		title: open ? "Mark shut again" : "Mark open",
-		onclick: ev => { ev.stopPropagation(); setOwnLockOpen(fort, !open); render(); },
-	}, open ? "🔓" : "🔒"));
-	chip.appendChild(el("span", { class: "src" },
-		local ? "here" : (fort.hint === "unknown" ? "key: ?" : "key: elsewhere")));
-	return chip;
 }
 
 // A lock the player has walked up to but cannot yet pin on a fortress — the

--- a/web/maze-tracker.html
+++ b/web/maze-tracker.html
@@ -33,6 +33,39 @@
 .tracker { max-width: 1400px; zoom: var(--tracker-scale, 1); }
 .tracker .note { font-size: 0.82rem; color: #7a7a96; }
 
+/* **The controls live OUTSIDE the card, and size against the VIEWPORT.**
+   The size slider used to sit inside the board's card. Zoom changes that card's
+   width and the card is centred, so every point inside it moves as you drag —
+   measured at 729px sideways across 60-150%. The thumb walks out from under the
+   pointer and the control is unusable.
+
+   Two things had to go, and the first alone was not enough:
+
+   - Counter-zooming the row fixed its SIZE and none of its MOVEMENT.
+   - Hoisting it above the card fixed movement only above 100%. Its `width:100%`
+     still resolved against a wrapper sized by its contents — the card — so
+     below 100% the bar shrank with the board and the slider slid left again
+     (840px wide at 60% against 1400px at 100%).
+
+   So the bar is a direct child of `body`, which this page lays out as a column
+   for exactly that reason. Its width is a percentage of the body content box,
+   which depends on the viewport and on nothing that zooms. The card may then be
+   any width at all without moving the control.
+
+   The card must NOT be capped by a wrapper either: `.tracker` gets its zoom
+   effect from `max-width` being a fixed length that zoom multiplies, and a
+   capped parent turns that back into a no-op. The cost of all this is that away
+   from 100% the bar no longer lines up with the card's edges. */
+body {
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+}
+.tracker-chrome {
+    width: 100%;
+    max-width: 1400px;
+    margin-bottom: 0.75rem;
+}
 .tracker-nav {
     display: flex;
     justify-content: space-between;
@@ -433,6 +466,20 @@
 </style>
 </head>
 <body>
+<div class="tracker-chrome">
+    <div class="tracker-nav">
+        <a href="index.html">&larr; Back to the randomizer</a>
+        <div class="tools">
+            <label class="scale" for="scale">
+                Size
+                <input id="scale" type="range" min="60" max="150" step="5" value="100">
+                <span id="scale-value">100%</span>
+            </label>
+            <button id="reset-btn" type="button">Reset</button>
+        </div>
+    </div>
+</div>
+
 <div class="page-wrapper">
 <div class="container tracker">
 
@@ -445,17 +492,6 @@
         </div>
     </header>
 
-    <div class="tracker-nav">
-        <a href="index.html">&larr; Back to the randomizer</a>
-        <div class="tools">
-            <label class="scale" for="scale">
-                Size
-                <input id="scale" type="range" min="60" max="150" step="5" value="100">
-                <span id="scale-value">100%</span>
-            </label>
-            <button id="reset-btn" type="button">Reset</button>
-        </div>
-    </div>
 
     <p class="note" style="margin-bottom:1rem">
         Fill this in as you explore. Worlds are numbered the way the game numbers


### PR DESCRIPTION
A world's fortress count no longer matches its lock count, so counting the
locks in front of you stops telling you how many fortresses are behind you.

## What it does

`maze::relocate` exchanges one or two fortresses a seed with a level slot in
another world. A world can then hold three locks and one fortress, or locks
with no fortress of its own at all.

The fill already broke the *dependency* — 76% of locks are opened by a fortress
elsewhere — but it never moved a node, so the counts still matched and the map
read as eight self-contained worlds with the keys shuffled between them. This
breaks the counts. The fort/lock bijection is untouched: every fortress still
opens exactly one lock, so what is lost is only the deduction, and the hint
tiles already say what that deduction used to.

**It changes nothing about difficulty or length.** The same fortresses open the
same locks at the same points; you walk somewhere else to find the key.

## Why it cannot fail

The same-sphere rule makes the move exact rather than checked, so the pass has
no accept test and no retry — the same discipline the constructive fill uses.

Round 0 of the fixpoint reads terrain and all-locks-shut, so it cannot depend on
what occupies a slot. If the fortress's identity travels with it to a cell
reached in the same round, the same locks open in the same round, and the
induction carries. The module header writes it out, along with the two
relaxations it declines: an earlier sphere is free but collapses spheres, and a
later one is where real maze depth would come from but needs an accept test.

World 8 is held out on both sides — its locks are the dealt bridge spans to the
castle and the wand gate stands on the same approach, so a fortress moved on or
off that corridor changes the endgame rather than how the map reads.

## Measured, 400 seeds

| | |
|---|---|
| Worlds whose lock count differs from fort count | 31.4% |
| Worlds with locks and no fortress | 3.5% |
| Worlds with a fortress and no lock | **0** (the counts make it impossible) |
| Most fortresses in one W1-W7 world | 5 |
| W1-W7 fortress total | 13 on every seed |
| Escapable start regions | 93.5% → 93.6% (unpaired; the pass shifts the RNG stream) |

`relocation_leaves_the_fixpoint_identical` is the load-bearing test: per round,
the cells first reached and the lock indices that open, before and after.
Comparing the cells fortresses are *beaten on* fails on every seed the pass
touches — those move, and that is the feature.

## The tracker had to follow

`locksIn` drew one lock per fortress *standing* in a world. It now draws one per
fortress anywhere whose key points there, so a remote or Dark-Land fortress no
longer conjures a lock beside itself.

The trap: `lockCapacity` read `FORTS_MAX`, so bumping the fortress cap alone
would have silently raised the lock ceiling and killed the overfull warning.
Split into `FORTS_MAX = 5` (3 dealt plus up to 2 moved in) and `LOCKS_MAX = 3`
(locks never move). Without the higher cap the tracker would refuse to log a
legitimate fourth fortress.

The claim was in the player-facing prose too — the legend said a lock you cannot
account for means a fortress *here* you have not found.

## One unrelated commit rides along

`8bb4bba` fixes the tracker's size slider, which is **already broken on
`beta/next`** and unrelated to the maze work — I hit it while verifying the lock
change. The slider sat inside the card that `--tracker-scale` zooms, so it moved
729px sideways and 88px down as you dragged it. It is cleanly separable if you
would rather it land on its own.

## What this does not have

- **No playtesting.** Like the rest of the world maze.
- **No test guarding the tracker changes.** They were verified by driving the
  page's own functions headlessly, which does not run in CI.

## Open questions I did not decide

- Whether 3.5% of worlds having no fortress of their own is the right feel.
  `MAX_SWAPS` is the dial.
- **Hints Off** players lose the count deduction and get nothing back — the hint
  tiles are what replaced it.
- Whether `blankState` should stop seeding a fortress into every world 1-7 now
  that a world can hold none.
- A pre-existing bug I left alone: the empty aiming bar shows on every load
  (`.aiming { display: flex }` beats the `hidden` attribute). It ships on
  `beta/next` today.

Gates: `cargo fmt --check` clean, both clippy passes clean, 621 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wLx2t4mCA5koCY5CnaQHb
