### PR TITLE
docs: on Full hints the world number replaces the lock's tint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -472,8 +472,9 @@ struct Cli {
     /// World maze: how much the map tells you about which fortress opens which
     /// lock — off, some, or full (default: some). `some` gives each fortress a
     /// design saying whether its lock is local, elsewhere, or in World 8, and
-    /// tints a lock whose key is in another world; `full` also numbers that lock
-    /// with the world to go to. Ignored outside `--world-maze`.
+    /// tints a lock whose key is in another world; `full` keeps the designs and
+    /// stamps that lock with the world number *instead* of the tint. Ignored
+    /// outside `--world-maze`.
     #[arg(long, default_value = "some", value_parser = parse_hints)]
     hints: HintMode,
 

--- a/web/maze-tracker.html
+++ b/web/maze-tracker.html
@@ -533,8 +533,9 @@ body {
             <dt><span class="chip lock"><span class="body">Lock</span></span></dt>
             <dd>Plain lock — the fortress that opens it is in this world.</dd>
             <dt><span class="chip lock away"><span class="body">Lock</span></span></dt>
-            <dd>Tinted lock — its fortress is somewhere else. On Full hints it also
-                wears the world number to go to.</dd>
+            <dd>Tinted lock — its fortress is somewhere else. The board always
+                tints one; the game says it with the colour on Some hints, and with
+                the world number in place of the colour on Full.</dd>
             <dt><span class="chip lock unattributed"><span class="body">Lock</span></span></dt>
             <dd>Dashed: a lock you have seen but cannot yet pin on a fortress. Say
                 which world its key is in and it joins up with one. There are seventeen

--- a/web/options.js
+++ b/web/options.js
@@ -347,7 +347,7 @@ export const SCHEMA = [
 		mode: "maze" },
 	{ id: "hints", type: "tri", options: OFF_SOME_FULL, default: "some",
 		label: "Hints",
-		tip: "How much the map gives away about which fortress opens which lock. Some marks a fortress with the design for where its lock is, and tints a lock whose key is in another world. Full also stamps that lock with the world number to go to.",
+		tip: "What the map gives away about which fortress opens which lock. On Some the colour is the mark: tan means a fortress and its lock are together in one world, the odd colour on either one means the two are apart, and the beta fortress opens a lock or bridge in World 8. On Full the number is the mark instead — a lock wears the number of the world its fortress is in, and a lock with no number is local. Fortress designs read the same either way. On Off the designs are picked at random and say nothing. Hints never change the map, so the same seed has the same locks and fortresses whichever you pick.",
 		group: "maze", inFlagKey: true,
 		mode: "maze" },
 


### PR DESCRIPTION
All three player-facing descriptions of the Hints flag said `full` "also" numbers an away lock, which reads as tint *and* number. It is one or the other.

`lock_keys::lock_tile` takes the `HINT_TILES` branch when `numbers_locks()` and never reaches `ALT_REMOTE_TILES`, and the numbered ground tiles are page 1 — the same palette as a plain lock. So on Full a lock wears a number and no tint, and **a lock with no number is local**. `local_sky_tile` returns `None` there for the same reason: the local-sky relocation only exists to keep "odd colour means elsewhere" true, which is a Some-mode rule.

Three sites, no behaviour change and no ROM bytes touched:

- **`--hints` help** — `full` keeps the fortress designs and stamps the lock with the world number *instead* of the tint.
- **The web tip** — rewritten to say which mark carries the meaning in each mode (colour on Some, number on Full), in the tan / odd colour / beta vocabulary the tracker already uses, and ending on the fact that hints never move the seed. That last part is worth a player knowing: `overworld_writer::grid` draws the cosmetic fortress tile first every time and only then decides whether to use it, so the flag cannot change the map.
- **The tracker legend** — it always tints an away lock, which is the board's own convention rather than what the game does on Full. It said the game "also" numbers that lock; now it distinguishes the board's mark from the game's.

`cargo fmt --check` and `cargo clippy` clean.

The one thing a tooltip can't carry, noted here instead: a World 8 army sprite standing on a fortress cell silently drops that fortress's hint, because the writer blanks the cell beneath the sprite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wLx2t4mCA5koCY5CnaQHb
